### PR TITLE
Match 2D/3D regridder interfaces

### DIFF
--- a/MAPL_Base/CFIOCollection.F90
+++ b/MAPL_Base/CFIOCollection.F90
@@ -59,7 +59,7 @@ contains
     type (StringIntegerMapIterator) :: iter
 
     type (NetCDF4_FileFormatter) :: fmtr
-    class (AbstractGridFactory), pointer :: factory
+    class (AbstractGridFactory), allocatable :: factory
 
     file_id => this%file_ids%at(trim(file_name))
     if (associated(file_id)) then

--- a/MAPL_Base/MAPL_AbstractRegridder.F90
+++ b/MAPL_Base/MAPL_AbstractRegridder.F90
@@ -182,12 +182,13 @@ contains
    end subroutine regrid_scalar_3d_real64
 
 
-   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
       real(kind=REAL32), intent(out) :: u_out(:,:)
       real(kind=REAL32), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real32'
 
@@ -202,12 +203,13 @@ contains
    end subroutine regrid_vector_2d_real32
 
 
-   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
       real(kind=REAL64), intent(out) :: u_out(:,:)
       real(kind=REAL64), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real64'
 
@@ -564,12 +566,13 @@ contains
    end subroutine transpose_regrid_scalar_3d_real64
 
    
-   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
       real(kind=REAL32), intent(out) :: u_out(:,:)
       real(kind=REAL32), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real32'
@@ -587,12 +590,13 @@ contains
    end subroutine transpose_regrid_vector_2d_real32
 
 
-   subroutine transpose_regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
+   subroutine transpose_regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
       real(kind=REAL64), intent(out) :: u_out(:,:)
       real(kind=REAL64), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real64'

--- a/MAPL_Base/MAPL_EsmfRegridder.F90
+++ b/MAPL_Base/MAPL_EsmfRegridder.F90
@@ -493,12 +493,13 @@ contains
    end subroutine transpose_regrid_scalar_3d_real32
 
 
-   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (EsmfRegridder), intent(in) :: this
       real, intent(in) :: u_in(:,:)
       real, intent(in) :: v_in(:,:)
       real, intent(out) :: u_out(:,:)
       real, intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(*), parameter :: Iam = 'MAPL_EsmfRegridder::regrid_vector_2d_real32()'
@@ -506,6 +507,7 @@ contains
 
       type (RegridderSpec) :: spec
       class (AbstractGridFactory), pointer :: factory
+      character(len=ESMF_MAXSTR) :: grid_axis_in, grid_axis_out
 
       real, pointer :: p_src(:,:,:,:), p_dst(:,:,:,:)
       type (ESMF_Field) :: src_field, dst_field
@@ -526,9 +528,17 @@ contains
       _ASSERT(im_dst == size(v_out,1))
       _ASSERT(jm_dst == size(v_out,2))
 
+      grid_axis_in = 'north-south'
+      grid_axis_out = 'north-south'
+      if (present(rotate)) then
+         if (rotate) then
+            grid_axis_in = 'xyz'
+            grid_axis_out = 'grid'
+         end if
+      end if
+
       factory => grid_manager%get_factory(spec%grid_in,rc=status)
       _VERIFY(status)
-      
       
       ! TODO support other staggerings
       src_field = ESMF_FieldCreate(spec%grid_in, typekind=ESMF_TYPEKIND_R4, &
@@ -540,7 +550,7 @@ contains
       if (hasDE) then
          call ESMF_FieldGet(src_field,localDE=0,farrayPtr=p_src,rc=status)
          _VERIFY(status)
-         call factory%spherical_to_cartesian(u_in, v_in, p_src, 'north-south', rc=status)
+         call factory%spherical_to_cartesian(u_in, v_in, p_src, grid_axis_in, rc=status)
          _VERIFY(status)
       end if
       
@@ -563,7 +573,7 @@ contains
       factory => grid_manager%get_factory(spec%grid_out,rc=status)
       _VERIFY(status)
       if (hasDE) then
-         call factory%cartesian_to_spherical(p_dst, u_out, v_out, 'north-south', rc=status)
+         call factory%cartesian_to_spherical(p_dst, u_out, v_out, grid_axis_out, rc=status)
          _VERIFY(status)
       end if
 
@@ -577,12 +587,13 @@ contains
    end subroutine regrid_vector_2d_real32
 
 
-   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rotate, rc)
      class (EsmfRegridder), intent(in) :: this
      real(real64), intent(in) :: u_in(:,:)
      real(real64), intent(in) :: v_in(:,:)
      real(real64), intent(out) :: u_out(:,:)
      real(real64), intent(out) :: v_out(:,:)
