### PR TITLE
Fixes #190. Add oversubscribe for Open MPI

### DIFF
--- a/GMAO_pFIO/tests/CMakeLists.txt
+++ b/GMAO_pFIO/tests/CMakeLists.txt
@@ -57,7 +57,12 @@ ecbuild_add_executable (
 set_target_properties(${TESTO} PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
 target_link_libraries(${TESTO} GMAO_pFIO ${NETCDF_LIBRARIES})
 
-
+# Detect if we are using Open MPI and add oversubscribe
+string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
+list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
+if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
+   list(APPEND MPIEXEC_PREFLAGS "-oversubscribe")
+endif()
 
 set(TESTO_FLAGS
   -nc 6 -nsi 6 -nso 6 -ngo 1 -ngi 1 -v T,U )


### PR DESCRIPTION
This commit (along with ESMA_cmake 2.1.1) allow for the MAPL tests to
run on a desktop using Open MPI. The code (based on code from the CMake
ESMA-Baselibs) uses CMake to get the MPI Version string and parse the
first word. If it is 'Open', assume Open MPI and add `-oversubscribe`.