### PR TITLE
Hotfix/bmauer/#179

### DIFF
--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -17,8 +17,7 @@ module MAPL_FileMetadataUtilsMod
       procedure :: create
       procedure :: get_coordinate_info
       procedure :: get_variable_attribute
-      procedure :: get_time_units
-      procedure :: get_time_vec
+      procedure :: get_time_info
       procedure :: get_level_name
       procedure :: is_var_present
       procedure :: get_file_name
@@ -48,7 +47,7 @@ module MAPL_FileMetadataUtilsMod
    end subroutine create
 
 
-   subroutine get_time_units(this,startTime,startyear,startmonth,startday,starthour,startmin,startsec,units,rc)
+   subroutine get_time_info(this,startTime,startyear,startmonth,startday,starthour,startmin,startsec,units,timeVector,rc)
       class (FileMetadataUtils), intent(inout) :: this
       type(ESMF_Time), optional, intent(inout) :: startTime
       integer,optional,intent(out) ::        startYear 
@@ -57,14 +56,17 @@ module MAPL_FileMetadataUtilsMod
       integer,optional,intent(out) ::        startHour
       integer,optional,intent(out) ::        startMin 
       integer,optional,intent(out) ::        startSec
+      type(ESMF_Time), allocatable, optional :: timeVector(:)
+      type(ESMF_Time), allocatable :: tVec(:)
       character(len=*), optional, intent(out) :: units
       integer, optional, intent(out) :: rc
 
       integer :: status
-      class(Variable), pointer :: var
+      class(CoordinateVariable), pointer :: var
       type(Attribute), pointer :: attr
       class(*), pointer :: pTimeUnits
       character(len=ESMF_MAXSTR) :: timeUnits
+      integer :: i,tsize
 
       integer ypos(2), mpos(2), dpos(2), hpos(2), spos(2)
       integer strlen
@@ -72,8 +74,12 @@ module MAPL_FileMetadataUtilsMod
       integer firstcolon, lastcolon
       integer lastspace,since_pos
       integer year,month,day,hour,min,sec
+      type(ESMF_Time) :: unmodStartTime
+      class(*), pointer :: ptr(:)
+      real(REAL64), allocatable :: tr_r64(:)
+      type(ESMF_TimeInterval) :: tint
 
-      var => this%get_variable('time',rc=status)
+      var => this%get_coordinate_variable('time',rc=status)
       _VERIFY(status)
       attr => var%get_attribute('units')
       ptimeUnits => attr%get_value()
@@ -153,44 +159,13 @@ module MAPL_FileMetadataUtilsMod
       class default
          _ASSERT(.false.,"Time unit must be character")
       end select
-
-      if (present(startYear)) startYear=year
-      if (present(startMonth)) startMonth=month
-      if (present(startDay)) startDay=day
-      if (present(startHour)) startHour=hour
-      if (present(startmin)) startMin=min
-      if (present(startsec)) startSec=sec
-      if (present(startTime)) then
-         call ESMF_TimeSet(startTime,yy=year,mm=month,dd=day,h=hour,m=min,s=sec,rc=status)
-         _VERIFY(status)
-      end if
-
-   end subroutine get_time_units
- 
-   subroutine get_time_vec(this,tvec,rc)
-      class (FileMetadataUtils), intent(inout) :: this
-      type(ESMF_Time), allocatable :: tvec(:)
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      class(CoordinateVariable), pointer :: var
-      type(Attribute), pointer :: attr
-      integer :: tsize,i
-      type(ESMF_Time) :: startTime
-      character(len=10) :: timeUnits
-      class(*), pointer :: ptr(:)
-      real(REAL64), allocatable :: tr_r64(:)
-      type(ESMF_TimeInterval) :: tint
-      
-
-      var => this%get_coordinate_variable('time',rc=status)
+      call ESMF_TimeSet(unmodStartTime,yy=year,mm=month,dd=day,h=hour,m=min,s=sec,rc=status)
       _VERIFY(status)
+
       call this%get_coordinate_info('time',coordSize=tsize,rc=status)
       _VERIFY(status)
       allocate(tr_r64(tsize))
       allocate(tvec(tsize))
-      call this%get_time_units(startTime=startTime,units=timeUnits,rc=status)
-      _VERIFY(status)
       ptr => var%get_coordinate_data()
       _ASSERT(associated(ptr),"time variable coordinate data not found")
       select type (ptr)
