### PR TITLE
Fixes #98 - MAPL Code Generator for GridComp specs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
+*~
 /@cmake
-/Externals.cfg~

--- a/Python/DataSpec.py
+++ b/Python/DataSpec.py
@@ -1,0 +1,97 @@
+class DataSpec:
+    """Declare and manipulate an import/export/internal specs for a 
+       MAPL Gridded component"""
+
+    mandatory_options = ['DIMS', 'SHORT_NAME']
+    # The following must be quoted when emitted as Fortran source.
+    stringlike_options = ['SHORT_NAME', 'LONG_NAME', 'UNITS']
+    # The following should NOT be quoted when emitted as Fortran source.
+    literal_options = ['DIMS', 'VLOCATION', 'NUM_SUBTILES',
+                       'REFRESH_INTERVAL', 'AVERAGING_INTERVAL', 'HALOWIDTH',
+                       'PRECISION','DEFAULT','RESTART', 'UNGRIDDED_DIMS',
+                       'FIELD_TYPE', 'STAGGERING', 'ROTATION']
+    all_options = stringlike_options + literal_options
+
+
+    def __init__(self, category, args, indent=3):
+        self.category = category
+        self.args = args
+        self.indent  = indent
+        self.has_condition = 'CONDITION' in self.args and DataSpec.not_empty(self.args['CONDITION'])
+
+
+    def not_empty(string):
+        return string and not string.isspace()
+        
+    def newline(self):
+        return "\n" + " "*self.indent
+
+    def continue_line(self):
+        return "&" + self.newline() + "& "
+
+    def emit_declare_spec(self):
+        return self.wrap_conditional(self.emit_MAPL_AddSpec)
+
+    def wrap_conditional(self, content_method):
+        text = self.newline()
+        if self.has_condition:
+            text = text + "if (" + self.args['CONDITION']  + ") then"
+            self.indent = self.indent + 3
+            text = text + self.newline()
+        text = text + content_method()
+        if self.has_condition:
+            self.indent = self.indent - 3
+            text = text + self.newline()
+            text = text + "endif"
+        return text + self.newline()
+        
+    def get_rank(self):
+        gridded_ranks = {'MAPL_DimsHorzVert':3, 'MAPL_DimsHorzOnly':2, 'MAPL_DimsVertOnly':1}
+        if 'UNGRIDDED_DIMS' in self.args:
+            extra_dims = self.args['UNGRIDDED_DIMS'].strip('][').split(',')
+            extra_rank = len(extra_dims)
+        else:
+            extra_rank = 0
+        return gridded_ranks[self.args['DIMS']] + extra_rank
+        
+    def emit_declare_local_variable(self):
+        return self.wrap_conditional(self.emit_MAPL_declare_local_variable)
+
+    def emit_MAPL_declare_local_variable(self):
+        type = 'real'
+        kind = 'REAL32'
+        rank = self.get_rank()
+        dimension = 'dimension(:' + ',:'*(rank-1) + ')'
+        text = type + '(kind=' + str(kind) + '), ' + dimension + ' :: ' + self.args['LOCAL_NAME'] + ' => null()'
+        return text
+
+    def emit_get_pointer(self):
+        return self.wrap_conditional(self.emit_MAPL_GetPointer)
+
+    def emit_MAPL_GetPointer(self):
+        text = "call MAPL_GetPointer(" + self.category + ', ' + self.args['LOCAL_NAME'] + ", '" + self.args['SHORT_NAME'] + "', rc=status); VERIFY_(status)" 
+        return text
+
+
+    def emit_MAPL_AddSpec(self):
+        self.indent = self.indent + 5
+        text = "call MAPL_Add" + self.category + "Spec(" + self.continue_line()
+        for option in DataSpec.all_options:
+            text = text + self.emit_arg(option)
+        text = text + 'rc=status)' + self.newline()
+        self.indent = self.indent - 5
+        text = text + 'VERIFY_(status)'
+        return text
+
+    def emit_arg(self, option):
+        text = ''
+        if option in self.args:
+            value = self.args[option]
+            text = text + option + "="
+            if option in DataSpec.stringlike_options:
+                value = "'" + value + "'"
+            text = text + value + ", " + self.continue_line()
+        return text
+
+
+

