### PR TITLE
Fix fractional regridding

### DIFF
--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -96,6 +96,7 @@ module MAPL_newCFIOMod
         if (present(read_collection_id)) newCFIO%read_collection_id=read_collection_id
         if (present(metadata_collection_id)) newCFIO%metadata_collection_id=metadata_collection_id
         if (present(items)) newCFIO%items=items
+        if (present(fraction)) newCFIO%fraction=fraction
         _RETURN(ESMF_SUCCESS)
      end function new_MAPL_newCFIO
 


### PR DESCRIPTION
Fixes #187 

Was not actually setting the fraction value when passed into the creation method! No wonder it was always selecting 0.