### PR TITLE
Fix intelmpi for MAPL_CFIOWrite

### DIFF
--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -876,6 +876,10 @@ contains
     mcfio%krank=0
     allocate(MCFIO%pairList(LT), stat=STATUS)
     _VERIFY(STATUS)
+    if (allocated(MAPL_NodeRankList)) then
+       call MAPL_RoundRobinPEList(mcfio%krank,size(MAPL_NodeRankList),rc=status)
+       VERIFY_(status)
+    end if
 
     MCFIO%pairList = 0
 

--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -878,7 +878,7 @@ contains
     _VERIFY(STATUS)
     if (allocated(MAPL_NodeRankList)) then
        call MAPL_RoundRobinPEList(mcfio%krank,size(MAPL_NodeRankList),rc=status)
-       VERIFY_(status)
+       _VERIFY(status)
     end if
 
     MCFIO%pairList = 0


### PR DESCRIPTION
hotfix so that intel mpi will work MAPL_CFIOWrite. Apparently intel MPI is not happy with every trying to gather to the root but MPT was.