### PR TITLE
Fix gcc build and run

### DIFF
--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -17,6 +17,7 @@ module MAPL_FileMetadataUtilsMod
    private
       character(len=:), allocatable :: filename 
    contains
+      procedure :: create
       procedure :: get_coordinate_info
       procedure :: get_variable_attribute
       procedure :: get_time_units
@@ -40,6 +41,15 @@ module MAPL_FileMetadataUtilsMod
       metadata_utils%filename = fName
       
    end function new_FilemetadataUtils
+
+   subroutine create(this,metadata,fname)
+      class(FileMetadataUtils), intent(inout) :: this
+      type (FileMetadata), intent(in) :: metadata
+      character(len=*), intent(in) :: fName
+      this%Filemetadata = metadata
+      this%filename = fName
+   end subroutine create
+
 
    subroutine get_time_units(this,startTime,startyear,startmonth,startday,starthour,startmin,startsec,units,rc)
       class (FileMetadataUtils), intent(inout) :: this

--- a/MAPL_Base/MAPL_ExtDataCollection.F90
+++ b/MAPL_Base/MAPL_ExtDataCollection.F90
@@ -67,7 +67,6 @@ contains
        if (this%metadatas%size() >= MAX_FORMATTERS) then
           metadata => this%metadatas%front()
           call this%metadatas%erase(this%metadatas%begin())
-          !deallocate(metadata)
           nullify(metadata)
 
           iter = this%file_ids%begin()
@@ -97,7 +96,8 @@ contains
        _VERIFY(status)
        call formatter%close(rc=status)
        _VERIFY(status)
-       metadata = FileMetadataUtils(basic_metadata,file_name)
+       !metadata = FileMetadataUtils(basic_metadata,file_name)
+       call metadata%create(basic_metadata,file_name)
        call this%metadatas%push_back(metadata)
        deallocate(metadata)
        metadata => this%metadatas%back()

--- a/MAPL_Base/MAPL_ExtDataCollection.F90
+++ b/MAPL_Base/MAPL_ExtDataCollection.F90
@@ -96,7 +96,6 @@ contains
        _VERIFY(status)
        call formatter%close(rc=status)
        _VERIFY(status)
-       !metadata = FileMetadataUtils(basic_metadata,file_name)
        call metadata%create(basic_metadata,file_name)
        call this%metadatas%push_back(metadata)
        deallocate(metadata)

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -2043,11 +2043,13 @@ CONTAINS
         logical                    :: found,lFound,intOK
         integer                    :: maxOffset
         character(len=:), allocatable :: levname
-        character(len=:), pointer :: positive => null()
+        character(len=:), pointer :: positive 
         type(FileMetadataUtils), pointer :: metadata
         type(ESMF_Grid) :: fileGrid
 
         type(ESMF_TimeInterval)    :: zero
+
+        positive=>null()
 
         call ESMF_TimeIntervalSet(zero,__RC__)
 
@@ -2129,7 +2131,7 @@ CONTAINS
            if (item%havePressure) then
               if (levFile(1)>levFile(size(levFile))) item%fileVDir="up"
            else
-              positive = metadata%get_variable_attribute(levName,'positive',__RC__)
+              positive => metadata%get_variable_attribute(levName,'positive',__RC__)
               if (associated(positive)) then
                  if (trim(positive)=='up') item%fileVDir="up"
               end if

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -118,7 +118,6 @@ contains
       call ESMF_ConfigDestroy(config, rc=status)
       _VERIFY(status)
 
-      write(*,*)'bma get name ',this%split_comm%get_name()
       select case(this%split_comm%get_name())
       case('model')
          iter = cases%begin()


### PR DESCRIPTION
This fixes both build and run issues with gcc 8
I'm not sure why gcc was unhappy with creating the filemetadatautilities with the constructor rather than a subroutine call on the object to add the base filemeta to the class but both intel and gcc appear to be happy with this now.