### PR TITLE
Feature/remove cfio fromextdata

### DIFF
--- a/GMAO_pFIO/ExtDataCollection.F90
+++ b/GMAO_pFIO/ExtDataCollection.F90
@@ -1,8 +1,10 @@
+#include "pFIO_ErrLog.h"
 module pFIO_ExtDataCollectionMod
   use pFIO_StringIntegerMapMod
   use pFIO_NetCDF4_FileFormatterMod
   use pFIO_FormatterPtrVectorMod
   use pFIO_ConstantsMod
+  use pFIO_ErrorHandlingMod
   implicit none
   private
 
@@ -40,13 +42,15 @@ contains
 
 
 
-  function find(this, file_name) result(formatter)
+  function find(this, file_name, rc) result(formatter)
     type (NetCDF4_FileFormatter), pointer :: formatter
     class (ExtDataCollection), intent(inout) :: this
     character(len=*), intent(in) :: file_name
+    integer, optional, intent(out) :: rc
 
     integer, pointer :: file_id
     type (StringIntegerMapIterator) :: iter
+    integer :: status
 
 
     file_id => this%file_ids%at(file_name)
@@ -55,9 +59,10 @@ contains
     else
        if (this%formatters%size() >= MAX_FORMATTERS) then
           formatter => this%formatters%front()
-          call formatter%close()
+          call formatter%close(rc=status)
+          _VERIFY(status)
           call this%formatters%erase(this%formatters%begin())
-          deallocate(formatter)
+          !deallocate(formatter)
           nullify(formatter)
 
           iter = this%file_ids%begin()
@@ -84,6 +89,8 @@ contains
        
        call formatter%open(file_name, pFIO_READ)
        call this%formatters%push_back(formatter)
+       deallocate(formatter)
+       formatter => this%formatters%back()
        ! size() returns 64-bit integer;  cast to 32 bit for this usage.
        call this%file_ids%insert(file_name, int(this%formatters%size()))
     end if

--- a/GMAO_pFIO/HistoryCollection.F90
+++ b/GMAO_pFIO/HistoryCollection.F90
@@ -96,12 +96,14 @@ contains
     type(NetCDF4_FileFormatter), pointer :: f_ptr
     type(StringNetCDF4_FileFormatterMapIterator) :: iter
     character(:),pointer :: file_name
+    integer :: status
 
     iter = this%formatters%begin()
     do while (iter /= this%formatters%end())
       file_name => iter%key()
       f_ptr => this%formatters%at(file_name)
-      call f_ptr%close()
+      call f_ptr%close(rc=status)
+      _VERIFY(status)
       ! remove the files
       call this%formatters%erase(iter)
       iter = this%formatters%begin()

--- a/GMAO_pFIO/NetCDF4_FileFormatter.F90
+++ b/GMAO_pFIO/NetCDF4_FileFormatter.F90
@@ -1214,7 +1214,6 @@ module pFIO_FormatterPtrVectorMod
   use pFIO_NetCDF4_FileFormatterMod
 
 #define _type type(NetCDF4_FileFormatter)
-#define _pointer
 
 #define _vector FormatterPtrVector
 #define _iterator FormatterPtrVectorIterator
@@ -1223,7 +1222,6 @@ module pFIO_FormatterPtrVectorMod
 #undef _iterator
 #undef _vector
 #undef _type
-#undef _pointer
 end module pFIO_FormatterPtrVectorMod
 
 module pFIO_StringNetCDF4_FileFormatterMapMod

--- a/MAPL_Base/CFIOCollection.F90
+++ b/MAPL_Base/CFIOCollection.F90
@@ -1,3 +1,5 @@
+#include "pFIO_ErrLog.h"
+
 module ESMF_CFIOCollectionMod
    use pFIO_StringIntegerMapMod
    use ESMF
@@ -10,6 +12,7 @@ module ESMF_CFIOCollectionMod
   use pFIO
   use MAPL_GridManagerMod
   use MAPL_AbstractGridFactoryMod
+  use pFIO_ErrorHandlingMod
   implicit none
   private
 
@@ -50,16 +53,18 @@ contains
 
 
 
-  function find(this, file_name) result(formatter)
+  function find(this, file_name, rc) result(formatter)
     type (ESMF_CFIO), pointer :: formatter
     class (CFIOCollection), target, intent(inout) :: this
     character(len=*), intent(in) :: file_name
+    integer, optional, intent(out) :: rc
 
     integer, pointer :: file_id
     type (StringIntegerMapIterator) :: iter
 
     type (NetCDF4_FileFormatter) :: fmtr
     class (AbstractGridFactory), pointer :: factory
+    integer :: status
 
     file_id => this%file_ids%at(trim(file_name))
     if (associated(file_id)) then
@@ -104,10 +109,12 @@ contains
        ! size() returns 64-bit integer;  cast to 32 bit for this usage.
        call this%file_ids%insert(trim(file_name), int(this%formatters%size()))
 
-       call fmtr%open(trim(file_name), mode=pFIO_READ)
+       call fmtr%open(trim(file_name), mode=pFIO_READ, rc=status)
+       _VERIFY(status)
        ! file is the metadata, not the file name
        call this%files%push_back(fmtr%read())
