### PR TITLE
clean up "use pfio" statements in MAPL_Base

### DIFF
--- a/GMAO_pFIO/pFIO.F90
+++ b/GMAO_pFIO/pFIO.F90
@@ -29,6 +29,11 @@ module pFIO
    use pFIO_StringVectorMod
    use pFIO_StringIntegerMapMod
    use pFIO_DownBitMod
+   use pFIO_ErrorHandlingMod
+   use pFIO_ThrowMod
+   use pFIO_IntegerVectorMod
+   use pFIO_LocalMemReferenceMod
+   use pFIO_FormatterPtrVectorMod
 
    integer, save :: debug_unit = 0
 

--- a/MAPL_Base/AbstractCommSplitter.F90
+++ b/MAPL_Base/AbstractCommSplitter.F90
@@ -2,7 +2,7 @@
 #include "unused_dummy.H"
 
 module MAPL_AbstractCommSplitterMod
-   use pFIO_StringVectorMod
+   use pFIO
    use MPI
    implicit none
    private

--- a/MAPL_Base/CFIOCollection.F90
+++ b/MAPL_Base/CFIOCollection.F90
@@ -1,7 +1,6 @@
 #include "pFIO_ErrLog.h"
 
 module ESMF_CFIOCollectionMod
-   use pFIO_StringIntegerMapMod
    use ESMF
   use ESMF_CFIOMod
   use MAPL_BaseMod, only : MAPL_GridGet
@@ -12,7 +11,6 @@ module ESMF_CFIOCollectionMod
   use pFIO
   use MAPL_GridManagerMod
   use MAPL_AbstractGridFactoryMod
-  use pFIO_ErrorHandlingMod
   implicit none
   private
 
@@ -142,7 +140,7 @@ end module ESMF_CFIOCollectionMod
 
 
 module ESMF_CFIOCollectionVectorMod
-   use pFIO_ThrowMod
+   use pFIO
    use ESMF_CFIOCollectionMod
    
    ! Create a map (associative array) between names and pFIO_Attributes.

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -22,7 +22,6 @@ module MAPL_FileMetadataUtilsMod
       procedure :: get_level_name
       procedure :: is_var_present
       procedure :: get_file_name
-      procedure :: create_bundle_from_metadata
    end type FileMetadataUtils
 
    interface FileMetadataUtils
@@ -370,30 +369,6 @@ module MAPL_FileMetadataUtilsMod
 
       _RETURN(_SUCCESS)
    end function get_file_name
