### PR TITLE
Feature/remove a2d2c

### DIFF
--- a/MAPL_Base/MAPL_AbstractGridFactory.F90
+++ b/MAPL_Base/MAPL_AbstractGridFactory.F90
@@ -44,7 +44,6 @@ module MAPL_AbstractGridFactoryMod
 
       ! from MAPL_stubs
       procedure(halo), deferred :: halo
-      procedure :: A2D2C
 
       procedure (generate_grid_name), deferred :: generate_grid_name
       procedure :: to_string
@@ -247,28 +246,6 @@ contains
       allocate(clone, source=this)
 
    end function clone
-
-   subroutine A2D2C(this, u, v, lm, getC, unusable, rc)
-      use MAPL_KeywordEnforcerMod
-      class (AbstractGridFactory), intent(in) :: this
-      real, intent(inout) :: u(:,:,:)
-      real, intent(inout) :: v(:,:,:)
-      integer, intent(in) :: lm
-      logical, intent(in) :: getC
-      class (KeywordEnforcer), optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-
-      character(len=*), parameter :: Iam= MOD_NAME // 'A2D2C'
-
-      _UNUSED_DUMMY(this)
-      _UNUSED_DUMMY(u)
-      _UNUSED_DUMMY(v)
-      _UNUSED_DUMMY(lm)
-      _UNUSED_DUMMY(getC)
-      _UNUSED_DUMMY(unusable)
-      _RETURN(_FAILURE)
-
-   end subroutine A2D2C
 
    function make_grid(this, unusable, rc) result(grid)
       use esmf

--- a/MAPL_Base/MAPL_GridManager.F90
+++ b/MAPL_Base/MAPL_GridManager.F90
@@ -516,7 +516,6 @@ module MAPL_GridManagerMod
    public :: get_instance
    public :: get_factory_id
    public :: get_factory
-   public :: a2d2c
 
    ! singleton instance
    type (GridManager), target, save :: grid_manager
@@ -569,30 +568,4 @@ contains
 
    end function get_factory
 
-   subroutine A2D2C(grid, u, v, lm, getC, unusable, rc)
-      type (ESMF_Grid), intent(in) :: grid
-      real, intent(inout) :: u(:,:,:)
-      real, intent(inout) :: v(:,:,:)
-      integer, intent(in) :: lm
-      logical, intent(in) :: getC
-      class (KeywordEnforcer), optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      character(len=*), parameter :: Iam= MOD_NAME // 'get_a2d2c'
-      class (AbstractGridFactory), pointer :: factory
-
-      _UNUSED_DUMMY(unusable)
-      factory => grid_manager%get_factory(grid, rc=status)
-      _VERIFY(status)
-
-      call factory%a2d2c(u, v, lm, getC, rc=status)
-      _VERIFY(status)
-
-      _RETURN(_SUCCESS)
-
-   end subroutine A2D2C
-
-
-      
 end module MAPL_GridManagerMod


### PR DESCRIPTION
Remove a2d2c stuff. Now that the cubed sphere grid factory is in MAPL we can't use this anyway. CTM has to call this and rotate the winds itself when it moves to MAPL 2. Corresponding pull request in FV3 that goes with this.