### PR TITLE
Feature/pnorris/#78 add equation of time bugfix

### DIFF
--- a/MAPL_Base/sun.H
+++ b/MAPL_Base/sun.H
@@ -292,7 +292,8 @@
          if(present(DIST)) DIST = 0.0
 
          call MAPL_SunGetInsolation( LONS, LATS, ORBIT, ZTT, SLT, &
-              CLOCK=MYCLOCK, TIME=TIME, DIST=DD, RC=STATUS)
+              CLOCK=MYCLOCK, TIME=TIME, DIST=DD, &
+              EOT=apply_EOT, RC=STATUS)
          _VERIFY(STATUS)
 
          if(present(ZTH1)) ZTH1 = max(ZTT,0.0)
@@ -315,7 +316,8 @@
             _VERIFY(STATUS)
 
             call MAPL_SunGetInsolation( LONS, LATS, ORBIT, ZTT, SLT, &
-                 CLOCK=MYCLOCK, TIME=TIME, ZTHB=ZTB, ZTHD=ZTD, DIST=DD, RC=STATUS)
+                 CLOCK=MYCLOCK, TIME=TIME, ZTHB=ZTB, ZTHD=ZTD, DIST=DD, &
+                 EOT=apply_EOT, RC=STATUS)
             _VERIFY(STATUS)
 
             SLR = SLR +     SLT*0.5


### PR DESCRIPTION
Bug-fix to feature/pnorris/#78-add-equation-of-time ... only MAPL_Base/sun.H updated.
  The previous version did not pass on the apply_EOT logical to the recursive
   MAPL_SunGetInsolation subscalls in a time-averaged MAPL_SunGetInsolation call.
Still zero-diff because by default the Equation of Time correction is disabled.
NOTE: This was submitted for merging to master BUT it should INSTEAD be merged to DEVELOP as per Tom's previous decision for feature/pnorris/#78-add-equation-of-time.