### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+# The MAPL Team owns all the files
+* @GEOS-ESM/mapl-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 


### PR DESCRIPTION
Have @GEOS-ESM/mapl-team own all the files in this repo.

In a way, this is not as useful as similar efforts in other repos as @tclune and I are part of the @GEOS-ESM/cmake-team as well as @GEOS-ESM/mapl-team. Thus, if there is a CMake change, we will still approve everything. :smile: 