### PR TITLE
Fix MPI_Init call

### DIFF
--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -306,7 +306,7 @@ contains
 
       _UNUSED_DUMMY(unusable)
 
-      call MPI_Init_(ierror)
+      call MPI_Init(ierror)
 
       this%comm_world=MPI_COMM_WORLD
       call MPI_Comm_rank(this%comm_world, this%rank, ierror); _VERIFY(ierror)


### PR DESCRIPTION
Test building on macOS found this issue. I'm assuming @bena-nasa wanted `MPI_Init` as the arguments aren't enough for `MPI_Init_Thread`

I'm not sure why Linux doesn't seem to care. 🤷‍♂ 