-
-   function create_bundle_from_metadata(this,grid,variables,rc) result(bundle)
-      class (FileMetadataUtils), intent(inout) :: this
-      type(ESMF_Grid), intent(in), optional :: grid
-      type(StringVector), intent(in), optional :: variables
-      integer, optional, intent(out) :: rc
-      type(ESMF_FieldBundle) :: bundle
-      integer :: status
-      logical :: exists
-
-      type(ESMF_Grid) :: mygrid
-      class (AbstractGridFactory), allocatable :: factory
- 
-      if (present(grid)) then
-         mygrid=grid
-      else
-         inquire(file=trim(this%filename),exist=exists)
-         _ASSERT(exists,trim(this%filename)//" you are trying to make grid from does not exist")
-         allocate(factory, source=grid_manager%make_factory(trim(this%filename)))
-         mygrid = grid_manager%make_grid(factory)
-      end if
-
-
-   end function create_bundle_from_metadata
 
 end module MAPL_FileMetadataUtilsMod
 

--- a/MAPL_Base/MAPL_AbstractGridFactory.F90
+++ b/MAPL_Base/MAPL_AbstractGridFactory.F90
@@ -109,6 +109,7 @@ module MAPL_AbstractGridFactoryMod
 
       subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
         use MAPL_KeywordEnforcerMod
+        use pFIO
         import AbstractGridFactory
         class (AbstractGridFactory), intent(inout)  :: this
         type (FileMetadata), target, intent(in) :: file_metadata
@@ -149,6 +150,7 @@ module MAPL_AbstractGridFactoryMod
       end function generate_grid_name
 
       subroutine append_metadata(this, metadata)
+         use pFIO
          import AbstractGridFactory
          class (AbstractGridFactory), intent(inout) :: this
          type (FileMetadata), intent(inout) :: metadata
@@ -161,6 +163,7 @@ module MAPL_AbstractGridFactoryMod
       end function get_grid_vars
 
       subroutine append_variable_metadata(this,var)
+         use pFIO
          import AbstractGridFactory
          class (AbstractGridFactory), intent(inout) :: this
          type(Variable), intent(inout) :: var

--- a/MAPL_Base/MAPL_AbstractGridFactory.F90
+++ b/MAPL_Base/MAPL_AbstractGridFactory.F90
@@ -107,8 +107,8 @@ module MAPL_AbstractGridFactoryMod
 
 
       subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-        use pFIO_FileMetadataMod
-        use pFIO_NetCDF4_FileFormatterMod
+        use pFIO
+        use pFIO
         use MAPL_KeywordEnforcerMod
         import AbstractGridFactory
         class (AbstractGridFactory), intent(inout)  :: this
@@ -163,7 +163,7 @@ module MAPL_AbstractGridFactoryMod
       end function get_grid_vars
 
       subroutine append_variable_metadata(this,var)
-         use pFIO_VariableMod
+         use pFIO
          import AbstractGridFactory
          class (AbstractGridFactory), intent(inout) :: this
          type(Variable), intent(inout) :: var

--- a/MAPL_Base/MAPL_AbstractGridFactory.F90
+++ b/MAPL_Base/MAPL_AbstractGridFactory.F90
@@ -3,6 +3,7 @@
 
 module MAPL_AbstractGridFactoryMod
    use ESMF
+   use pFIO
    use MAPL_ErrorHandlingMod
    use MAPL_BaseMod, only: MAPL_UNDEF
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
@@ -107,8 +108,6 @@ module MAPL_AbstractGridFactoryMod
 
 
       subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-        use pFIO
-        use pFIO
         use MAPL_KeywordEnforcerMod
         import AbstractGridFactory
         class (AbstractGridFactory), intent(inout)  :: this
@@ -150,7 +149,6 @@ module MAPL_AbstractGridFactoryMod
       end function generate_grid_name
 
       subroutine append_metadata(this, metadata)
-         use pFIO
          import AbstractGridFactory
          class (AbstractGridFactory), intent(inout) :: this
          type (FileMetadata), intent(inout) :: metadata
@@ -163,7 +161,6 @@ module MAPL_AbstractGridFactoryMod
       end function get_grid_vars
 
       subroutine append_variable_metadata(this,var)
-         use pFIO
          import AbstractGridFactory
          class (AbstractGridFactory), intent(inout) :: this
          type(Variable), intent(inout) :: var

--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -40,7 +40,6 @@ module MAPL_CFIOMod
   use MAPL_ConfigMod
   use MAPL_RegridderSpecMod
   use MAPL_MemUtilsMod
-  use pFIO_IntegerVectorMod
   use ESMF_CFIOCollectionVectorMod
   use ESMF_CFIOCollectionMod
   use PFIO

--- a/MAPL_Base/MAPL_CapGridComp.F90
+++ b/MAPL_Base/MAPL_CapGridComp.F90
@@ -21,7 +21,7 @@ module MAPL_CapGridCompMod
   use MAPL_CFIOServerMod
   use MAPL_ConfigMod
   use MAPL_DirPathMod
-  use pFIO_StringVectorMod
+  use pFIO
 
   use iso_fortran_env
   

--- a/MAPL_Base/MAPL_CubedSphereGridFactory.F90
+++ b/MAPL_Base/MAPL_CubedSphereGridFactory.F90
@@ -19,6 +19,7 @@ module MAPL_CubedSphereGridFactoryMod
    use MAPL_MinMaxMod
    use MAPL_KeywordEnforcerMod
    use ESMF
+   use pFIO
    use MAPL_CommsMod
    use MAPL_ConstantsMod
    use MAPL_IOMod, only : GETFILE, FREE_FILE 
@@ -282,8 +283,6 @@ contains
    end function create_basic_grid
    
    subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-      use pFIO_FileMetadataMod
-      use pFIO_NetCDF4_FileFormatterMod
       use MAPL_KeywordEnforcerMod
       use MAPL_BaseMod, only: MAPL_DecomposeDim
 
@@ -801,7 +800,6 @@ contains
    end function generate_grid_name
 
    subroutine append_metadata(this, metadata)!, unusable, rc)