-       call fmtr%close()
+       call fmtr%close(rc=status)
+       _VERIFY(status)
        this%file => this%files%back()
        if (allocated(this%src_grid)) then
        end if

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -67,6 +67,8 @@ set (srcs
   CFIOCollection.F90 ESMF_CFIOPtrVectorMod.F90
   MAPL_TransposeRegridder.F90 MAPL_GetLatLonCoord.F90 MAPL_EsmfRegridder.F90
   MAPL_NUOPCWrapperMod.F90 MAPL_CubedSphereGridFactory.F90
+  MAPL_ExtDataCollection.F90 MAPL_ExtDataCollectionManager.F90
+  FileMetadataUtilities.F90 FileMetadataUtilitiesVector.F90
   )
 
 esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4)

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -1,0 +1,369 @@
+#include "MAPL_ErrLog.h"
+
+module MAPL_FileMetadataUtilsMod
+   use pFIO_FileMetadataMod
+   use pFIO_VariableMod
+   use pFIO_AttributeMod
+   use pFIO_CoordinateVariableMod
+   use pFIO_StringVariableMapMod
+   use pFIO_ThrowMod
+   use ESMF
+   use MAPL_ErrorHandlingMod
+   use, intrinsic :: iso_fortran_env, only: REAL64,REAL32,INT64,INT32
+   
+   public :: FileMetadataUtils
+   type, extends(Filemetadata) :: FileMetadataUtils
+
+   private
+      character(len=:), allocatable :: filename 
+   contains
+      procedure :: get_coordinate_info
+      procedure :: get_variable_units
+      procedure :: get_time_units
+      procedure :: get_time_vec
+      procedure :: get_level_name
+      procedure :: is_var_present
+      procedure :: get_file_name
+   end type FileMetadataUtils
+
+   interface FileMetadataUtils
+      module procedure new_FilemetadataUtils
+   end interface
+
+   contains
+
+   function new_FilemetadataUtils(metadata,fName) result(metadata_utils)
+      type (FileMetadataUtils) :: metadata_utils
+      type (FileMetadata), intent(in) :: metadata
+      character(len=*), intent(in) :: fName
+      metadata_utils%Filemetadata = metadata
+      metadata_utils%filename = fName
+      
+   end function new_FilemetadataUtils
+
+   subroutine get_time_units(this,startTime,startyear,startmonth,startday,starthour,startmin,startsec,units,rc)
+      class (FileMetadataUtils), intent(inout) :: this
+      type(ESMF_Time), optional, intent(inout) :: startTime
+      integer,optional,intent(out) ::        startYear 
+      integer,optional,intent(out) ::        startMonth
+      integer,optional,intent(out) ::        startDay 
+      integer,optional,intent(out) ::        startHour
+      integer,optional,intent(out) ::        startMin 
+      integer,optional,intent(out) ::        startSec
+      character(len=*), optional, intent(out) :: units
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      class(Variable), pointer :: var
+      type(Attribute), pointer :: attr
+      class(*), pointer :: pTimeUnits
+      character(len=ESMF_MAXSTR) :: timeUnits
+
+      integer ypos(2), mpos(2), dpos(2), hpos(2), spos(2)
+      integer strlen
+      integer firstdash, lastdash
+      integer firstcolon, lastcolon
+      integer lastspace,since_pos
+      integer year,month,day,hour,min,sec
+
+      var => this%get_variable('time',rc=status)
+      _VERIFY(status)
+      attr => var%get_attribute('units')
+      ptimeUnits => attr%get_value()
+      select type(pTimeUnits)
+      type is (character(*))
+         timeUnits = pTimeUnits
+         strlen = LEN_TRIM (TimeUnits)
+
+         since_pos = index(TimeUnits, 'since')
+         if (present(units)) units = trim(TimeUnits(:since_pos-1))
+
+         firstdash = index(TimeUnits, '-')
+         lastdash  = index(TimeUnits, '-', BACK=.TRUE.)
+
+         if (firstdash .LE. 0 .OR. lastdash .LE. 0) then
+           rc = -1
+           return
+         endif
+
+         ypos(2) = firstdash - 1
+         mpos(1) = firstdash + 1
+         ypos(1) = ypos(2) - 3
+
+         mpos(2) = lastdash - 1
+         dpos(1) = lastdash + 1
+         dpos(2) = dpos(1) + 1
+
+         read ( TimeUnits(ypos(1):ypos(2)), * ) year
+         read ( TimeUnits(mpos(1):mpos(2)), * ) month
+         read ( TimeUnits(dpos(1):dpos(2)), * ) day
+
+         firstcolon = index(TimeUnits, ':')
+         if (firstcolon .LE. 0) then
+
+           ! If no colons, check for hour.
+
+           ! Logic below assumes a null character or something else is after the hour
+           ! if we do not find a null character add one so that it correctly parses time
+           if (TimeUnits(strlen:strlen) /= char(0)) then
+              TimeUnits = trim(TimeUnits)//char(0)
+              strlen=len_trim(TimeUnits)
+           endif
+           lastspace = index(TRIM(TimeUnits), ' ', BACK=.TRUE.)
+           if ((strlen-lastspace).eq.2 .or. (strlen-lastspace).eq.3) then
+             hpos(1) = lastspace+1
+             hpos(2) = strlen-1
+             read (TimeUnits(hpos(1):hpos(2)), * ) hour
+             min  = 0
+             sec  = 0
+           else
+             print *, 'ParseTimeUnits: Assuming a starting time of 00z'
+             hour = 0
+             min  = 0
+             sec  = 0
+           endif
+
+         else
+           hpos(1) = firstcolon - 2
+           hpos(2) = firstcolon - 1
+           lastcolon =  index(TimeUnits, ':', BACK=.TRUE.)
+           if ( lastcolon .EQ. firstcolon ) then
+             mpos(1) = firstcolon + 1
+             mpos(2) = firstcolon + 2
+             read (TimeUnits(hpos(1):hpos(2)), * ) hour
+             read (TimeUnits(mpos(1):mpos(2)), * ) min
+             sec = 0
+           else
+             mpos(1) = firstcolon + 1
+             mpos(2) = lastcolon - 1
+             spos(1) = lastcolon + 1
+             spos(2) = lastcolon + 2
+             read (TimeUnits(hpos(1):hpos(2)), * ) hour
+             read (TimeUnits(mpos(1):mpos(2)), * ) min
+             read (TimeUnits(spos(1):spos(2)), * ) sec
+           endif
+         endif
+      class default
+         _ASSERT(.false.,"Time unit must be character")
+      end select
+
+      if (present(startYear)) startYear=year
+      if (present(startMonth)) startMonth=month
+      if (present(startDay)) startDay=day
+      if (present(startHour)) startHour=hour
+      if (present(startmin)) startMin=min
+      if (present(startsec)) startSec=sec
+      if (present(startTime)) then
+         call ESMF_TimeSet(startTime,yy=year,mm=month,dd=day,h=hour,m=min,s=sec,rc=status)
+         _VERIFY(status)
+      end if
+
+   end subroutine get_time_units
+ 
+   subroutine get_time_vec(this,tvec,rc)
+      class (FileMetadataUtils), intent(inout) :: this
+      type(ESMF_Time), allocatable :: tvec(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      class(CoordinateVariable), pointer :: var
+      type(Attribute), pointer :: attr
+      integer :: tsize,i
+      type(ESMF_Time) :: startTime
+      character(len=10) :: timeUnits
+      class(*), pointer :: ptr(:)
+      real(REAL64), allocatable :: tr_r64(:)
+      type(ESMF_TimeInterval) :: tint
+      
+
+      var => this%get_coordinate_variable('time',rc=status)
+      _VERIFY(status)
+      call this%get_coordinate_info('time',coordSize=tsize,rc=status)
+      _VERIFY(status)
+      allocate(tr_r64(tsize))
+      allocate(tvec(tsize))
+      call this%get_time_units(startTime=startTime,units=timeUnits,rc=status)
+      _VERIFY(status)
+      ptr => var%get_coordinate_data()
+      _ASSERT(associated(ptr),"time variable coordinate data not found")
+      select type (ptr)
+      type is (real(kind=REAL64))
+         tr_r64=ptr
+      type is (real(kind=REAL32))
+         tr_r64=ptr
+      type is (integer(kind=INT64))
+         tr_r64=ptr
+      type is (integer(kind=INT32))
+         tr_r64=ptr
+      class default
+         _ASSERT(.false.,"unsupported time variable type")
+      end select
+      do i=1,tsize
+        select case(trim(timeUnits))
+        case ("hours")
+           call ESMF_TimeIntervalSet(tint,h_r8=tr_r64(i),rc=status)
+           _VERIFY(status)
+           tvec(i)=startTime+tint
+        case ("minutes")
+           call ESMF_TimeIntervalSet(tint,m_r8=tr_r64(i),rc=status)
+           _VERIFY(status)
+           tvec(i)=startTime+tint
+        case ("seconds")
+           call ESMF_TimeIntervalSet(tint,s_r8=tr_r64(i),rc=status)
+           _VERIFY(status)
+           tvec(i)=startTime+tint
+        case default
+           _ASSERT(.false.,"unsupported time unit")
+        end select
+      enddo
+
+   end subroutine get_time_vec
+
+   function is_var_present(this,var_name,rc) result(isPresent)
+      class (FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      integer, optional, intent(out) :: rc
+
+      logical :: isPresent
+      integer :: status
+      class(Variable), pointer :: var
+
+      var => this%get_variable(var_name)
+      isPresent = associated(var)
+
+   end function is_var_present
+
+   function get_variable_units(this,var_name,rc) result(units)
+      class (FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      integer, optional, intent(out) :: rc
+
+      character(len=:), pointer :: units
+      type(Attribute), pointer :: attr
+      class(Variable), pointer :: var
+      class(*), pointer :: vunits
+      integer :: status
+    
+      var => this%get_variable(var_name,rc=status)
+      _VERIFY(status)
+      attr => var%get_attribute('units')
+      if (associated(attr)) then
+         vunits => attr%get_value()
+         select type(vunits)
+         type is (character(*))
+            units => vunits
+         class default
+            _ASSERT(.false.,'units must be string')
+         end select
+      end if
+      _RETURN(_SUCCESS)
+
+   end function get_variable_units
+
+   subroutine get_coordinate_info(this,coordinate_name,coordSize,coordUnits,coords,rc)
+      class (FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: coordinate_name
+      integer, optional, intent(out) :: coordSize
+      character(len=*), optional, intent(out) :: coordUnits
+      real, allocatable, optional,  intent(inout) :: coords(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      class(CoordinateVariable), pointer :: var
+      type(Attribute), pointer :: attr
+      character(len=:), pointer :: vdim
+      class(*), pointer :: coordUnitPtr
+      class(*), pointer :: ptr(:)
+ 
+      var => this%get_coordinate_variable(trim(coordinate_name),rc=status)
+      _VERIFY(status)
+   
+      if (present(coordSize)) then
+         vdim => var%get_ith_dimension(1)
+         coordSize = this%get_dimension(vdim,rc=status)
+      end if
+
+      if (present(coordUnits)) then
+         attr => var%get_attribute('units')
+         coordUnitPtr => attr%get_value()
+         select type(coordUnitPtr)
+         type is (character(*))
+            coordUnits = trim(coordUnitPtr)
+         class default
+            _ASSERT(.false.,'units must be string')
+         end select
+      end if 
+
+      if (present(coords)) then
+         ptr => var%get_coordinate_data()
+         _ASSERT(associated(ptr),"coord variable coordinate data not found")
+         select type (ptr)
+         type is (real(kind=REAL64))
+            coords=ptr
+         type is (real(kind=REAL32))
+            coords=ptr
+         type is (integer(kind=INT64))
+            coords=ptr
+         type is (integer(kind=INT32))
+            coords=ptr
+         class default
+            _ASSERT(.false.,"unsupported coordel variable type")
+         end select
+      end if
+
+   end subroutine get_coordinate_info
+
+   function get_level_name(this,rc) result(lev_name)
+      class (FileMetadataUtils), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      character(len=:), pointer :: units
+      character(len=:), allocatable :: lev_name
+      type(CoordinateVariable), pointer :: var
+      type (StringVariableMap), pointer :: vars
+      type (StringVariableMapIterator) :: var_iter
+      character(len=:), pointer :: var_name
+      
+      vars => this%get_variables()
+      var_iter = vars%begin()
+      do while(var_iter /=vars%end())
+         var_name => var_iter%key()
+         var => this%get_coordinate_variable(trim(var_name))
+         if (associated(var)) then
+            if (index(var_name,'lev') .ne. 0 .or. index(var_name,'height') .ne. 0) then
+               lev_name=var_name
+               _RETURN(_SUCCESS)
+            else
+               units => this%get_variable_units(var_name)
+               if (associated(units)) then
+                  if (trim(units) .eq. 'hPa' .or. trim(units) .eq. 'sigma_level' .or. &
+                      trim(units) .eq. 'mb'  .or. trim(units) .eq. 'millibar') then
+                     lev_name=var_name
+                     _RETURN(_SUCCESS)
+                  end if
+               end if
+            end if
+         end if
+         call var_iter%next()
+      enddo
+      lev_name=''
+      _RETURN(_SUCCESS)
+
+   end function get_level_name
+
+   function get_file_name(this,rc) result(fname)
+      class (FileMetadataUtils), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      character(len=:), allocatable :: fname
+
+      fname = this%fileName
+
+      _RETURN(_SUCCESS)
+   end function get_file_name
+
+end module MAPL_FileMetadataUtilsMod
+
+
+      
+ 

--- a/MAPL_Base/FileMetadataUtilitiesVector.F90
+++ b/MAPL_Base/FileMetadataUtilitiesVector.F90
@@ -1,0 +1,9 @@
+module MAPL_FileMetadataUtilsVectorMod
+   use MAPL_FileMetadataUtilsMod
+
+#define _type type (FileMetadataUtils)
+#define _vector FileMetadataUtilsVector
+#define _iterator FileMetadataUtilsVectorIterator
+#include "templates/vector.inc"
+
+end module MAPL_FileMetadataUtilsVectorMod

--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -83,6 +83,7 @@ module MAPL_CFIOMod
   public MAPL_CFIOReadBundleWait
   public MAPL_CFIOReadParallel
   public MAPL_CFIOAddCollection
+  !public MAPL_ExtDataAddCollection
   public MAPL_CFIOReadBundlePrefetch
   public MAPL_CFIOReadBundleReadPrefetch
   public MAPL_CFIOGetTimeFromIndex

--- a/MAPL_Base/MAPL_ExtDataCollection.F90
+++ b/MAPL_Base/MAPL_ExtDataCollection.F90
@@ -1,0 +1,132 @@
+#include "pFIO_ErrLog.h"
+
+module MAPL_ExtDataCollectionMod
+  use pFIO_StringIntegerMapMod
+  use pFIO_NetCDF4_FileFormatterMod
+  use pFIO_FormatterPtrVectorMod
+  use pFIO_ConstantsMod
+  use pFIO_FileMetaDataMod
+  use MAPL_FileMetadataUtilsVectorMod
+  use MAPL_FileMetadataUtilsMod
+  use MAPL_GridManagerMod
+  use MAPL_AbstractGridFactoryMod
+  use pFIO_ErrorHandlingMod
+  implicit none
+  private
+
+  public :: MAPLExtDataCollection
+  public :: new_MAPLExtDataCollection
+
+  type :: MAPLExtDataCollection
+    character(len=:), allocatable :: template
+    type (FileMetadataUtilsVector) :: metadatas
+    type (StringIntegerMap) :: file_ids
+    type(ESMF_Grid), allocatable :: src_grid
+  contains
+    procedure :: find
+  end type MAPLExtDataCollection
+
+  interface MAPLExtDataCollection
+    module procedure new_MAPLExtDataCollection
+  end interface MAPLExtDataCollection
+
+
+  integer, parameter :: MAX_FORMATTERS = 2
+
+contains
+
+
+  function new_MAPLExtDataCollection(template) result(collection)
+    type (MAPLExtDataCollection) :: collection
+    character(len=*), intent(in) :: template
+
+    collection%template = template 
+
+  end function new_MAPLExtDataCollection
+
+
+
+  function find(this, file_name, rc) result(metadata)
+    type (FileMetadataUtils), pointer :: metadata
+    class (MAPLExtDataCollection), intent(inout) :: this
+    character(len=*), intent(in) :: file_name
+    integer, optional, intent(out) :: rc
+
+    type (NetCDF4_FileFormatter) :: formatter
+    type (FileMetadata) :: basic_metadata
+    integer, pointer :: file_id
+    type (StringIntegerMapIterator) :: iter
+    class (AbstractGridFactory), pointer :: factory
+    integer :: status
+
+
+    file_id => this%file_ids%at(file_name)
+    if (associated(file_id)) then
+       metadata => this%metadatas%at(file_id)
+    else
+       if (this%metadatas%size() >= MAX_FORMATTERS) then
+          metadata => this%metadatas%front()
+          call this%metadatas%erase(this%metadatas%begin())
+          !deallocate(metadata)
+          nullify(metadata)
+
+          iter = this%file_ids%begin()
+          do while (iter /= this%file_ids%end())
+             file_id => iter%value()
+             if (file_id == 1) then
+                call this%file_ids%erase(iter)
+                exit
+             end if
+             call iter%next()
+          end do
+
+          ! Fix the old file_id's accordingly
+          iter = this%file_ids%begin()
+          do while (iter /= this%file_ids%end())
+             file_id => iter%value()
+             file_id = file_id -1
+             call iter%next()
+          end do
+          
+       end if
+
+       allocate(metadata)
+       call formatter%open(file_name, pFIO_READ,rc=status)
+       _VERIFY(status)
+       basic_metadata = formatter%read(rc=status)
+       _VERIFY(status)
+       call formatter%close(rc=status)
+       _VERIFY(status)
+       metadata = FileMetadataUtils(basic_metadata,file_name)
+       call this%metadatas%push_back(metadata)
+       deallocate(metadata)
+       metadata => this%metadatas%back()
+       if (.not. allocated(this%src_grid)) then
+          allocate(factory, source=grid_manager%make_factory(trim(file_name)))
+          this%src_grid = grid_manager%make_grid(factory)
+       end if
+       ! size() returns 64-bit integer;  cast to 32 bit for this usage.
+       call this%file_ids%insert(file_name, int(this%metadatas%size()))
+    end if
+
+  end function find
+
+end module MAPL_ExtDataCollectionMod
+
+
+module MAPL_CollectionVectorMod
+   use pFIO_ThrowMod
+   use MAPL_ExtDataCollectionMod
+   
+   ! Create a map (associative array) between names and pFIO_Attributes.
+   
+#define _type type (MAPLExtDataCollection)
+#define _vector MAPLCollectionVector
+#define _iterator MAPLCollectionVectorIterator
+
+#define _FTL_THROW pFIO_throw_exception
+
+#include "templates/vector.inc"
+   
+end module MAPL_CollectionVectorMod
+

--- a/MAPL_Base/MAPL_ExtDataCollection.F90
+++ b/MAPL_Base/MAPL_ExtDataCollection.F90
@@ -56,7 +56,7 @@ contains
     type (FileMetadata) :: basic_metadata
     integer, pointer :: file_id
     type (StringIntegerMapIterator) :: iter
-    class (AbstractGridFactory), pointer :: factory
+    class (AbstractGridFactory), allocatable :: factory
     integer :: status
 
 

--- a/MAPL_Base/MAPL_ExtDataCollectionManager.F90
+++ b/MAPL_Base/MAPL_ExtDataCollectionManager.F90
@@ -1,0 +1,47 @@
+module MAPL_ExtDataCollectionManagerMod
+use MAPL_CollectionVectorMod
+use MAPL_ExtDataCollectionMod
+implicit none
+private
+
+type(MAPLCollectionVector) :: ExtDataCollections
+
+public ExtDataCollections
+public MAPL_ExtDataAddCollection
+
+contains
+
+  function MAPL_ExtDataAddCollection(template) result(id)
+     character(len=*), intent(in) :: template
+      integer :: n
+      logical :: found
+      type (MAPLCollectionVectorIterator) :: iter
+      type (MAPLExtDataCollection), pointer :: collection
+      type (MAPLExtDataCollection) :: c
+      integer :: id
+
+      iter = ExtDatacollections%begin()
+      n = 1
+
+      ! Is it a new collection?
+      found = .false.
+      do while (iter /= ExtDatacollections%end())
+         collection => iter%get()
+         if (template == collection%template) then
+            found = .true.
+            exit
+         end if
+         n = n + 1
+         call iter%next()
+      end do
+
+      if (.not. found) then
+         c = MAPLExtDataCollection(template)
+         call ExtDatacollections%push_back(c)
+      end if
+
+      id = n
+
+   end function MAPL_ExtDataAddCollection
+
+end module 

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -892,7 +892,8 @@ CONTAINS
                    VarName = trim(derived%item(i)%name)
                    call ESMF_StateGet(self%ExtDataState,VarName,field,__RC__)
                    VarName=trim(primary%item(j)%name)
-                   fieldnew = MAPL_FieldCreate(field,varname,doCopy=.true.,__RC__) 
+                   fieldnew = MAPL_FieldCreate(field,varname,doCopy=.true.,__RC__)
+                   primary%item(j)%fileVars%xname=trim(primary%item(j)%var) 
                    call MAPL_StateAdd(self%ExtDataState,fieldnew,__RC__)
                    PrimaryVarNeeded(j) = .true.
                    primary%item(j)%ExtDataAlloc = .true.
@@ -4420,7 +4421,6 @@ CONTAINS
          _VERIFY(STATUS)
          call MAPL_FieldBundleAdd(pbundle,Field2,rc=status)
          _VERIFY(STATUS)
-
 
          !block
             !character(len=ESMF_MAXSTR) :: vectorlist(2)

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -2138,7 +2138,13 @@ CONTAINS
            if (trim(item%levUnit) == 'hPa') then
               item%havePressure = .true.
            end if
-           item%units = metadata%get_variable_units(trim(item%var),rc=status)
+           if (item%isVector) then
+              item%units = metadata%get_variable_units(trim(item%fcomp1),rc=status)
+              _VERIFY(status)
+           else
+              item%units = metadata%get_variable_units(trim(item%var),rc=status)
+              _VERIFY(status)
+           end if
 
         else
            item%LM=0

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -45,7 +45,13 @@
    use MAPL_ExtData_IOBundleMod
    use MAPL_ExtData_IOBundleVectorMod
    use MAPL_ErrorHandlingMod
+   use MAPL_ExtDataCollectionMod
+   use MAPL_CollectionVectorMod
+   use MAPL_ExtDataCollectionManagerMod
+   use MAPL_FileMetadataUtilsMod
    use MAPL_ioClientsMod
+   use MAPL_newCFIOItemMod
+   use MAPL_newCFIOItemVectorMod
 
    IMPLICIT NONE
    PRIVATE
@@ -72,6 +78,15 @@
   logical                    :: hasRun
   character(len=ESMF_MAXSTR) :: error_msg_str
 
+  type BracketingFields
+     ! fields to store endpoints for interpolation of a vector pair
+     type(ESMF_Field)             :: v1_finterp1, v1_finterp2
+     type(ESMF_Field)             :: v2_finterp1, v2_finterp2
+     ! if vertically interpolating vector fields
+     type(ESMF_Field)             :: v1_faux1, v1_faux2
+     type(ESMF_Field)             :: v2_faux1, v2_faux2
+  end type BracketingFields
+
 ! Primary Exports
 ! ---------------
   type PrimaryExport
@@ -96,8 +111,6 @@
      real                         :: Const
      integer                      :: vartype ! MAPL_FieldItem or MAPL_BundleItem
 
-     ! bracketing data
-     type(ESMF_Field)             :: finterp1, finterp2
      type(ESMF_FieldBundle)       :: binterp1, binterp2
      type(ESMF_Time)              :: time1, time2
      type(ESMF_Time)              :: interp_time1, interp_time2
@@ -105,24 +118,21 @@
      integer                      :: climyear
      type(ESMF_TimeInterval)      :: frequency
      type(ESMF_Time)              :: reff_time
-     ! if vertically interpolating need auxiliary fields
-     type(ESMF_Field)             :: faux1, faux2
 
      ! if primary export represents a pair of vector fields
      logical                      :: isVector, foundComp1, foundComp2
-     ! fields to store endpoints for interpolation of a vector pair
-     type(ESMF_Field)             :: v1_finterp1, v1_finterp2
-     type(ESMF_Field)             :: v2_finterp1, v2_finterp2
-     ! if vertically interpolating vector fields
-     type(ESMF_Field)             :: v1_faux1, v1_faux2
-     type(ESMF_Field)             :: v2_faux1, v2_faux2
+     type(BracketingFields)       :: modelGridFields
+     type(BracketingFields)       :: fileLevelFields
 
      ! names of the two vector components in the gridded component where import is declared
      character(len=ESMF_MAXSTR)   :: vcomp1, vcomp2
      ! the corresponding names of the two vector components on file
      character(len=ESMF_MAXSTR)   :: fcomp1, fcomp2
+     type(newCFIOitem)            :: fileVars
 
      integer                      :: collection_id
+     integer                      :: pfioCollection_id
+     integer                      :: iclient_collection_id
      
      logical                      :: ExtDataAlloc
      ! time shifting during continuous update
@@ -404,6 +414,7 @@ CONTAINS
    logical, allocatable              :: LocalVarNeeded(:)
 
    type(ESMF_CFIO), pointer          :: cfio
+   type(FileMetadataUtils), pointer  :: metadata
    integer                           :: counter
    real, pointer                     :: ptr2d(:,:) => null()
    real, pointer                     :: ptr3d(:,:,:) => null()
@@ -416,7 +427,7 @@ CONTAINS
    logical           :: caseSensitiveVarNames
    character(len=ESMF_MAXSTR) :: component1,component2
    character(len=ESMF_MAXPATHLEN) :: expression
-   integer           :: idx,nhms,ihr,imn,isc
+   integer           :: idx,nhms,ihr,imn,isc,tsteps
    logical           :: isNegative
    character(len=ESMF_MAXPATHLEN) :: thisLine
    logical           :: inBlock
@@ -585,6 +596,11 @@ CONTAINS
                         PrimaryVarNames(totalPrimaryEntries) = primary%item(totalPrimaryEntries)%name
                         ! check if this represents a vector by looking for semicolon
                         primary%item(totalPrimaryEntries)%isVector = ( index(primary%item(totalPrimaryEntries)%name,';').ne.0 )
+                        if ( index(primary%item(totalPrimaryEntries)%name,';').ne.0 ) then
+                           primary%item(totalPrimaryEntries)%fileVars%itemType = ItemTypeVector
+                        else
+                           primary%item(totalPrimaryEntries)%fileVars%itemType = ItemTypeScalar
+                        end if
                         primary%item(totalPrimaryEntries)%vartype = MAPL_ExtDataVectorItem
                         primary%item(totalPrimaryEntries)%foundComp2 = .false.
                         primary%item(totalPrimaryEntries)%foundComp1 = .false.
@@ -736,6 +752,7 @@ CONTAINS
                 primary%item(j)%vcomp1 = component1
                 idx = index(primary%item(j)%var,";")
                 primary%item(j)%fcomp1 = primary%item(j)%var(1:idx-1)
+                primary%item(j)%fileVars%xname=trim(primary%item(j)%fcomp1)
                 itemCounter = itemCounter + 1
                 found = .true.
                 primary%item(j)%foundComp1 = .true.
@@ -751,6 +768,7 @@ CONTAINS
                 primary%item(j)%vcomp2 = component2
                 idx = index(primary%item(j)%var,";")
                 primary%item(j)%fcomp2 = primary%item(j)%var(idx+1:)
+                primary%item(j)%fileVars%yname=trim(primary%item(j)%fcomp2)
                 itemCounter = itemCounter + 1
                 found = .true.
                 primary%item(j)%foundComp2 = .true.
@@ -774,6 +792,7 @@ CONTAINS
                 PrimaryVarNeeded(j) = .true.
                 primary%item(j)%ExtDataAlloc = .false.
                 VarName=trim(primary%item(J)%name)
+                primary%item(j)%fileVars%xname=trim(primary%item(J)%var)
     
                 if (ITEMTYPES(I) == ESMF_StateItem_Field) then
                    primary%item(J)%vartype = MAPL_FieldItem
@@ -922,6 +941,7 @@ CONTAINS
       item => self%primary%item(i)
 
       item%collection_id = MAPL_CFIOAddCollection(item%file)
+      item%pfioCollection_id = MAPL_ExtDataAddCollection(item%file)
 
       ! parse refresh template to see if we have a time shift during constant updating
       k = index(item%refresh_template,';')
@@ -1000,8 +1020,9 @@ CONTAINS
       ! by that it is an untemplated file with one time that could not possibly be time interpolated
       if (PrimaryExportIsConstant_(item)) then
          if (index(item%file,'%') == 0) then
-            call MakeCFIO(item%file,item%collection_id,cfio,__RC__)
-            if (cfio%tsteps == 1) then
+            call MakeMetadata(item%file,item%pfioCollection_id,metadata,__RC__)
+            call metadata%get_coordinate_info('time',coordSize=tsteps,__RC__)
+            if (tsteps == 1) then
                item%cyclic = 'single'
                item%doInterpolate = .false.
             end if
@@ -1012,6 +1033,9 @@ CONTAINS
       call GetClimYear(item,__RC__)
       ! get levels, other information
       call GetLevs(item,time,self%allowExtrap,__RC__)
+      call ESMF_VMBarrier(vm)
+      ! register collections
+      item%iclient_collection_id=i_clients%add_ext_collection(trim(item%file))
       ! create interpolating fields, check if the vertical levels match the file
       if (item%vartype == MAPL_FieldItem) then
 
@@ -1028,8 +1052,11 @@ CONTAINS
          else if (item%lm /= lm .and. lm /= 0) then
             item%do_Fill = .true.
          end if
-         item%finterp1 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
-         item%finterp2 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
+         item%modelGridFields%v1_finterp1 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
+         item%modelGridFields%v1_finterp2 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
+         if (item%do_fill .or. item%do_vertInterp) then
+            call createFileLevBracket(item,cf_master,__RC__)
+         end if
 
       else if (item%vartype == MAPL_BundleItem) then
 
@@ -1073,11 +1100,15 @@ CONTAINS
          else if (item%lm /= lm .and. lm /= 0) then
             item%do_Fill = .true.
          end if
-         item%v1_finterp1 = MAPL_FieldCreate(field, item%fcomp1,doCopy=.true.,__RC__)
-         item%v1_finterp2 = MAPL_FieldCreate(field, item%fcomp1,doCopy=.true.,__RC__)
+         item%modelGridFields%v1_finterp1 = MAPL_FieldCreate(field, item%fcomp1,doCopy=.true.,__RC__)
+         item%modelGridFields%v1_finterp2 = MAPL_FieldCreate(field, item%fcomp1,doCopy=.true.,__RC__)
          call ESMF_StateGet(self%ExtDataState, trim(item%vcomp2), field,__RC__)
-         item%v2_finterp1 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
-         item%v2_finterp2 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
+         item%modelGridFields%v2_finterp1 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
+         item%modelGridFields%v2_finterp2 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
+         if (item%do_fill .or. item%do_vertInterp) then
+            call createFileLevBracket(item,cf_master,__RC__)
+         end if
+
       end if
 
       allocate(item%refresh_time,__STAT__)
@@ -1265,7 +1296,6 @@ CONTAINS
    type(IOBundleVector), target     :: IOBundles
    type(IOBundleVectorIterator) :: bundle_iter
    type(ExtData_IOBundle), pointer :: io_bundle
-   type (ESMF_VM) :: vm
 !  Declare pointers to IMPORT/EXPORT/INTERNAL states 
 !  -------------------------------------------------
 !  #include "MAPL_ExtData_DeclarePointer___.h"
@@ -1382,63 +1412,7 @@ CONTAINS
             call MAPL_TimerOn(MAPLSTATE,'--Swap')
             DO_SWAP: if (swap) then
 
-               item%interp_time1 = item%interp_time2
-
-               if (item%vartype == MAPL_FieldItem) then
-
-                  call ESMF_FieldGet(item%finterp1, dimCount=fieldRank,__RC__)
-                  if (fieldRank == 2) then
-                     call ESMF_FieldGet(item%finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-                     call ESMF_FieldGet(item%finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
-                     var2d_prev=var2d_next
-                  else if (fieldRank == 3) then
-                     call ESMF_FieldGet(item%finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-                     call ESMF_FieldGet(item%finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
-                     var3d_prev=var3d_next
-                  endif
-
-               else if (item%vartype == MAPL_BundleItem) then
-
-                  call ESMF_FieldBundleGet(item%binterp2, fieldCount = fieldCount, __RC__)
-                  allocate(names(fieldCount),__STAT__)
-                  call ESMF_FieldBundleGet(item%binterp2, fieldNameList = Names, __RC__)
-                  do j = 1,fieldCount
-                     call ESMF_FieldBundleGet(item%binterp1, names(j), field=field1, __RC__)
-                     call ESMF_FieldBundleGet(item%binterp2, names(j), field=field2, __RC__)
-                     call ESMF_FieldGet(field1, dimCount=fieldRank, __RC__) 
-                     if (fieldRank == 2) then
-                        call ESMF_FieldGet(field1, localDE=0, farrayPtr=var2d_prev, __RC__)
-                        call ESMF_FieldGet(field2, localDE=0, farrayPtr=var2d_next, __RC__)
-                        var2d_prev=var2d_next
-                     else if (fieldRank == 3) then
-                        call ESMF_FieldGet(field1, localDE=0, farrayPtr=var3d_prev, __RC__)
-                        call ESMF_FieldGet(field2, localDE=0, farrayPtr=var3d_next, __RC__)
-                        var3d_prev=var3d_next
-                     endif
-                  enddo
-
-                  deallocate(names)
-
-               else if (item%vartype == MAPL_ExtDataVectorItem) then
-
-                  call ESMF_FieldGet(item%v1_finterp1, dimCount=fieldRank, __RC__)
-                  if (fieldRank == 2) then
-                     call ESMF_FieldGet(item%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-                     call ESMF_FieldGet(item%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
-                     var2d_prev=var2d_next
-                     call ESMF_FieldGet(item%v2_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-                     call ESMF_FieldGet(item%v2_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
-                     var2d_prev=var2d_next
-                  else if (fieldRank == 3) then
-                     call ESMF_FieldGet(item%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-                     call ESMF_FieldGet(item%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
-                     var3d_prev=var3d_next
-                     call ESMF_FieldGet(item%v2_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-                     call ESMF_FieldGet(item%v2_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
-                     var3d_prev=var3d_next
-                  endif
-
-               end if
+               call swapBracketInformation(item,__RC__)
 
             end if DO_SWAP
 
@@ -1488,13 +1462,13 @@ CONTAINS
       bracket_side = io_bundle%bracket_side
       entry_num = io_bundle%entry_index
       file_Processed = io_bundle%file_name
-      call MAPL_CFIOSet(io_bundle%cfio,fname=file_Processed,rc=status)
-      _VERIFY(Status)
-      call MAPL_CFIOSet(io_bundle%cfio,collectionId=self%primary%item(entry_num)%collection_id,rc=status)
-      _VERIFY(Status)
+      !call MAPL_CFIOSet(io_bundle%cfio,fname=file_Processed,rc=status)
+      !_VERIFY(Status)
+      !call MAPL_CFIOSet(io_bundle%cfio,collectionId=self%primary%item(entry_num)%collection_id,rc=status)
+      !_VERIFY(Status)
       item => self%primary%item(entry_num)
 
-      io_bundle%pbundle = ESMF_FieldBundleCreate(name="bob",rc=status)
+      io_bundle%pbundle = ESMF_FieldBundleCreate(rc=status)
       _VERIFY(STATUS)
 
       call MAPL_ExtDataPopulateBundle(self,item,bracket_side,io_bundle%pbundle,rc=status)
@@ -1508,33 +1482,22 @@ CONTAINS
    _VERIFY(status)
    call MAPL_TimerOff(MAPLSTATE,"---CreateCFIO")
 
-   if (self%prefetch) then
-      call MAPL_TimerOn(MAPLSTATE,"---prefetch")
-      call MAPL_ExtDataPrefetch(IOBundles,self%BlockSize,MAPLSTATE, rc=status)
-      _VERIFY(status)
-      call MAPL_TimerOff(MAPLSTATE,"---prefetch")
-      _VERIFY(STATUS)
-      call MAPL_TimerOn(MAPLSTATE,"---IclientDone")
-
-      call i_Clients%done_collective_prefetch()
-
-      call MAPL_TimerOff(MAPLSTATE,"---IclientDone")
-      _VERIFY(STATUS)
-   end if
-  
-   if (self%prefetch) then
-      call MAPL_TimerOn(MAPLSTATE,"---read-prefetch")
-      call MAPL_ExtDataReadPrefetch(IOBundles,self%BlockSize,MAPLSTATE,rc=status) 
-      _VERIFY(status)
-      call MAPL_TimerOff(MAPLSTATE,"---read-prefetch")
-   else
-      call MAPL_ExtDataParallelRead(IOBundles,self%blocksize,rc=status)
-      _VERIFY(status)
-      if (self%distributed_trans) then
-         call MAPL_ExtDataSerialRead(IOBundles,self%ignorecase,__RC__)
-      end if
-   end if
+   call MAPL_TimerOn(MAPLSTATE,"---prefetch")
+   call MAPL_ExtDataPrefetch(IOBundles, rc=status)
    _VERIFY(status)
+   call MAPL_TimerOff(MAPLSTATE,"---prefetch")
+   _VERIFY(STATUS)
+   call MAPL_TimerOn(MAPLSTATE,"---IclientDone")
+
+   call i_Clients%done_collective_prefetch()
+
+   call MAPL_TimerOff(MAPLSTATE,"---IclientDone")
+   _VERIFY(STATUS)
+  
+   call MAPL_TimerOn(MAPLSTATE,"---read-prefetch")
+   call MAPL_ExtDataReadPrefetch(IOBundles,rc=status) 
+   _VERIFY(status)
+   call MAPL_TimerOff(MAPLSTATE,"---read-prefetch")
    call MAPL_TimerOff(MAPLSTATE,"--PRead")
 
    bundle_iter = IOBundles%begin()
@@ -1702,13 +1665,6 @@ CONTAINS
 
          if (self%primary%item(i)%isConst) cycle
 
-         if (trim(self%primary%item(i)%refresh_template) == "0") then
-            if (self%primary%item(i)%vartype == MAPL_FieldItem) then
-               call ESMF_FieldDestroy(self%primary%item(i)%finterp1,__RC__)
-               call ESMF_FieldDestroy(self%primary%item(i)%finterp2,__RC__)
-            end if
-         end if
-
          if (associated(self%primary%item(i)%refresh_time)) then
             deallocate(self%primary%item(i)%refresh_time)
          end if
@@ -1809,1349 +1765,1407 @@ CONTAINS
      type (ESMF_Field), intent(inout)  :: field
      integer, optional, intent (inout) :: rc
 
-     __Iam__('scale_field_')
+        integer       :: fieldRank
+        real, pointer :: xy(:,:)    => null()
+        real, pointer :: xyz(:,:,:) => null()
 
-     integer       :: fieldRank
-     real, pointer :: xy(:,:)    => null()
-     real, pointer :: xyz(:,:,:) => null()
+        integer :: status
 
 
-     call ESMF_FieldGet(field, dimCount=fieldRank, __RC__)
+        call ESMF_FieldGet(field, dimCount=fieldRank, __RC__)
 
-     _ASSERT(fieldRank == 2 .or. fieldRank == 3,'Field rank must be 2 or 3')
+        _ASSERT(fieldRank == 2 .or. fieldRank == 3,'Field rank must be 2 or 3')
 
-     if (fieldRank == 2) then
-        call ESMF_FieldGet(field, farrayPtr=xy, __RC__)
+        if (fieldRank == 2) then
+           call ESMF_FieldGet(field, farrayPtr=xy, __RC__)
 
-        if (associated(xy)) then
-           xy = offset + scale_factor*xy
+           if (associated(xy)) then
+              xy = offset + scale_factor*xy
+           end if
+        else if (fieldRank == 3) then
+           call ESMF_FieldGet(field, farrayPtr=xyz, __RC__)
+
+           if (associated(xyz)) then
+              xyz = offset + scale_factor*xyz
+           end if
         end if
-     else if (fieldRank == 3) then
-        call ESMF_FieldGet(field, farrayPtr=xyz, __RC__)
 
-        if (associated(xyz)) then
-           xyz = offset + scale_factor*xyz
+        _RETURN(_SUCCESS)
+     end subroutine scale_field_
+
+   ! ............................................................................
+
+     type (ESMF_Time) function timestamp_(time, template, rc)
+        type(ESMF_Time), intent(inout)         :: time
+        character(len=ESMF_MAXSTR), intent(in) :: template
+        integer, optional, intent(inout)       :: rc 
+
+        ! locals
+        integer, parameter :: DATETIME_MAXSTR_ = 32
+        integer :: yy, mm, dd, hs, ms, ss
+        character(len=DATETIME_MAXSTR_) :: buff, buff_date, buff_time
+        character(len=DATETIME_MAXSTR_) :: str_yy, str_mm, str_dd
+        character(len=DATETIME_MAXSTR_) :: str_hs, str_ms, str_ss
+
+        integer :: i, il, ir
+        integer :: status
+       
+        ! test the length of the timestamp template
+        _ASSERT(len_trim(template) < DATETIME_MAXSTR_,'Timestamp template is greater than Maximum allowed len')
+
+        buff = trim(template)
+        buff = ESMF_UtilStringLowerCase(buff, __RC__)
+         
+        ! test if the template is empty and return the current time as result
+        if (buff == '-'  .or. buff == '--'   .or. buff == '---' .or. &
+            buff == 'na' .or. buff == 'none' .or. buff == 'n/a') then
+
+           timestamp_ = time
+        else   
+           ! split the time stamp template into a date and time strings
+           i = scan(buff, 't')
+           If (.not.(i > 3)) Then
+              _ASSERT(.False.,'ERROR: Time stamp ' // trim(template) // ' uses the fixed format, and must therefore contain a T')
+           End If
+
+           buff_date = buff(1:i-1)
+           buff_time = buff(i+1:)
+
+           ! parse the date string
+           il = scan(buff_date, '-', back=.false.)
+           ir = scan(buff_date, '-', back=.true. )
+           str_yy = trim(buff_date(1:il-1))
+           str_mm = trim(buff_date(il+1:ir-1))
+           str_dd = trim(buff_date(ir+1:))
+
+           ! parse the time string
+           il = scan(buff_time, ':', back=.false.)
+           ir = scan(buff_time, ':', back=.true. )
+           str_hs = trim(buff_time(1:il-1))
+           str_ms = trim(buff_time(il+1:ir-1))
+           str_ss = trim(buff_time(ir+1:))
+        
+           ! remove the trailing 'Z' from the seconds string
+           i = scan(str_ss, 'z')
+           if (i > 0) then
+              str_ss = trim(str_ss(1:i-1))
+           end if
+
+           ! apply the timestamp template
+           call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=hs, m=ms, s=ss, __RC__)
+
+           i = scan(str_yy, '%'); if (i == 0) read (str_yy, '(I4)') yy
+           i = scan(str_mm, '%'); if (i == 0) read (str_mm, '(I2)') mm
+           i = scan(str_dd, '%'); if (i == 0) read (str_dd, '(I2)') dd
+           i = scan(str_hs, '%'); if (i == 0) read (str_hs, '(I2)') hs
+           i = scan(str_ms, '%'); if (i == 0) read (str_ms, '(I2)') ms
+           i = scan(str_ss, '%'); if (i == 0) read (str_ss, '(I2)') ss
+
+           call ESMF_TimeSet(timestamp_, yy=yy, mm=mm, dd=dd, h=hs, m=ms, s=ss, __RC__)
         end if
-     end if
 
-     return 
-  end subroutine scale_field_
+        _RETURN(ESMF_SUCCESS)
 
-! ............................................................................
-
-  type (ESMF_Time) function timestamp_(time, template, rc)
-     type(ESMF_Time), intent(inout)         :: time
-     character(len=ESMF_MAXSTR), intent(in) :: template
-     integer, optional, intent(inout)       :: rc 
-
-      __Iam__('timestamp_')
-
-     ! locals
-     integer, parameter :: DATETIME_MAXSTR_ = 32
-     integer :: yy, mm, dd, hs, ms, ss
-     character(len=DATETIME_MAXSTR_) :: buff, buff_date, buff_time
-     character(len=DATETIME_MAXSTR_) :: str_yy, str_mm, str_dd
-     character(len=DATETIME_MAXSTR_) :: str_hs, str_ms, str_ss
-
-     integer :: i, il, ir
+     end function timestamp_
     
-     ! test the length of the timestamp template
-     _ASSERT(len_trim(template) < DATETIME_MAXSTR_,'Timestamp template is greater than Maximum allowed len')
+     subroutine CreateTimeInterval(item,clock,rc)
+        type(PrimaryExport)      , intent(inout) :: item
+        type(ESMF_Clock)          , intent(in   ) :: clock
+        integer, optional         , intent(out  ) :: rc
 
-     buff = trim(template)
-     buff = ESMF_UtilStringLowerCase(buff, __RC__)
-      
-     ! test if the template is empty and return the current time as result
-     if (buff == '-'  .or. buff == '--'   .or. buff == '---' .or. &
-         buff == 'na' .or. buff == 'none' .or. buff == 'n/a') then
-
-        timestamp_ = time
-     else   
-        ! split the time stamp template into a date and time strings
-        i = scan(buff, 't')
-        If (.not.(i > 3)) Then
-           _ASSERT(.False.,'ERROR: Time stamp ' // trim(template) // ' uses the fixed format, and must therefore contain a T')
-        End If
-
-        buff_date = buff(1:i-1)
-        buff_time = buff(i+1:)
-
-        ! parse the date string
-        il = scan(buff_date, '-', back=.false.)
-        ir = scan(buff_date, '-', back=.true. )
-        str_yy = trim(buff_date(1:il-1))
-        str_mm = trim(buff_date(il+1:ir-1))
-        str_dd = trim(buff_date(ir+1:))
-
-        ! parse the time string
-        il = scan(buff_time, ':', back=.false.)
-        ir = scan(buff_time, ':', back=.true. )
-        str_hs = trim(buff_time(1:il-1))
-        str_ms = trim(buff_time(il+1:ir-1))
-        str_ss = trim(buff_time(ir+1:))
-     
-        ! remove the trailing 'Z' from the seconds string
-        i = scan(str_ss, 'z')
-        if (i > 0) then
-           str_ss = trim(str_ss(1:i-1))
-        end if
-
-        ! apply the timestamp template
-        call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=hs, m=ms, s=ss, __RC__)
-
-        i = scan(str_yy, '%'); if (i == 0) read (str_yy, '(I4)') yy
-        i = scan(str_mm, '%'); if (i == 0) read (str_mm, '(I2)') mm
-        i = scan(str_dd, '%'); if (i == 0) read (str_dd, '(I2)') dd
-        i = scan(str_hs, '%'); if (i == 0) read (str_hs, '(I2)') hs
-        i = scan(str_ms, '%'); if (i == 0) read (str_ms, '(I2)') ms
-        i = scan(str_ss, '%'); if (i == 0) read (str_ss, '(I2)') ss
-
-        call ESMF_TimeSet(timestamp_, yy=yy, mm=mm, dd=dd, h=hs, m=ms, s=ss, __RC__)
-     end if
-
-     _RETURN(ESMF_SUCCESS)
-
-  end function timestamp_
+        integer                    :: iyy,imm,idd,ihh,imn,isc
+        integer                    :: lasttoken
+        character(len=2)           :: token
+        type(ESMF_Time)            :: time
+        integer                    :: cindex,pindex
+        character(len=ESMF_MAXSTR) :: creffTime, ctInt
+       
+        __Iam__('CreateTimeInterval')
  
-  subroutine CreateTimeInterval(item,clock,rc)
-     type(PrimaryExport)      , intent(inout) :: item
-     type(ESMF_Clock)          , intent(in   ) :: clock
-     integer, optional         , intent(out  ) :: rc
+        creffTime = ''
+        ctInt     = ''
+        call ESMF_ClockGet (CLOCK, currTIME=time, __RC__)
+        if (.not.item%hasFileReffTime) then
+           ! if int_frequency is less than zero than try to guess it from the file template
+           ! if that fails then it must be a single file or a climatology 
 
-     __Iam__('CreateTimeInterval')
-     
-     integer                    :: iyy,imm,idd,ihh,imn,isc
-     integer                    :: lasttoken
-     character(len=2)           :: token
-     type(ESMF_Time)            :: time
-     integer                    :: cindex,pindex
-     character(len=ESMF_MAXSTR) :: creffTime, ctInt
-     
-     creffTime = ''
-     ctInt     = ''
-     call ESMF_ClockGet (CLOCK, currTIME=time, __RC__)
-     if (.not.item%hasFileReffTime) then
-        ! if int_frequency is less than zero than try to guess it from the file template
-        ! if that fails then it must be a single file or a climatology 
-
-        call ESMF_TimeGet(time, yy=iyy, mm=imm, dd=idd,h=ihh, m=imn, s=isc  ,__RC__)
-        !=======================================================================
-        ! Using "now" as a reference time makes it difficult to find a file if
-        ! we need to extrapolate, and doesn't make an awful lot of sense anyway.
-        ! Instead, use the start of (current year - 20) or 1985, whichever is
-        ! earlier (SDE 2016-12-30)
-        iyy = Min(iyy-20,1985)
-        imm = 1
-        idd = 1
-        ihh = 0
-        imn = 0
-        isc = 0
-        !=======================================================================
-        lasttoken = index(item%file,'%',back=.true.)
-        if (lasttoken.gt.0) then
-           token = item%file(lasttoken+1:lasttoken+2)
-           select case(token)
-           case("y4") 
-              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=1,dd=1,h=0,m=0,s=0,__RC__)
-              call ESMF_TimeIntervalSet(item%frequency,yy=1,__RC__)
-           case("m2") 
-              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=1,h=0,m=0,s=0,__RC__)
-              call ESMF_TimeIntervalSet(item%frequency,mm=1,__RC__)
-           case("d2") 
-              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=0,m=0,s=0,__RC__)
-              call ESMF_TimeIntervalSet(item%frequency,d=1,__RC__)
-           case("h2") 
-              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=0,s=0,__RC__)
-              call ESMF_TimeIntervalSet(item%frequency,h=1,__RC__)
-           case("n2") 
-              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=0,__RC__)
-              call ESMF_TimeIntervalSet(item%frequency,m=1,__RC__)
-           end select
+           call ESMF_TimeGet(time, yy=iyy, mm=imm, dd=idd,h=ihh, m=imn, s=isc  ,__RC__)
+           !=======================================================================
+           ! Using "now" as a reference time makes it difficult to find a file if
+           ! we need to extrapolate, and doesn't make an awful lot of sense anyway.
+           ! Instead, use the start of (current year - 20) or 1985, whichever is
+           ! earlier (SDE 2016-12-30)
+           iyy = Min(iyy-20,1985)
+           imm = 1
+           idd = 1
+           ihh = 0
+           imn = 0
+           isc = 0
+           !=======================================================================
+           lasttoken = index(item%file,'%',back=.true.)
+           if (lasttoken.gt.0) then
+              token = item%file(lasttoken+1:lasttoken+2)
+              select case(token)
+              case("y4") 
+                 call ESMF_TimeSet(item%reff_time,yy=iyy,mm=1,dd=1,h=0,m=0,s=0,__RC__)
+                 call ESMF_TimeIntervalSet(item%frequency,yy=1,__RC__)
+              case("m2") 
+                 call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=1,h=0,m=0,s=0,__RC__)
+                 call ESMF_TimeIntervalSet(item%frequency,mm=1,__RC__)
+              case("d2") 
+                 call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=0,m=0,s=0,__RC__)
+                 call ESMF_TimeIntervalSet(item%frequency,d=1,__RC__)
+              case("h2") 
+                 call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=0,s=0,__RC__)
+                 call ESMF_TimeIntervalSet(item%frequency,h=1,__RC__)
+              case("n2") 
+                 call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=0,__RC__)
+                 call ESMF_TimeIntervalSet(item%frequency,m=1,__RC__)
+              end select
+           else
+              ! couldn't find any tokens so all the data must be on one file
+              call ESMF_TimeIntervalSet(item%frequency,__RC__)
+           end if
         else
-           ! couldn't find any tokens so all the data must be on one file
-           call ESMF_TimeIntervalSet(item%frequency,__RC__)
+           ! Reference time should look like:
+           ! YYYY-MM-DDThh:mm:ssPYYYY-MM-DDThh:mm:ss
+           ! The date before the P is the reference time, from which future times
+           ! will be taken. The date after the P is the frequency with which the
+           ! file changes. For example, if the data is referenced to 1985 and
+           ! there is 1 file per year, the reference time should be
+           ! 1985-01-01T00:00:00P0001-00-00T00:00:00
+           ! Get refference time, if not provided use current model date
+           pindex=index(item%FileReffTime,'P')
+           if (pindex==0) then 
+              _ASSERT(.false., 'ERROR: File template ' // item%file // ' has invalid reference date format')
+           end if
+           cReffTime = item%FileReffTime(1:pindex-1) 
+           if (trim(cReffTime) == '') then
+              item%reff_time = Time
+           else
+              call MAPL_NCIOParseTimeUnits(cReffTime,iyy,imm,idd,ihh,imn,isc,status)
+              _VERIFY(STATUS)
+              call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=isc,rc=status)
+              _VERIFY(STATUS)
+           end if
+           ! now get time interval. Put 0000-00-00 in front if not there so parsetimeunits doesn't complain
+           ctInt = item%FileReffTime(pindex+1:)
+           cindex = index(ctInt,'T')
+           if (cindex == 0) ctInt = '0000-00-00T'//trim(ctInt)
+           call MAPL_NCIOParseTimeUnits(ctInt,iyy,imm,idd,ihh,imn,isc,status)
+           _VERIFY(STATUS)
+           call ESMF_TimeIntervalSet(item%frequency,yy=iyy,mm=imm,d=idd,h=ihh,m=imn,s=isc,rc=status)
+           _VERIFY(STATUS) 
         end if
-     else
-        ! Reference time should look like:
-        ! YYYY-MM-DDThh:mm:ssPYYYY-MM-DDThh:mm:ss
-        ! The date before the P is the reference time, from which future times
-        ! will be taken. The date after the P is the frequency with which the
-        ! file changes. For example, if the data is referenced to 1985 and
-        ! there is 1 file per year, the reference time should be
-        ! 1985-01-01T00:00:00P0001-00-00T00:00:00
-        ! Get refference time, if not provided use current model date
-        pindex=index(item%FileReffTime,'P')
-        if (pindex==0) then 
-           _ASSERT(.false., 'ERROR: File template ' // item%file // ' has invalid reference date format')
-        end if
-        cReffTime = item%FileReffTime(1:pindex-1) 
-        if (trim(cReffTime) == '') then
-           item%reff_time = Time
+
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+           Write(*,'(5(a))') ' >> REFFTIME for ',trim(item%file),': ',trim(item%FileReffTime)
+           call ESMF_TimeGet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=isc,rc=status)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> Reference time: ',iYy,'-',iMm,'-',iDd,' ',iHh,':',iMn,':',iSc
+           call ESMF_TimeIntervalGet(item%frequency,yy=iyy,mm=imm,d=idd,h=ihh,m=imn,s=isc,rc=status)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> Frequency     : ',iYy,'-',iMm,'-',iDd,' ',iHh,':',iMn,':',iSc
+        End If
+        _RETURN(ESMF_SUCCESS) 
+
+     end subroutine CreateTimeInterval
+
+     subroutine GetClimYear(item, rc)
+
+        type(PrimaryExport)      , intent(inout) :: item
+        integer, optional        , intent(out  ) :: rc
+
+        integer(ESMF_KIND_I4)      :: iyr
+        type(ESMF_TimeInterval)    :: zero
+        integer                    :: lasttoken
+        character(len=ESMF_MAXPATHLEN) :: file
+        character(len=2)           :: token
+        integer                    :: nymd, nhms, climYear
+        character(len=ESMF_MAXSTR) :: buffer
+        logical                    :: inRange
+        type(FileMetadataUtils), pointer :: metadata
+        integer :: status
+
+        buffer = trim(item%cyclic)
+
+        if (trim(buffer) == 'n') then
+
+           item%cyclic = "n"
+           _RETURN(ESMF_SUCCESS)
+
+        else if (trim(buffer) == 'single') then
+
+           _RETURN(ESMF_SUCCESS)
+        else if (trim(buffer) == 'y') then
+
+           item%cyclic = "y"
+
+           call ESMF_TimeIntervalSet(zero,__RC__)
+
+           if (item%frequency == zero) then
+              file = item%file
+           else
+              lasttoken = index(item%file,'%',back=.true.)
+              token = item%file(lasttoken+1:lasttoken+2)
+              _ASSERT(token == "m2",'Clim year must be month template "%m2"')
+              ! just put a time in so we can evaluate the template to open a file
+              nymd = 20000101
+              nhms = 0
+              call ESMF_CFIOStrTemplate(file,item%file,'GRADS',nymd=nymd,nhms=nhms,__STAT__)
+           end if
+           call MakeMetadata(file,item%pfioCollection_id,metadata,__RC__)
+           call metadata%get_time_units(startYear=iyr)
+           item%climYear=iYr
+           _RETURN(ESMF_SUCCESS)
         else
-           call MAPL_NCIOParseTimeUnits(cReffTime,iyy,imm,idd,ihh,imn,isc,status)
-           _VERIFY(STATUS)
-           call ESMF_TimeSet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=isc,rc=status)
-           _VERIFY(STATUS)
+           read(buffer,'(I4)') climYear
+           inRange = 0 <= climYear .and. climYear <= 3000
+           if (inRange) then
+              item%cyclic = "y"
+              item%climYear = climYear
+              _RETURN(ESMF_SUCCESS)
+           else
+              _ASSERT(.false., 'cyclic keyword was not y, n, or a valid year (0 < year < 3000)')
+           end if
         end if
-        ! now get time interval. Put 0000-00-00 in front if not there so parsetimeunits doesn't complain
-        ctInt = item%FileReffTime(pindex+1:)
-        cindex = index(ctInt,'T')
-        if (cindex == 0) ctInt = '0000-00-00T'//trim(ctInt)
-        call MAPL_NCIOParseTimeUnits(ctInt,iyy,imm,idd,ihh,imn,isc,status)
-        _VERIFY(STATUS)
-        call ESMF_TimeIntervalSet(item%frequency,yy=iyy,mm=imm,d=idd,h=ihh,m=imn,s=isc,rc=status)
-        _VERIFY(STATUS) 
-     end if
 
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-        Write(*,'(5(a))') ' >> REFFTIME for ',trim(item%file),': ',trim(item%FileReffTime)
-        call ESMF_TimeGet(item%reff_time,yy=iyy,mm=imm,dd=idd,h=ihh,m=imn,s=isc,rc=status)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> Reference time: ',iYy,'-',iMm,'-',iDd,' ',iHh,':',iMn,':',iSc
-        call ESMF_TimeIntervalGet(item%frequency,yy=iyy,mm=imm,d=idd,h=ihh,m=imn,s=isc,rc=status)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> Frequency     : ',iYy,'-',iMm,'-',iDd,' ',iHh,':',iMn,':',iSc
-     End If
-     _RETURN(ESMF_SUCCESS) 
+     end subroutine GetClimYear
 
-  end subroutine CreateTimeInterval
+     subroutine GetLevs(item, time, allowExtrap, rc)
 
-  subroutine GetClimYear(item, rc)
+        type(PrimaryExport)      , intent(inout) :: item
+        type(ESMF_Time)          , intent(inout) :: time
+        logical                  , intent(in   ) :: allowExtrap
+        integer, optional        , intent(out  ) :: rc
 
-     type(PrimaryExport)      , intent(inout) :: item
-     integer, optional        , intent(out  ) :: rc
+        __Iam__('GetLevs')
 
-     __Iam__('GetClimYear')
+        integer(ESMF_KIND_I4)      :: iyr,imm,idd,ihr,imn,iss,i,n,refYear
+        character(len=ESMF_MAXPATHLEN) :: file
+        integer                    :: nymd, nhms
+        type(ESMF_Time)            :: fTime
+        real, allocatable          :: levFile(:) 
+        character(len=ESMF_MAXSTR) :: cfiovarname,units,varname,buff
+        logical                    :: found,lFound,intOK
+        integer                    :: maxOffset
+        character(len=:), allocatable :: levname
+        type(FileMetadataUtils), pointer :: metadata
+        type(ESMF_Grid) :: fileGrid
 
-     type(ESMF_CFIO),pointer    :: cfio
-     integer(ESMF_KIND_I4)      :: iyr,imm,idd
-     integer                    :: begDate
-     type(ESMF_TimeInterval)    :: zero
-     integer                    :: lasttoken
-     character(len=ESMF_MAXPATHLEN) :: file
-     character(len=2)           :: token
-     integer                    :: nymd, nhms, climYear
-     character(len=ESMF_MAXSTR) :: buffer
-     logical                    :: inRange
-
-     buffer = trim(item%cyclic)
-
-     if (trim(buffer) == 'n') then
-
-        item%cyclic = "n"
-        _RETURN(ESMF_SUCCESS)
-
-     else if (trim(buffer) == 'single') then
-
-        _RETURN(ESMF_SUCCESS)
-     else if (trim(buffer) == 'y') then
-
-        item%cyclic = "y"
+        type(ESMF_TimeInterval)    :: zero
 
         call ESMF_TimeIntervalSet(zero,__RC__)
 
         if (item%frequency == zero) then
+
            file = item%file
+           Inquire(file=trim(file),EXIST=found)
+
         else
-           lasttoken = index(item%file,'%',back=.true.)
-           token = item%file(lasttoken+1:lasttoken+2)
-           _ASSERT(token == "m2",'Clim year must be month template "%m2"')
-           ! just put a time in so we can evaluate the template to open a file
-           nymd = 20000101
-           nhms = 0
-           call ESMF_CFIOStrTemplate(file,item%file,'GRADS',nymd=nymd,nhms=nhms,__STAT__)
-        end if
-        call MakeCFIO(file, item%collection_id, cfio, __RC__)
-        begDate = cfio%date
-        call MAPL_UnpackTime(begDate,iyr,imm,idd)
-        item%climyear = iyr
-        nullify(CFIO)
-        _RETURN(ESMF_SUCCESS)
-     else
-        read(buffer,'(I4)') climYear
-        inRange = 0 <= climYear .and. climYear <= 3000
-        if (inRange) then
-           item%cyclic = "y"
-           item%climYear = climYear
-           _RETURN(ESMF_SUCCESS)
-        else
-           _ASSERT(.false., 'cyclic keyword was not y, n, or a valid year (0 < year < 3000)')
-        end if
-     end if
-
-  end subroutine GetClimYear
-
-  subroutine GetLevs(item, time, allowExtrap, rc)
-
-     type(PrimaryExport)      , intent(inout) :: item
-     type(ESMF_Time)          , intent(inout) :: time
-     logical                  , intent(in   ) :: allowExtrap
-     integer, optional        , intent(out  ) :: rc
-
-     __Iam__('GetLevs')
-
-     type(ESMF_CFIO), pointer    :: cfio
-     type(ESMF_CFIOGRID),pointer :: cfiogrid
-     integer(ESMF_KIND_I4)      :: iyr,imm,idd,ihr,imn,iss,i,n,refYear
-     character(len=ESMF_MAXPATHLEN) :: file
-     integer                    :: nymd, nhms
-     type(ESMF_Time)            :: fTime
-     real, pointer              :: levFile(:) => null()
-     integer                    :: nVars
-     type(ESMF_CFIOVarInfo), pointer :: vars(:)
-     character(len=ESMF_MAXSTR) :: cfiovarname,units,varname,buff
-     logical                    :: found,lFound,intOK
-     integer                    :: maxOffset
-
-     type(ESMF_TimeInterval)    :: zero
-
-     call ESMF_TimeIntervalSet(zero,__RC__)
-
-     if (item%frequency == zero) then
-
-        file = item%file
-        Inquire(file=trim(file),EXIST=found)
-
-     else
-        buff = trim(item%refresh_template)
-        buff = ESMF_UtilStringLowerCase(buff, __RC__)
-        if ( index(buff,'t')/=0) then
-           if (index(buff,'p') == 0) then
-              ftime = timestamp_(time,buff,__RC__)
+           buff = trim(item%refresh_template)
+           buff = ESMF_UtilStringLowerCase(buff, __RC__)
+           if ( index(buff,'t')/=0) then
+              if (index(buff,'p') == 0) then
+                 ftime = timestamp_(time,buff,__RC__)
+              else
+                 ftime = time
+              end if
            else
               ftime = time
            end if
+
+           call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=iss,__RC__)
+           if (item%cyclic == 'y') then
+              iyr = item%climyear
+           end if
+          call MAPL_PackTime(nymd,iyr,imm,idd)
+          call MAPL_PackTime(nhms,ihr,imn,iss)
+          call ESMF_CFIOStrTemplate(file,item%file,'GRADS',nymd=nymd,nhms=nhms,__STAT__)
+          Inquire(file=trim(file),EXIST=found)
+
+        end if
+
+        if (found) then
+           call MakeMetadata(file,item%pfioCollection_id,metadata,__RC__)
+           call makeGridFromCollection(file,item%pfioCollection_id,fileGrid,__RC__)
         else
-           ftime = time
-        end if
+           if (allowExtrap .and. (item%cyclic == 'n') ) then
 
-        call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=iss,__RC__)
-        if (item%cyclic == 'y') then
-           iyr = item%climyear
-        end if
-       call MAPL_PackTime(nymd,iyr,imm,idd)
-       call MAPL_PackTime(nhms,ihr,imn,iss)
-       call ESMF_CFIOStrTemplate(file,item%file,'GRADS',nymd=nymd,nhms=nhms,__STAT__)
-       Inquire(file=trim(file),EXIST=found)
+              ftime = item%reff_time
+              n = 0
+              maxOffSet = 100
+              call ESMF_TimeGet(item%reff_time,yy=refYear)
+              lfound = .false.
+              intOK = .true.
+              do while (intOK .and. (.not.lfound))
+                 call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=iss,__RC__)
+                 call MAPL_PackTime(nymd,iyr,imm,idd)
+                 call MAPL_PackTime(nhms,ihr,imn,iss)
+                 call gx_(file,item%file,nymd=nymd,nhms=nhms,__STAT__)
+                 Inquire(file=trim(file),exist=lfound)
+                 intOK = (abs(iYr-refYear)<maxOffset)
+                 if (.not.lfound) then
+                    n = n + 1
+                    ftime = ftime + item%frequency
+                 else
+                    call MakeMetadata(file,item%pfioCollection_id,metadata,__RC__)
+                    call makeGridFromCollection(file,item%pfioCollection_id,fileGrid,__RC__)
+                 end if
+              enddo
 
-     end if
-
-     if (found) then
-        call MakeCFIO(file, item%collection_id, cfio, __RC__)
-     else
-        if (allowExtrap .and. (item%cyclic == 'n') ) then
-
-           ftime = item%reff_time
-           n = 0
-           maxOffSet = 100
-           call ESMF_TimeGet(item%reff_time,yy=refYear)
-           lfound = .false.
-           intOK = .true.
-           do while (intOK .and. (.not.lfound))
-              call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=iss,__RC__)
-              call MAPL_PackTime(nymd,iyr,imm,idd)
-              call MAPL_PackTime(nhms,ihr,imn,iss)
-              call gx_(file,item%file,nymd=nymd,nhms=nhms,__STAT__)
-              Inquire(file=trim(file),exist=lfound)
-              intOK = (abs(iYr-refYear)<maxOffset)
               if (.not.lfound) then
-                 n = n + 1
-                 ftime = ftime + item%frequency
-              else
-                 call MakeCFIO(file, item%collection_id, cfio, __RC__)
+                 _ASSERT(.false., 'From ' // trim(item%file) // ' could not find file with extrapolation')
               end if
-           enddo
-
-           if (.not.lfound) then
-              _ASSERT(.false., 'From ' // trim(item%file) // ' could not find file with extrapolation')
+           else
+              _ASSERT(.false.,'From ' // trim(item%file) // ' could not find time no extrapolation')
            end if
+
+        end if
+        levName = metadata%get_level_name(rc=status)
+        _VERIFY(status)
+        if (trim(levName) /='') then
+           call metadata%get_coordinate_info(levName,coordSize=item%lm,coordUnits=item%levUnit,coords=levFile,__RC__)
+           allocate(item%levs(item%lm),__STAT__)
+           if (levFile(1)>levFile(size(levFile))) then
+              item%flip = .true.
+              do i=1,size(levFile)
+                 item%levs(i)=levFile(size(levFile)-i+1)
+              enddo
+           else
+              item%levs=levFile
+           end if
+           if (trim(item%levUnit)=='hPa') item%levs=item%levs*100.0
+           ! check if the level unit matches something that is pressure
+           if (trim(item%levUnit) == 'hPa') then
+              item%havePressure = .true.
+           end if
+           item%units = metadata%get_variable_units(trim(item%var),rc=status)
+
         else
-           _ASSERT(.false.,'From ' // trim(item%file) // ' could not find time no extrapolation')
+           item%LM=0
         end if
 
-     end if
-     call ESMF_CFIOGet       (CFIO,     grid=CFIOGRID,__RC__)
-     call ESMF_CFIOGridGet   (CFIOGRID,KM=item%LM,__RC__)
-     if (item%LM /= 0) then
-        call ESMF_CFIOGridGet   (CFIOGRID,lev=levFile,levUnit=item%levUnit,__RC__)
-        allocate(item%levs(size(levFile)),__STAT__)
+        _RETURN(ESMF_SUCCESS)
 
-        if (levFile(1)>levFile(size(levFile))) then
-           item%flip = .true.
-           do i=1,size(levFile)
-              item%levs(i)=levFile(size(levFile)-i+1)
-           enddo
-        else
-           item%levs=levFile
-        end if
-        if (trim(item%levUnit)=='hPa') item%levs=item%levs*100.0
-        ! check if the level unit matches something that is pressure
-        if (trim(item%levUnit) == 'hPa') then
-           item%havePressure = .true.
-        end if
+     end subroutine GetLevs
 
-     end if
-     deallocate(CFIOGRID)
+     subroutine UpdateBracketTime(item,cTime,bSide,interpTime,fileTime,file_processed,allowExtrap,rc)
+        type(PrimaryExport),                 intent(inout) :: item
+        type(ESMF_Time),                     intent(inout) :: cTime
+        character(len=1),                    intent(in   ) :: bSide
+        type(ESMF_TIME),                     intent(inout) :: interpTime
+        type(ESMF_TIME),                     intent(inout) :: fileTime
+        character(len=*),                    intent(inout) :: file_processed
+        logical,                             intent(in   ) :: allowExtrap
+        integer, optional,                   intent(out  ) :: rc
 
-     call ESMF_CFIOGet (CFIO,varObjs=VARS, nVars=nVars, RC=STATUS)
-     _VERIFY(STATUS)
-     varname = ESMF_UtilStringUpperCase(item%var,rc=status)
-     do i=1,nVars
-        call ESMF_CFIOVarInfoGet(Vars(i),vname=CFIOVARNAME, vunits=UNITS,rc=status)
-        _VERIFY(STATUS)
-        cfiovarname = ESMF_UtilStringUpperCase(cfiovarname,rc=status)
-        if (trim(cfiovarname)==trim(varname)) then
-           item%units=units
-        endif
-     enddo
-!@     call ESMF_CFIOVarInfoDestroy(vars, __RC__)
-     deallocate(vars)
-     if (associated(levFile)) then
-        deallocate(levFile)
-        nullify(levFile)
-     end if
-     nullify(cfio)
-     _RETURN(ESMF_SUCCESS)
+        __Iam__('UpdateBracketTime')
 
-  end subroutine GetLevs
+        type(ESMF_Time)                            :: newTime
+        integer                                    :: curDate,curTime,n,tindex
+        integer(ESMF_KIND_I4)                      :: iyr, imm, idd, ihr, imn, isc, oldYear
+        integer(ESMF_KIND_I4)                      :: fyr, fmm, fdd, fhr, fmn, fsc
+        type(ESMF_TimeInterval)                    :: zero
+        type(ESMF_Time)                            :: fTime
+        logical                                    :: UniFileClim
+        type(ESMF_Time)                            :: readTime
 
-  subroutine UpdateBracketTime(item,cTime,bSide,interpTime,fileTime,file_processed,allowExtrap,rc)
-     type(PrimaryExport),                 intent(inout) :: item
-     type(ESMF_Time),                     intent(inout) :: cTime
-     character(len=1),                    intent(in   ) :: bSide
-     type(ESMF_TIME),                     intent(inout) :: interpTime
-     type(ESMF_TIME),                     intent(inout) :: fileTime
-     character(len=*),                    intent(inout) :: file_processed
-     logical,                             intent(in   ) :: allowExtrap
-     integer, optional,                   intent(out  ) :: rc
+        ! Allow for extrapolation.. up to a limit
+        integer                                    :: yrOffset,yrOffsetStamp
+        integer(ESMF_KIND_I4)                      :: cYearOff, refYear
+        character(len=ESMF_MAXSTR)                 :: buff
+        integer, parameter                         :: maxOffset=10000
+        logical                                    :: found, newFile
+        logical                                    :: LExtrap, RExtrap, LExact, RExact
+        logical                                    :: LSide, RSide, intOK, bracketScan
 
-     __Iam__('UpdateBracketTime')
+        type (ESMF_CFIO), pointer                  :: xCFIO
+        type(ESMF_Time), allocatable               :: xTSeries(:)
+        type(FileMetaDataUtils), pointer           :: fdata
+      
+        call ESMF_TimeIntervalSet(zero,__RC__)
 
-     type(ESMF_Time)                            :: newTime
-     integer                                    :: curDate,curTime,n,tindex
-     integer(ESMF_KIND_I4)                      :: iyr, imm, idd, ihr, imn, isc, oldYear
-     integer(ESMF_KIND_I4)                      :: fyr, fmm, fdd, fhr, fmn, fsc
-     type(ESMF_TimeInterval)                    :: zero
-     type(ESMF_Time)                            :: fTime
-     logical                                    :: UniFileClim
-     type(ESMF_Time)                            :: readTime
+        ! Default
+        fTime = cTime
+        bracketScan = .False.
 
-     ! Allow for extrapolation.. up to a limit
-     integer                                    :: yrOffset,yrOffsetStamp
-     integer(ESMF_KIND_I4)                      :: cYearOff, refYear
-     character(len=ESMF_MAXSTR)                 :: buff
-     integer, parameter                         :: maxOffset=10000
-     logical                                    :: found, newFile
-     logical                                    :: LExtrap, RExtrap, LExact, RExact
-     logical                                    :: LSide, RSide, intOK, bracketScan
-
-     type (ESMF_CFIO), pointer                  :: xCFIO
-     type(ESMF_Time), allocatable               :: xTSeries(:)
-   
-     call ESMF_TimeIntervalSet(zero,__RC__)
-
-     ! Default
-     fTime = cTime
-     bracketScan = .False.
-
-     ! Is there only one file for this dataset?
-     if (item%frequency == zero) then
-        if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
-           write(*,'(a,a,a,a)') ' DEBUG: Scanning fixed file ',trim(item%file),' for side ',bSide
-        end if
-        UniFileClim = .false.
-        ! if the file is constant, i.e. no tokens in in the template
-        ! but it was marked as cyclic we must have a year long climatology 
-        ! on one file, set UniFileClim to true
-        if (trim(item%cyclic)=='y') UniFileClim = .true.
-        file_processed = item%file
-        ! Generate CFIO if needed
-        call MakeCFIO(file_processed,item%collection_id,xCFIO,rc=status)
-        ! Retrieve the time series
-        allocate(xTSeries(xCFIO%tSteps))
-        call GetTimesOnFile(xCFIO,xTSeries,rc=status)
-        If (status /= ESMF_SUCCESS) then
-           if (mapl_am_I_root()) Then
-              write(*,'(a,a)') ' ERROR: Time vector retrieval failed on fixed file ',trim(item%file)
-           end if
-           _RETURN(ESMF_FAILURE)
-        end if
-        call GetBracketTimeOnSingleFile(xCFIO,xTSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,item%climYear,rc=status)
-        if (status /= ESMF_SUCCESS) then
-           if (mapl_am_I_root()) Then
-              write(*,'(a,a,a,a)') ' ERROR: Bracket timing request failed on fixed file ',trim(item%file),' for side ',bSide
-           end if
-           _RETURN(ESMF_FAILURE)
-        end if
-     else 
-        if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
-           write(*,'(a,a,a,a)') ' DEBUG: Scanning template ',trim(item%file),' for side ',bSide
-           call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Target time   : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-           call ESMF_TimeGet(item%reff_time,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Reference time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-        end if
-        UniFileClim = .false.
-        found = .false.
-        ! Start by assuming the file we want exists
-        if (trim(item%cyclic)=='y') then
-           ! if climatology compute year offset
-           call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-           yrOffset = item%climYear - iyr
-           call OffsetTimeYear(cTime,yrOffset,fTime,rc)
-        else
-           yrOffset = 0
-           if (item%reff_time > cTime) then
-              _ASSERT(.False.,'Reference time for file ' // trim(item%file) // ' is too late')
-           end if
-           ! This approach causes a problem if cTime and item%reff_time are too far
-           ! apart - do it the hard way instead... 
-           ftime = item%reff_time
-           n = 0
-           ! SDE DEBUG: This caused problems in the past but the
-           ! alternative is far too slow... need to keep an eye 
-           ! on this but the Max(0,...) should help.
-           n = max(0,floor((cTime-item%reff_time)/item%frequency))
-           if (n>0) fTime = fTime + (n*item%frequency)
-           do while (.not.found)
-              ! SDE: This needs to be ">"
-              found = ((ftime + item%frequency) > ctime)
-              if (.not.found) then
-                 n = n + 1
-                 ftime = fTime+item%frequency
-              end if
-           end do
+        ! Is there only one file for this dataset?
+        if (item%frequency == zero) then
            if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
-              write(*,'(a,a,a,a)') ' DEBUG: Untemplating ',trim(item%file)
+              write(*,'(a,a,a,a)') ' DEBUG: Scanning fixed file ',trim(item%file),' for side ',bSide
+           end if
+           UniFileClim = .false.
+           ! if the file is constant, i.e. no tokens in in the template
+           ! but it was marked as cyclic we must have a year long climatology 
+           ! on one file, set UniFileClim to true
+           if (trim(item%cyclic)=='y') UniFileClim = .true.
+           file_processed = item%file
+           call MakeMetadata(file_processed,item%pfioCollection_id,fdata,__RC__)
+           ! Retrieve the time series
+           call fdata%get_time_vec(xTSeries,rc=status)
+           If (status /= ESMF_SUCCESS) then
+              if (mapl_am_I_root()) Then
+                 write(*,'(a,a)') ' ERROR: Time vector retrieval failed on fixed file ',trim(item%file)
+              end if
+              _RETURN(ESMF_FAILURE)
+           end if
+           call GetBracketTimeOnSingleFile(fdata,xTSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,item%climYear,rc=status)
+           if (status /= ESMF_SUCCESS) then
+              if (mapl_am_I_root()) Then
+                 write(*,'(a,a,a,a)') ' ERROR: Bracket timing request failed on fixed file ',trim(item%file),' for side ',bSide
+              end if
+              _RETURN(ESMF_FAILURE)
+           end if
+        else 
+           if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
+              write(*,'(a,a,a,a)') ' DEBUG: Scanning template ',trim(item%file),' for side ',bSide
               call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
               Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Target time   : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-              call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File time     : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-              call ESMF_TimeIntervalGet(item%frequency,yy=iyr,mm=imm,d=idd,h=ihr,m=imn,s=isc,__RC__)
-              Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> item%frequency     : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-              Write(*,'(a,I5)')             ' >> >> >> N             : ',n
-           end if
-        end if
-        readTime = cTime
-        call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        call MAPL_PackTime(curDate,iyr,imm,idd)
-        call MAPL_PackTime(curTime,ihr,imn,isc)
-        call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
-        Inquire(FILE=trim(file_processed),EXIST=found)
-        If (found) Then
-           if (mapl_am_I_root().and.(Ext_Debug > 19)) Then 
-              write(*,'(a,a,a,a)') ' DEBUG: Target file for ',trim(item%file),' found and is ',trim(file_processed)
-           end if
-           !yrOffset = 0
-        Else if (allowExtrap) then 
-           if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
-              write(*,'(a,a,a)') ' DEBUG: Propagating forwards on ',trim(item%file),' from reference time'
               call ESMF_TimeGet(item%reff_time,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
               Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Reference time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
            end if
-           ! Go back to the reference time, and propagate forwards until we find
-           ! the first valid file
-           ftime = item%reff_time
-           call ESMF_TimeGet(item%reff_time,yy=refYear,__RC__)
-           If (refYear.lt.1850) Then
-              if (mapl_am_I_root()) Then
-                 write(*,'(a,I0.4,a,a)') 'Reference year too early (', refYear, '). Aborting search for data from ',trim(item%file)
-              end if
-              _RETURN(ESMF_FAILURE)
-           End If
-           intOK = .True.
+           UniFileClim = .false.
            found = .false.
-           ! yrOffset currently tracking how far we are from the reference year
-           n = 0
-           yrOffset = 0
-           ftime = item%reff_time
-           Do While (intOK.and.(.not.found))
-              call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              call MAPL_PackTime(curDate,iyr,imm,idd)
-              call MAPL_PackTime(curTime,ihr,imn,isc)
-              call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
-              Inquire(FILE=trim(file_processed),EXIST=found)
-              yrOffset = iYr-refYear
-              intOK = (abs(yrOffset)<maxOffset)
-              if (.not.found) then
-                 n = n + 1
-                 ftime = ftime + item%frequency
+           ! Start by assuming the file we want exists
+           if (trim(item%cyclic)=='y') then
+              ! if climatology compute year offset
+              call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              yrOffset = item%climYear - iyr
+              call OffsetTimeYear(cTime,yrOffset,fTime,rc)
+           else
+              yrOffset = 0
+              if (item%reff_time > cTime) then
+                 _ASSERT(.False.,'Reference time for file ' // trim(item%file) // ' is too late')
               end if
-           End Do
-           If (.not.found) Then
-              if (mapl_am_I_root()) Then
-                 write(*,'(a,a)') 'Could not find data within maximum offset range from ',trim(item%file)
-                 write(*,'(a,2(x,I0.5))') 'Test year and reference year: ', iYr, refYear
-                 call ESMF_TimeGet(item%reff_time,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Reference time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-                 call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Last check    : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-              end if
-              _RETURN(ESMF_FAILURE)
-           End If
-          ! Generate CFIO
-           call MakeCFIO(file_processed,item%collection_id,xCFIO,rc=status)
-           ! Retrieve the time series
-           if (allocated(xTseries)) deallocate(xTseries)
-           allocate(xTSeries(xCFIO%tSteps))
-           call GetTimesOnFile(xCFIO,xTSeries,rc=rc)
-           ! Is this before or after our target time?
-           LSide   = (bSide == "L")
-           RSide   = (.not.LSide)
-           LExact  = (cTime == xTSeries(1))
-           LExtrap = (cTime <  xTSeries(1))
-           RExact  = (cTime == xTSeries(xCFIO%tSteps))
-           RExtrap = (cTime >  xTSeries(xCFIO%tSteps))
-           found = .false.
-           If (LExtrap.or.(LExact.and.RSide)) Then
-              if (mapl_am_I_root().and.(Ext_Debug>2)) Then
-                 write(*,'(a,a,a,a)') ' Extrapolating BACKWARD for bracket ', bSide, ' for file ',trim(item%file)
-              end if
-              ! We have data from future years
-              ! Advance the target time until we can have what we want
-              call ESMF_TimeGet(cTime,yy=cYearOff,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              iYr = refYear + yrOffset
-              ! Convert year offset to the future value
-              yrOffset = iYr - cYearOff
-              ! Determine the template time
-              call ESMF_TimeSet(newTime,yy=iYr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              ! This approach causes a problem if cTime and item%reff_time are too far
+              ! apart - do it the hard way instead... 
               ftime = item%reff_time
               n = 0
+              ! SDE DEBUG: This caused problems in the past but the
+              ! alternative is far too slow... need to keep an eye 
+              ! on this but the Max(0,...) should help.
+              n = max(0,floor((cTime-item%reff_time)/item%frequency))
+              if (n>0) fTime = fTime + (n*item%frequency)
               do while (.not.found)
-                 found = ((ftime + item%frequency) > newtime)
+                 ! SDE: This needs to be ">"
+                 found = ((ftime + item%frequency) > ctime)
                  if (.not.found) then
                     n = n + 1
                     ftime = fTime+item%frequency
                  end if
               end do
-              ! untemplate file
-              call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              ! Build file name
-              call MAPL_PackTime(curDate,iyr,imm,idd)
-              call MAPL_PackTime(curTime,ihr,imn,isc)
-              call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
-              Inquire(FILE=trim(file_processed),EXIST=found)
-              If (.not.found) Then
+              if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
+                 write(*,'(a,a,a,a)') ' DEBUG: Untemplating ',trim(item%file)
+                 call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Target time   : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+                 call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File time     : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+                 call ESMF_TimeIntervalGet(item%frequency,yy=iyr,mm=imm,d=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> item%frequency     : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+                 Write(*,'(a,I5)')             ' >> >> >> N             : ',n
+              end if
+           end if
+           readTime = cTime
+           call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           call MAPL_PackTime(curDate,iyr,imm,idd)
+           call MAPL_PackTime(curTime,ihr,imn,isc)
+           call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
+           Inquire(FILE=trim(file_processed),EXIST=found)
+           If (found) Then
+              if (mapl_am_I_root().and.(Ext_Debug > 19)) Then 
+                 write(*,'(a,a,a,a)') ' DEBUG: Target file for ',trim(item%file),' found and is ',trim(file_processed)
+              end if
+              !yrOffset = 0
+           Else if (allowExtrap) then 
+              if (mapl_am_I_root().and.(Ext_Debug > 19)) Then
+                 write(*,'(a,a,a)') ' DEBUG: Propagating forwards on ',trim(item%file),' from reference time'
+                 call ESMF_TimeGet(item%reff_time,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Reference time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+              end if
+              ! Go back to the reference time, and propagate forwards until we find
+              ! the first valid file
+              ftime = item%reff_time
+              call ESMF_TimeGet(item%reff_time,yy=refYear,__RC__)
+              If (refYear.lt.1850) Then
                  if (mapl_am_I_root()) Then
-                    write(*,'(a,a,a,a)') ' ERROR: Failed to project data from ',trim(item%file),' for side ',bSide
+                    write(*,'(a,I0.4,a,a)') 'Reference year too early (', refYear, '). Aborting search for data from ',trim(item%file)
                  end if
                  _RETURN(ESMF_FAILURE)
               End If
-           ElseIf (RExtrap.or.(RExact.and.RSide)) Then
-              if (mapl_am_I_root().and.(Ext_Debug>2)) Then
-                 write(*,'(a,a,a,a)') ' Extrapolating FORWARD for bracket ', bSide, ' for file ',trim(item%file)
-              end if
-              ! We have data from past years
-              ! Rewind the target time until we can have what we want
-              call ESMF_TimeGet(cTime,yy=refYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              intOK = .True.
+              found = .false.
+              ! yrOffset currently tracking how far we are from the reference year
+              n = 0
               yrOffset = 0
-              fTime = cTime
-              ! yrOffset: Number of years added from current time to get file time
-              Do While ((.not.found).and.(abs(yrOffset).lt.maxOffset))
-                 yrOffset = yrOffset - 1
-                 iYr = refYear + yrOffset
-                 call ESMF_TimeSet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                 ! Error check - if the new time is before the first file time,
-                 ! all is lost
-                 If (newTime.lt.xTSeries(1)) exit
-                 do while (ftime > newTime)
-                    fTime = fTime - item%frequency
-                    n = n - 1
-                 end do 
-                 ! untemplate file
+              ftime = item%reff_time
+              Do While (intOK.and.(.not.found))
                  call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
                  call MAPL_PackTime(curDate,iyr,imm,idd)
                  call MAPL_PackTime(curTime,ihr,imn,isc)
                  call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
                  Inquire(FILE=trim(file_processed),EXIST=found)
+                 yrOffset = iYr-refYear
+                 intOK = (abs(yrOffset)<maxOffset)
+                 if (.not.found) then
+                    n = n + 1
+                    ftime = ftime + item%frequency
+                 end if
               End Do
               If (.not.found) Then
                  if (mapl_am_I_root()) Then
-                    write(*,'(a,a,a,a)') ' ERROR: Could not determine upper bounds on ',trim(item%file),' for side ',bSide
+                    write(*,'(a,a)') 'Could not find data within maximum offset range from ',trim(item%file)
+                    write(*,'(a,2(x,I0.5))') 'Test year and reference year: ', iYr, refYear
+                    call ESMF_TimeGet(item%reff_time,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Reference time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+                    call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Last check    : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
                  end if
                  _RETURN(ESMF_FAILURE)
               End If
-           Else
-              if (mapl_am_I_root()) Then
-                 write(*,'(a,a,a,a)') ' ERROR: Unkown error while scanning ',trim(item%file),' for side ',bSide
-              end if
-              _RETURN(ESMF_FAILURE)
-           End If
-        End If
-
-        ! Should now have the "correct" time
-        ! Generate CFIO for the "current" file
-        If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a)') ' DEBUG: Generating CFIO for ', trim(file_processed)
-        ! Generate CFIO
-        call MakeCFIO(file_processed,item%collection_id,xCFIO,rc=status)
-        ! Retrieve the time series
-        if (allocated(xTseries)) deallocate(xTseries)
-        allocate(xTSeries(xCFIO%tSteps))
-        call GetTimesOnFile(xCFIO,xTSeries,rc=rc)
-
-        ! We now have a time which, when passed to the FILE TEMPLATE, returns a valid file
-        ! However, if the file template does not include a year token, then the file in
-        ! question could actually be for a different year. We therefore feed the file time
-        ! into the refresh template and see if the result has the same year. If it doesn't,
-        ! then we can assume that the year is actually fixed, and the times in the file will
-        ! correspond to the year in the refresh template. In this case, an additional year 
-        ! offset must be applied.
-        yrOffsetStamp = 0
-        buff = trim(item%refresh_template)
-        buff = ESMF_UtilStringLowerCase(buff, __RC__)
-        If (buff /= "0" .and. index(buff,"p")==0) Then
-           newTime = timestamp_(fTime,item%refresh_template,__RC__)
-           if (newTime .ne. fTime) Then
-              call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              call ESMF_TimeGet(newTime,yy=fyr,mm=fmm,dd=fdd,h=fhr,m=fmn,s=fsc,__RC__)
-              yrOffsetStamp = fYr - iYr
-           End If
-        End If
-
-        ! try to get bracketing time on file using current time
-        call GetBracketTimeOnFile(xCFIO,xTSeries,readTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt=yrOffset+yrOffsetStamp,rc=status)
-        found = (status==ESMF_SUCCESS)
-
-        If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,L1)') ' DEBUG: Status of ', trim(file_processed),': ', found
-
-        ! if we didn't find the bracketing time look forwards or backwards depending on
-        ! whether it is the right or left time   
-        if (.not.found) then
-           If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,a,a,L1)') ' DEBUG: Scanning for bracket ', bSide, ' of ', trim(file_processed), '. RSide: ', (bSide=="R")
-           bracketScan = .True.
-           newTime = fTime
-           if (bSide == "R") then
-              found=.false.
-              newFile=allowExtrap
-              status = ESMF_SUCCESS
-              If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,I5,x,2L1)') ' DEBUG: Sanity check on file ', trim(file_processed), ' with flags: ', status, status==ESMF_SUCCESS,found
-              do while ((status==ESMF_SUCCESS).and.(.not.found))
-                 ! check next time
-                 newTime = fTime + item%frequency
-                 if (trim(item%cyclic)=='y') then
-                    call ESMF_TimeGet(fTime,yy=OldYear)
-                    call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                    if (oldyear/=iyr) then
-                       call ESMF_TimeSet(newTime,yy=oldyear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                       yrOffset = yrOffset - 1
-                       If (MAPL_Am_I_Root()) Write(*,'(a,I0.4,5(a,I0.2))') ' DEBUG: IN clim after ',Oldyear,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
-                    end if
+              call MakeMetadata(file_processed,item%pfioCollection_id,fdata,__RC__)
+              ! Retrieve the time series
+              if (allocated(xTseries)) deallocate(xTseries)
+              call fdata%get_time_vec(xTseries,__RC__)
+              ! Is this before or after our target time?
+              LSide   = (bSide == "L")
+              RSide   = (.not.LSide)
+              LExact  = (cTime == xTSeries(1))
+              LExtrap = (cTime <  xTSeries(1))
+              RExact  = (cTime == xTSeries(size(xTSeries)))
+              RExtrap = (cTime >  xTSeries(size(XTSeries)))
+              found = .false.
+              If (LExtrap.or.(LExact.and.RSide)) Then
+                 if (mapl_am_I_root().and.(Ext_Debug>2)) Then
+                    write(*,'(a,a,a,a)') ' Extrapolating BACKWARD for bracket ', bSide, ' for file ',trim(item%file)
                  end if
+                 ! We have data from future years
+                 ! Advance the target time until we can have what we want
+                 call ESMF_TimeGet(cTime,yy=cYearOff,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 iYr = refYear + yrOffset
+                 ! Convert year offset to the future value
+                 yrOffset = iYr - cYearOff
+                 ! Determine the template time
+                 call ESMF_TimeSet(newTime,yy=iYr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 ftime = item%reff_time
+                 n = 0
+                 do while (.not.found)
+                    found = ((ftime + item%frequency) > newtime)
+                    if (.not.found) then
+                       n = n + 1
+                       ftime = fTime+item%frequency
+                    end if
+                 end do
                  ! untemplate file
-                 call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-
+                 call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 ! Build file name
                  call MAPL_PackTime(curDate,iyr,imm,idd)
                  call MAPL_PackTime(curTime,ihr,imn,isc)
                  call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
-                 If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,I0.4,5(a,I0.2))') ' DEBUG: Testing for file ', trim(file_processed), ' for target time ',iYr,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
                  Inquire(FILE=trim(file_processed),EXIST=found)
-                 If (found) Then
-                    fTime = newTime
-                 Else If (newFile) Then
-                    ! We went RIGHT - cycle round by SUBTRACTING a year
+                 If (.not.found) Then
+                    if (mapl_am_I_root()) Then
+                       write(*,'(a,a,a,a)') ' ERROR: Failed to project data from ',trim(item%file),' for side ',bSide
+                    end if
+                    _RETURN(ESMF_FAILURE)
+                 End If
+              ElseIf (RExtrap.or.(RExact.and.RSide)) Then
+                 if (mapl_am_I_root().and.(Ext_Debug>2)) Then
+                    write(*,'(a,a,a,a)') ' Extrapolating FORWARD for bracket ', bSide, ' for file ',trim(item%file)
+                 end if
+                 ! We have data from past years
+                 ! Rewind the target time until we can have what we want
+                 call ESMF_TimeGet(cTime,yy=refYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 yrOffset = 0
+                 fTime = cTime
+                 ! yrOffset: Number of years added from current time to get file time
+                 Do While ((.not.found).and.(abs(yrOffset).lt.maxOffset))
                     yrOffset = yrOffset - 1
-                    newFile = .False. ! Only one attempt
-                    call OffsetTimeYear(fTime,-1,newTime,rc)
-                    fTime = newTime
-                 Else
-                    status = ESMF_FAILURE
-                 End If
-              End Do
-              if (status /= ESMF_SUCCESS) then
-                 if (mapl_am_I_root()) write(*,*)'ExtData could not find appropriate file from file template ',trim(item%file),' for side ',bSide
-                 _RETURN(ESMF_FAILURE)
-              end if
-           else if (bSide == "L") then
-              found=.false.
-              newFile=allowExtrap
-              status = ESMF_SUCCESS
-              do while ((status==ESMF_SUCCESS).and.(.not.found))
-                 ! check next time
-                 newTime = fTime - item%frequency
-                 if (trim(item%cyclic)=='y') then
-                    call ESMF_TimeGet(fTime,yy=OldYear)
-                    call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                    if (oldyear/=iyr) then
-                       call ESMF_TimeSet(newTime,yy=oldyear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                       yrOffset = yrOffset + 1
-                       If (MAPL_Am_I_Root()) Write(*,'(a,I0.4,5(a,I0.2))') ' DEBUG: IN clim after ',Oldyear,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
+                    iYr = refYear + yrOffset
+                    call ESMF_TimeSet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    ! Error check - if the new time is before the first file time,
+                    ! all is lost
+                    If (newTime.lt.xTSeries(1)) exit
+                    do while (ftime > newTime)
+                       fTime = fTime - item%frequency
+                       n = n - 1
+                    end do 
+                    ! untemplate file
+                    call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    call MAPL_PackTime(curDate,iyr,imm,idd)
+                    call MAPL_PackTime(curTime,ihr,imn,isc)
+                    call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
+                    Inquire(FILE=trim(file_processed),EXIST=found)
+                 End Do
+                 If (.not.found) Then
+                    if (mapl_am_I_root()) Then
+                       write(*,'(a,a,a,a)') ' ERROR: Could not determine upper bounds on ',trim(item%file),' for side ',bSide
                     end if
-                 end if
-                 ! untemplate file
-                 call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-
-                 call MAPL_PackTime(curDate,iyr,imm,idd)
-                 call MAPL_PackTime(curTime,ihr,imn,isc)
-                 call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
-                 Inquire(FILE=trim(file_processed),EXIST=found)
-                 If (found) Then
-                    fTime = newTime
-                 Else If (newFile) Then
-                    ! We went LEFT - cycle round by ADDING a year
-                    yrOffset = yrOffset + 1
-                    newFile = .False. ! Only one attempt
-                    call OffsetTimeYear(fTime,+1,newTime,rc)
-                    fTime = newTime
-                 Else
-                    status = ESMF_FAILURE
+                    _RETURN(ESMF_FAILURE)
                  End If
-              End Do
-              if (status /= ESMF_SUCCESS) then
-                 if (mapl_am_I_root()) write(*,*)'ExtData could not find appropriate file from file template ',trim(item%file),' for side ',bSide
+              Else
+                 if (mapl_am_I_root()) Then
+                    write(*,'(a,a,a,a)') ' ERROR: Unkown error while scanning ',trim(item%file),' for side ',bSide
+                 end if
                  _RETURN(ESMF_FAILURE)
-              end if
-           end if
+              End If
+           End If
 
-           ! fTime is now ALWAYS the time which was applied to the file template to get the current file
-           ! Generate CFIO
-           call MakeCFIO(file_processed,item%collection_id,xCFIO,rc=status)
-           if (allocated(xTSeries)) deallocate(xTSeries)
+           ! Should now have the "correct" time
+           If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a)') ' DEBUG: Generating CFIO for ', trim(file_processed)
+           call MakeMetadata(file_processed,item%pfioCOllection_id,fdata,__RC__)
            ! Retrieve the time series
-           allocate(xTSeries(xCFIO%tSteps))
-           call GetTimesOnFile(xCFIO,xTSeries,rc=rc)
+           if (allocated(xTseries)) deallocate(xTseries)
+           call fdata%get_time_vec(xTSeries,__RC__)
 
-           !If (Mapl_Am_I_Root()) Write (*,'(a,a,x,a)') ' SUPERDEBUG: File/template: ',Trim(file_processed),Trim(item%refresh_template)
-           ! The file template may be "hiding" a year offset from us
+           ! We now have a time which, when passed to the FILE TEMPLATE, returns a valid file
+           ! However, if the file template does not include a year token, then the file in
+           ! question could actually be for a different year. We therefore feed the file time
+           ! into the refresh template and see if the result has the same year. If it doesn't,
+           ! then we can assume that the year is actually fixed, and the times in the file will
+           ! correspond to the year in the refresh template. In this case, an additional year 
+           ! offset must be applied.
            yrOffsetStamp = 0
            buff = trim(item%refresh_template)
            buff = ESMF_UtilStringLowerCase(buff, __RC__)
-           If (buff /= "0" .and. index(buff,"p")==0 ) Then
+           If (buff /= "0" .and. index(buff,"p")==0) Then
               newTime = timestamp_(fTime,item%refresh_template,__RC__)
-              If (Mapl_Am_I_Root().and.Ext_Debug > 24) Then
-                 call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                 call ESMF_TimeGet(newTime,yy=fyr,mm=fmm,dd=fdd,h=fhr,m=fmn,s=fsc,__RC__)
-                 Write(*,'(3a,I0.4,5(a,I0.2),a,I0.4,5(a,I0.2),2a)') ' DEBUG: Template ',Trim(item%refresh_template),' applied: ',&
-                    iyr,'-',imm,'-',idd,' ',ihr,':',imn,':',isc,' -> ',&
-                    fyr,'-',fmm,'-',fdd,' ',fhr,':',fmn,':',fsc,&
-                    ' on file ',Trim(file_processed)
-              End If
               if (newTime .ne. fTime) Then
                  call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
                  call ESMF_TimeGet(newTime,yy=fyr,mm=fmm,dd=fdd,h=fhr,m=fmn,s=fsc,__RC__)
                  yrOffsetStamp = fYr - iYr
-                 If (Mapl_Am_I_Root().and.Ext_Debug > 19) Then
-                    Write(*,'(2(a,I4),2a)') ' DEBUG: Year offset modified from ',yrOffset,' to ',yrOffset+yrOffsetStamp,' to satisfy refresh template for ', Trim(file_processed)
-                 End If
               End If
            End If
 
-           ! try to get bracketing time on file using new time
-           call GetBracketTimeOnFile(xCFIO,xTSeries,readTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt=yrOffset+yrOffsetStamp,rc=status)
-           found = (status == ESMF_SUCCESS)
+           ! try to get bracketing time on file using current time
+           call GetBracketTimeOnFile(fdata,xTSeries,readTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt=yrOffset+yrOffsetStamp,rc=status)
+           found = (status==ESMF_SUCCESS)
+
+           If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,L1)') ' DEBUG: Status of ', trim(file_processed),': ', found
+
+           ! if we didn't find the bracketing time look forwards or backwards depending on
+           ! whether it is the right or left time   
            if (.not.found) then
-              if (mapl_am_I_root()) write(*,*)'ExtData could not find bracketing data from file template ',trim(item%file),' for side ',bSide
-              _RETURN(ESMF_FAILURE)
+              If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,a,a,L1)') ' DEBUG: Scanning for bracket ', bSide, ' of ', trim(file_processed), '. RSide: ', (bSide=="R")
+              bracketScan = .True.
+              newTime = fTime
+              if (bSide == "R") then
+                 found=.false.
+                 newFile=allowExtrap
+                 status = ESMF_SUCCESS
+                 If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,I5,x,2L1)') ' DEBUG: Sanity check on file ', trim(file_processed), ' with flags: ', status, status==ESMF_SUCCESS,found
+                 do while ((status==ESMF_SUCCESS).and.(.not.found))
+                    ! check next time
+                    newTime = fTime + item%frequency
+                    if (trim(item%cyclic)=='y') then
+                       call ESMF_TimeGet(fTime,yy=OldYear)
+                       call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                       if (oldyear/=iyr) then
+                          call ESMF_TimeSet(newTime,yy=oldyear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                          yrOffset = yrOffset - 1
+                          If (MAPL_Am_I_Root()) Write(*,'(a,I0.4,5(a,I0.2))') ' DEBUG: IN clim after ',Oldyear,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
+                       end if
+                    end if
+                    ! untemplate file
+                    call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+
+                    call MAPL_PackTime(curDate,iyr,imm,idd)
+                    call MAPL_PackTime(curTime,ihr,imn,isc)
+                    call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
+                    If (MAPL_Am_I_Root().and.(Ext_Debug > 19)) Write(*,'(a,a,a,I0.4,5(a,I0.2))') ' DEBUG: Testing for file ', trim(file_processed), ' for target time ',iYr,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
+                    Inquire(FILE=trim(file_processed),EXIST=found)
+                    If (found) Then
+                       fTime = newTime
+                    Else If (newFile) Then
+                       ! We went RIGHT - cycle round by SUBTRACTING a year
+                       yrOffset = yrOffset - 1
+                       newFile = .False. ! Only one attempt
+                       call OffsetTimeYear(fTime,-1,newTime,rc)
+                       fTime = newTime
+                    Else
+                       status = ESMF_FAILURE
+                    End If
+                 End Do
+                 if (status /= ESMF_SUCCESS) then
+                    if (mapl_am_I_root()) write(*,*)'ExtData could not find appropriate file from file template ',trim(item%file),' for side ',bSide
+                    _RETURN(ESMF_FAILURE)
+                 end if
+              else if (bSide == "L") then
+                 found=.false.
+                 newFile=allowExtrap
+                 status = ESMF_SUCCESS
+                 do while ((status==ESMF_SUCCESS).and.(.not.found))
+                    ! check next time
+                    newTime = fTime - item%frequency
+                    if (trim(item%cyclic)=='y') then
+                       call ESMF_TimeGet(fTime,yy=OldYear)
+                       call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                       if (oldyear/=iyr) then
+                          call ESMF_TimeSet(newTime,yy=oldyear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                          yrOffset = yrOffset + 1
+                          If (MAPL_Am_I_Root()) Write(*,'(a,I0.4,5(a,I0.2))') ' DEBUG: IN clim after ',Oldyear,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
+                       end if
+                    end if
+                    ! untemplate file
+                    call ESMF_TimeGet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+
+                    call MAPL_PackTime(curDate,iyr,imm,idd)
+                    call MAPL_PackTime(curTime,ihr,imn,isc)
+                    call gx_(file_processed,item%file,nymd=curDate,nhms=curTime,__STAT__)
+                    Inquire(FILE=trim(file_processed),EXIST=found)
+                    If (found) Then
+                       fTime = newTime
+                    Else If (newFile) Then
+                       ! We went LEFT - cycle round by ADDING a year
+                       yrOffset = yrOffset + 1
+                       newFile = .False. ! Only one attempt
+                       call OffsetTimeYear(fTime,+1,newTime,rc)
+                       fTime = newTime
+                    Else
+                       status = ESMF_FAILURE
+                    End If
+                 End Do
+                 if (status /= ESMF_SUCCESS) then
+                    if (mapl_am_I_root()) write(*,*)'ExtData could not find appropriate file from file template ',trim(item%file),' for side ',bSide
+                    _RETURN(ESMF_FAILURE)
+                 end if
+              end if
+
+              ! fTime is now ALWAYS the time which was applied to the file template to get the current file
+              call MakeMetadata(file_processed,item%pfioCollection_id,fdata,rc=status)
+              if (allocated(xTSeries)) deallocate(xTSeries)
+              call fdata%get_time_vec(xTSeries,__RC__)
+
+              !If (Mapl_Am_I_Root()) Write (*,'(a,a,x,a)') ' SUPERDEBUG: File/template: ',Trim(file_processed),Trim(item%refresh_template)
+              ! The file template may be "hiding" a year offset from us
+              yrOffsetStamp = 0
+              buff = trim(item%refresh_template)
+              buff = ESMF_UtilStringLowerCase(buff, __RC__)
+              If (buff /= "0" .and. index(buff,"p")==0 ) Then
+                 newTime = timestamp_(fTime,item%refresh_template,__RC__)
+                 If (Mapl_Am_I_Root().and.Ext_Debug > 24) Then
+                    call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    call ESMF_TimeGet(newTime,yy=fyr,mm=fmm,dd=fdd,h=fhr,m=fmn,s=fsc,__RC__)
+                    Write(*,'(3a,I0.4,5(a,I0.2),a,I0.4,5(a,I0.2),2a)') ' DEBUG: Template ',Trim(item%refresh_template),' applied: ',&
+                       iyr,'-',imm,'-',idd,' ',ihr,':',imn,':',isc,' -> ',&
+                       fyr,'-',fmm,'-',fdd,' ',fhr,':',fmn,':',fsc,&
+                       ' on file ',Trim(file_processed)
+                 End If
+                 if (newTime .ne. fTime) Then
+                    call ESMF_TimeGet(fTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    call ESMF_TimeGet(newTime,yy=fyr,mm=fmm,dd=fdd,h=fhr,m=fmn,s=fsc,__RC__)
+                    yrOffsetStamp = fYr - iYr
+                    If (Mapl_Am_I_Root().and.Ext_Debug > 19) Then
+                       Write(*,'(2(a,I4),2a)') ' DEBUG: Year offset modified from ',yrOffset,' to ',yrOffset+yrOffsetStamp,' to satisfy refresh template for ', Trim(file_processed)
+                    End If
+                 End If
+              End If
+
+              ! try to get bracketing time on file using new time
+              call GetBracketTimeOnFile(fdata,xTSeries,readTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt=yrOffset+yrOffsetStamp,rc=status)
+              found = (status == ESMF_SUCCESS)
+              if (.not.found) then
+                 if (mapl_am_I_root()) write(*,*)'ExtData could not find bracketing data from file template ',trim(item%file),' for side ',bSide
+                 _RETURN(ESMF_FAILURE)
+
+              end if
 
            end if
 
         end if
 
-     end if
-
-     ! Debug
-     If (Mapl_Am_I_Root().and.Ext_Debug > 10) Then 
-        Write(*,'(a,a,a,a)') '  >> >> Updated bracket ', bSide, ' for ', Trim(file_processed)
-        call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Time requested: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-        call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Record time   : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-        call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Effective time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-     End If
-     ! If we made it this far, then I guess we are OK?
-     if (bside =='R') then
-        item%tindex2=tindex
-     else if (bside =='L') then
-        item%tindex1=tindex
-     end if
-     _RETURN(ESMF_SUCCESS)
-    
-  end subroutine UpdateBracketTime
-
-  subroutine MakeCFIO(file,collection_id,cfio,rc)
-     character(len=*), intent(in   ) :: file
-     integer, intent(in)                       :: collection_id
-     type(ESMF_CFIO), pointer, intent(inout)   :: cfio
-     integer, optional,          intent(out  ) :: rc
-     type(CFIOCollection), pointer :: collection => null()
-
-     __Iam__('MakeCFIO')
-
-     collection => collections%at(collection_id)
-     cfio => collection%find(file)
-
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 9)) Then
-        Write(6,'(a,a)') ' DEBUG: Retrieving cfioobject for: ', Trim(file)
-     End If
-
-     _RETURN(ESMF_SUCCESS)
-  end subroutine
-
-  subroutine GetTimesOnFile(cfio,tSeries,rc)
-     type(ESMF_CFIO)                           :: cfio
-     type(ESMF_Time)                           :: tSeries(:)
-     integer, optional,          intent(out  ) :: rc
-
-     __Iam__('GetTimesOnFile')
-
-     integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     integer                            :: i
-     integer(ESMF_KIND_I8)              :: iCurrInterval
-     integer                            :: nhmsB, nymdB
-     integer                            :: begDate, begTime
-     integer(ESMF_KIND_I8),allocatable  :: tSeriesInt(:)
-
-     allocate(tSeriesInt(cfio%tSteps))
-     call getDateTimeVec(cfio%fid,begDate,begTime,tSeriesInt,__RC__)
-     
-     ! Assume success
-     If (present(rc))  rc=ESMF_SUCCESS
-
-     ! Debug level 3
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 2)) Then
-        Write(*,'(a,a)') '  >> >> Reading times from ', Trim(cfio%fName)
-        Write(*,'(a,2(x,I0.10),x,I0.4)') '  >> >> File timing info:', begDate, begTime, cfio%tSteps
-     End If
-
-     do i=1,cfio%tSteps
-        iCurrInterval = tSeriesInt(i)
-        call GetDate ( begDate, begTime, iCurrInterval, nymdB, nhmsB, status )
-        call MAPL_UnpackTime(nymdB,iyr,imm,idd)
-        call MAPL_UnpackTime(nhmsB,ihr,imn,isc)
-        ! Debug level 4
-        If (Mapl_Am_I_Root()) Then
-           If ((Ext_Debug > 4).or.((Ext_Debug > 3).and.((i.eq.1).or.(i.eq.cfio%tSteps)))) Then
-              Write(*,'(a,I0.6,a,I0.4,5(a,I0.2))') ' >> >> STD Sample ',i,':  ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-           End If
+        ! Debug
+        If (Mapl_Am_I_Root().and.Ext_Debug > 10) Then 
+           Write(*,'(a,a,a,a)') '  >> >> Updated bracket ', bSide, ' for ', Trim(file_processed)
+           call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Time requested: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+           call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Record time   : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+           call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Effective time: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
         End If
-        call ESMF_TimeSet(tSeries(i), yy=iyr, mm=imm, dd=idd,  h=ihr,  m=imn, s=isc,__RC__)
-     enddo
+        ! If we made it this far, then I guess we are OK?
+        if (bside =='R') then
+           item%tindex2=tindex
+        else if (bside =='L') then
+           item%tindex1=tindex
+        end if
+        _RETURN(ESMF_SUCCESS)
+       
+     end subroutine UpdateBracketTime
+ 
+     subroutine swapBracketInformation(item,rc)
+        type(PrimaryExport), intent(inout) :: item
+        integer, optional, intent(out) :: rc
 
-     deallocate(tSeriesInt)
-     return
+        integer :: status
+        integer :: j, fieldRank, fieldCount
+        type(ESMF_Field) :: field1, field2
+        real, pointer :: var2d_prev(:,:)
+        real, pointer :: var3d_prev(:,:,:)
+        real, pointer :: var2d_next(:,:)
+        real, pointer :: var3d_next(:,:,:)
+        character(len=ESMF_MAXSTR), ALLOCATABLE  :: NAMES (:)
 
-  end subroutine GetTimesOnFile
+        item%interp_time1 = item%interp_time2
 
-  subroutine OffsetTimeYear(inTime,yrOffset,outTime,rc)
+        if (item%vartype == MAPL_FieldItem) then
+
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp1, dimCount=fieldRank,__RC__)
+           if (fieldRank == 2) then
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+              var2d_prev=var2d_next
+           else if (fieldRank == 3) then
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+              var3d_prev=var3d_next
+           endif
+
+        else if (item%vartype == MAPL_BundleItem) then
+
+           call ESMF_FieldBundleGet(item%binterp2, fieldCount = fieldCount, __RC__)
+           allocate(names(fieldCount),__STAT__)
+           call ESMF_FieldBundleGet(item%binterp2, fieldNameList = Names, __RC__)
+           do j = 1,fieldCount
+              call ESMF_FieldBundleGet(item%binterp1, names(j), field=field1, __RC__)
+              call ESMF_FieldBundleGet(item%binterp2, names(j), field=field2, __RC__)
+              call ESMF_FieldGet(field1, dimCount=fieldRank, __RC__) 
+              if (fieldRank == 2) then
+                 call ESMF_FieldGet(field1, localDE=0, farrayPtr=var2d_prev, __RC__)
+                 call ESMF_FieldGet(field2, localDE=0, farrayPtr=var2d_next, __RC__)
+                 var2d_prev=var2d_next
+              else if (fieldRank == 3) then
+                 call ESMF_FieldGet(field1, localDE=0, farrayPtr=var3d_prev, __RC__)
+                 call ESMF_FieldGet(field2, localDE=0, farrayPtr=var3d_next, __RC__)
+                 var3d_prev=var3d_next
+              endif
+           enddo
+
+           deallocate(names)
+
+        else if (item%vartype == MAPL_ExtDataVectorItem) then
+
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp1, dimCount=fieldRank, __RC__)
+           if (fieldRank == 2) then
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+              var2d_prev=var2d_next
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+              var2d_prev=var2d_next
+           else if (fieldRank == 3) then
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+              var3d_prev=var3d_next
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+              var3d_prev=var3d_next
+           endif
+
+        end if
+
+     end subroutine swapBracketInformation
+
+     subroutine makeMetadata(file,collection_id,metadata,rc)
+        character(len=*), intent(in   ) :: file
+        integer, intent(in)                       :: collection_id
+        type(FileMetadataUtils), pointer, intent(inout)   :: metadata
+        integer, optional,          intent(out  ) :: rc
+        type(MAPLExtDataCollection), pointer :: collection => null()
+        integer :: status
+
+        Collection => ExtDataCollections%at(collection_id)
+        metadata => collection%find(file)
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 9)) Then
+           Write(6,'(a,a)') ' DEBUG: Retrieving formatter for: ', Trim(file)
+        End If
+        _RETURN(_SUCCESS)
+
+     end subroutine makeMetadata
+
+     subroutine makeGridFromCollection(file,collection_id,grid,rc)
+        character(len=*), intent(in   ) :: file
+        integer, intent(in)                       :: collection_id
+        type(ESMF_Grid), intent(inout) :: grid
+        integer, optional,          intent(out  ) :: rc
+        type(MAPLExtDataCollection), pointer :: collection => null()
+
+        Collection => ExtDataCollections%at(collection_id)
+        grid = collection%src_grid
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 9)) Then
+           Write(6,'(a,a)') ' DEBUG: Retrieving grid for: ', Trim(file)
+        End If
+
+     end subroutine makeGridFromCollection
+
+     subroutine GetTimesOnFile(cfio,tSeries,rc)
+        type(ESMF_CFIO)                           :: cfio
+        type(ESMF_Time)                           :: tSeries(:)
+        integer, optional,          intent(out  ) :: rc
+
+        __Iam__('GetTimesOnFile')
+
+        integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
+        integer                            :: i
+        integer(ESMF_KIND_I8)              :: iCurrInterval
+        integer                            :: nhmsB, nymdB
+        integer                            :: begDate, begTime
+        integer(ESMF_KIND_I8),allocatable  :: tSeriesInt(:)
+
+        allocate(tSeriesInt(cfio%tSteps))
+        call getDateTimeVec(cfio%fid,begDate,begTime,tSeriesInt,__RC__)
         
-     type(ESMF_Time),            intent(in   ) :: inTime
-     integer                                   :: yrOffset
-     type(ESMF_Time),            intent(out  ) :: outTime
-     integer, optional,          intent(out  ) :: rc
+        ! Assume success
+        If (present(rc))  rc=ESMF_SUCCESS
 
-     __Iam__('OffsetTimeYear')
+        ! Debug level 3
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 2)) Then
+           Write(*,'(a,a)') '  >> >> Reading times from ', Trim(cfio%fName)
+           Write(*,'(a,2(x,I0.10),x,I0.4)') '  >> >> File timing info:', begDate, begTime, cfio%tSteps
+        End If
 
-     integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     logical                            :: srcLeap, targLeap
+        do i=1,cfio%tSteps
+           iCurrInterval = tSeriesInt(i)
+           call GetDate ( begDate, begTime, iCurrInterval, nymdB, nhmsB, status )
+           call MAPL_UnpackTime(nymdB,iyr,imm,idd)
+           call MAPL_UnpackTime(nhmsB,ihr,imn,isc)
+           ! Debug level 4
+           If (Mapl_Am_I_Root()) Then
+              If ((Ext_Debug > 4).or.((Ext_Debug > 3).and.((i.eq.1).or.(i.eq.cfio%tSteps)))) Then
+                 Write(*,'(a,I0.6,a,I0.4,5(a,I0.2))') ' >> >> STD Sample ',i,':  ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+              End If
+           End If
+           call ESMF_TimeSet(tSeries(i), yy=iyr, mm=imm, dd=idd,  h=ihr,  m=imn, s=isc,__RC__)
+        enddo
 
-     call ESMF_TimeGet(inTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-     ! If the source year is a leap year but the new one isn't, modify to day 28
-     iYr = iYr + yrOffset
-     targLeap = ((imm.eq.2).and.(idd.eq.29))
-     if (targLeap) then
-        if (iyr.lt.1582) then
-           srcLeap = .False.
-        else if (modulo(iYr,4).ne.0) then
-           srcLeap = .False.
-        else if (modulo(iYr,100).ne.0) then
-           srcLeap = .True.
-        else if (modulo(iYr,400).ne.0) then
-           srcLeap = .False.
+        deallocate(tSeriesInt)
+        return
+
+     end subroutine GetTimesOnFile
+
+     subroutine OffsetTimeYear(inTime,yrOffset,outTime,rc)
+           
+        type(ESMF_Time),            intent(in   ) :: inTime
+        integer                                   :: yrOffset
+        type(ESMF_Time),            intent(out  ) :: outTime
+        integer, optional,          intent(out  ) :: rc
+
+        __Iam__('OffsetTimeYear')
+
+        integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
+        logical                            :: srcLeap, targLeap
+
+        call ESMF_TimeGet(inTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+        ! If the source year is a leap year but the new one isn't, modify to day 28
+        iYr = iYr + yrOffset
+        targLeap = ((imm.eq.2).and.(idd.eq.29))
+        if (targLeap) then
+           if (iyr.lt.1582) then
+              srcLeap = .False.
+           else if (modulo(iYr,4).ne.0) then
+              srcLeap = .False.
+           else if (modulo(iYr,100).ne.0) then
+              srcLeap = .True.
+           else if (modulo(iYr,400).ne.0) then
+              srcLeap = .False.
+           else
+              srcLeap = .True.
+           end if
         else
            srcLeap = .True.
         end if
-     else
-        srcLeap = .True.
-     end if
-     if (targLeap.and.(.not.srcLeap)) idd=28
-     call ESMF_TimeSet(outTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+        if (targLeap.and.(.not.srcLeap)) idd=28
+        call ESMF_TimeSet(outTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
 
-     RETURN_(ESMF_SUCCESS)
+        RETURN_(ESMF_SUCCESS)
 
-  end subroutine OffsetTimeYear
+     end subroutine OffsetTimeYear
 
-  subroutine GetBracketTimeOnSingleFile(cfio,tSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,climyear,rc)
-     type(ESMF_CFIO),                     intent(in   ) :: cfio
-     type(ESMF_Time),                     intent(in   ) :: tSeries(:)
-     type(ESMF_Time),                     intent(inout) :: cTime
-     character(len=1),                    intent(in   ) :: bSide
-     logical,                             intent(in   ) :: UniFileClim
-     type(ESMF_TIME),                     intent(inout) :: interpTime
-     type(ESMF_TIME),                     intent(inout) :: fileTime
-     integer,                             intent(inout) :: tindex
-     logical,                             intent(in   ) :: allowExtrap
-     integer,                             intent(in   ) :: climYear
-     integer, optional,                   intent(out  ) :: rc
+     subroutine GetBracketTimeOnSingleFile(fdata,tSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,climyear,rc)
+        class(FileMetadataUtils),            intent(inout) :: fdata
+        type(ESMF_Time),                     intent(in   ) :: tSeries(:)
+        type(ESMF_Time),                     intent(inout) :: cTime
+        character(len=1),                    intent(in   ) :: bSide
+        logical,                             intent(in   ) :: UniFileClim
+        type(ESMF_TIME),                     intent(inout) :: interpTime
+        type(ESMF_TIME),                     intent(inout) :: fileTime
+        integer,                             intent(inout) :: tindex
+        logical,                             intent(in   ) :: allowExtrap
+        integer,                             intent(in   ) :: climYear
+        integer, optional,                   intent(out  ) :: rc
 
-     __Iam__('GetBracketTimeOnSingleFile')
+        __Iam__('GetBracketTimeOnSingleFile')
 
-     integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     integer                            :: i
-     type(ESMF_Time)                    :: climTime
-     logical                            :: found
-     logical                            :: LExtrap,RExtrap,LExact,RExact
-     logical                            :: LSide, RSide
-     integer                            :: yrOffset, yrOffsetNeg, targYear
-     integer                            :: iEntry
-     type(ESMF_Time), allocatable       :: tSeriesC(:)
-     logical                            :: foundYear
-     integer                            :: tSteps, curYear
+        integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
+        integer                            :: i
+        type(ESMF_Time)                    :: climTime
+        logical                            :: found
+        logical                            :: LExtrap,RExtrap,LExact,RExact
+        logical                            :: LSide, RSide
+        integer                            :: yrOffset, yrOffsetNeg, targYear
+        integer                            :: iEntry
+        type(ESMF_Time), allocatable       :: tSeriesC(:)
+        logical                            :: foundYear
+        integer                            :: tSteps, curYear, nsteps
 
-     yrOffset=0
-     ! Store the target time which was actually requested
-     yrOffset=0
-     call ESMF_TimeGet(cTime,yy=targYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+        ! Store the target time which was actually requested
+        yrOffset=0
+        nsteps = size(tSeries)
+        call ESMF_TimeGet(cTime,yy=targYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
 
-     ! Debug output
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then
-        Write(6,'(a,a)') ' DEBUG: GetBracketTimeOnSingleFile called for ', trim(cfio%fName)
-     End If
-
-     ! Debug level 3
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 2) ) Then
-        Write(*,'(a,L1,a,a)') '  >> >> Reading times from fixed (',UniFileClim,') file ', Trim(cfio%fName)
-        call ESMF_TimeGet(tSeries(1),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File start    : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-        call ESMF_TimeGet(tSeries(cfio%tSteps),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File end      : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-        call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Time requested: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
-     End If
-
-     if (uniFileClim) then
-
-        call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        iyr = climYear
-        if (idd == 29 .and. imm == 2) idd = 28
-        call ESMF_TimeSet(climTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-
-        tsteps=0
-        foundYear = .false.
-        do i=1,cfio%tSteps
-
-           call ESMF_TimeGet(tseries(i),yy=iyr,__RC__)
-           if (iyr==climYear) then
-              if (foundYear .eqv. .false.) then
-                 iEntry = i
-                 foundYear = .true.
-              end if
-              tsteps=tsteps+1
-           end if
-
-        end do
-    
-        allocate(tSeriesC(tsteps),__STAT__)
-        do i=1,tsteps
-           tSeriesC(i)=tSeries(iEntry+i-1)
-        enddo
-
-        found = .false.
-        if (bSide == "L") then
-           if ( (climTime < tSeriesC(1)) ) then
-              fileTime = tSeriesC(tSteps)
-              tindex = tSteps
-              call ESMF_TimeGet(tSeriesC(tSteps),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              call ESMF_TimeGet(cTime,yy=curYear,__RC__)
-              iyr = curYear - 1
-              call ESMF_TimeSet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              found = .true.
-           else
-              do i=tSteps,1,-1
-                 if (climTime >= tSeriesC(i)) then
-                    fileTime = tSeriesC(i)
-                    tindex = i
-                    if (UniFileClim) then
-                       call ESMF_TimeGet(cTime,yy=curYear,__RC__)
-                       call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                       call ESMF_TimeSet(interpTime,yy=curYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                    else
-                       interpTime = tSeriesC(i)
-                    end if
-                    found = .true.
-                    exit
-                 end if
-              end do
-           end if
-        else if (bSide == "R") then
-           if ( (climTime >= tSeriesC(tSteps)) ) then
-              fileTime = tSeriesC(1)
-              tindex = 1
-              call ESMF_TimeGet(tSeriesC(1),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              call ESMF_TimeGet(cTime,yy=curYear,__RC__)
-              iyr = curYear + 1
-              call ESMF_TimeSet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              found = .true.
-           else
-              do i=1,tSteps
-                 if (climTime < tSeriesC(i)) then
-                    fileTime = tSeriesC(i)
-                    tindex = i
-                    if (UniFileClim) then
-                       call ESMF_TimeGet(cTime,yy=curYear,__RC__)
-                       call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                       call ESMF_TimeSet(interpTime,yy=curYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-                    else
-                       interpTime = tSeriesC(i)
-                    end if
-                    found = .true.
-                    exit
-                 end if
-              end do
-           end if
-        end if 
-
-     else
-
-        yrOffset = 0
-        climTime = cTime
-
-        ! Is the requested time within the range of values offered?
-        LSide = (bSide == "L")
-        RSide = (.not.LSide)
-        LExact  = (cLimTime == tSeries(1))
-        RExact  = (cLimTime == tSeries(cfio%tSteps))
-        LExtrap = (cLimTime <  tSeries(1)) 
-        RExtrap = (cLimTime >  tSeries(cfio%tSteps))
-        found = .false.
-        If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-           Write(*,'(a,4(L1,x),a,a)') ' DEBUG: Extrapolation flags (0) are ',LExact,RExact,LExtrap,RExtrap,'for file ', trim(cfio%fName)
+        ! Debug output
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then
+           Write(6,'(a,a)') ' DEBUG: GetBracketTimeOnSingleFile called for ', trim(fdata%get_file_name())
         End If
 
-        if (allowExtrap) then
-           If (LExtrap) Then
-              If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-                 Write(6,'(a,a)') ' DEBUG: Requested time is before first available sample in file ', trim(cfio%fName)
-              End If
-              ! Increase the target time until it is within range
-              Do While (LExtrap)
-                 yrOffset = yrOffset + 1
-                 iYr = targYear + yrOffset
-                 call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
-                 If (LSide) Then
-                    LExtrap = (cLimTime <  tSeries(1))
-                 Else
-                    LExtrap = (cLimTime <= tSeries(1))
-                    ! When scanning for the right side, if we find that we
-                    ! have an exact match to the first entry, then as long
-                    ! as there is a second entry, we have the correct offset
-                    If (LExtrap.and.(cfio%tSteps > 1)) Then
-                       LExact  = (cLimTime == tSeries(1))
-                       LExtrap = (LExtrap.and.(.not.LExact))
-                    End If
-                 End If
-              End Do
-           Else If (RExtrap.or.(RExact.and.RSide)) Then
-              If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-                 Write(6,'(a,a)') ' DEBUG: Requested time is after or on last available sample in file ', trim(cfio%fName)
-              End If
-              Do While (RExtrap.or.(RExact.and.RSide))
-                 yrOffset = yrOffset - 1
-                 iYr = targYear + yrOffset
-                 call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
-                 If (LSide) Then
-                    RExtrap = (cLimTime >  tSeries(cfio%tSteps))
-                 Else
-                    RExtrap = (cLimTime >= tSeries(cfio%tSteps))
-                    RExact  = (cLimTime == tSeries(cfio%tSteps))
-                 End If
-              End Do
-           End If
+        ! Debug level 3
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 2) ) Then
+           Write(*,'(a,L1,a,a)') '  >> >> Reading times from fixed (',UniFileClim,') file ', Trim(fdata%get_file_name())
+           call ESMF_TimeGet(tSeries(1),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File start    : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+           call ESMF_TimeGet(tSeries(nsteps),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> File end      : ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+           call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(*,'(a,I0.4,5(a,I0.2))') ' >> >> >> Time requested: ',iYr,'-',iMM,'-',iDD,' ',iHr,':',iMn,':',iSc
+        End If
 
-           ! Retest for an exact match - note this is only useful if we want bracket L
-           LExact  =  (cLimTime == tSeries(1))
-           RExact  =  (cLimTime == tSeries(cfio%tSteps))
-           If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-              Write(*,'(a,4(L1,x),a,a)') ' DEBUG: Extrapolation flags (2) are ',LExact,RExact,LExtrap,RExtrap,'for file ', trim(cfio%fName)
-           End If
+        if (uniFileClim) then
 
-        End IF
+           yrOffset = 0
+           call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           iyr = climYear
+           if (idd == 29 .and. imm == 2) idd = 28
+           call ESMF_TimeSet(climTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
 
-        If (LSide.and.LExact) Then
-           found = .true.
-           iEntry = 1
-        Else If (LSide.and.RExact) Then
-           found = .true.
-           iEntry = cfio%tSteps
-        Else
+           tsteps=0
+           foundYear = .false.
+           do i=1,nsteps
+
+              call ESMF_TimeGet(tseries(i),yy=iyr,__RC__)
+              if (iyr==climYear) then
+                 if (foundYear .eqv. .false.) then
+                    iEntry = i
+                    foundYear = .true.
+                 end if
+                 tsteps=tsteps+1
+              end if
+
+           end do
+       
+           allocate(tSeriesC(tsteps),__STAT__)
+           do i=1,tsteps
+              tSeriesC(i)=tSeries(iEntry+i-1)
+           enddo
+
+           found = .false.
            if (bSide == "L") then
-              do i=cfio%tSteps,1,-1
-                 if (climTime >= tSeries(i)) then
-                    iEntry = i
-                    found = .true.
-                    exit
-                 end if
-              end do
+              if ( (climTime < tSeriesC(1)) ) then
+                 fileTime = tSeriesC(tSteps)
+                 tindex = tSteps
+                 call ESMF_TimeGet(tSeriesC(tSteps),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 call ESMF_TimeGet(cTime,yy=curYear,__RC__)
+                 iyr = curYear - 1
+                 call ESMF_TimeSet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 found = .true.
+              else
+                 do i=tSteps,1,-1
+                    if (climTime >= tSeriesC(i)) then
+                       fileTime = tSeriesC(i)
+                       tindex = i
+                       if (UniFileClim) then
+                          call ESMF_TimeGet(cTime,yy=curYear,__RC__)
+                          call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                          call ESMF_TimeSet(interpTime,yy=curYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                       else
+                          interpTime = tSeriesC(i)
+                       end if
+                       found = .true.
+                       exit
+                    end if
+                 end do
+              end if
            else if (bSide == "R") then
-              do i=1,cfio%tSteps
-                 if (climTime < tSeries(i)) then
-                    iEntry = i
-                    found = .true.
-                    exit
-                 end if
-              end do
+              if ( (climTime >= tSeriesC(tSteps)) ) then
+                 fileTime = tSeriesC(1)
+                 tindex = 1
+                 call ESMF_TimeGet(tSeriesC(1),yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 call ESMF_TimeGet(cTime,yy=curYear,__RC__)
+                 iyr = curYear + 1
+                 call ESMF_TimeSet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 found = .true.
+              else
+                 do i=1,tSteps
+                    if (climTime < tSeriesC(i)) then
+                       fileTime = tSeriesC(i)
+                       tindex = i
+                       if (UniFileClim) then
+                          call ESMF_TimeGet(cTime,yy=curYear,__RC__)
+                          call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                          call ESMF_TimeSet(interpTime,yy=curYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                       else
+                          interpTime = tSeriesC(i)
+                       end if
+                       found = .true.
+                       exit
+                    end if
+                 end do
+              end if
+           end if 
+
+        else
+
+           yrOffset = 0
+           climTime = cTime
+
+           ! Is the requested time within the range of values offered?
+           LSide = (bSide == "L")
+           RSide = (.not.LSide)
+           LExact  = (cLimTime == tSeries(1))
+           RExact  = (cLimTime == tSeries(nsteps))
+           LExtrap = (cLimTime <  tSeries(1)) 
+           RExtrap = (cLimTime >  tSeries(nsteps))
+           found = .false.
+           If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+              Write(*,'(a,4(L1,x),a,a)') ' DEBUG: Extrapolation flags (0) are ',LExact,RExact,LExtrap,RExtrap,'for file ', trim(fdata%get_file_name())
+           End If
+
+           if (allowExtrap) then
+              If (LExtrap) Then
+                 If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+                    Write(6,'(a,a)') ' DEBUG: Requested time is before first available sample in file ', trim(fdata%get_file_name())
+                 End If
+                 ! Increase the target time until it is within range
+                 Do While (LExtrap)
+                    yrOffset = yrOffset + 1
+                    iYr = targYear + yrOffset
+                    call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
+                    If (LSide) Then
+                       LExtrap = (cLimTime <  tSeries(1))
+                    Else
+                       LExtrap = (cLimTime <= tSeries(1))
+                       ! When scanning for the right side, if we find that we
+                       ! have an exact match to the first entry, then as long
+                       ! as there is a second entry, we have the correct offset
+                       If (LExtrap.and.(nsteps > 1)) Then
+                          LExact  = (cLimTime == tSeries(1))
+                          LExtrap = (LExtrap.and.(.not.LExact))
+                       End If
+                    End If
+                 End Do
+              Else If (RExtrap.or.(RExact.and.RSide)) Then
+                 If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+                    Write(6,'(a,a)') ' DEBUG: Requested time is after or on last available sample in file ', trim(fdata%get_file_name())
+                 End If
+                 Do While (RExtrap.or.(RExact.and.RSide))
+                    yrOffset = yrOffset - 1
+                    iYr = targYear + yrOffset
+                    call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
+                    If (LSide) Then
+                       RExtrap = (cLimTime >  tSeries(nsteps))
+                    Else
+                       RExtrap = (cLimTime >= tSeries(nsteps))
+                       RExact  = (cLimTime == tSeries(nsteps))
+                    End If
+                 End Do
+              End If
+
+              ! Retest for an exact match - note this is only useful if we want bracket L
+              LExact  =  (cLimTime == tSeries(1))
+              RExact  =  (cLimTime == tSeries(nsteps))
+              If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+                 Write(*,'(a,4(L1,x),a,a)') ' DEBUG: Extrapolation flags (2) are ',LExact,RExact,LExtrap,RExtrap,'for file ', trim(fdata%get_file_name)
+              End If
+
+           End IF
+
+           If (LSide.and.LExact) Then
+              found = .true.
+              iEntry = 1
+           Else If (LSide.and.RExact) Then
+              found = .true.
+              iEntry = nsteps
+           Else
+              if (bSide == "L") then
+                 do i=nsteps,1,-1
+                    if (climTime >= tSeries(i)) then
+                       iEntry = i
+                       found = .true.
+                       exit
+                    end if
+                 end do
+              else if (bSide == "R") then
+                 do i=1,nsteps
+                    if (climTime < tSeries(i)) then
+                       iEntry = i
+                       found = .true.
+                       exit
+                    end if
+                 end do
+              end if
            end if
+
+           if (found) then
+              fileTime = tSeries(iEntry)
+              tindex = iEntry
+              if (yrOffset == 0) Then
+                 interpTime = fileTime
+              Else
+                 yrOffsetNeg = -1*yrOffset
+                 call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
+              End If
+           end if
+
         end if
 
         if (found) then
-           fileTime = tSeries(iEntry)
-           tindex = iEntry
-           if (yrOffset == 0) Then
-              interpTime = fileTime
-           Else
-              yrOffsetNeg = -1*yrOffset
-              call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
+           If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then
+              call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,a,a,a)') &
+                 ' DEBUG: Data from time ', iYr, '-', iMm, '-', iDd, &
+                 ' ', iHr, ':', iMn, ' set for bracket ', bSide,&
+                 ' of file ', Trim(fdata%get_file_name())
+              Write(*,'(a,I5)') ' DEBUG: ==>> Year offset: ', yrOffset
+              If (yrOffset .ne. 0) Then
+                 call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
+                    ' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
+                    ' ', iHr, ':', iMn
+                 call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
+                    ' DEBUG: ==> Target to: ', iYr, '-', iMm, '-', iDd, &
+                    ' ', iHr, ':', iMn
+              End If
            End If
+           RETURN_(ESMF_SUCCESS)
+        else
+           Write(6,'(a,a)') 'WARNING: Requested sample not found in file ', trim(fdata%get_file_name())
+           RETURN_(ESMF_FAILURE)
+        endif
+
+     end subroutine GetBracketTimeOnSingleFile
+
+     subroutine GetBracketTimeOnFile(fdata,tSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt,rc)
+        class(FileMetadataUtils),            intent(inout) :: fdata
+        type(ESMF_Time),                     intent(in   ) :: tSeries(:)
+        type(ESMF_Time),                     intent(inout) :: cTime
+        character(len=1),                    intent(in   ) :: bSide
+        logical,                             intent(in   ) :: UniFileClim
+        type(ESMF_TIME),                     intent(inout) :: interpTime
+        type(ESMF_TIME),                     intent(inout) :: fileTime
+        integer,                             intent(inout) :: tindex
+        integer, optional,                   intent(in   ) :: yrOffsetInt
+        integer, optional,                   intent(out  ) :: rc
+
+        __Iam__('GetBracketTimeOnFile')
+
+        integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
+        integer                            :: i
+        type(ESMF_Time)                    :: climTime
+        logical                            :: found, outOfBounds
+        integer                            :: yrOffset, yrOffsetNeg
+        integer                            :: climSize,tsteps
+
+        tsteps = size(tSeries)
+        ! Assume that the requested time is within range
+        If (Present(yrOffsetInt)) Then
+           yrOffset = yrOffsetInt
+        Else
+           yrOffset = 0
+        End If
+
+        if (UniFileClim) then
+           If (MAPL_Am_I_Root()) Write(*,'(a)') 'GetBracketTimeOnFile called with UniFileClim'
+           RETURN_(ESMF_FAILURE)
         end if
 
-     end if
-
-     if (found) then
+        ! Debug output
         If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then
-           call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-           Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,a,a,a)') &
-              ' DEBUG: Data from time ', iYr, '-', iMm, '-', iDd, &
-              ' ', iHr, ':', iMn, ' set for bracket ', bSide,&
-              ' of file ', Trim(cfio%fName)
-           Write(*,'(a,I5)') ' DEBUG: ==>> Year offset: ', yrOffset
-           If (yrOffset .ne. 0) Then
-              call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
-                 ' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
-                 ' ', iHr, ':', iMn
-              call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
-                 ' DEBUG: ==> Target to: ', iYr, '-', iMm, '-', iDd, &
-                 ' ', iHr, ':', iMn
+           Write(6,'(4a)') ' DEBUG: GetBracketTimeOnFile (',Trim(bSide),') called for ', trim(fdata%get_file_name())
+        End If
+
+        if (yrOffset.ne.0) then
+           ! If the source year is a leap year but this isn't, modify to day 28
+           call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
+        else
+           climTime = cTime
+        end if   
+        climSize = 1
+
+        ! Debug output
+        If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
+           call ESMF_TimeGet(cLimTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           Write(6,'(a,I2,3a,I0.4,5(a,I0.2))') ' DEBUG: Year offset of ',yrOffset,&
+              ' applied while scanning ', trim(fdata%get_file_name()),&
+              ' to give target time ',iYr,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
+        End If
+
+        found = .false.
+        ! we will have to specially handle a climatology in one file
+        ! might be better way but can not think of one
+        if (bSide == "L") then
+           OutOfBounds = (cLimTime < tSeries(1))
+           If (OutOfBounds) Then
+              ! This can be an acceptable outcome - no printout
+              if(present(RC)) RC = ESMF_FAILURE
+              Return
            End If
-        End If
-        RETURN_(ESMF_SUCCESS)
-     else
-        Write(6,'(a,a)') 'WARNING: Requested sample not found in file ', trim(cfio%fName)
-        RETURN_(ESMF_FAILURE)
-     endif
-
-  end subroutine GetBracketTimeOnSingleFile
-
-  subroutine GetBracketTimeOnFile(cfio,tSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,yrOffsetInt,rc)
-     type(ESMF_CFIO),                     intent(in   ) :: cfio
-     type(ESMF_Time),                     intent(in   ) :: tSeries(:)
-     type(ESMF_Time),                     intent(inout) :: cTime
-     character(len=1),                    intent(in   ) :: bSide
-     logical,                             intent(in   ) :: UniFileClim
-     type(ESMF_TIME),                     intent(inout) :: interpTime
-     type(ESMF_TIME),                     intent(inout) :: fileTime
-     integer,                             intent(inout) :: tindex
-     integer, optional,                   intent(in   ) :: yrOffsetInt
-     integer, optional,                   intent(out  ) :: rc
-
-     __Iam__('GetBracketTimeOnFile')
-
-     integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     integer                            :: i
-     type(ESMF_Time)                    :: climTime
-     logical                            :: found, outOfBounds
-     integer                            :: yrOffset, yrOffsetNeg
-     integer                            :: climSize
-
-     ! Assume that the requested time is within range
-     If (Present(yrOffsetInt)) Then
-        yrOffset = yrOffsetInt
-     Else
-        yrOffset = 0
-     End If
-
-     if (UniFileClim) then
-        If (MAPL_Am_I_Root()) Write(*,'(a)') 'GetBracketTimeOnFile called with UniFileClim'
-        RETURN_(ESMF_FAILURE)
-     end if
-
-     ! Debug output
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then
-        Write(6,'(4a)') ' DEBUG: GetBracketTimeOnFile (',Trim(bSide),') called for ', trim(cfio%fName)
-     End If
-
-     if (yrOffset.ne.0) then
-        ! If the source year is a leap year but this isn't, modify to day 28
-        call OffsetTimeYear(cTime,yrOffset,cLimTime,rc)
-     else
-        climTime = cTime
-     end if   
-     climSize = 1
-
-     ! Debug output
-     If (Mapl_Am_I_Root().and.(Ext_Debug > 19)) Then
-        call ESMF_TimeGet(cLimTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-        Write(6,'(a,I2,3a,I0.4,5(a,I0.2))') ' DEBUG: Year offset of ',yrOffset,&
-           ' applied while scanning ', trim(cfio%fName),&
-           ' to give target time ',iYr,'-',iMm,'-',iDd,' ',iHr,':',iMn,':',iSc
-     End If
-
-     found = .false.
-     ! we will have to specially handle a climatology in one file
-     ! might be better way but can not think of one
-     if (bSide == "L") then
-        OutOfBounds = (cLimTime < tSeries(1))
-        If (OutOfBounds) Then
-           ! This can be an acceptable outcome - no printout
-           if(present(RC)) RC = ESMF_FAILURE
-           Return
-        End If
-        do i=cfio%tSteps,1,-1
-           if (climTime >= tSeries(i)) then
-              fileTime = tSeries(i)
-              tindex = i
-              if (yrOffset .ne. 0) Then
-                 yrOffsetNeg = -1*yrOffset
-                 Call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
-              else
-                 interpTime = fileTime
+           do i=tSteps,1,-1
+              if (climTime >= tSeries(i)) then
+                 fileTime = tSeries(i)
+                 tindex = i
+                 if (yrOffset .ne. 0) Then
+                    yrOffsetNeg = -1*yrOffset
+                    Call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
+                 else
+                    interpTime = fileTime
+                 end if
+                 found = .true.
+                 exit
               end if
-              found = .true.
-              exit
-           end if
-        end do
-     else if (bSide == "R") then
-        ! Is the requested time within the range of values offered?
-        OutOfBounds = (cLimTime >= tSeries(cfio%tSteps))
-        If (OutOfBounds) Then
-           ! This can be an acceptable outcome - no printout
-           if(present(RC)) RC = ESMF_FAILURE
-           Return
-        End If
-        do i=1,cfio%tSteps
-           if (climTime < tSeries(i)) then
-              fileTime = tSeries(i)
-              tindex = i
-              if (yrOffset .ne. 0) Then
-                 yrOffsetNeg = -1*yrOffset
-                 Call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
-              else
-                 interpTime = fileTime
-              end if
-              found = .true.
-              exit
-           end if
-        end do
-     end if
-
-     if (found) then
-        If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then 
-           call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-           Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,a,a,a)') &
-              ' DEBUG: Data from time ', iYr, '-', iMm, '-', iDd, &
-              ' ', iHr, ':', iMn, ' set for bracket ', bSide,&
-              ' of file ', Trim(cfio%fName)
-           If (yrOffset .ne. 0) Then
-              call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
-              !Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
-                 !' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
-                 !' ', iHr, ':', iMn
-              Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
-                 ' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
-                 ' ', iHr, ':', iMn, ' Offset:', yrOffset
+           end do
+        else if (bSide == "R") then
+           ! Is the requested time within the range of values offered?
+           OutOfBounds = (cLimTime >= tSeries(tSteps))
+           If (OutOfBounds) Then
+              ! This can be an acceptable outcome - no printout
+              if(present(RC)) RC = ESMF_FAILURE
+              Return
            End If
-        End If
-        RETURN_(ESMF_SUCCESS)
-     else
-        Write(6,'(a,a)') 'WARNING: Requested sample not found in file ', trim(cfio%fName)
+           do i=1,tSteps
+              if (climTime < tSeries(i)) then
+                 fileTime = tSeries(i)
+                 tindex = i
+                 if (yrOffset .ne. 0) Then
+                    yrOffsetNeg = -1*yrOffset
+                    Call OffsetTimeYear(fileTime,yrOffsetNeg,interpTime,rc)
+                 else
+                    interpTime = fileTime
+                 end if
+                 found = .true.
+                 exit
+              end if
+           end do
+        end if
+
+        if (found) then
+           If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then 
+              call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,a,a,a)') &
+                 ' DEBUG: Data from time ', iYr, '-', iMm, '-', iDd, &
+                 ' ', iHr, ':', iMn, ' set for bracket ', bSide,&
+                 ' of file ', Trim(fdata%get_file_name())
+              If (yrOffset .ne. 0) Then
+                 call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 !Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
+                    !' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
+                    !' ', iHr, ':', iMn
+                 Write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
+                    ' DEBUG: ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
+                    ' ', iHr, ':', iMn, ' Offset:', yrOffset
+              End If
+           End If
+           RETURN_(ESMF_SUCCESS)
+        else
+           Write(6,'(a,a)') 'WARNING: Requested sample not found in file ', trim(fdata%get_file_name())
         RETURN_(ESMF_FAILURE)
      endif
      !end if 
@@ -3253,19 +3267,19 @@ CONTAINS
      if (fieldRank == 2) then
 
         if (item%vartype == MAPL_FieldItem) then
-           call ESMF_FieldGet(item%finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-           call ESMF_FieldGet(item%finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
         else if (item%vartype == MAPL_BundleItem) then
            call ESMFL_BundleGetPointerToData(item%binterp1,name,var2d_prev,__RC__)
            call ESMFL_BundleGetPointerToData(item%binterp2,name,var2d_next,__RC__)
         else if (item%vartype == MAPL_ExtDataVectorItem) then
            _ASSERT(present(vector_comp),'Vector comp must be present when performing vector interpolation')
            if (vector_comp == 1) then
-              call ESMF_FieldGet(item%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-              call ESMF_FieldGet(item%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
            else if (vector_comp == 2) then
-              call ESMF_FieldGet(item%v2_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
-              call ESMF_FieldGet(item%v2_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp1, localDE=0, farrayPtr=var2d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp2, localDE=0, farrayPtr=var2d_next, __RC__)
           end if
         end if
         call ESMF_FieldGet(field, localDE=0, farrayPtr=var2d, __RC__)
@@ -3300,19 +3314,19 @@ CONTAINS
       else if (fieldRank == 3) then
 
         if (item%vartype == MAPL_FieldItem) then
-           call ESMF_FieldGet(item%finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-           call ESMF_FieldGet(item%finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+           call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
         else if (item%vartype == MAPL_BundleItem) then
            call ESMFL_BundleGetPointerToData(item%binterp1,name,var3d_prev,__RC__)
            call ESMFL_BundleGetPointerToData(item%binterp2,name,var3d_next,__RC__)
         else if (item%vartype == MAPL_ExtDataVectorItem) then
            _ASSERT(present(vector_comp),'Vector comp must be present when performing vector interpolation')
            if (vector_comp == 1) then
-              call ESMF_FieldGet(item%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-              call ESMF_FieldGet(item%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v1_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
            else if (vector_comp == 2) then
-              call ESMF_FieldGet(item%v2_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
-              call ESMF_FieldGet(item%v2_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp1, localDE=0, farrayPtr=var3d_prev, __RC__)
+              call ESMF_FieldGet(item%modelGridFields%v2_finterp2, localDE=0, farrayPtr=var3d_next, __RC__)
            end if
         end if
         call ESMF_FieldGet(field, localDE=0, farrayPtr=var3d, __RC__)
@@ -3951,19 +3965,16 @@ CONTAINS
 
      type(ESMF_Time) :: stime
 
-     character(len=ESMF_MAXSTR), parameter :: IAM="MAPL_ExtDataGetFStartTime"
      integer                               :: status
 
      integer :: iyr,imm,idd,ihr,imn,isc,begDate,begTime
-     type(ESMF_CFIO), pointer :: cfio
+     type(FileMetadataUtils), pointer :: metadata => null()
 
-     call MakeCFIO(fname,item%collection_id,cfio,__RC__)
-     begDate = cfio%date
-     begTime = cfio%begTime
-     call MAPL_UnpackTime(begDate,iyr,imm,idd)
-     call MAPL_UnpackTime(begTime,ihr,imn,isc)
+     call MakeMetadata(fname,item%pfiocollection_id,metadata,__RC__)
+     call Metadata%get_time_units(startyear=iyr,startmonth=imm,startday=idd,starthour=ihr,startmin=imn,startsec=isc,rc=status)
+     _VERIFY(status)
      call ESMF_TimeSet(sTime, yy=iyr, mm=imm, dd=idd,  h=ihr,  m=imn, s=isc, __RC__)
-     nullify(CFIO)
+     nullify(metadata)
 
      _RETURN(ESMF_SUCCESS)
 
@@ -4207,70 +4218,34 @@ CONTAINS
 
            if (Bside == MAPL_ExtDataLeft .and. vcomp == 1) then 
               if (getRL_) then
-                 call ESMF_FieldValidate(item%v1_faux1,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%v1_faux1
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%v1_finterp1,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%v1_faux1 = MAPL_FieldCreate(item%v1_finterp1,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
-                    field = item%v1_faux1
-                    _RETURN(ESMF_SUCCESS)
-                 end if
+                 field = item%modelGridFields%v1_faux1
+                 _RETURN(ESMF_SUCCESS)
               else
-                 field = item%v1_finterp1
+                 field = item%modelGridFields%v1_finterp1
                  _RETURN(ESMF_SUCCESS)
               end if
            else if (Bside == MAPL_ExtDataLeft .and. vcomp == 2) then 
               if (getRL_) then
-                 call ESMF_FieldValidate(item%v2_faux1,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%v2_faux1
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%v2_finterp1,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%v2_faux1 = MAPL_FieldCreate(item%v2_finterp1,newGrid,lm=item%lm,newName=trim(item%fcomp2),__RC__)
-                    field = item%v2_faux1
-                    _RETURN(ESMF_SUCCESS)
-                 end if
+                 field = item%modelGridFields%v2_faux1
+                 _RETURN(ESMF_SUCCESS)
               else
-                 field = item%v2_finterp1
+                 field = item%modelGridFields%v2_finterp1
                  _RETURN(ESMF_SUCCESS)
               end if
            else if (Bside == MAPL_ExtDataRight .and. vcomp == 1) then 
               if (getRL_) then
-                 call ESMF_FieldValidate(item%v1_faux2,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%v1_faux2
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%v1_finterp2,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%v1_faux2 = MAPL_FieldCreate(item%v1_finterp2,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
-                    field = item%v1_faux2
-                    _RETURN(ESMF_SUCCESS)
-                 end if
+                 field = item%modelGridFields%v1_faux2
+                 _RETURN(ESMF_SUCCESS)
               else
-                 field = item%v1_finterp2
+                 field = item%modelGridFields%v1_finterp2
                  _RETURN(ESMF_SUCCESS)
               end if
            else if (Bside == MAPL_ExtDataRight .and. vcomp == 2) then 
               if (getRL_) then
-                 call ESMF_FieldValidate(item%v2_faux2,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%v2_faux2
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%v2_finterp2,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%v2_faux2 = MAPL_FieldCreate(item%v2_finterp2,newGrid,lm=item%lm,newName=trim(item%fcomp2),__RC__)
-                    field = item%v2_faux2
-                    _RETURN(ESMF_SUCCESS)
-                 end if
+                 field = item%modelGridFields%v2_faux2
+                 _RETURN(ESMF_SUCCESS)
               else
-                 field = item%v2_finterp2
+                 field = item%modelGridFields%v2_finterp2
                  _RETURN(ESMF_SUCCESS)
               end if
 
@@ -4285,36 +4260,18 @@ CONTAINS
         if (present(field)) then
            if (Bside == MAPL_ExtDataLeft) then
               if (getRL_) then
-                 call ESMF_FieldValidate(item%faux1,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%faux1
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%finterp1,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%faux1 = MAPL_FieldCreate(item%finterp1,newGrid,lm=item%lm,newName=trim(item%var),__RC__)
-                    field = item%faux1
-                    _RETURN(ESMF_SUCCESS)
-                 end if   
+                 field = item%modelGridFields%v1_faux1
+                 _RETURN(ESMF_SUCCESS)
               else 
-                 field = item%finterp1
+                 field = item%modelGridFields%v1_finterp1
                  _RETURN(ESMF_SUCCESS)
               end if
            else if (Bside == MAPL_ExtDataRight) then
               if (getRL_) then
-                 call ESMF_FieldValidate(item%faux2,rc=status)
-                 if (status == ESMF_SUCCESS) then
-                    field = item%faux2
-                    _RETURN(ESMF_SUCCESS)
-                 else
-                    call ESMF_FieldGet(item%finterp2,grid=grid,__RC__)
-                    newGrid = MAPL_ExtDataGridChangeLev(grid,ExtState%cf,item%lm,__RC__)
-                    item%faux2 = MAPL_FieldCreate(item%finterp2,newGrid,lm=item%lm,newName=trim(item%var),__RC__)
-                    field = item%faux2
-                    _RETURN(ESMF_SUCCESS)
-                 end if   
+                 field = item%modelGridFields%v1_faux2
+                 _RETURN(ESMF_SUCCESS)
               else 
-                 field = item%finterp2
+                 field = item%modelGridFields%v1_finterp2
                  _RETURN(ESMF_SUCCESS)
               end if
            end if
@@ -4375,7 +4332,7 @@ CONTAINS
       type(ESMF_Field) :: Field,field1,field2
       real, pointer    :: ptr(:,:,:)
       real, allocatable :: ptemp(:,:,:)
-      integer :: i,lm
+      integer :: lm
 
       if (item%flip) then
 
@@ -4459,14 +4416,14 @@ CONTAINS
          _VERIFY(STATUS)
 
 
-         block
-            character(len=ESMF_MAXSTR) :: vectorlist(2)
-            vectorlist(1) = item%fcomp1
-            vectorlist(2) = item%fcomp2
-            call ESMF_AttributeSet(pbundle,name="VectorList:", itemCount=2, &
-                 valuelist = vectorlist, rc=status)
-            _VERIFY(STATUS)
-         end block
+         !block
+            !character(len=ESMF_MAXSTR) :: vectorlist(2)
+            !vectorlist(1) = item%fcomp1
+            !vectorlist(2) = item%fcomp2
+            !call ESMF_AttributeSet(pbundle,name="VectorList:", itemCount=2, &
+                 !valuelist = vectorlist, rc=status)
+            !_VERIFY(STATUS)
+         !end block
 
       else
 
@@ -4535,112 +4492,33 @@ CONTAINS
 
   end subroutine MAPL_ExtDataDestroyCFIO
 
-  subroutine MAPL_ExtDataParallelRead(IOBundles,blocksize,rc)
-     type(IOBundleVector), target, intent(inout) :: IOBundles
-     integer,                intent(in   ) :: blocksize
-     integer, optional,      intent(out  ) :: rc
-
-     integer, allocatable :: slices(:), psize(:), root(:),gslices(:)
-     logical, allocatable :: reading(:)
-     integer :: i,n,nn,n1,n2,nfiles,nPet,maxSlices,scount,nnodes
-
-     type(ExtData_IoBundle), pointer :: io_bundle
-     type(ESMF_VM) :: vm
-     __Iam__('MAPL_ExtDataReadParallel')
-
-     If (present(rc))  rc=ESMF_SUCCESS
-
-     call esmf_vmgetcurrent(vm,rc=status)
-     _VERIFY(status)
-     call ESMF_VMGet(vm,petCount=nPet,rc=status)
-     _VERIFY(status)
-     nnodes = size(MAPL_NodeRankList)
-
-     nfiles = IOBundles%size()
-     allocate(gslices(nfiles),stat=status)
-     _VERIFY(status)
-     do n=1,nfiles
-        io_bundle => IOBundles%at(n)
-        call MAPL_CFIOGet(io_bundle%cfio,krank=gslices(n),rc=status)
-        _VERIFY(status)
-     enddo
-
-     maxSlices = maxval(gslices)
-     maxSlices = max(maxSlices,nPet)
-     deallocate(gslices)
-
-     do n = 1, nfiles
-        io_bundle => IOBundles%at(n)
-        call MAPL_CFIOReadBundleRead(io_bundle%cfio, io_bundle%time_index, rc=status)
-        _VERIFY(status)
-     end do
-
-     _RETURN(ESMF_SUCCESS)
-
-  end subroutine MAPL_ExtDataParallelRead
-
-  subroutine MAPL_ExtDataPrefetch(IOBundles,blocksize,state,rc)
+  subroutine MAPL_ExtDataPrefetch(IOBundles,rc)
      type(IoBundleVector), target, intent(inout) :: IOBundles
-     integer,                intent(in   ) :: blocksize
-     type (MAPL_MetaComp), intent(inout) :: state
      integer, optional,      intent(out  ) :: rc
 
-     integer, allocatable :: slices(:), psize(:), root(:),gslices(:)
-     logical, allocatable :: reading(:)
-     integer :: i,n,nn,n1,n2,nfiles,nPet,maxSlices,scount,nnodes
-     type(ExtData_IoBundle), pointer :: io_bundle
-     character(:), pointer :: ftmpl
-     type(ESMF_VM) :: vm
-     __Iam__('MAPL_ExtDataPrefetch')
+     integer :: n,nfiles
+     type(ExtData_IoBundle), pointer :: io_bundle => null()
+     integer :: status
 
      logical :: init = .false.
-     integer :: pet
      
-     call ESMF_VMGetCurrent(vm,rc=status)
-     _VERIFY(status)
-     call ESMF_VMGet(vm,petCount=nPet,localpet=pet, rc=status)
-     _VERIFY(status)
-     nnodes = size(MAPL_NodeRankList)
-
-!!$     nfiles = IOBundles%size()
-!!$     allocate(gslices(nfiles),stat=status)
-!!$     _VERIFY(status)
-!!$     do n=1,nfiles
-!!$        io_bundle => IOBundles%at(n)
-!!$      call MAPL_CFIOGet(io_bundle%cfio,krank=gslices(n),rc=status)
-!!$      _VERIFY(status)
-!!$     enddo
-!!$
-!!$     maxSlices = maxval(gslices)
-!!$     maxSlices = max(maxSlices,nPet)
-!!$     deallocate(gslices)
-
      nfiles = IOBundles%size()
-!!$     allocate(slices(blocksize),psize(blocksize),root(blocksize),reading(blocksize),stat=status)
-!!$     _VERIFY(STATUS)
 
      do n = 1, nfiles
         io_bundle => IOBundles%at(n)
-        call MAPL_CFIOReadBundlePrefetch(io_bundle%cfio, io_bundle%time_index, io_bundle%template, state=state, init=init, rc=status)
+        call io_bundle%cfio%request_data_from_file(io_bundle%file_name,io_bundle%time_index,rc=status)
         _VERIFY(status)
-        init = .true.
      enddo
 
-!!$     deallocate(slices,psize,root,reading)
-  
      _RETURN(ESMF_SUCCESS)
 
   end subroutine MAPL_ExtDataPrefetch
 
-  subroutine MAPL_ExtDataReadPrefetch(IOBundles,blocksize,state,rc)
+  subroutine MAPL_ExtDataReadPrefetch(IOBundles,rc)
      type(IOBundleVector), target, intent(inout) :: IOBundles
-     integer,                intent(in   ) :: blocksize
-     type (MAPL_MetaComp), intent(inout) :: state
      integer, optional,      intent(out  ) :: rc
 
-     integer, allocatable :: slices(:),gslices(:)
-     logical, allocatable :: reading(:)
-     integer :: i,n,nn,n1,n2,nfiles,nPet,maxSlices,scount,nnodes
+     integer :: nfiles, n
      type (ExtData_IoBundle), pointer :: io_bundle
      __Iam__('MAPL_ExtDataReadPrefetch')
 
@@ -4648,7 +4526,7 @@ CONTAINS
      nfiles = IOBundles%size()
      do n=1, nfiles
         io_bundle => IOBundles%at(n)
-        call MAPL_CFIOReadBundleReadPrefetch(io_bundle%cfio,state=state,rc=status)
+        call io_bundle%cfio%process_data_from_file(rc=status)
         _VERIFY(status)
      enddo
 
@@ -4656,47 +4534,30 @@ CONTAINS
 
   end subroutine MAPL_ExtDataReadPrefetch
 
-  subroutine mapl_extdataserialread(iobundles,ignoreCase,rc)
-     type(iobundlevector), intent(inout) :: iobundles
-     logical,                intent(in   ) :: ignoreCase
-     integer, optional,      intent(out  ) :: rc
+  subroutine createFileLevBracket(item,cf,rc)
+     type(PrimaryExport), intent(inout) :: item
+     type(ESMF_Config), intent(inout) :: cf
+     integer, optional, intent(out) :: rc
 
-     __Iam__('mapl_extdataserialread')
+     integer :: status
+     character(len=ESMF_MAXSTR) :: Iam = "createFileLevBracket"
+     type (ESMF_Grid) :: grid, newgrid
 
-     type(ESMF_Time) :: time
-     integer :: nfiles,n,trans,collection_id
-     type (ExtData_IoBundle), pointer :: io_bundle
+     if (item%vartype==MAPL_FieldItem .or. item%vartype==MAPL_ExtDataVectorItem) then
+        call ESMF_FieldGet(item%modelGridFields%v1_finterp1,grid=grid,__RC__)
+        newGrid = MAPL_ExtDataGridChangeLev(grid,cf,item%lm,__RC__)
+        call ESMF_FieldGet(item%modelGridFields%v1_finterp1,grid=grid,__RC__)
+        item%modelGridFields%v1_faux1 = MAPL_FieldCreate(item%modelGridFields%v1_finterp1,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
+        item%modelGridFields%v1_faux2 = MAPL_FieldCreate(item%modelGridFields%v1_finterp2,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
+     end if
+     if (item%vartype==MAPL_ExtDataVectorItem) then
+        call ESMF_FieldGet(item%modelGridFields%v1_finterp1,grid=grid,__RC__)
+        item%modelGridFields%v2_faux1 = MAPL_FieldCreate(item%modelGridFields%v2_finterp1,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
+        item%modelGridFields%v2_faux2 = MAPL_FieldCreate(item%modelGridFields%v2_finterp2,newGrid,lm=item%lm,newName=trim(item%fcomp1),__RC__)
+     end if
+     _RETURN(_SUCCESS)
 
-     nfiles = iobundles%size()
-     do n=1,nfiles
-        io_bundle => iobundles%at(n)
-        if (io_bundle%parallel_skip) then
-           trans = IO_BUNDLE%regrid_method
-           call MAPL_CFIOGet(Io_Bundle%cfio,collection_id=collection_id,__RC__)
-           call MAPL_CFIOGetTimeFromIndex(io_bundle%cfio,Io_Bundle%time_index,time,__RC__) 
-           if (trans == REGRID_METHOD_BILINEAR) then
-              call MAPL_CFIORead(IO_BUNDLE%file_name,time,IO_BUNDLE%pbundle, &
-                   time_is_cyclic=.false., time_interp=.false., ignoreCase = ignoreCase, &
-                   collection_id=collection_id,__RC__)
-           else if (trans == REGRID_METHOD_CONSERVE) then
-              call MAPL_CFIORead(IO_BUNDLE%file_name,time,IO_BUNDLE%pbundle, &
-                   time_is_cyclic=.false., time_interp=.false., ignoreCase = ignoreCase, &
-                   Conservative = .true., collection_id=collection_id,__RC__)
-           else if (trans == REGRID_METHOD_VOTE) then
-              call MAPL_CFIORead(IO_BUNDLE%file_name,time,IO_BUNDLE%pbundle, &
-                   time_is_cyclic=.false., time_interp=.false., ignoreCase = ignoreCase, &
-                   Conservative = .true., Voting = .true., collection_id=collection_id,__RC__)
-           else if (trans == REGRID_METHOD_FRACTION) then
-              call MAPL_CFIORead(IO_BUNDLE%file_name,time,IO_BUNDLE%pbundle, &
-                   time_is_cyclic=.false., time_interp=.false., ignoreCase = ignoreCase, &
-                   Conservative = .true., getFrac = Io_Bundle%fraction, collection_id=collection_id, __RC__)
-           end if           
-        end if
-     enddo
-
-     _RETURN(ESMF_SUCCESS)
-
-  end subroutine mapl_extdataserialread
+  end subroutine createFileLevBracket
 
 
   subroutine IOBundle_Add_Entry(IOBundles,item,entry_num,file,bside,time_index,rc)
@@ -4711,8 +4572,12 @@ CONTAINS
      __Iam__('IOBUNDLE_Add_Entry')
 
      type (ExtData_IOBundle) :: io_bundle
+     type (NewCFIOItemVector) :: items
 
-     io_bundle = ExtData_IOBundle(bside, entry_num, file, time_index, item%trans, item%fracval, item%file,__RC__)
+     call items%push_back(item%fileVars)
+     io_bundle = ExtData_IOBundle(bside, entry_num, file, time_index, item%trans, item%fracval, item%file, &
+         item%pfioCollection_id,item%iclient_collection_id,items,rc=status)
+     _VERIFY(status)
 
      call IOBundles%push_back(io_bundle)
 

--- a/MAPL_Base/MAPL_GridManager.F90
+++ b/MAPL_Base/MAPL_GridManager.F90
@@ -495,7 +495,7 @@ contains
 
      call factory%initialize(file_metadata, rc=status)
      _VERIFY(status)
-     call file_formatter%close()
+     call file_formatter%close(rc=status)
 
      _RETURN(_SUCCESS)
      

--- a/MAPL_Base/MAPL_HistoryGridComp.F90
+++ b/MAPL_Base/MAPL_HistoryGridComp.F90
@@ -413,7 +413,7 @@ contains
     character(len=:), pointer :: key
     type(StringFieldSetMapIterator) :: field_set_iter
     character(ESMF_MAXSTR) :: field_set_name
-    integer :: nfields
+    integer :: nfields,collection_id
 
 ! Begin
 !------
@@ -2342,7 +2342,8 @@ ENDDO PARSER
              call list(n)%mNewCFIO%CreateFileMetaData(list(n)%items,list(n)%bundle,list(n)%timeInfo,vdata=list(n)%vdata,rc=status)
              _VERIFY(status)
           end if
-          list(n)%mNewCFIO%collection_id = o_Clients%add_hist_collection(list(n)%mNewCFIO%metadata)
+          collection_id = o_Clients%add_hist_collection(list(n)%mNewCFIO%metadata)
+          call list(n)%mNewCFIO%set_param(write_collection_id=collection_id)
        end if
    end do
 

--- a/MAPL_Base/MAPL_LatLonGridFactory.F90
+++ b/MAPL_Base/MAPL_LatLonGridFactory.F90
@@ -666,13 +666,14 @@ contains
 
       character(:), allocatable :: lon_name
       character(:), allocatable :: lat_name
-      logical :: hasLon, hasLat, hasLongitude, hasLatitude
+      character(:), allocatable :: lev_name
+      logical :: hasLon, hasLat, hasLongitude, hasLatitude, hasLev,hasLevel
       _UNUSED_DUMMY(unusable)
 
       ! Cannot assume that lats and lons are evenly spaced
       this%is_regular = .false.
       
-      associate (im => this%im_world, jm => this%jm_world)
+      associate (im => this%im_world, jm => this%jm_world, lm => this%lm)
          lon_name = 'lon'
          hasLon = file_metadata%has_dimension(lon_name)
          if (hasLon) then
@@ -703,7 +704,22 @@ contains
                _ASSERT(.false.)
             end if
          end if
-
+         hasLev=.false.
+         hasLevel=.false.
+         lev_name = 'lev'
+         hasLev = file_metadata%has_dimension(lev_name)
+         if (hasLev) then
+            lm = file_metadata%get_dimension(lev_name,rc=status)
+            _VERIFY(status)
+         else
+            lev_name = 'levels'
+            hasLevel = file_metadata%has_dimension(lev_name)
+            if (hasLevel) then
+               lm = file_metadata%get_dimension(lev_name,rc=status)
+               _VERIFY(status)
+            end if
+         end if   
+         
         ! TODO: if 'lat' and 'lon' are not present then
         ! assume ... pole/dateline are ?
         

--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -19,6 +19,9 @@ module MAPL_newCFIOMod
   use MAPL_newCFIOItemMod
   use MAPL_ErrorHandlingMod
   use pFIO_ClientManagerMod
+  use MAPL_ExtDataCollectionMod
+  use MAPL_ExtDataCOllectionManagerMod
+  use MAPL_ioClientsMod
   use, intrinsic :: ISO_C_BINDING
   use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
@@ -27,12 +30,14 @@ module MAPL_newCFIOMod
 
   type, public :: MAPL_newCFIO
      type(FileMetaData) :: metadata
-     integer :: collection_id
+     integer :: write_collection_id
+     integer :: read_collection_id
+     integer :: metadata_collection_id
      class (AbstractRegridder), pointer :: regrid_handle => null()
      type(ESMF_Grid) :: output_grid
-     logical :: doVertRegrid
+     logical :: doVertRegrid = .false.
      type(ESMF_FieldBundle) :: output_bundle
-     type(ESMF_FieldBundle) :: bundle
+     type(ESMF_FieldBundle) :: input_bundle
      type(ESMF_Time) :: startTime
      integer :: regrid_method = REGRID_METHOD_BILINEAR
      integer :: nbits = 1000
@@ -44,6 +49,7 @@ module MAPL_newCFIOMod
      integer :: deflateLevel = 0
      integer, allocatable :: chunking(:)
      logical :: itemOrderAlphabetical = .true.
+     integer :: fraction
      contains
         procedure :: CreateFileMetaData
         procedure :: CreateVariable
@@ -56,9 +62,42 @@ module MAPL_newCFIOMod
         procedure :: set_param
         procedure :: set_default_chunking
         procedure :: alphabatize_variables
+        procedure :: request_data_from_file
+        procedure :: process_data_from_file
   end type MAPL_newCFIO
 
+  interface MAPL_newCFIO
+     module procedure new_MAPL_newCFIO
+  end interface MAPL_newCFIO
+
   contains
+
+     function new_MAPL_newCFIO(metadata,input_bundle,output_bundle,write_collection_id,read_collection_id, &
+             metadata_collection_id,regrid_method,fraction,items,rc) result(newCFIO)
+        type(MAPL_newCFIO) :: newCFIO
+        type(Filemetadata), intent(in), optional :: metadata
+        type(ESMF_FieldBundle), intent(in), optional :: input_bundle
+        type(ESMF_FieldBundle), intent(in), optional :: output_bundle
+        integer, intent(in), optional :: write_collection_id
+        integer, intent(in), optional :: read_collection_id
+        integer, intent(in), optional :: metadata_collection_id
+        integer, intent(in), optional :: regrid_method
+        integer, intent(in), optional :: fraction
+        type(newCFIOitemVector), intent(in), optional :: items
+        integer, intent(out), optional :: rc
+
+        integer :: status
+      
+        if (present(metadata)) newCFIO%metadata=metadata 
+        if (present(input_bundle)) newCFIO%input_bundle=input_bundle
+        if (present(output_bundle)) newCFIO%output_bundle=output_bundle
+        if (present(regrid_method)) newCFIO%regrid_method=regrid_method
+        if (present(write_collection_id)) newCFIO%write_collection_id=write_collection_id
+        if (present(read_collection_id)) newCFIO%read_collection_id=read_collection_id
+        if (present(metadata_collection_id)) newCFIO%metadata_collection_id=metadata_collection_id
+        if (present(items)) newCFIO%items=items
+        _RETURN(ESMF_SUCCESS)
+     end function new_MAPL_newCFIO
 
      subroutine CreateFileMetaData(this,items,bundle,timeInfo,vdata,ogrid,rc)
         class (MAPL_newCFIO), intent(inout) :: this
@@ -80,16 +119,16 @@ module MAPL_newCFIOMod
         integer :: status
 
         this%items = items
-        this%bundle = bundle
+        this%input_bundle = bundle
         this%output_bundle = ESMF_FieldBundleCreate(rc=status)
         _VERIFY(status)
         this%timeInfo = timeInfo
-        call ESMF_FieldBundleGet(this%bundle,grid=input_grid,rc=status)
+        call ESMF_FieldBundleGet(this%input_bundle,grid=input_grid,rc=status)
         _VERIFY(status)
         if (present(ogrid)) then
            this%output_grid=ogrid
         else
-           call ESMF_FieldBundleGet(this%bundle,grid=this%output_grid,rc=status)
+           call ESMF_FieldBundleGet(this%input_bundle,grid=this%output_grid,rc=status)
            _VERIFY(status)
         end if
         this%regrid_handle => new_regridder_manager%make_regridder(input_grid,this%output_grid,this%regrid_method,rc=status)
@@ -106,10 +145,10 @@ module MAPL_newCFIOMod
            this%vdata=VerticalData(rc=status)
            _VERIFY(status)
         end if
-        call this%vdata%append_vertical_metadata(this%metadata,this%bundle,rc=status)
+        call this%vdata%append_vertical_metadata(this%metadata,this%input_bundle,rc=status)
         _VERIFY(status)
         this%doVertRegrid = (this%vdata%regrid_type /= VERTICAL_METHOD_NONE)
-        if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%bundle,rc=status)
+        if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%input_bundle,rc=status)
         _VERIFY(status)
 
         call this%timeInfo%add_time_to_metadata(this%metadata,rc=status)
@@ -146,13 +185,14 @@ module MAPL_newCFIOMod
        
      end subroutine CreateFileMetaData
 
-     subroutine set_param(this,deflation,chunking,nbits,regrid_method,itemOrder,rc)
+     subroutine set_param(this,deflation,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
         class (MAPL_newCFIO), intent(inout) :: this
         integer, optional, intent(in) :: deflation
         integer, optional, intent(in) :: chunking(:)
         integer, optional, intent(in) :: nbits
         integer, optional, intent(in) :: regrid_method
         logical, optional, intent(in) :: itemOrder
+        integer, optional, intent(in) :: write_collection_id
         integer, optional, intent(out) :: rc
 
         integer :: status
@@ -165,6 +205,7 @@ module MAPL_newCFIOMod
            _VERIFY(status)
         end if
         if (present(itemOrder)) this%itemOrderAlphabetical = itemOrder
+        if (present(write_collection_id)) this%write_collection_id=write_collection_id
         _RETURN(ESMF_SUCCESS)
 
      end subroutine set_param
@@ -213,7 +254,7 @@ module MAPL_newCFIOMod
         character(len=:), allocatable :: vdims
         type(Variable) :: v
 
-        call ESMF_FieldBundleGet(this%bundle,itemName,field=field,rc=status)
+        call ESMF_FieldBundleGet(this%input_bundle,itemName,field=field,rc=status)
         _VERIFY(status)
         factory => get_factory(this%output_grid,rc=status)
         _VERIFY(status)
@@ -280,7 +321,7 @@ module MAPL_newCFIOMod
         call this%metadata%modify_variable('time',v,rc=status)
         _VERIFY(status)
         call var_map%insert('time',v)
-        call oClients%modify_metadata(this%collection_id, var_map=var_map, rc=status)
+        call oClients%modify_metadata(this%write_collection_id, var_map=var_map, rc=status)
         _VERIFY(status)
         _RETURN(ESMF_SUCCESS)
 
@@ -303,7 +344,7 @@ module MAPL_newCFIOMod
         this%times = this%timeInfo%compute_time_vector(this%metadata,rc=status)
         _VERIFY(status)
         ref = ArrayReference(this%times)
-        call oClients%stage_nondistributed_data(this%collection_id,trim(filename),'time',ref) 
+        call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref) 
 
         tindex = size(this%times)
         if (tindex==1) then
@@ -367,7 +408,7 @@ module MAPL_newCFIOMod
         _VERIFY(status)
 
         if (this%doVertRegrid) then
-           call ESMF_FieldBundleGet(this%bundle,itemName,field=field,rc=status)
+           call ESMF_FieldBundleGet(this%input_bundle,itemName,field=field,rc=status)
            _VERIFY(status)
            call ESMF_FieldGet(Field,rank=fieldRank,rc=status)
            _VERIFY(status)
@@ -389,24 +430,26 @@ module MAPL_newCFIOMod
            if (associated(ptr3d)) nullify(ptr3d)
         end if
 
-        call ESMF_FieldBundleGet(this%bundle,itemName,field=field,rc=status)
+        call ESMF_FieldBundleGet(this%input_bundle,itemName,field=field,rc=status)
         _VERIFY(status)
         call ESMF_FieldGet(field,rank=fieldRank,rc=status)
         _VERIFY(status)
         if (fieldRank==2) then
-           call ESMF_FieldGet(field,farrayPtr=ptr2d,rc=status)
+           call MAPL_FieldGetPointer(field,ptr2d,rc=status)
            _VERIFY(status)
            call MAPL_FieldGetPointer(OutField,outptr2d,rc=status)
            _VERIFY(status)
+           if (this%regrid_method==REGRID_METHOD_FRACTION) ptr2d=ptr2d-this%fraction
            call this%regrid_handle%regrid(ptr2d,outPtr2d,rc=status)
            _VERIFY(status)
         else if (fieldRank==3) then
            if (.not.associated(ptr3d)) then
-              call ESMF_FieldGet(field,farrayPtr=ptr3d,rc=status)
+              call MAPL_FieldGetPointer(field,ptr3d,rc=status)
               _VERIFY(status)
            end if
            call MAPL_FieldGetPointer(OutField,outptr3d,rc=status)
            _VERIFY(status)
+           if (this%regrid_method==REGRID_METHOD_FRACTION) ptr3d=ptr3d-this%fraction
            call this%regrid_handle%regrid(ptr3d,outPtr3d,rc=status)
            _VERIFY(status)
         end if
@@ -439,7 +482,7 @@ module MAPL_newCFIOMod
         _VERIFY(status)
 
         if (this%doVertRegrid) then
-           call ESMF_FieldBundleGet(this%bundle,xName,field=xfield,rc=status)
+           call ESMF_FieldBundleGet(this%input_bundle,xName,field=xfield,rc=status)
            _VERIFY(status)
            call ESMF_FieldGet(xField,rank=fieldRank,rc=status)
            _VERIFY(status)
@@ -457,7 +500,7 @@ module MAPL_newCFIOMod
               end if
               xptr3d => xptr3d_inter
            end if
-           call ESMF_FieldBundleGet(this%bundle,yName,field=yfield,rc=status)
+           call ESMF_FieldBundleGet(this%input_bundle,yName,field=yfield,rc=status)
            _VERIFY(status)
            call ESMF_FieldGet(yField,rank=fieldRank,rc=status)
            _VERIFY(status)
@@ -480,19 +523,19 @@ module MAPL_newCFIOMod
            if (associated(yptr3d)) nullify(yptr3d)
         end if
 
-        call ESMF_FieldBundleGet(this%bundle,xname,field=xfield,rc=status)
+        call ESMF_FieldBundleGet(this%input_bundle,xname,field=xfield,rc=status)
         _VERIFY(status)
-        call ESMF_FieldBundleGet(this%bundle,yname,field=yfield,rc=status)
+        call ESMF_FieldBundleGet(this%input_bundle,yname,field=yfield,rc=status)
         _VERIFY(status)
         call ESMF_FieldGet(xfield,rank=fieldRank,rc=status)
         _VERIFY(status)
         if (fieldRank==2) then
-           call ESMF_FieldGet(xfield,farrayPtr=xptr2d,rc=status)
+           call MAPL_FieldGetPointer(xfield,xptr2d,rc=status)
            _VERIFY(status)
            call MAPL_FieldGetPointer(xOutField,xoutptr2d,rc=status)
            _VERIFY(status)
 
-           call ESMF_FieldGet(yfield,farrayPtr=yptr2d,rc=status)
+           call MAPL_FieldGetPointer(yfield,yptr2d,rc=status)
            _VERIFY(status)
            call MAPL_FieldGetPointer(yOutField,youtptr2d,rc=status)
            _VERIFY(status)
@@ -501,14 +544,14 @@ module MAPL_newCFIOMod
            _VERIFY(status)
         else if (fieldRank==3) then
            if (.not.associated(xptr3d)) then
-              call ESMF_FieldGet(xfield,farrayPtr=xptr3d,rc=status)
+              call MAPL_FieldGetPointer(xfield,xptr3d,rc=status)
               _VERIFY(status)
            end if
            call MAPL_FieldGetPointer(xOutField,xoutptr3d,rc=status)
            _VERIFY(status)
 
            if (.not.associated(yptr3d)) then
-              call ESMF_FieldGet(yfield,farrayPtr=yptr3d,rc=status)
+              call MAPL_FieldGetPointer(yfield,yptr3d,rc=status)
               _VERIFY(status)
            end if
            call MAPL_FieldGetPointer(yOutField,youtptr3d,rc=status)
@@ -553,7 +596,7 @@ module MAPL_newCFIOMod
         if (.not.allocated(this%lons)) allocate(this%lons(size(ptr2d,1),size(ptr2d,2)))
         this%lons=ptr2d*MAPL_RADIANS_TO_DEGREES
         ref = ArrayReference(this%lons)
-        call oClients%collective_stage_data(this%collection_id,trim(filename),'lons', &
+        call oClients%collective_stage_data(this%write_collection_id,trim(filename),'lons', &
                      ref,start=[i1,j1-tile*global_dim(1),tile+1], &
                      global_start=[1,1,1], global_count=[global_dim(1),global_dim(1),6])
         call ESMF_GridGetCoord(this%output_grid, localDE=0, coordDim=2, &
@@ -564,7 +607,7 @@ module MAPL_newCFIOMod
         !ref = ArrayReference(ptr2d)
         this%lats=ptr2d*MAPL_RADIANS_TO_DEGREES
         ref = ArrayReference(this%lats)
-        call oClients%collective_stage_data(this%collection_id,trim(filename),'lats', &
+        call oClients%collective_stage_data(this%write_collection_id,trim(filename),'lats', &
                      ref,start=[i1,j1-tile*global_dim(1),tile+1], &
                      global_start=[1,1,1], global_count=[global_dim(1),global_dim(1),6])
      end if
@@ -616,7 +659,7 @@ module MAPL_newCFIOMod
               end if
            end if
            ref = ArrayReference(ptr2d)
-           call oClients%collective_stage_data(this%collection_id,trim(filename),trim(fieldName), &
+           call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(fieldName), &
                         ref,start=[i1,j1-tile*global_dim(1),tile+1,1], &
                         global_start=[1,1,1,tindex], global_count=[global_dim(1),global_dim(1),6,1])
         else if (fieldRank==3) then
@@ -631,7 +674,7 @@ module MAPL_newCFIOMod
            cptr = c_loc(ptr3d)
            call C_F_pointer(cptr,ptr_ref_3d,[size(ptr3d,1),size(ptr3d,2),1,size(ptr3d,3),1])
            ref = ArrayReference(ptr_ref_3d)
-           call oClients%collective_stage_data(this%collection_id,trim(filename),trim(fieldName), &
+           call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(fieldName), &
                         ref,start=[i1,j1-tile*global_dim(1),tile+1,1,1], &
                         global_start=[1,1,1,1,tindex], global_count=[global_dim(1),global_dim(1),6,lm,1])
         end if
@@ -646,7 +689,7 @@ module MAPL_newCFIOMod
               end if
            end if
            ref = ArrayReference(Ptr2D)
-           call oClients%collective_stage_data(this%collection_id,trim(filename),trim(fieldName), &
+           call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(fieldName), &
                         ref,start=[i1,j1,1], &
                         global_start=[1,1,tindex], global_count=[global_dim(1),global_dim(2),1])
          else if (fieldRank==3) then
@@ -659,7 +702,7 @@ module MAPL_newCFIOMod
                end if
             end if
             ref = ArrayReference(Ptr3D)
-            call oClients%collective_stage_data(this%collection_id,trim(filename),trim(fieldName), &
+            call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(fieldName), &
                       ref,start=[i1,j1,1,1], &
                       global_start=[1,1,1,tindex], global_count=[global_dim(1),global_dim(2),lm,1])
          end if
@@ -718,5 +761,139 @@ module MAPL_newCFIOMod
      _RETURN(_SUCCESS)
  
   end subroutine alphabatize_variables
+
+  subroutine request_data_from_file(this,filename,timeindex,rc)
+     class(mapl_newcfio), intent(inout) :: this
+     character(len=*), intent(in) :: filename
+     integer, intent(in) :: timeindex
+     integer, intent(out), optional :: rc
+
+     integer :: status
+     type(esmf_grid) :: filegrid
+     type(maplextdatacollection), pointer :: collection
+     integer :: i,numVars
+     character(len=ESMF_MAXSTR), allocatable :: names(:)
+     type(ESMF_Field) :: output_field
+     type(ESMF_Field), allocatable :: input_fields(:)
+     integer :: ub(1),lb(1),i1,in,j1,jn,img,jmg,dims(3),lm,rank
+     type(ArrayReference) :: ref
+     real, pointer :: ptr2d(:,:) => null()
+     real, pointer :: ptr3d(:,:,:) => null()
+     integer, allocatable :: start(:)
+     integer, allocatable :: global_start(:)
+     integer, allocatable :: global_count(:)
+     type(ESMF_Grid) :: output_grid
+     logical :: hasDE
+
+     collection => extdatacollections%at(this%metadata_collection_id)
+     filegrid = collection%src_grid
+     hasDE=MAPL_GridHasDE(filegrid,rc=status)
+     _VERIFY(status)
+     call ESMF_FieldBundleGet(this%output_bundle,grid=output_grid,rc=status)
+     _VERIFY(status)
+     this%regrid_handle => new_regridder_manager%make_regridder(filegrid,output_grid,this%regrid_method,rc=status)
+     _VERIFY(status)
+     call MAPL_Grid_Interior(filegrid,i1,in,j1,jn)
+     call MAPL_GridGet(filegrid,globalCellCountPerdim=dims,rc=status)
+     _VERIFY(status)
+     img=dims(1)
+     jmg=dims(2)
+     lm=dims(3)
+     ! create input bundle
+     call ESMF_FieldBundleGet(this%output_bundle,fieldCount=numVars,rc=status)
+     _VERIFY(status)
+     allocate(names(numVars),stat=status)
+     _VERIFY(status)
+     allocate(input_fields(numVars),stat=status)
+     _VERIFY(status)
+     call ESMF_FieldBundleGet(this%output_bundle,fieldNameList=names,rc=status)
+     _VERIFY(status)
+     do i=1,numVars
+        call ESMF_FieldBundleGet(this%output_bundle,names(i),field=output_field,rc=status)
+        _VERIFY(status)
+        call ESMF_FieldGet(output_field,rank=rank,rc=status)
+        _VERIFY(status)
+        if (rank==2) then
+           input_fields(i) = ESMF_FieldCreate(filegrid,typekind=ESMF_TYPEKIND_R4,gridToFieldMap=[1,2],name=trim(names(i)),rc=status)
+           _VERIFY(status)
+           if (hasDE) then
+              call ESMF_FieldGet(input_fields(I),0,farrayPtr=ptr2d,rc=status)
+              _VERIFY(status)
+           end if
+           ref=ArrayReference(ptr2d)
+           start = [i1, j1, timeIndex] ! (i,j,t)
+           global_start = [1, 1, timeIndex] ! (i,j,t)
+           global_count = [img, jmg, 1]           
+        else if (rank==3) then
+           call ESMF_FieldGet(output_field,ungriddedLBound=lb,ungriddedUBound=ub,rc=status)
+           _VERIFY(status)
+           input_fields(i) = ESMF_FieldCreate(filegrid,typekind=ESMF_TYPEKIND_R4,gridToFieldMap=[1,2], &
+              ungriddedLBound=lb,ungriddedUBound=ub,name=trim(names(i)),rc=status)
+           _VERIFY(status)
+           if (hasDE) then
+              call ESMF_FieldGet(input_fields(I),0,farrayPtr=ptr3d,rc=status)
+              _VERIFY(status)
+           end if
+           ref=ArrayReference(ptr3d)
+           start = [i1, j1, 1, timeIndex] ! (i,j,t)
+           global_start = [1, 1, 1, timeIndex] ! (i,j,t)
+           global_count = [img, jmg, lm, 1]           
+        end if
+        call i_Clients%collective_prefetch_data( &
+             this%read_collection_id, fileName, trim(names(i)), &
+             & ref, start=start, global_start=global_start, global_count=global_count)
+        deallocate(start,global_start,global_count)
+     enddo
+     this%input_bundle = ESMF_FieldBundleCreate(fieldList=input_fields,rc=status)
+     _VERIFY(status)
+     _RETURN(_SUCCESS)
+
+  end subroutine request_data_from_file
+
+  subroutine process_data_from_file(this,rc)
+     class(mapl_newcfio), intent(inout) :: this
+     integer, intent(out), optional :: rc
+
+     integer :: status     
+     integer :: i,numVars
+     character(len=ESMF_MAXSTR), allocatable :: names(:)
+     type(ESMF_Field) :: field
+     type(newCFIOitem), pointer :: item
+     type(newCFIOitemVectorIterator) :: iter
+
+     call ESMF_FieldBundleGet(this%output_bundle,fieldCount=numVars,rc=status)
+     _VERIFY(status)
+     allocate(names(numVars),stat=status)
+     _VERIFY(status)
+     call ESMF_FieldBundleGet(this%output_bundle,fieldNameList=names,rc=status)
+     _VERIFY(status)
+     iter = this%items%begin()
+     do while(iter /= this%items%end())
+        item => iter%get()
+        if (item%itemType == ItemTypeScalar) then
+           call this%regridScalar(trim(item%xname),rc=status)
+           _VERIFY(status)
+        else if (item%itemTYpe == ItemTypeVector) then
+           call this%regridVector(trim(item%xname),trim(item%yname),rc=status)
+           _VERIFY(status)
+        end if
+        call iter%next()
+     enddo
+     !do i=1,numVars
+        !call this%regridScalar(trim(names(i)),rc=status)
+        !_VERIFY(status)
+     !enddo
+
+     do i=1,numVars
+        call ESMF_FieldBundleGet(this%input_bundle,trim(names(i)),field=field,rc=status)
+        _VERIFY(status)
+        call ESMF_FieldDestroy(field,rc=status)
+        _VERIFY(status)
+     enddo
+     call ESMF_FieldBundleDestroy(this%input_bundle,rc=status)
+     _VERIFY(status)
+     _RETURN(_SUCCESS)
+
+  end subroutine process_data_from_file
 
 end module MAPL_newCFIOMod

--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -873,16 +873,12 @@ module MAPL_newCFIOMod
         if (item%itemType == ItemTypeScalar) then
            call this%regridScalar(trim(item%xname),rc=status)
            _VERIFY(status)
-        else if (item%itemTYpe == ItemTypeVector) then
+        else if (item%itemType == ItemTypeVector) then
            call this%regridVector(trim(item%xname),trim(item%yname),rc=status)
            _VERIFY(status)
         end if
         call iter%next()
      enddo
-     !do i=1,numVars
-        !call this%regridScalar(trim(names(i)),rc=status)
-        !_VERIFY(status)
-     !enddo
 
      do i=1,numVars
         call ESMF_FieldBundleGet(this%input_bundle,trim(names(i)),field=field,rc=status)


### PR DESCRIPTION
Fixes #44 

This update removes the use of the MAPL "little" and "big" CFIO layer in ExtData. An extension to the basic file metadata class was made to provide a few more capabilities that the "little" cfio provided that were above the basic functionality of the file metadata class specific to CF type data. In addition the "newCFIO" layer (still needs a better name) was extended so that ExtData can use this layer as well for file IO. This is a zero-diff change.