### PR TITLE
Fixes #118 - spurious ESMF dependence in pFIO.

### DIFF
--- a/GMAO_pFIO/Attribute.F90
+++ b/GMAO_pFIO/Attribute.F90
@@ -77,7 +77,6 @@ end module pFIO_AttributeMod
 
 module pFIO_StringAttributeMapMod
    use pFIO_ThrowMod
-   use ESMF
    use pFIO_AttributeMod
    
 #include "types/key_deferredLengthString.inc"   

--- a/GMAO_pFIO/CMakeLists.txt
+++ b/GMAO_pFIO/CMakeLists.txt
@@ -107,21 +107,19 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES GNU)
   ecbuild_add_executable (
     TARGET pfio_server_demo.x
     SOURCES pfio_server_demo.F90
-    LIBS ${this} ${ESMF_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
+    LIBS ${this} ${NETCDF_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
   set_target_properties (pfio_server_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
   set_target_properties(pfio_server_demo.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
     
   ecbuild_add_executable (
     TARGET pfio_collective_demo.x
     SOURCES pfio_collective_demo.F90
-    LIBS ${this} ${ESMF_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
+    LIBS ${this} ${NETCDF_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
   set_target_properties (pfio_collective_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
   set_target_properties(pfio_collective_demo.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
 endif ()
 
 #--------------------
-include_directories (${INC_ESMF})
-include_directories (${INC_gFTL})
 include_directories (${INC_NETCDF})
 
 #--------------------

--- a/GMAO_pFIO/NetCDF4_FileFormatter.F90
+++ b/GMAO_pFIO/NetCDF4_FileFormatter.F90
@@ -1226,7 +1226,6 @@ end module pFIO_FormatterPtrVectorMod
 
 module pFIO_StringNetCDF4_FileFormatterMapMod
    use pFIO_ThrowMod
-   use ESMF
    use pFIO_NetCDF4_FileFormatterMod
 
 #include "types/key_deferredLengthString.inc"

--- a/GMAO_pFIO/StringInt64Map.F90
+++ b/GMAO_pFIO/StringInt64Map.F90
@@ -1,7 +1,6 @@
 module pFIO_StringInt64MapMod
    use, intrinsic :: iso_fortran_env, only: INT64
    use pFIO_ThrowMod
-   use ESMF
 
    ! Create a map (associative array) between names and integers.
 

--- a/GMAO_pFIO/StringIntegerMap.F90
+++ b/GMAO_pFIO/StringIntegerMap.F90
@@ -1,6 +1,5 @@
 module pFIO_StringIntegerMapMod
    use pFIO_ThrowMod
-   use ESMF
 
    ! Create a map (associative array) between names and integers.
 

--- a/GMAO_pFIO/StringStringMap.F90
+++ b/GMAO_pFIO/StringStringMap.F90
@@ -1,6 +1,5 @@
 module pFIO_StringStringMapMod
    use pFIO_ThrowMod
-   use ESMF
 
    ! Create a map (associative array) between names and integers.
 

--- a/GMAO_pFIO/StringVariableMap.F90
+++ b/GMAO_pFIO/StringVariableMap.F90
@@ -3,7 +3,6 @@
 
 module pFIO_StringVariableMapMod
    use pFIO_ThrowMod
-   use ESMF
    use pFIO_VariableMod
    use pFIO_CoordinateVariableMod 
 

--- a/GMAO_pFIO/UnlimitedEntity.F90
+++ b/GMAO_pFIO/UnlimitedEntity.F90
@@ -647,7 +647,6 @@ end module pFIO_UnlimitedEntityMod
 
 module pFIO_StringUnlimitedEntityMapMod
    use pFIO_ThrowMod
-   use ESMF
    use pFIO_UnlimitedEntityMod
    
 #include "types/key_deferredLengthString.inc"   

--- a/GMAO_pFIO/tests/CMakeLists.txt
+++ b/GMAO_pFIO/tests/CMakeLists.txt
@@ -52,10 +52,10 @@ ecbuild_add_executable (
   TARGET ${TESTO}
   PROPERTIES EXCLUDE_FROM_ALL=TRUE
   SOURCES pfio_ctest_io.F90
-  LIBS GMAO_pFIO ${ESMF_LIBRARIES}
+  LIBS GMAO_pFIO ${NETCDF_LIBRARIES}
   DEFINITIONS USE_MPI)
 set_target_properties(${TESTO} PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
-target_link_libraries(${TESTO} GMAO_pFIO ${ESMF_LIBRARIES})
+target_link_libraries(${TESTO} GMAO_pFIO ${NETCDF_LIBRARIES})
 
 
 
@@ -79,9 +79,9 @@ ecbuild_add_executable (
   PROPERTIES EXCLUDE_FROM_ALL=TRUE
   SOURCES pfio_performance.F90
   DEFINITIONS USE_MPI
-  LIBS GMAO_pFIO ${ESMF_LIBRARIES})
+  LIBS GMAO_pFIO ${NETCDF_LIBRARIES})
 set_target_properties(${TESTPERF} PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
-target_link_libraries(${TESTPERF} GMAO_pFIO ${ESMF_LIBRARIES})
+target_link_libraries(${TESTPERF} GMAO_pFIO ${NETCDF_LIBRARIES})
 
 add_dependencies(tests pFIO_tests)
 add_dependencies(tests ${TESTO})

--- a/GMAO_pFIO/tests/pFIO_Initialize.F90
+++ b/GMAO_pFIO/tests/pFIO_Initialize.F90
@@ -2,7 +2,6 @@ module pFIO_pFUNIT_Initialize
 
 contains
   subroutine Initialize()
-     use ESMF
      use MAPL_pFUnit_ThrowMod
      use pFIO_ThrowMod
    


### PR DESCRIPTION
Several "USE ESMF" statements have been erroneously copied into pFIO.
ESMF is not actually used, so deleting those statements should have no
effect on actual runs.