### PR TITLE
Fix CFIO read for intel - Do not delete branch!

### DIFF
--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -844,7 +844,10 @@ VERIFY_(STATUS)
 mcfio%krank=0
 allocate(MCFIO%pairList(LT), stat=STATUS)
 VERIFY_(STATUS)
-call MAPL_RoundRobinPEList(mcfio%krank,size(MAPL_NodeRankList),rc=status)
+if (allocated(MAPL_NodeRankList)) then
+   call MAPL_RoundRobinPEList(mcfio%krank,size(MAPL_NodeRankList),rc=status)
+   VERIFY_(status)
+end if
 
 MCFIO%pairList = 0
 

--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -844,6 +844,7 @@ VERIFY_(STATUS)
 mcfio%krank=0
 allocate(MCFIO%pairList(LT), stat=STATUS)
 VERIFY_(STATUS)
+call MAPL_RoundRobinPEList(mcfio%krank,size(MAPL_NodeRankList),rc=status)
 
 MCFIO%pairList = 0
 


### PR DESCRIPTION
This is a change we found that is needed when running intel mpi on SLES12, apparently intel mpi by default does not like all the gathers to be to root when writing. Apparently MPT runs just fine like this. This round robins them among all processors if the node rank list has been allocated by doing the node detection in shmem.

Do not delete this branch! There may be more changes that we might want to push here, but I just wanted to make sure we got this hotfix into master and making a new branch with identical code seemed rather pointless.