### PR TITLE
Add new restart attributes to MAPL: bootstrapped and skip initial restart

### DIFF
--- a/MAPL_Base/MAPL_Base.F90
+++ b/MAPL_Base/MAPL_Base.F90
@@ -157,6 +157,8 @@ integer, public, parameter :: MAPL_HorzTransOrderSample   = 99
 integer, public, parameter :: MAPL_RestartOptional = 0
 integer, public, parameter :: MAPL_RestartSkip = 1
 integer, public, parameter :: MAPL_RestartRequired = 2
+integer, public, parameter :: MAPL_RestartBootstrap = 3
+integer, public, parameter :: MAPL_RestartSkipInitial = 4
 
 integer, public, parameter :: MAPL_TileNameLength = 128
 

--- a/MAPL_Base/MAPL_IO.F90
+++ b/MAPL_Base/MAPL_IO.F90
@@ -7435,7 +7435,8 @@ module MAPL_IOMod
              else
                 RST = MAPL_RestartOptional
              end if
-             skipReading = (RST == MAPL_RestartSkip)
+             skipReading = (RST == MAPL_RestartSkip .or.   &
+                            RST == MAPL_RestartSkipInitial)
              if (skipReading) cycle
              bootstrapable_ = bootstrapable .and. (RST == MAPL_RestartOptional)
 
@@ -7487,6 +7488,9 @@ module MAPL_IOMod
                else
                   if (bootStrapable_ .and. (RST == MAPL_RestartOptional)) then
                      call WRITE_PARALLEL("  Bootstrapping Variable: "//trim(FieldName)//" in "//trim(filename))
+                     call ESMF_AttributeSet ( field, name='RESTART', &
+                             value=MAPL_RestartBootstrap, rc=status)
+
                   else
                      _ASSERT(.false., "  Could not find field "//trim(FieldName)//" in "//trim(filename))
                   end if
@@ -7539,6 +7543,8 @@ module MAPL_IOMod
              else
                 if (bootStrapable .and. (RST == MAPL_RestartOptional)) then
                     call WRITE_PARALLEL("  Bootstrapping Variable: "//trim(FieldName)//" in "//trim(filename))
+                    call ESMF_AttributeSet ( field, name='RESTART', &
+                            value=MAPL_RestartBootstrap, rc=status)
                 else
                     _ASSERT(.false., "  Could not find field "//trim(Fieldname)//" in "//trim(filename))
                 end if


### PR DESCRIPTION
New restart attributes are MAPL_RestartBootstrap, denoting fields that
are bootstrapped by MAPL, and MAPL_RestartSkipInitial, denoting field
that do not need to be in the input restart file but should be written
out to the output restart file.

These updates are used by GCHP to allow missing variables in the restart
file and to mark variables that are bootstrapped for later custom
initialization.