+     logical, optional, intent(in) :: rotate
      integer, optional, intent(out) :: rc
 
      character(*), parameter :: Iam = 'MAPL_EsmfRegridder::regrid_vector_2d_real64()'
@@ -593,6 +604,7 @@ contains
 
      real(real64), pointer :: p_src(:,:,:,:), p_dst(:,:,:,:)
      type (ESMF_Field) :: src_field, dst_field
+     character(len=ESMF_MAXSTR) :: grid_axis_in, grid_axis_out
 
      integer :: im_src, jm_src
      integer :: im_dst, jm_dst
@@ -610,9 +622,17 @@ contains
      _ASSERT(im_dst == size(v_out,1))
      _ASSERT(jm_dst == size(v_out,2))
 
+      grid_axis_in = 'north-south'
+      grid_axis_out = 'north-south'
+      if (present(rotate)) then
+         if (rotate) then
+            grid_axis_in = 'xyz'
+            grid_axis_out = 'grid'
+         end if
+      end if
+
      factory => grid_manager%get_factory(spec%grid_in,rc=status)
      _VERIFY(status)
-
 
      ! TODO support other staggerings
      src_field = ESMF_FieldCreate(spec%grid_in, typekind=ESMF_TYPEKIND_R8, &
@@ -624,7 +644,7 @@ contains
      if (hasDE) then
         call ESMF_FieldGet(src_field,localDE=0,farrayPtr=p_src,rc=status)
         _VERIFY(status)
-        call factory%spherical_to_cartesian(u_in, v_in, p_src, 'north-south', rc=status)
+        call factory%spherical_to_cartesian(u_in, v_in, p_src, grid_axis_in, rc=status)
         _VERIFY(status)
      end if
 
@@ -647,7 +667,7 @@ contains
      factory => grid_manager%get_factory(spec%grid_out,rc=status)
      _VERIFY(status)
      if (hasDE) then
-        call factory%cartesian_to_spherical(p_dst, u_out, v_out, 'north-south', rc=status)
+        call factory%cartesian_to_spherical(p_dst, u_out, v_out, grid_axis_out, rc=status)
         _VERIFY(status)
      end if
 
@@ -661,12 +681,13 @@ contains
    end subroutine regrid_vector_2d_real64
 
    
-   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (EsmfRegridder), intent(in) :: this
       real, intent(in) :: u_in(:,:)
       real, intent(in) :: v_in(:,:)
       real, intent(out) :: u_out(:,:)
       real, intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(*), parameter :: Iam = 'MAPL_EsmfRegridder::transpose_regrid_vector_2d_real32()'
@@ -677,6 +698,7 @@ contains
 
       real, pointer :: p_src(:,:,:,:), p_dst(:,:,:,:)
       type (ESMF_Field) :: src_field, dst_field
+      character(len=ESMF_MAXSTR) :: grid_axis_in, grid_axis_out
 
       integer :: im_src, jm_src
       integer :: im_dst, jm_dst
@@ -694,6 +716,15 @@ contains
       _ASSERT(im_dst == size(v_out,1))
       _ASSERT(jm_dst == size(v_out,2))
 
+      grid_axis_in = 'north-south'
+      grid_axis_out = 'north-south'
+      if (present(rotate)) then
+         if (rotate) then
+            grid_axis_in = 'grid'
+            grid_axis_out = 'xyz'
+         end if
+      end if
+
       factory => grid_manager%get_factory(spec%grid_out,rc=status)
       _VERIFY(status)
       hasDE = MAPL_GridHasDE(spec%grid_out,rc=status)
@@ -704,7 +735,7 @@ contains
       if (hasDE) then
          call ESMF_FieldGet(src_field,localDE=0,farrayPtr=p_src,rc=status)
          _VERIFY(status)
-         call factory%spherical_to_cartesian(u_in, v_in, p_src, 'north-south', rc=status)
+         call factory%spherical_to_cartesian(u_in, v_in, p_src, grid_axis_in, rc=status)
          _VERIFY(status)
       end if
       
@@ -726,7 +757,7 @@ contains
       factory => grid_manager%get_factory(spec%grid_in,rc=status)
       _VERIFY(status)
       if (hasDE) then
-         call factory%cartesian_to_spherical(p_dst, u_out, v_out, 'north-south', rc=status)
+         call factory%cartesian_to_spherical(p_dst, u_out, v_out, grid_axis_out, rc=status)
          _VERIFY(status)
       end if
 

--- a/MAPL_Base/MAPL_IdentityRegridder.F90
+++ b/MAPL_Base/MAPL_IdentityRegridder.F90
@@ -91,7 +91,7 @@ contains
       
    end subroutine regrid_scalar_3d_real32
 
-   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       use MAPL_CommsMod
       use MAPL_BaseMod
       use, intrinsic :: iso_fortran_env, only: REAL32
@@ -100,6 +100,7 @@ contains
       real(kind=REAL32), intent(in) :: v_in(:,:)
       real(kind=REAL32), intent(out) :: u_out(:,:)
       real(kind=REAL32), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_3d_real32'

--- a/MAPL_Base/MAPL_TransposeRegridder.F90
+++ b/MAPL_Base/MAPL_TransposeRegridder.F90
@@ -137,13 +137,14 @@ contains
    end subroutine regrid_scalar_3d_real64
 
 
-   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       use, intrinsic :: iso_fortran_env, only: REAL32
       class (TransposeRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
       real(kind=REAL32), intent(out) :: u_out(:,:)
       real(kind=REAL32), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real32'
 
@@ -154,13 +155,14 @@ contains
    end subroutine regrid_vector_2d_real32
 
 
-   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
+   subroutine regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rotate, rc)
       use, intrinsic :: iso_fortran_env, only: REAL64
       class (TransposeRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
       real(kind=REAL64), intent(out) :: u_out(:,:)
       real(kind=REAL64), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real64'
 
@@ -306,13 +308,14 @@ contains
    end subroutine transpose_regrid_scalar_3d_real64
 
    
-   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rc)
+   subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       use, intrinsic :: iso_fortran_env, only: REAL32
       class (TransposeRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
       real(kind=REAL32), intent(in) :: v_in(:,:)
       real(kind=REAL32), intent(out) :: u_out(:,:)
       real(kind=REAL32), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real32'
@@ -324,13 +327,14 @@ contains
    end subroutine transpose_regrid_vector_2d_real32
 
 
-   subroutine transpose_regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rc)
+   subroutine transpose_regrid_vector_2d_real64(this, u_in, v_in, u_out, v_out, rotate, rc)
       use, intrinsic :: iso_fortran_env, only: REAL64
       class (TransposeRegridder), intent(in) :: this
       real(kind=REAL64), intent(in) :: u_in(:,:)
       real(kind=REAL64), intent(in) :: v_in(:,:)
       real(kind=REAL64), intent(out) :: u_out(:,:)
       real(kind=REAL64), intent(out) :: v_out(:,:)
+      logical, optional, intent(in) :: rotate
       integer, optional, intent(out) :: rc
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real64'
 


### PR DESCRIPTION
Just a quick fix so that the 2D and 3D interfaces for the "regrid" method take the same "rotate" argument. There was a bit of an inconsistency that the 3D vector methods took this argument and acted on it but the 2D did not. Cleaning this up for consistency. In the long run this should be revisited. Does not change the default behavior.