### PR TITLE
Fix i-server crash

### DIFF
--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -228,6 +228,12 @@ contains
            allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), s_name))
            call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
            call this%directory_service%connect_to_client(s_name, this%i_server)
+           call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
+           if (rank == 0 .and. this%cap_options%nodes_input_server(1) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%nodes_input_server(i)," nodes"
+           else if (rank==0 .and. this%cap_options%npes_input_server(1) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%npes_input_server(i)," pes"
+           end if
         endif
 
         if ( index(s_name, 'model') /=0 ) then

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -229,9 +229,9 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
            call this%directory_service%connect_to_client(s_name, this%i_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. this%cap_options%nodes_input_server(1) /=0 ) then
+           if (rank == 0 .and. this%cap_options%nodes_input_server(i) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%nodes_input_server(i)," nodes"
-           else if (rank==0 .and. this%cap_options%npes_input_server(1) /=0 ) then
+           else if (rank==0 .and. this%cap_options%npes_input_server(i) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%npes_input_server(i)," pes"
            end if
         endif
@@ -254,9 +254,9 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%o_server), this%o_server)
            call this%directory_service%connect_to_client(s_name, this%o_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. this%cap_options%nodes_output_server(1) /=0 ) then
+           if (rank == 0 .and. this%cap_options%nodes_output_server(i) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO output server on ",this%cap_options%nodes_output_server(i)," nodes"
-           else if (rank==0 .and. this%cap_options%npes_output_server(1) /=0 ) then
+           else if (rank==0 .and. this%cap_options%npes_output_server(i) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO output server on ",this%cap_options%npes_output_server(i)," pes"
            end if
         endif

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -1491,6 +1491,7 @@ CONTAINS
    call MAPL_TimerOn(MAPLSTATE,"---IclientDone")
 
    call i_Clients%done_collective_prefetch()
+   call i_Clients%wait()
 
    call MAPL_TimerOff(MAPLSTATE,"---IclientDone")
    _VERIFY(STATUS)


### PR DESCRIPTION
I forgot to put the wait call in on the iclient when refactory this code. Causes a crash because data arrays being filled are not done being filled yet when used without the wait call. Also add a print so we know if the i-server is being started on dedicated resources.