@@ -206,26 +181,42 @@ module MAPL_FileMetadataUtilsMod
          _ASSERT(.false.,"unsupported time variable type")
       end select
       do i=1,tsize
-        select case(trim(timeUnits))
+        select case(trim(Units))
         case ("hours")
            call ESMF_TimeIntervalSet(tint,h_r8=tr_r64(i),rc=status)
            _VERIFY(status)
-           tvec(i)=startTime+tint
+           tvec(i)=unmodStartTime+tint
         case ("minutes")
            call ESMF_TimeIntervalSet(tint,m_r8=tr_r64(i),rc=status)
            _VERIFY(status)
-           tvec(i)=startTime+tint
+           tvec(i)=unmodStartTime+tint
         case ("seconds")
            call ESMF_TimeIntervalSet(tint,s_r8=tr_r64(i),rc=status)
            _VERIFY(status)
-           tvec(i)=startTime+tint
+           tvec(i)=unmodStartTime+tint
         case default
            _ASSERT(.false.,"unsupported time unit")
         end select
       enddo
 
-   end subroutine get_time_vec
+      call ESMF_TimeGet(tVec(1),yy=year,mm=month,dd=day,h=hour,m=min,s=sec,rc=status)
+      _VERIFY(status)
+      if (present(startYear)) startYear=year
+      if (present(startMonth)) startMonth=month
+      if (present(startDay)) startDay=day
+      if (present(startHour)) startHour=hour
+      if (present(startmin)) startMin=min
+      if (present(startsec)) startSec=sec
+      if (present(startTime)) then
+          startTime=tVec(1)
+      end if
+      if (present(timeVector)) then
+         allocate(timeVector,source=tVec,stat=status)
+         _VERIFY(status)
+      end if
 
