### PR TITLE
Refactorings for ESMF 8.0.0

### DIFF
--- a/MAPL_Base/MAPL_CubedSphereGridFactory.F90
+++ b/MAPL_Base/MAPL_CubedSphereGridFactory.F90
@@ -190,7 +190,7 @@ contains
       integer :: i,nTile
       integer, allocatable :: ims(:,:), jms(:,:)
       real(kind=ESMF_KIND_R8), pointer :: lats(:,:),lons(:,:)
-      type(ESMF_CS_Arguments) :: transformArgument
+      type(ESMF_CubedSphereTransform_Args) :: transformArgument
       integer :: status
       character(len=*), parameter :: Iam = MOD_NAME // 'create_basic_grid'
 
@@ -223,7 +223,7 @@ contains
             grid = ESMF_GridCreateCubedSPhere(this%im_world,countsPerDEDim1PTile=ims, &
                       countsPerDEDim2PTile=jms ,name=this%grid_name, &
                       staggerLocList=[ESMF_STAGGERLOC_CENTER,ESMF_STAGGERLOC_CORNER], coordSys=ESMF_COORDSYS_SPH_RAD, & 
-                      transformArgument=transformArgument,rc=status)
+                      transformArgs=transformArgument,rc=status)
             _VERIFY(status)
             call ESMF_AttributeSet(grid, name='STRETCH_FACTOR', value=this%stretch_factor,rc=status)
             _VERIFY(status)


### PR DESCRIPTION
Hi everyone,

In the offical release of ESMF 8.0.0 the name of `type(ESMF_CS_Arguments)` and the `ESMF_GridCreateCubedSphereReg()` argument `transformArguments` were changed. These changes are:

- `type(ESMF_CS_Arguments)` -> `type(ESMF_CubedSphereTransform_Args)`
- `transformArguments` ->  `transformArgs`

This was the only source code modification I had to make to compile MAPL with the official ESMF 8 release. 

**Note**: This change *is not* compatible with ESMF 8 pre-releases. 