--- a/Python/DataSpecsReader.py
+++ b/Python/DataSpecsReader.py
@@ -1,0 +1,38 @@
+import csv
+import pandas as pd
+
+def read(specs_filename):
+    
+    def csv_record_reader(csv_reader):
+        """ Read a csv reader iterator until a blank line is found. """
+        prev_row_blank = True
+        for row in csv_reader:
+            if not (len(row) == 0):
+                if row[0].startswith('#'):
+                    continue
+                yield row
+                prev_row_blank = False
+            elif not prev_row_blank:
+                return
+
+    specs = {}
+    with open(specs_filename, 'r') as specs_file:
+        specs_reader = csv.reader(specs_file, skipinitialspace=True)
+        while True:
+            try:
+                gen = csv_record_reader(specs_reader)
+                category = next(gen)[0]
+                columns = next(gen)
+                specs[category] = pd.DataFrame(gen, columns=columns)
+            except StopIteration:
+                break
+
+    if '*ALIASES*' in specs:
+        for alias in specs['*ALIASES*'].to_dict('records'):
+            specs['IMPORT'].replace({alias['OPTION']:{alias['ALIAS']:alias['VALUE']}},inplace=True)
+            specs['EXPORT'].replace({alias['OPTION']:{alias['ALIAS']:alias['VALUE']}},inplace=True)
+            specs['INTERNAL'].replace({alias['OPTION']:{alias['ALIAS']:alias['VALUE']}},inplace=True)
+
+    return specs
+
+

--- a/Python/MAPL_SpecsCodeGenerator.py
+++ b/Python/MAPL_SpecsCodeGenerator.py
@@ -1,0 +1,33 @@
+import argparse
+import DataSpec
+import DataSpecsReader
+
+# command line arguments
+parser = argparse.ArgumentParser(description='Generate import/export/internal specs for MAPL Gridded Component')
+parser.add_argument('-i','--input', action='store')
+parser.add_argument('--declare_specs', action='store', default='declare_specs.h')
+parser.add_argument('--declare_local', action='store', default='declare_local.h')
+parser.add_argument('--get_pointer', action='store', default='get_pointer.h')
+args = parser.parse_args()
+
+
+f_spec = open(args.declare_specs,'w') 
+f_local = open(args.declare_local,'w') 
+f_get_pointer = open(args.get_pointer,'w') 
+
+specs = DataSpecsReader.read(args.input)
+for category in ('IMPORT','EXPORT','INTERNAL'):
+    for item in specs[category].to_dict('records'):
+        spec = DataSpec.DataSpec(category.capitalize(), item)
+        f_spec.write(spec.emit_declare_spec())
+        f_local.write(spec.emit_declare_local_variable())
+        f_get_pointer.write(spec.emit_get_pointer())
+
+f_spec.close()
+f_local.close()
+f_get_pointer.close()
+
+
+
+            
+            


### PR DESCRIPTION
This is the initial implementation of a python package to generate
include files for MAPL GridComps.    Each grid comp has a certain
degree of repetitive declarations related to ESMF import, export, and
interal states.   These are more cleanly expressed and maintained in
a comma-separated-value (CSV) file.   There is a downside though that
developers must now look for this information into a separate file.

This new python layer generates 3 include files for each grid comp
corresponding to

1. calls to MAPL_Add*Spec() for import/export/internal items.
2. calls to MAPL_GetPointer() to relate items to local variables
3. declarations of local variables.

Developers should edit input CSV files with an editor mode that
supports this format.  E.g., csv-mode in emacs or even Excel.
Such tools can show the fields in an aligned fashion withou forcing
the maintainers to adjust spacing with each change.