### PR TITLE
Fix binary output

### DIFF
--- a/MAPL_Base/MAPL_HistoryGridComp.F90
+++ b/MAPL_Base/MAPL_HistoryGridComp.F90
@@ -2805,7 +2805,7 @@ ENDDO PARSER
                   VERIFY_(STATUS)
                   list(n)%unit = -2
                else
-                  list(n)%unit = GETFILE( trim(filename(n)))
+                  list(n)%unit = GETFILE( trim(filename(n)),all_pes=.true.)
                end if
             end if
 


### PR DESCRIPTION
Binary output was hanging, same problem we have seen before, a getfile call nees the all_pes option to true