### PR TITLE
Fixes bugs found on 12/10

### DIFF
--- a/MAPL_Base/MAPL_Base.F90
+++ b/MAPL_Base/MAPL_Base.F90
@@ -75,6 +75,7 @@ public MAPL_Range
 public MAPL_DistGridGet
 public MAPL_GridGetCorners
 public MAPL_GridGetInterior
+public MAPL_TrimString
 
 ! !PUBLIC PARAMETERS
 !
@@ -4293,6 +4294,25 @@ and so on.
      end if
 
  end subroutine MAPL_DistGridGet
+
+ function MAPL_TrimString(istring,rc) result(ostring)
+    character(len=*), intent(in) :: istring
+    integer, optional, intent(out) :: rc
+
+    character(len=:), allocatable :: ostring
+    integer :: strlen
+    integer :: status
+
+    strlen = len_trim(istring)
+    if (istring(strlen:strlen)==char(0)) then
+       allocate(ostring,source=istring(1:strlen-1),stat=status)
+       _VERIFY(status)
+    else
+       allocate(ostring,source=istring(1:strlen),stat=status)
+       _VERIFY(status)
+    end if
+    _RETURN(_SUCCESS)
+ end function MAPL_TrimString
 
 end module MAPL_BaseMod
 

--- a/MAPL_Base/MAPL_VerticalMethods.F90
+++ b/MAPL_Base/MAPL_VerticalMethods.F90
@@ -427,7 +427,7 @@ module MAPL_VerticalDataMod
                  call metadata%add_variable('lev',v,rc=status)
               end if
 
-           else if (this%regrid_type == VERTICAL_METHOD_ETA2LEV .or. this%regrid_type == VERTICAL_METHOD_SELECT) then
+           else if (this%regrid_type == VERTICAL_METHOD_ETA2LEV) then
               call metadata%add_dimension('lev', size(this%levs), rc=status)
               v = Variable(PFIO_REAL64, dimensions='lev')
               call v%add_attribute('long_name','vertical level')
@@ -437,9 +437,12 @@ module MAPL_VerticalDataMod
               else
                  call v%add_attribute('positive','up')
               end if
-              call v%add_attribute('coordinate','eta')
-              call v%add_attribute('standard_name','model_layer')
+              call v%add_attribute('coordinate',trim(this%vvar))
+              call v%add_attribute('standard_name',trim(this%vvar)//"_level")
               call v%add_const_value(UnlimitedEntity(this%levs))
+              call metadata%add_variable('lev',v,rc=status)
+
+           else if (this%regrid_type == VERTICAL_METHOD_SELECT) then
               call metadata%add_dimension('lev', lm, rc=status)
               v = Variable(PFIO_REAL64, dimensions='lev')
               call v%add_attribute('long_name','vertical level')


### PR DESCRIPTION
Found 2 bugs needing fixing.
1. Somehow attributes being read from netcdf had c null character at the end that was ruining string comparisons. Those need to be checked for and trimmed off if they are present.
2. The metadata for the levels was not being properly created when regridding to pressure levels in history. Not sure what I did but looks like I committed incomplete code in the subroutine that handles the creation of vertical metadata.