### PR TITLE
Use LaTeX detection from ESMA_cmake v1.0.9

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = v1.0.2
+tag = v1.0.9
 externals = Externals.cfg
 protocol = git
 

--- a/GMAO_pFIO/CMakeLists.txt
+++ b/GMAO_pFIO/CMakeLists.txt
@@ -118,8 +118,7 @@ include_directories (${INC_NETCDF})
 file (COPY unused_dummy.H DESTINATION ${include_${this}})
 
 # Users guide 
-if ($ENV{USE_LATEX} MATCHES NO)
-else ()
+if (LATEX_FOUND)
 #  add_subdirectory (TeX)
 endif ()
 

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -106,8 +106,7 @@ file (COPY mapl_acg.pl DESTINATION ${esma_include}/${this})
 file (COPY mapl_stub.pl DESTINATION ${esma_include}/${this})
 
 # Users guide 
-if ($ENV{USE_LATEX} MATCHES NO)
-else ()
+if (LATEX_FOUND)
   add_subdirectory (TeX)
 endif ()
 


### PR DESCRIPTION
This now defines a good LATEX_FOUND variable that helps on machines that
don't have a complete LaTeX stack (e.g., NAS compute)