### PR TITLE
Add day-of-week scale factor handling to ExtData

### DIFF
--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -1990,9 +1990,13 @@ CONTAINS
         else if (trim(buffer) == 'single') then
 
            _RETURN(ESMF_SUCCESS)
-        else if (trim(buffer) == 'y') then
+        else if (trim(buffer) == 'y' .or. trim(buffer) == 'd') then
 
-           item%cyclic = "y"
+           if (trim(buffer) == 'y') then
+               item%cyclic = "y"
+           else if (trim(buffer) == 'd') then
+               item%cyclic = "d"
+           endif
 
            call ESMF_TimeIntervalSet(zero,__RC__)
 
@@ -2186,10 +2190,12 @@ CONTAINS
         type(ESMF_Time)                            :: newTime
         integer                                    :: curDate,curTime,n,tindex
         integer(ESMF_KIND_I4)                      :: iyr, imm, idd, ihr, imn, isc, oldYear
+        integer(ESMF_KIND_I4)                      :: cYear, cMonth
         integer(ESMF_KIND_I4)                      :: fyr, fmm, fdd, fhr, fmn, fsc
         type(ESMF_TimeInterval)                    :: zero
         type(ESMF_Time)                            :: fTime
         logical                                    :: UniFileClim
+        logical                                    :: UniFileDOW
         type(ESMF_Time)                            :: readTime
 
         ! Allow for extrapolation.. up to a limit
@@ -2221,6 +2227,8 @@ CONTAINS
            ! but it was marked as cyclic we must have a year long climatology 
            ! on one file, set UniFileClim to true
            if (trim(item%cyclic)=='y') UniFileClim = .true.
+           ! If file is constant and marked as DOW, set UniFileDOW to true
+           UniFileDOW = (trim(item%cyclic)=='d')
            file_processed = item%file
            call MakeMetadata(file_processed,item%pfioCollection_id,fdata,__RC__)
            ! Retrieve the time series
@@ -2231,7 +2239,7 @@ CONTAINS
               end if
               _RETURN(ESMF_FAILURE)
            end if
-           call GetBracketTimeOnSingleFile(fdata,xTSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,item%climYear,rc=status)
+           call GetBracketTimeOnSingleFile(fdata,xTSeries,cTime,bSide,UniFileClim,UniFileDOW,interpTime,fileTime,tindex,allowExtrap,item%climYear,rc=status)
            if (status /= ESMF_SUCCESS) then
               if (mapl_am_I_root()) Then
                  write(*,'(a,a,a,a)') ' ERROR: Bracket timing request failed on fixed file ',trim(item%file),' for side ',bSide