+   end subroutine get_time_info
+ 
    function is_var_present(this,var_name,rc) result(isPresent)
       class (FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: var_name
@@ -250,12 +241,15 @@ module MAPL_FileMetadataUtilsMod
       type(Attribute), pointer :: attr => null()
       class(Variable), pointer :: var => null()
       class(*), pointer :: vunits
+      logical :: isPresent
       integer :: status
     
       var => this%get_variable(var_name,rc=status)
       _VERIFY(status)
-      attr => var%get_attribute(trim(attr_name))
-      if (associated(attr)) then
+      isPresent = var%is_attribute_present(trim(attr_name))
+      if (isPresent) then
+         attr => var%get_attribute(trim(attr_name))
+      !if (associated(attr)) then
          vunits => attr%get_value()
          select type(vunits)
          type is (character(*))

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -182,7 +182,11 @@ module MAPL_FileMetadataUtilsMod
          _ASSERT(.false.,"unsupported time variable type")
       end select
       do i=1,tsize
-        select case(trim(tUnits))
+        select case (trim(tUnits))
+        case ("days")
+           call ESMF_TimeIntervalSet(tint,d_r8=tr_r64(i),rc=status)
+           _VERIFY(status)
+           tvec(i)=unmodStartTime+tint
         case ("hours")
            call ESMF_TimeIntervalSet(tint,h_r8=tr_r64(i),rc=status)
            _VERIFY(status)

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -131,7 +131,6 @@ module MAPL_FileMetadataUtilsMod
              min  = 0
              sec  = 0
            else
-             print *, 'ParseTimeUnits: Assuming a starting time of 00z'
              hour = 0
              min  = 0
              sec  = 0

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -65,7 +65,7 @@ module MAPL_FileMetadataUtilsMod
       class(CoordinateVariable), pointer :: var
       type(Attribute), pointer :: attr
       class(*), pointer :: pTimeUnits
-      character(len=ESMF_MAXSTR) :: timeUnits
+      character(len=ESMF_MAXSTR) :: timeUnits,tUnits
       integer :: i,tsize
 
       integer ypos(2), mpos(2), dpos(2), hpos(2), spos(2)
@@ -89,7 +89,8 @@ module MAPL_FileMetadataUtilsMod
          strlen = LEN_TRIM (TimeUnits)
 
          since_pos = index(TimeUnits, 'since')
-         if (present(units)) units = trim(TimeUnits(:since_pos-1))
+         tUnits = trim(TimeUnits(:since_pos-1))
+         if (present(units)) units = trim(tUnits)
 
          firstdash = index(TimeUnits, '-')
          lastdash  = index(TimeUnits, '-', BACK=.TRUE.)
@@ -181,7 +182,7 @@ module MAPL_FileMetadataUtilsMod
          _ASSERT(.false.,"unsupported time variable type")
       end select
       do i=1,tsize
-        select case(trim(Units))
+        select case(trim(tUnits))
         case ("hours")
            call ESMF_TimeIntervalSet(tint,h_r8=tr_r64(i),rc=status)
            _VERIFY(status)

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -2008,7 +2008,7 @@ CONTAINS
               call ESMF_CFIOStrTemplate(file,item%file,'GRADS',nymd=nymd,nhms=nhms,__STAT__)
            end if
            call MakeMetadata(file,item%pfioCollection_id,metadata,__RC__)
-           call metadata%get_time_units(startYear=iyr)
+           call metadata%get_time_info(startYear=iyr)
            item%climYear=iYr
            _RETURN(ESMF_SUCCESS)
         else
@@ -2224,7 +2224,7 @@ CONTAINS
            file_processed = item%file
            call MakeMetadata(file_processed,item%pfioCollection_id,fdata,__RC__)
            ! Retrieve the time series
-           call fdata%get_time_vec(xTSeries,rc=status)
+           call fdata%get_time_info(timeVector=xTSeries,rc=status)
            If (status /= ESMF_SUCCESS) then
               if (mapl_am_I_root()) Then
                  write(*,'(a,a)') ' ERROR: Time vector retrieval failed on fixed file ',trim(item%file)
@@ -2347,7 +2347,7 @@ CONTAINS
               call MakeMetadata(file_processed,item%pfioCollection_id,fdata,__RC__)
               ! Retrieve the time series
               if (allocated(xTseries)) deallocate(xTseries)
-              call fdata%get_time_vec(xTseries,__RC__)
+              call fdata%get_time_info(timeVector=xTseries,__RC__)
               ! Is this before or after our target time?
               LSide   = (bSide == "L")
               RSide   = (.not.LSide)
@@ -2437,7 +2437,7 @@ CONTAINS
            call MakeMetadata(file_processed,item%pfioCOllection_id,fdata,__RC__)
            ! Retrieve the time series
            if (allocated(xTseries)) deallocate(xTseries)
-           call fdata%get_time_vec(xTSeries,__RC__)
+           call fdata%get_time_info(timeVector=xTSeries,__RC__)
 
            ! We now have a time which, when passed to the FILE TEMPLATE, returns a valid file
            ! However, if the file template does not include a year token, then the file in
@@ -2555,7 +2555,7 @@ CONTAINS
               ! fTime is now ALWAYS the time which was applied to the file template to get the current file
               call MakeMetadata(file_processed,item%pfioCollection_id,fdata,rc=status)
               if (allocated(xTSeries)) deallocate(xTSeries)
-              call fdata%get_time_vec(xTSeries,__RC__)
+              call fdata%get_time_info(timeVector=xTSeries,__RC__)
 
               !If (Mapl_Am_I_Root()) Write (*,'(a,a,x,a)') ' SUPERDEBUG: File/template: ',Trim(file_processed),Trim(item%refresh_template)
               ! The file template may be "hiding" a year offset from us
@@ -3987,7 +3987,7 @@ CONTAINS
      type(FileMetadataUtils), pointer :: metadata => null()
 
      call MakeMetadata(fname,item%pfiocollection_id,metadata,__RC__)
-     call Metadata%get_time_units(startyear=iyr,startmonth=imm,startday=idd,starthour=ihr,startmin=imn,startsec=isc,rc=status)
+     call Metadata%get_time_info(startyear=iyr,startmonth=imm,startday=idd,starthour=ihr,startmin=imn,startsec=isc,rc=status)
      _VERIFY(status)
      call ESMF_TimeSet(sTime, yy=iyr, mm=imm, dd=idd,  h=ihr,  m=imn, s=isc, __RC__)
      nullify(metadata)


### PR DESCRIPTION
Fixes #179

Testing with GEOS-Chem found that when the start time in the file was not zero I was not handling that. The old cfio layer did handle this correctly. I ended up combining two routines into and making the call to get the time vector from the metadata an option to a single call to get time information from the filemetadata.

Note as far as I can tell no files used for gocart have this issue. It was a file used only for GEOS-Chem that appears to have been made by Christoph that tripped this.