-      use pFIO
       class (CubedSphereGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
 !!$      class (KeywordEnforcer), optional, intent(in) :: unusable
@@ -948,7 +946,6 @@ contains
    end subroutine append_metadata
 
    function get_grid_vars(this) result(vars)
-      use pFIO
       class (CubedSphereGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
@@ -958,7 +955,6 @@ contains
    end function get_grid_vars
 
    subroutine append_variable_metadata(this,var)
-      use pFIO
       class (CubedSphereGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
 

--- a/MAPL_Base/MAPL_DirPath.F90
+++ b/MAPL_Base/MAPL_DirPath.F90
@@ -1,6 +1,6 @@
 module MAPL_DirPathMod
    use MAPL_KeywordEnforcerMod
-   use pFIO_StringVectorMod
+   use pFIO
    private
 
    public :: DirPath

--- a/MAPL_Base/MAPL_ExtDataCollection.F90
+++ b/MAPL_Base/MAPL_ExtDataCollection.F90
@@ -1,16 +1,11 @@
 #include "pFIO_ErrLog.h"
 
 module MAPL_ExtDataCollectionMod
-  use pFIO_StringIntegerMapMod
-  use pFIO_NetCDF4_FileFormatterMod
-  use pFIO_FormatterPtrVectorMod
-  use pFIO_ConstantsMod
-  use pFIO_FileMetaDataMod
+  use pFIO
   use MAPL_FileMetadataUtilsVectorMod
   use MAPL_FileMetadataUtilsMod
   use MAPL_GridManagerMod
   use MAPL_AbstractGridFactoryMod
-  use pFIO_ErrorHandlingMod
   implicit none
   private
 
@@ -114,7 +109,7 @@ end module MAPL_ExtDataCollectionMod
 
 
 module MAPL_CollectionVectorMod
-   use pFIO_ThrowMod
+   use pFIO
    use MAPL_ExtDataCollectionMod
    
    ! Create a map (associative array) between names and pFIO_Attributes.

--- a/MAPL_Base/MAPL_Generic.F90
+++ b/MAPL_Base/MAPL_Generic.F90
@@ -108,7 +108,7 @@ module MAPL_GenericMod
   use ESMFL_Mod
 
   use ESMF_CFIOMod, only: ESMF_CFIOStrTemplate
-  use pFIO_UtilitiesMod, only: i_to_string
+  use pFIO
   use pFIO_ClientManagerMod
   use MAPL_ioClientsMod, only: i_Clients, o_Clients
   use MAPL_BaseMod
@@ -7723,7 +7723,6 @@ recursive subroutine MAPL_WireComponent(GC, RC)
 
   
   subroutine print_resource(printrc, label, val, default)
-    use pFIO_StringVectorMod
     integer, intent(in) :: printrc
     character(len=*), intent(in) :: label
     class(*), intent(in) :: val

--- a/MAPL_Base/MAPL_IO.F90
+++ b/MAPL_Base/MAPL_IO.F90
@@ -20,21 +20,8 @@ module MAPL_IOMod
   use MAPL_RangeMod
   use MAPL_ErrorHandlingMod
   use netcdf
-  use pFIO_CoordinateVariableMod
-  use pFIO_ConstantsMod
-  use pFIO_FileMetadataMod
+  use pFIO
   use pFIO_ClientManagerMod
-  use pFIO_NetCDF4_FileFormatterMod
-  use pFIO_AttributeMod
-  use pFIO_StringAttributeMapMod
-  use pFIO_VariableMod
-  use pFIO_StringVariableMapMod
-  use pFIO_StringVectorMod
-  use pFIO_StringIntegerMapMod
-  use pFIO_StringVariableMapMod
-  use pFIO_ArrayReferenceMod
-  use pFIO_LocalMemReferenceMod
-  use pFIO_UtilitiesMod, only: i_to_string
   use, intrinsic :: ISO_C_BINDING
   use, intrinsic :: iso_fortran_env
   implicit none

--- a/MAPL_Base/MAPL_LatLonGridFactory.F90
+++ b/MAPL_Base/MAPL_LatLonGridFactory.F90
@@ -19,6 +19,7 @@ module MAPL_LatLonGridFactoryMod
    use MAPL_KeywordEnforcerMod
    use MAPL_ConstantsMod
    use ESMF
+   use pFIO
    use MAPL_CommsMod
    use MAPL_IOMod, only : GETFILE, FREE_FILE
    use, intrinsic :: iso_fortran_env, only: REAL32
@@ -649,7 +650,6 @@ contains
 
 
    subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-      use pFIO
       use MAPL_KeywordEnforcerMod
       use MAPL_BaseMod, only: MAPL_DecomposeDim
 
@@ -1631,7 +1631,6 @@ contains
 
 
    subroutine append_metadata(this, metadata)
-      use pFIO
       use MAPL_ConstantsMod
       class (LatLonGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
@@ -1658,7 +1657,6 @@ contains
    end subroutine append_metadata
 
    function get_grid_vars(this) result(vars)
-      use pFIO
       class (LatLonGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
@@ -1668,7 +1666,6 @@ contains
    end function get_grid_vars
 
    subroutine append_variable_metadata(this,var)
-      use pFIO_VariableMod
       class (LatLonGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
    end subroutine append_variable_metadata

--- a/MAPL_Base/MAPL_TilingRegridder.F90
+++ b/MAPL_Base/MAPL_TilingRegridder.F90
@@ -495,7 +495,7 @@ contains
    ! ------------------------------------------------------------------------
    subroutine copy_global_to_local(this)
       use MAPL_BaseMod, only: MAPL_Grid_interior
-      use pFIO_IntegerVectorMod
+      use pFIO
       class (TilingRegridder), intent(inout) :: this
 
       type (IntegerVector) :: local_indices

--- a/MAPL_Base/MAPL_TimeMethods.F90
+++ b/MAPL_Base/MAPL_TimeMethods.F90
@@ -4,7 +4,6 @@ module MAPL_TimeDataMod
   use ESMF
   use MAPL_GenericMod
   use MAPL_BaseMod
-  use pFIO_IntegerVectorMod
   use pFIO
   use MAPL_ErrorHandlingMod
   use MAPL_ESMFTimeVectorMod

--- a/MAPL_Base/MAPL_TripolarGridFactory.F90
+++ b/MAPL_Base/MAPL_TripolarGridFactory.F90
@@ -19,6 +19,7 @@ module MAPL_TripolarGridFactoryMod
    use MAPL_AbstractGridFactoryMod
    use MAPL_KeywordEnforcerMod
    use ESMF
+   use pFIO
    use, intrinsic :: iso_fortran_env, only: REAL32
    use, intrinsic :: iso_fortran_env, only: REAL64
    implicit none
@@ -236,8 +237,6 @@ contains
 
 
    subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-      use pFIO_FileMetadataMod
-      use pFIO_NetCDF4_FileFormatterMod
       use MAPL_KeywordEnforcerMod
 
       class (TripolarGridFactory), intent(inout)  :: this
@@ -855,7 +854,6 @@ contains
    end subroutine halo
       
    subroutine append_metadata(this, metadata)
-      use pFIO
       class (TripolarGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
 
@@ -866,7 +864,6 @@ contains
    end subroutine append_metadata
 
    function get_grid_vars(this) result(vars)
-      use pFIO
       class (TripolarGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
@@ -876,7 +873,6 @@ contains
    end function get_grid_vars
 
    subroutine append_variable_metadata(this,var)
-      use pFIO_VariableMod
       class (TripolarGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
    end subroutine append_variable_metadata

--- a/MAPL_Base/MAPL_VerticalMethods.F90
+++ b/MAPL_Base/MAPL_VerticalMethods.F90
@@ -4,7 +4,6 @@ module MAPL_VerticalDataMod
   use ESMF
   use MAPL_GenericMod
   use MAPL_BaseMod
-  use pFIO_IntegerVectorMod
   use pFIO
   use MAPL_AbstractRegridderMod
   use MAPL_ErrorHandlingMod

--- a/MAPL_Base/MAPL_ioClients.F90
+++ b/MAPL_Base/MAPL_ioClients.F90
@@ -7,7 +7,6 @@ module MAPL_ioClientsMod
    use MAPL_KeywordEnforcerMod
    use pFIO_ClientManagerMod
    use PFIO
-   use pFIO_IntegerVectorMod
 
    implicit none
    private

--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -8,7 +8,6 @@ module MAPL_newCFIOMod
   use MAPL_GridManagerMod
   use MAPL_GenericMod
   use MAPL_BaseMod
-  use pFIO_IntegerVectorMod
   use MAPL_RegridderManagerMod
   use MAPL_RegridderSpecMod
   use MAPL_TimeDataMod

--- a/MAPL_Base/SimpleCommSplitter.F90
+++ b/MAPL_Base/SimpleCommSplitter.F90
@@ -11,7 +11,7 @@ module MAPL_SimpleCommSplitterMod
    use MAPL_CommGroupDescriptionVectorMod
    use MAPL_ErrorHandlingMod
    use MAPL_AbstractCommSplitterMod
-   use pFIO_IntegerVectorMod
+   use pFIO
    use MAPL_KeywordEnforcerMod
    use MAPL_SplitCommunicatorMod
    use MPI

--- a/MAPL_Base/cub2latlon_regridder.F90
+++ b/MAPL_Base/cub2latlon_regridder.F90
@@ -18,14 +18,7 @@ module SupportMod
    use ESMF
    use MAPL_ThrowMod
    use MAPL_BaseMod
-   use pFIO_FileMetadataMod
-   use pFIO_ConstantsMod
-   use pFIO_NetCDF4_FileFormatterMod
-   use pFIO_AttributeMod
-   use pFIO_StringAttributeMapMod
-   use pFIO_VariableMod
-   use pFIO_StringVariableMapMod
-   use pFIO_StringVectorMod
+   use pFIO
    use MAPL_ConstantsMod
    use MAPL_RangeMod
    use MAPL_StringRouteHandleMapMod
@@ -209,7 +202,6 @@ contains
    contains      
 
       subroutine add_grid_dimensions()
-         use pFIO_StringIntegerMapMod
          integer :: status
          type (StringIntegerMap), pointer :: dims
 
@@ -1205,8 +1197,7 @@ end module SupportMod
 program main
    use ESMF
    use SupportMod
-   use pFIO_FileMetadataMod
-   use pFIO_NetCDF4_FileFormatterMod
+   use pFIO
    implicit none
 
    integer :: c00, c0, c1, crate

--- a/MAPL_Base/tests/MockGridFactory.F90
+++ b/MAPL_Base/tests/MockGridFactory.F90
@@ -8,6 +8,7 @@
 module MockGridFactoryMod
    use MAPL_AbstractGridFactoryMod
    use MAPL_KeywordEnforcerMod
+   use pFIO
    implicit none
    private
 
@@ -149,8 +150,6 @@ contains
    end function generate_grid_name
 
    subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
-      use pFIO_FileMetadataMod
-      use pFIO_NetCDF4_FileFormatterMod
       use MAPL_KeywordEnforcerMod
       class (MockGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
@@ -160,7 +159,6 @@ contains
 
 
    subroutine append_metadata(this, metadata)
-      use pFIO
       class (MockGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
 
@@ -172,7 +170,6 @@ contains
    end subroutine append_metadata
 
    function get_grid_vars(this) result(vars)
-      use pFIO
       class (MockGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
@@ -182,7 +179,6 @@ contains
    end function get_grid_vars
 
    subroutine append_variable_metadata(this,var)
-      use pFIO_VariableMod
       class (MockGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
    end subroutine append_variable_metadata


### PR DESCRIPTION
Another round of cleanup. Added a few more modules to pFIO.F90 so in MAPL_Base I could just "use pFIO" everywhere instead of "use pFIO_xxxMod". The one exception that needs more cleanup is the ClientManager.F90 in pfio used by MAPL_base. 

ClientManager.F90 itself has a "use pFIO" in it so it needs some work before it can be part of the pfio single mod.