### PR TITLE
Memory leak fix in extdata

### DIFF
--- a/MAPL_Base/MAPL_EsmfRegridder.F90
+++ b/MAPL_Base/MAPL_EsmfRegridder.F90
@@ -121,9 +121,9 @@ contains
 
       if (HasDE) q_out = p_dst
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
       
       _RETURN(ESMF_SUCCESS)

--- a/MAPL_Base/MAPL_EsmfRegridder.F90
+++ b/MAPL_Base/MAPL_EsmfRegridder.F90
@@ -176,9 +176,9 @@ contains
 
       if (HasDE) q_out = p_dst
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
       
       _RETURN(ESMF_SUCCESS)
@@ -228,9 +228,9 @@ contains
 
       if (hasDE) q_out = p_dst
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -311,9 +311,9 @@ contains
 
       if (HasDE) q_out = reshape(p_dst, shape(q_out), order=[3,1,2])
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -394,9 +394,9 @@ contains
 
       if (HasDE) q_out = reshape(p_dst, shape(q_out), order=[3,1,2])
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -483,9 +483,9 @@ contains
  
       if (HasDE) q_out = reshape(p_dst, shape(q_out), order=[3,1,2])
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -577,9 +577,9 @@ contains
          _VERIFY(status)
       end if
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -671,9 +671,9 @@ contains
         _VERIFY(status)
      end if
 
-     call ESMF_FieldDestroy(src_field, rc=status)
+     call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
      _VERIFY(status)
-     call ESMF_FieldDestroy(dst_field, rc=status)
+     call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
      _VERIFY(status)
 
      _RETURN(ESMF_SUCCESS)
@@ -761,9 +761,9 @@ contains
          _VERIFY(status)
       end if
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -875,9 +875,9 @@ contains
          _VERIFY(status)
       end if
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       _RETURN(ESMF_SUCCESS)
@@ -982,9 +982,9 @@ contains
         _VERIFY(status)
      end if
 
-     call ESMF_FieldDestroy(src_field, rc=status)
+     call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
      _VERIFY(status)
-     call ESMF_FieldDestroy(dst_field, rc=status)
+     call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
      _VERIFY(status)
 
      _RETURN(ESMF_SUCCESS)
@@ -1097,9 +1097,9 @@ contains
          _VERIFY(status)
       end if
 
-      call ESMF_FieldDestroy(src_field, rc=status)
+      call ESMF_FieldDestroy(src_field, noGarbage=.true., rc=status)
       _VERIFY(status)
-      call ESMF_FieldDestroy(dst_field, rc=status)
+      call ESMF_FieldDestroy(dst_field, noGarbage=.true., rc=status)
       _VERIFY(status)
 
       deallocate(p_src)

--- a/MAPL_Base/MAPL_ExtData_IOBundleMod.F90
+++ b/MAPL_Base/MAPL_ExtData_IOBundleMod.F90
@@ -27,8 +27,6 @@ module MAPL_ExtData_IOBundleMod
      character(:), allocatable :: file_name
      integer :: time_index
      integer :: fraction
-     logical :: distributed_trans = .false.
-     logical :: parallel_skip
      integer :: metadata_coll_id
      integer :: server_coll_id
      type(newCFIOItemVector) :: items
@@ -37,6 +35,8 @@ module MAPL_ExtData_IOBundleMod
      
      procedure :: clean
      procedure :: make_cfio
+     procedure :: assign
+     generic :: assignment(=) => assign
   end type ExtData_IoBundle
   
 
@@ -71,7 +71,6 @@ contains
     io_bundle%fraction = fraction
     io_bundle%template = trim(template)
 
-    io_bundle%parallel_skip = .false.
     io_bundle%metadata_coll_id=metadata_coll_id
     io_bundle%server_coll_id=server_coll_id
     io_bundle%items=items
@@ -85,7 +84,7 @@ contains
     integer, optional, intent(out) :: rc
 
      __Iam__('clean')
-    call ESMF_FieldBundleDestroy(this%pbundle, __RC__)
+    call ESMF_FieldBundleDestroy(this%pbundle, noGarbage=.true.,__RC__)
     
      _RETURN(ESMF_SUCCESS)
 
@@ -107,6 +106,26 @@ contains
      _RETURN(ESMF_SUCCESS)
 
    end subroutine make_cfio
+
+   subroutine assign(to,from)
+      class(ExtData_IOBundle), intent(out) :: to
+      type(ExtData_IOBundle), intent(in) :: from
+    
+    to%bracket_side = from%bracket_side
+    to%entry_index = from%entry_index
+    to%file_name = from%file_name
+    to%time_index = from%time_index
+    to%regrid_method = from%regrid_method
+    to%fraction = from%fraction
+    to%template = from%template
+
+    to%metadata_coll_id=from%metadata_coll_id
+    to%server_coll_id=from%server_coll_id
+    to%items=from%items 
+    to%pbundle=from%pbundle 
+    to%CFIO=from%CFIO 
+ 
+   end subroutine assign
 
 end module MAPL_ExtData_IOBundleMod
 

--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -883,10 +883,10 @@ module MAPL_newCFIOMod
      do i=1,numVars
         call ESMF_FieldBundleGet(this%input_bundle,trim(names(i)),field=field,rc=status)
         _VERIFY(status)
-        call ESMF_FieldDestroy(field,rc=status)
+        call ESMF_FieldDestroy(field,noGarbage=.true., rc=status)
         _VERIFY(status)
      enddo
-     call ESMF_FieldBundleDestroy(this%input_bundle,rc=status)
+     call ESMF_FieldBundleDestroy(this%input_bundle,noGarbage=.true.,rc=status)
      _VERIFY(status)
      _RETURN(_SUCCESS)
 


### PR DESCRIPTION
Fix some memory problems encountered in ExtData.
1.) The MAPL_ExtData_IOBundleMod.F90 was not properly destroying the allocatable character arrays it when you had a vector of the type. Tom found that overloading equals to explicitly fixed this for reasons beyond me.
2.) The ESMF_Field and Bundle destroy methods need doGarbage = .true., otherwise they really don't destroy everything and leave a memory footprint.