### PR TITLE
Fixes #205. Adds mepo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *~
-/@cmake
+/@cmake/
+/@env/
+/BUILD/
+/build*/
+/install*/
+/.mepo/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project (
   VERSION 2.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
-option(USE_MEPO "Set to use mepo to get external dependencies" OFF)
+option(USE_MEPO "Set to use mepo to get external dependencies" ON)
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)
   list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,44 @@ project (
   VERSION 2.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
-if (NOT COMMAND esma) # build as standalone project
-  # Invoke checkout_ externals, but only the first time we
-  # configure.  
-  if (NOT SKIP_MANAGE_EXTERNALS)
-    execute_process (
-      COMMAND "checkout_externals"
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      )
-  endif ()
-  option (SKIP_MANAGE_EXTERNALS "Set to skip manage externals step" ON)
+option(USE_MEPO "Set to use mepo to get external dependencies" OFF)
 
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)
   list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
   include (esma)
+else ()
+  if (NOT COMMAND esma) # build as standalone project
+
+    if (USE_MEPO)
+      if (NOT SKIP_MEPO)
+        set (MEPO_INIT_COMMAND mepo init)
+        execute_process (
+          COMMAND ${MEPO_INIT_COMMAND}
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+
+        set (MEPO_CLONE_COMMAND mepo clone)
+        execute_process (
+          COMMAND ${MEPO_CLONE_COMMAND}
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+      endif()
+      option (SKIP_MEPO "Set to skip mepo steps" ON)
+    else()
+      # Invoke checkout_externals, but only the first time we
+      # configure.
+      if (NOT SKIP_MANAGE_EXTERNALS)
+        execute_process (
+          COMMAND "checkout_externals"
+          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+          )
+      endif ()
+      option (SKIP_MANAGE_EXTERNALS "Set to skip manage externals step" ON)
+    endif()
+
+    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
+    include (esma)
+  endif()
 endif()
 
 ecbuild_declare_project()

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,3 +1,10 @@
+[ESMA_env]
+required = True
+repo_url = git@github.com:GEOS-ESM/ESMA_env.git
+local_path = ./@env
+branch = dev/MAPL-2.0
+protocol = git
+
 [GEOS_cmake]
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git

--- a/components.yaml
+++ b/components.yaml
@@ -1,0 +1,16 @@
+ESMA_env:
+  local: ./@env
+  remote: git@github.com:GEOS-ESM/ESMA_env.git
+  branch: dev/MAPL-2.0
+  develop: master
+
+ESMA_cmake:
+  local: ./@cmake
+  remote: git@github.com:GEOS-ESM/ESMA_cmake.git
+  tag: v2.1.1
+  develop: develop
+
+ecbuild:
+  local: ./@cmake/@ecbuild
+  remote: git@github.com:GEOS-ESM/ecbuild.git
+  tag: geos/v1.0.0


### PR DESCRIPTION
This commit adds support for `mepo`. At present, `mepo` is
"automatically" used only if `-DUSE_MEPO=ON` is passed in. For now we
default to `checkout_externals`.

Also, add some logic so that we don't try to clone `@cmake` *again* if
it already exists. That causes some ugly error output.

Finally, add some directories to `.gitignore` as well as add ESMA_env to
the `Externals.cfg`. This is *not* needed to build MAPL, but it is sort
of "expected" when building at NCCS/NAS. It's just some extra noise for
our Harvard friends though. Sorry.