@@ -2254,6 +2262,8 @@ CONTAINS
               call ESMF_TimeGet(cTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
               yrOffset = item%climYear - iyr
               call OffsetTimeYear(cTime,yrOffset,fTime,rc)
+           elseif (trim(item%cyclic)=='d') then
+              _ASSERT(.False.,'Day-of-week scaling factors must be given in a single file, but ' // trim(file_processed) // ' uses a refresh template')
            else
               yrOffset = 0
               if (item%reff_time > cTime) then
@@ -2788,12 +2798,13 @@ CONTAINS
 
      end subroutine OffsetTimeYear
 
-     subroutine GetBracketTimeOnSingleFile(fdata,tSeries,cTime,bSide,UniFileClim,interpTime,fileTime,tindex,allowExtrap,climyear,rc)
+     subroutine GetBracketTimeOnSingleFile(fdata,tSeries,cTime,bSide,UniFileClim,UniFileDOW,interpTime,fileTime,tindex,allowExtrap,climyear,rc)
         class(FileMetadataUtils),            intent(inout) :: fdata
         type(ESMF_Time),                     intent(in   ) :: tSeries(:)
         type(ESMF_Time),                     intent(inout) :: cTime
         character(len=1),                    intent(in   ) :: bSide
         logical,                             intent(in   ) :: UniFileClim
+        logical,                             intent(in   ) :: UniFileDOW
         type(ESMF_TIME),                     intent(inout) :: interpTime
         type(ESMF_TIME),                     intent(inout) :: fileTime
         integer,                             intent(inout) :: tindex
@@ -2811,6 +2822,9 @@ CONTAINS
         logical                            :: LSide, RSide
         integer                            :: yrOffset, yrOffsetNeg, targYear
         integer                            :: iEntry
+        integer                            :: yrAdjust, yCentury
+        integer                            :: yRem, TargDOW
+        integer                            :: monthOffset
         type(ESMF_Time), allocatable       :: tSeriesC(:)
         logical                            :: foundYear
         integer                            :: tSteps, curYear, nsteps
@@ -2819,6 +2833,64 @@ CONTAINS
         yrOffset=0
         nsteps = size(tSeries)
         call ESMF_TimeGet(cTime,yy=targYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+
+        ! If getting DOW, get the target day of the week
+        If (UniFileDOW) Then
+           ! DOW calculator
+           ! Tested for Jan 1st 1000 AD through Dec 31st 2199
+           ! Gives Sunday = 0 and Saturday = 6
+           yrAdjust = targYear
+           if (imm .lt. 3) yrAdjust = yrAdjust - 1
+           yCentury = floor(real(yrAdjust)/100.0)
+           yRem = yrAdjust - (yCentury*100)
+           targDOW = idd + floor(2.6*(real(mod(imm-3,12)+1)) - 0.2) - 2*yCentury + yRem + floor(real(yRem)/4.0) + floor(real(yCentury/4.0))
+           targDOW = mod(targDOW,7)
+           ! Fortran will allow a negative DOW
+           if (targDOW < 0) targDOW = targDOW + 7
+           ! Different behavior for different brackets
+           LSide = (bSide == "L")
+           If (LSide) Then
+              ! Straight-forward
+              call ESMF_TimeSet(interpTime,yy=targYear,mm=imm,dd=idd,h=0,m=0,s=0,__RC__)
+           Else
+              ! Change DOW to be the next day
+              targDOW = targDOW + 1
+              if (targDOW > 6) targDOW = targDOW - 7
+              ! Also set the target date to be the next day
+              call ESMF_TimeSet(interpTime,yy=targYear,mm=imm,dd=idd+1,h=0,m=0,s=0,__RC__)
+              ! Tricky: increasing the day may put us into a new month, so retrieve
+              ! the target month from the updated time
+              call ESMF_TimeGet(interpTime,yy=targYear,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+           End If
+           ! Do we have an individual set for each month?
+           if (nsteps == 7) then
+              monthOffset = 0
+           elseif (nsteps == 84) then
+              ! Separate scaling factors for each month
+              monthOffset = ((imm-1)*7)
+           else
+              write(*,'(a,a,a,I5)') ' ERROR: DOW files must have either 7 or 84 entries but ',trim(fdata%get_file_name()),' contains ', nsteps
+              rc = ESMF_FAILURE
+              return
+           end if
+           iEntry = targDOW + 1 + monthOffset
+           fileTime = tSeries(iEntry)
+           tindex = iEntry
+           if (Mapl_Am_I_Root().and.(Ext_Debug > 0)) then
+              write(*,'(a,I4,a,I4,4(a))') '               GetBracketTimeOnSingleFile: Reading data for DOW ',targDOW,' (entry ', iEntry, ') into bracket ', trim(bSide)
+              write(*,'(a,a)') &
+                 '                  ==> File: ', trim(fdata%get_file_name())
+              call ESMF_TimeGet(fileTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              write(*,'(a,I0.2,a,I0.2,a)') &
+                 '                  ==> Data from: month ', iMm, ', day-of-week ', iDd, ' (01=Sunday)'
+              call ESMF_TimeGet(interpTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+              write(*,'(a,I0.4,a,I0.2,a,I0.2,a,I0.2,a,I0.2)') &
+                 '                  ==> Mapped to: ', iYr, '-', iMm, '-', iDd, &
+                 ' ', iHr, ':', iMn
+           end if
+           rc = esmf_success
+           return
+        end if
 
         ! Debug output
         If (Mapl_Am_I_Root().and.(Ext_Debug > 15)) Then


### PR DESCRIPTION
This update was originally put into the geoschem/gchp repository by
S. Eastham in commit 1e459ba5. To use, put D in the climatology column
of ExtData.rc.

Files used with this option should have 7 or 84 entries for the time
dimension (7 days per week * 1 or 12 months). Time index in the file
is used to determine what scale factors to retrieve. The first 7 indexes
correspond to scale factors for January with the following index to
day mapping: 1=Sunday, 2=Monday, 3=Tuesday, 4=Wednesday, 5=Thursday,
6=Friday, 7=Saturday. The next 7 indexes correspond to February day-of-week
scale factors, and so on. If there are only 7 values in the file then
those day-of-week factors apply to all months.

Signed-off-by: Lizzie Lundgren <elundgren@seas.harvard.edu>