### PR TITLE
Vector regridding bug in cfio

### DIFF
--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -5420,7 +5420,7 @@ CONTAINS
     type(Ptr2Arr)        :: PtrTypeOut(2)
     integer, allocatable :: varids(:)
     logical, allocatable :: transDone(:)
-    integer :: status1,status2,rotation,gridStagger
+    integer :: status1,status2
     integer :: alloc_ra
 
     if (present(hw)) then


### PR DESCRIPTION
The GEOSctm developer was having problems. The issue was that the winds were be unnecessarily rotated. This came in during a development to introduce more parallelism into CFIO. Fix to match the logic used in the routine in MAPL_ExtData that used to specially handle the vectors.