### PR TITLE
Fixes #141. Reduce compiler warning messages

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = v2.1.1
+tag = v2.1.2
 externals = Externals.cfg
 protocol = git
 

--- a/GMAO_pFIO/AbstractServer.F90
+++ b/GMAO_pFIO/AbstractServer.F90
@@ -109,7 +109,6 @@ contains
       integer, intent(in) :: comm
 
       integer :: ierror, MyColor
-      integer :: i
 
       call MPI_Comm_dup(comm, this%comm, ierror)
       call MPI_Comm_rank(this%comm, this%rank, ierror)
@@ -289,6 +288,7 @@ contains
      logical, intent(in) :: multi
      integer, optional, intent(out) :: rc
      _ASSERT(.false.," no action of server_get_DataFromMem")
+     _UNUSED_DUMMY(multi)
    end subroutine get_DataFromMem
 
    function am_I_reading_PE(this,id) result (yes)

--- a/GMAO_pFIO/CMakeLists.txt
+++ b/GMAO_pFIO/CMakeLists.txt
@@ -87,11 +87,10 @@ set (srcs
   )
 
 esma_add_library (${this} SRCS ${srcs})
-target_link_libraries (${this} gftl gftl-shared ${NETCDF_LIBRARIES})
+target_link_libraries (${this} PUBLIC gftl gftl-shared 
+                               PRIVATE ${NETCDF_LIBRARIES} OpenMP::OpenMP_Fortran MPI::MPI_Fortran)
 
-target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
-target_link_libraries (${this} ${MPI_Fortran_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...
 foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
   target_link_libraries(${this} "-Xlinker -rpath -Xlinker ${dir}")

--- a/GMAO_pFIO/ClientManager.F90
+++ b/GMAO_pFIO/ClientManager.F90
@@ -96,7 +96,7 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       type (ClientThread), pointer :: clientPtr
-      integer :: i, i1,i2
+      integer :: i
       
       do i = 1, this%size()
          ClientPtr => this%clients%at(i)
@@ -138,7 +138,7 @@ contains
       integer, optional, intent(out) :: rc
 
       type (ClientThread), pointer :: clientPtr
-      integer :: request_id, ith, status
+      integer :: request_id, status
 
       clientPtr =>this%current()
       request_id = clientPtr%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)

--- a/GMAO_pFIO/ClientThread.F90
+++ b/GMAO_pFIO/ClientThread.F90
@@ -444,9 +444,6 @@ contains
    subroutine wait_all(this)
       use pFIO_AbstractRequestHandleMod
       class (ClientThread), target, intent(inout) :: this
-      integer :: request_id
-      type (IntegerRequestMapIterator) :: iter
-      integer :: status
 
       call this%clear_RequestHandle() 
       !call this%shake_hand()

--- a/GMAO_pFIO/DirectoryService.F90
+++ b/GMAO_pFIO/DirectoryService.F90
@@ -450,7 +450,6 @@ contains
       integer :: sz
       
       integer :: sizeof_char, sizeof_integer, sizeof_DirectoryEntry
-      integer :: ierror
       integer :: one_integer
       character :: one_char
 

--- a/GMAO_pFIO/ServerThread.F90
+++ b/GMAO_pFIO/ServerThread.F90
@@ -160,9 +160,7 @@ contains
       integer, optional, intent(out) :: rc
 
       class (AbstractMessage), pointer :: message
-      type(DoneMessage) :: dMessage
       class(AbstractSocket),pointer :: connection
-      logical :: all_backlog_is_empty
       integer :: status
 
       connection=>this%get_connection()
@@ -770,7 +768,8 @@ contains
      
       class(AbstractSocket),pointer :: connection
       type (DummyMessage) :: handshake_msg
-      integer :: status
+
+      _UNUSED_DUMMY(message)
  
       connection=>this%get_connection()
       call connection%send(handshake_msg)
@@ -1119,18 +1118,9 @@ contains
       type (CollectiveStageDoneMessage), intent(in) :: message
       integer, optional, intent(out) :: rc
 
-      type (LocalMemReference) :: mem_data_reference
-      class(AbstractDataReference),pointer :: dataRefPtr
-      class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
-      integer(kind=INT64) :: g_offset, offset,msize_word
-      type(c_ptr) :: offset_address
-      integer,pointer :: i_ptr(:)
-      type (MessageVectorIterator) :: iter
-      class (AbstractMessage), pointer :: msg
-      class(AbstractSocket),pointer :: connection
-      class (AbstractRequestHandle), pointer :: handle
       integer :: status
+
+      _UNUSED_DUMMY(message)
 
       this%containing_server%serverthread_done_msgs(this%thread_rank) = .true. 
       if ( .not. all(this%containing_server%serverthread_done_msgs)) then
@@ -1158,18 +1148,13 @@ contains
       type (StageDoneMessage), intent(in) :: message
       integer, optional, intent(out) :: rc
 
-      type (LocalMemReference) :: mem_data_reference
-      class(AbstractDataReference),pointer :: dataRefPtr
-      class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
-      integer(kind=INT64) :: g_offset, offset,msize_word
-      type(c_ptr) :: offset_address
-      integer,pointer :: i_ptr(:)
       type (MessageVectorIterator) :: iter
       class (AbstractMessage), pointer :: msg
       class(AbstractSocket),pointer :: connection
       class (AbstractRequestHandle), pointer :: handle
       integer :: status
+
+      _UNUSED_DUMMY(message)
 
       if ( this%request_backlog%empty()) then
          _RETURN(_SUCCESS)
@@ -1209,16 +1194,9 @@ contains
       integer, optional, intent(out) :: rc
 
       type (LocalMemReference) :: mem_data_reference
-      class(AbstractDataReference),pointer :: dataRefPtr
-      class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
-      integer(kind=INT64) :: g_offset, offset,msize_word
-      type(c_ptr) :: offset_address
-      integer,pointer :: i_ptr(:)
       type (MessageVectorIterator) :: iter
       class (AbstractMessage), pointer :: msg
       class(AbstractSocket),pointer :: connection
-      class (AbstractRequestHandle), pointer :: handle
       integer :: status
 
       iter = this%request_backlog%begin()
@@ -1255,17 +1233,7 @@ contains
       type (CollectivePrefetchDoneMessage), intent(in) :: message
       integer, optional, intent(out) :: rc
 
-      type (LocalMemReference) :: mem_data_reference
       class(AbstractDataReference),pointer :: dataRefPtr
-      class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
-      integer(kind=INT64) :: g_offset, offset,msize_word
-      type(c_ptr) :: offset_address
-      integer,pointer :: i_ptr(:)
-      type (MessageVectorIterator) :: iter
-      class (AbstractMessage), pointer :: msg
-      class(AbstractSocket),pointer :: connection
-      class (AbstractRequestHandle), pointer :: handle
       integer :: status
 
       ! first time handling the "Done" message, simple return
@@ -1299,15 +1267,13 @@ contains
       integer, optional, intent(out) :: rc
       type (LocalMemReference) :: mem_data_reference
       class(AbstractDataReference),pointer :: dataRefPtr
-      class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
+      integer :: node_rank, innode_rank
       integer(kind=INT64) :: g_offset, offset,msize_word
       type(c_ptr) :: offset_address
       integer,pointer :: i_ptr(:)
       type (MessageVectorIterator) :: iter
       class (AbstractMessage), pointer :: msg
       class(AbstractSocket),pointer :: connection
-      class (AbstractRequestHandle), pointer :: handle
       integer :: status      
 
       connection=>this%get_connection(status)

--- a/GMAO_pFIO/pfio_collective_demo.F90
+++ b/GMAO_pFIO/pfio_collective_demo.F90
@@ -307,7 +307,6 @@ program main
 
    integer :: rank, npes, ierror, provided,required
    integer :: status, color, key
-   class(AbstractServer),allocatable,target :: s
    class(AbstractServer),pointer :: server
    class(AbstractDirectoryService), pointer :: d_s => null()
 
@@ -367,6 +366,8 @@ contains
       class(AbstractDirectoryService),pointer :: d_s
 
       allocate(d_s, source=DirectoryService(MPI_COMM_WORLD))
+
+      _UNUSED_DUMMY(stype)
 
    end function
 

--- a/GMAO_pFIO/pfio_server_demo.F90
+++ b/GMAO_pFIO/pfio_server_demo.F90
@@ -201,10 +201,11 @@ contains
       
       type (ArrayReference) :: ref
 
-      integer :: i_var,i
+      integer :: i_var
+      !integer :: i
       integer :: lat0, lat1, nlats
       integer :: collection_id
-      character(len=4) :: tmp    
+      !character(len=4) :: tmp    
  
       lat0 = 1 + (this%rank*this%nlat)/this%npes
       lat1 = (this%rank+1)*this%nlat/this%npes
@@ -258,7 +259,6 @@ contains
 
    subroutine finalize(this)
       class (FakeExtData), intent(inout) :: this
-      integer :: ierror
       deallocate(this%bundle)
       call this%c%terminate()
    end subroutine finalize

--- a/GMAO_pFIO/tests/MockClient.F90
+++ b/GMAO_pFIO/tests/MockClient.F90
@@ -1,3 +1,5 @@
+#include "unused_dummy.H"
+
 module MockClientMod
    use pFIO_ClientThreadMod
    implicit none
@@ -16,6 +18,7 @@ contains
 
    function new_MockClient() result(c)
       type (MockClient) :: c
+      _UNUSED_DUMMY(c)
    end function new_MockClient
    
    

--- a/GMAO_pFIO/tests/Test_UnlimitedEntity.pf
+++ b/GMAO_pFIO/tests/Test_UnlimitedEntity.pf
@@ -62,7 +62,6 @@ contains
    @test
    subroutine test_is_empty()
       type (UnlimitedEntity) :: a
-      character(len=:), allocatable:: str
       logical :: is
       
       ! not initialized

--- a/GMAO_pFIO/tests/Test_pFIO_Utilities.pf
+++ b/GMAO_pFIO/tests/Test_pFIO_Utilities.pf
@@ -117,7 +117,7 @@ contains
 
    @test
    subroutine test_serialize_string()
-      character(len=:), allocatable :: str
+      !character(len=:), allocatable :: str
 
       !call check(str); if (anyExceptions()) return
       call check(''); if (anyExceptions()) return

--- a/GMAO_pFIO/tests/pfio_ctest_io.F90
+++ b/GMAO_pFIO/tests/pfio_ctest_io.F90
@@ -470,13 +470,12 @@ program main
    integer, parameter :: CLIENT_COLOR  = 2
    integer, parameter :: BOTH_COLOR    = 3
 
-   integer :: comm,num_threads
    type (FakeHistData0), target :: HistData
 
    integer :: my_comm_world, my_iComm, my_oComm, my_appcomm
 
-   integer :: client_start, size_group,low_rank,up_rank
-   integer :: local_rank, local_size, i,k, size_iclient, size_oclient
+   integer :: client_start, low_rank,up_rank
+   integer :: i,k, size_iclient, size_oclient
    integer :: app_start_rank, app_end_rank
    character(len = 20) :: out_file
    character(len = 100):: cmd

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -65,6 +65,9 @@ set (srcs
 
 esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4 gftl-shared FLAP::FLAP)
 target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
+if(DISABLE_GLOBAL_NAME_WARNING)
+   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${DISABLE_GLOBAL_NAME_WARNING})
+endif()
 target_compile_definitions (${this} PRIVATE TWO_SIDED_COMM MAPL_MODE)
 
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -63,7 +63,7 @@ set (srcs
   FileMetadataUtilities.F90 FileMetadataUtilitiesVector.F90
   )
 
-esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4 gftl-shared FLAP::FLAP)
+esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4 gftl-shared FLAP::FLAP MPI::MPI_Fortran)
 target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 if(DISABLE_GLOBAL_NAME_WARNING)
    set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${DISABLE_GLOBAL_NAME_WARNING})

--- a/MAPL_Base/FileMetadataUtilities.F90
+++ b/MAPL_Base/FileMetadataUtilities.F90
@@ -228,6 +228,7 @@ module MAPL_FileMetadataUtilsMod
 
       logical :: isPresent
       class(Variable), pointer :: var
+      _UNUSED_DUMMY(rc)
 
       var => this%get_variable(var_name)
       isPresent = associated(var)

--- a/MAPL_Base/MAPL_AbstractGridFactory.F90
+++ b/MAPL_Base/MAPL_AbstractGridFactory.F90
@@ -365,6 +365,8 @@ contains
       character(len=*), parameter :: Iam= MOD_NAME // 'spherical_to_cartesian_2d'
       integer :: status
      
+      _UNUSED_DUMMY(unusable)
+
       im = size(u,1)
       jm = size(u,2)
       _ASSERT(im == size(v,1), 'u-v shape mismatch for IM')
@@ -407,6 +409,8 @@ contains
       character(len=*), parameter :: Iam= MOD_NAME // 'spherical_to_cartesian_2d'
       integer :: status
      
+      _UNUSED_DUMMY(unusable)
+
       im = size(u,1)
       jm = size(u,2)
       _ASSERT(im == size(v,1), 'u-v shape mismatch for IM')
@@ -449,6 +453,8 @@ contains
       character(len=*), parameter :: Iam= MOD_NAME // 'spherical_to_cartesian_3d'
       integer :: status
     
+      _UNUSED_DUMMY(unusable)
+
       im = size(u,1)
       jm = size(u,2)
       km = size(u,3)
@@ -494,6 +500,8 @@ contains
      integer :: i, j, k, im, jm, km
      character(len=*), parameter :: Iam= MOD_NAME // 'spherical_to_cartesian_3d'
      integer :: status
+
+     _UNUSED_DUMMY(unusable)
 
      im = size(u,1)
      jm = size(u,2)
@@ -541,6 +549,8 @@ contains
       character(len=*), parameter :: Iam= MOD_NAME // 'cartesian_to_spherical_2d'
       integer :: status
 
+      _UNUSED_DUMMY(unusable)
+
       im = size(u,1)
       jm = size(u,2)
       _ASSERT(im == size(v,1), 'u-v shape mismatch for IM')
@@ -586,6 +596,8 @@ contains
      integer :: i, j, im, jm
      character(len=*), parameter :: Iam= MOD_NAME // 'cartesian_to_spherical_2d'
      integer :: status
+
+     _UNUSED_DUMMY(unusable)
 
      im = size(u,1)
      jm = size(u,2)
@@ -633,6 +645,8 @@ contains
       character(len=*), parameter :: Iam= MOD_NAME // 'cartesian_to_spherical_3d'
       integer :: status
      
+      _UNUSED_DUMMY(unusable)
+
       im = size(u,1)
       jm = size(u,2)
       km = size(u,3)
@@ -681,6 +695,8 @@ contains
      character(len=*), parameter :: Iam= MOD_NAME // 'cartesian_to_spherical_3d'
      integer :: status
 
+     _UNUSED_DUMMY(unusable)
+
      im = size(u,1)
      jm = size(u,2)
      km = size(u,3)
@@ -726,6 +742,8 @@ contains
       real(REAL64), pointer :: temp_vect(:,:,:,:)
       real(REAL64), pointer :: Xcoord(:,:) => null()
       real(REAL64), pointer :: Ycoord(:,:) => null()
+
+      _UNUSED_DUMMY(unusable)
 
       _ASSERT(allocated(this%grid), 'grid not allocated')
       select case (basis)
@@ -802,6 +820,8 @@ contains
       real(REAL64) :: p1(2),p2(2),p3(2),p4(2),c1(2)
       integer :: i, j, im, jm, counts(3)
 
+      _UNUSED_DUMMY(unusable)
+
       call MAPL_GridGet(grid,localCellCountPerDim=counts,rc=status)
       _VERIFY(status)
       im=counts(1)
@@ -852,6 +872,8 @@ contains
       integer :: status
       integer :: im, jm, i, j
       real(real64) :: dp,fac
+
+      _UNUSED_DUMMY(unusable)
 
       im = size(grid_basis,3)
       jm = size(grid_basis,4)

--- a/MAPL_Base/MAPL_AbstractRegridder.F90
+++ b/MAPL_Base/MAPL_AbstractRegridder.F90
@@ -196,6 +196,7 @@ contains
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(u_in)
       _UNUSED_DUMMY(v_in)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -217,6 +218,7 @@ contains
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(u_in)
       _UNUSED_DUMMY(v_in)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -237,6 +239,7 @@ contains
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(u_in)
       _UNUSED_DUMMY(v_in)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -583,6 +586,7 @@ contains
       _UNUSED_DUMMY(v_in)
       _UNUSED_DUMMY(u_out)
       _UNUSED_DUMMY(v_out)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -607,6 +611,7 @@ contains
       _UNUSED_DUMMY(v_in)
       _UNUSED_DUMMY(u_out)
       _UNUSED_DUMMY(v_out)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -631,6 +636,7 @@ contains
       _UNUSED_DUMMY(v_in)
       _UNUSED_DUMMY(u_out)
       _UNUSED_DUMMY(v_out)
+      _UNUSED_DUMMY(rotate)
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
@@ -943,6 +949,7 @@ contains
    function isTranspose(this) result(amTranspose)
       logical :: amTranspose
       class (AbstractRegridder), intent(in) :: this
+      _UNUSED_DUMMY(this)
       amTranspose = .false.
    end function isTranspose
 

--- a/MAPL_Base/MAPL_CFIO.F90
+++ b/MAPL_Base/MAPL_CFIO.F90
@@ -6528,10 +6528,8 @@ end subroutine MAPL_CFIOReadBundleReadPrefetch
      integer                                   :: tindex
      integer, optional,          intent(out  ) :: rc
 
-     __Iam__('GetTindex')
-
      integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     integer                            :: i
+     integer                            :: i,status
      integer(ESMF_KIND_I8)              :: iCurrInterval
      integer                            :: nhmsB, nymdB
      integer                            :: begDate, begTime
@@ -6563,10 +6561,8 @@ end subroutine MAPL_CFIOReadBundleReadPrefetch
      integer, intent(in)                       :: tindex
      integer, optional,          intent(out  ) :: rc
 
-     __Iam__('MAPL_CFIOGetTimeFromIndex')
-
      integer(ESMF_KIND_I4)              :: iyr,imm,idd,ihr,imn,isc
-     integer                            :: i
+     integer                            :: i,status
      integer(ESMF_KIND_I8)              :: iCurrInterval
      integer                            :: nhmsB, nymdB
      integer                            :: begDate, begTime

--- a/MAPL_Base/MAPL_CapOptions.F90
+++ b/MAPL_Base/MAPL_CapOptions.F90
@@ -47,7 +47,6 @@ contains
       character(*), optional, intent(in) :: ensemble_subdir_prefix 
 
       integer, optional, intent(out) :: rc
-      integer :: status
 
       _UNUSED_DUMMY(unusable)
 

--- a/MAPL_Base/MAPL_CubedSphereGridFactory.F90
+++ b/MAPL_Base/MAPL_CubedSphereGridFactory.F90
@@ -178,6 +178,8 @@ contains
       integer :: status
       character(len=*), parameter :: Iam = MOD_NAME // 'make_grid'
 
+      _UNUSED_DUMMY(unusable)
+
       grid = this%create_basic_grid(rc=status)
       _VERIFY(status)
 
@@ -199,6 +201,8 @@ contains
       type(ESMF_CubedSphereTransform_Args) :: transformArgument
       integer :: status
       character(len=*), parameter :: Iam = MOD_NAME // 'create_basic_grid'
+
+      _UNUSED_DUMMY(unusable)
 
       if (this%grid_type <=3) then
          nTile=6
@@ -579,6 +583,7 @@ contains
       integer :: status
       character(len=*), parameter :: Iam = MOD_NAME // 'check_and_fill_consistency'
 
+      _UNUSED_DUMMY(unusable)
 
       if (.not. allocated(this%grid_name)) then
          this%grid_name = GRID_NAME_DEFAULT
@@ -760,9 +765,14 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
-      integer :: status
       character(len=*), parameter :: Iam = MOD_NAME // 'CubedSphereGridFactory_initialize_from_esmf_distGrid'
 
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(dist_grid)
+      _UNUSED_DUMMY(lon_array)
+      _UNUSED_DUMMY(lat_array)
+      _UNUSED_DUMMY(unusable)
+      
       ! not implemented
       _ASSERT(.false.)
 
@@ -783,6 +793,8 @@ contains
       real, pointer :: ptr(:,:)
       integer :: useableHalo_width
 
+      _UNUSED_DUMMY(unusable)
+      
       if (.not. this%halo_initialized) then
          call this%halo_init(halo_width = halo_width)
          this%halo_initialized = .true.
@@ -973,6 +985,7 @@ contains
       class (CubedSphereGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
+      _UNUSED_DUMMY(this)
 
       vars = 'Xdim,Ydim,nf'
 
@@ -981,6 +994,7 @@ contains
    subroutine append_variable_metadata(this,var)
       class (CubedSphereGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
+      _UNUSED_DUMMY(this)
 
       call var%add_attribute('coordinates','lons lats')
       call var%add_attribute('grid_mapping','cubed_sphere')
@@ -1013,6 +1027,8 @@ contains
       integer :: status
       
       character(len=*), parameter :: Iam = MOD_NAME // 'get_fake_longitudes()'
+      
+      _UNUSED_DUMMY(unusable)
       
       grid = this%make_grid()
 
@@ -1083,6 +1099,8 @@ contains
       integer :: status
       
       character(len=*), parameter :: Iam = MOD_NAME // 'get_fake_latitudes()'
+
+      _UNUSED_DUMMY(unusable)
       
       grid = this%make_grid()
 
@@ -1142,6 +1160,7 @@ contains
       integer :: status
       integer :: global_dim(3),i1,j1,in,jn,tile
       character(len=*), parameter :: Iam = MOD_NAME // 'generate_file_bounds'
+      _UNUSED_DUMMY(this)
 
       call MAPL_GridGet(grid,globalCellCountPerDim=global_dim,rc=status)
       _VERIFY(status)
@@ -1160,6 +1179,7 @@ contains
       type(ArrayReference) :: ref
       class(CubedSphereGridFactory), intent(inout) :: this
       real, pointer, intent(in) :: fpointer(:,:)
+      _UNUSED_DUMMY(this)
       ref = ArrayReference(fpointer)
    end function generate_file_reference2D
 
@@ -1171,6 +1191,7 @@ contains
       real, pointer, intent(in) :: fpointer(:,:,:)
       type(c_ptr) :: cptr
       real, pointer :: ptr_ref(:,:,:,:,:)
+      _UNUSED_DUMMY(this)
       cptr = c_loc(fpointer)
       call C_F_pointer(cptr,ptr_ref,[size(fpointer,1),size(fpointer,2),1,size(fpointer,3),1])
       ref = ArrayReference(ptr_ref)

--- a/MAPL_Base/MAPL_DirPath.F90
+++ b/MAPL_Base/MAPL_DirPath.F90
@@ -1,3 +1,5 @@
+#include "unused_dummy.H"
+
 module MAPL_DirPathMod
    use MAPL_KeywordEnforcerMod
    use pFIO
@@ -34,6 +36,8 @@ contains
       character(len=:), pointer :: dir
       logical :: exist
 
+      _UNUSED_DUMMY(unusable)
+
       iter = this%begin()
       do while (iter /= this%end())
          dir => iter%get()
@@ -62,6 +66,8 @@ contains
       character(len=*), intent(in) :: directory
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
+
+      _UNUSED_DUMMY(unusable)
 
       call this%push_back(directory)
 

--- a/MAPL_Base/MAPL_EsmfRegridder.F90
+++ b/MAPL_Base/MAPL_EsmfRegridder.F90
@@ -71,6 +71,8 @@ contains
       use MAPL_BaseMod
       type (EsmfRegridder) :: regridder
 
+      _UNUSED_DUMMY(regridder)
+
       ! Nothing to do here
    end function new_EsmfRegridder
    

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -1306,6 +1306,10 @@ CONTAINS
    type(IOBundleVector), target     :: IOBundles
    type(IOBundleVectorIterator) :: bundle_iter
    type(ExtData_IOBundle), pointer :: io_bundle
+
+   _UNUSED_DUMMY(IMPORT)
+   _UNUSED_DUMMY(EXPORT)
+
 !  Declare pointers to IMPORT/EXPORT/INTERNAL states 
 !  -------------------------------------------------
 !  #include "MAPL_ExtData_DeclarePointer___.h"

--- a/MAPL_Base/MAPL_HistoryGridComp.F90
+++ b/MAPL_Base/MAPL_HistoryGridComp.F90
@@ -2676,7 +2676,7 @@ ENDDO PARSER
     type(ESMF_State)               :: state_out
     integer                        :: nymd, nhms
     character(len=ESMF_MAXSTR)     :: DateStamp
-    integer                        :: nn, CollBlock, scount
+    integer                        :: CollBlock
     type(MAPL_Communicators)       :: mapl_Comm
 
 !   variables for "backwards" mode

--- a/MAPL_Base/MAPL_IO.F90
+++ b/MAPL_Base/MAPL_IO.F90
@@ -2819,7 +2819,7 @@ module MAPL_IOMod
     integer                            :: J,K
     type (ESMF_DistGrid)               :: distGrid
     type (LocalMemReference) :: lMemRef
-    integer :: request_id, size_1d
+    integer :: size_1d
     
  
     call ESMF_FieldGet(field, grid=grid, rc=status)
@@ -5177,7 +5177,7 @@ module MAPL_IOMod
 
     integer                               :: status
     integer :: l
-    integer ::  i1, j1, in, jn,  global_dim(3), request_id
+    integer ::  i1, j1, in, jn,  global_dim(3)
     type(ArrayReference)     :: ref
 
     if (arrdes%write_restart_by_oserver) then
@@ -5240,7 +5240,7 @@ module MAPL_IOMod
 
     integer :: l
 
-    integer ::  i1, j1, in, jn,  global_dim(3), request_id
+    integer ::  i1, j1, in, jn,  global_dim(3)
     type(ArrayReference)     :: ref
 
 
@@ -5316,7 +5316,7 @@ module MAPL_IOMod
 
     logical :: AM_WRITER
     type (ArrayReference) :: ref
-    integer ::  i1, j1, in, jn,  global_dim(3), request_id
+    integer ::  i1, j1, in, jn,  global_dim(3)
 
     if (present(arrdes)) then
        if(arrdes%write_restart_by_oserver) then
@@ -6903,7 +6903,7 @@ module MAPL_IOMod
 
     logical :: AM_WRITER
     type (ArrayReference) :: ref
-    integer ::  i1, j1, in, jn,  global_dim(3), request_id
+    integer ::  i1, j1, in, jn,  global_dim(3)
 
     if (present(arrdes)) then
        if( arrdes%write_restart_by_oserver) then
@@ -7069,7 +7069,6 @@ module MAPL_IOMod
     integer                               :: IM_WORLD
     integer                               :: JM_WORLD
     integer                               :: status
-    character(len=ESMF_MAXSTR)            :: IAm='MAPL_VarReadNCpar_R8_2d'
 
     real(kind=ESMF_KIND_R8),  allocatable :: buf(:)
     integer                               :: I,J,N,K,L,myrow,myiorank,ndes_x
@@ -7314,7 +7313,6 @@ module MAPL_IOMod
     type (ESMF_Field)                    :: field
     integer                              :: status
     integer                              :: I, K
-    character(len=ESMF_MAXSTR)           :: IAm='MAPL_StateVarReadNCPar'
     integer                              :: J, ITEMCOUNT
     type (ESMF_StateItem_Flag), pointer  :: ITEMTYPES(:)
     character(len=ESMF_MAXSTR ), pointer :: ITEMNAMES(:)
@@ -8797,7 +8795,6 @@ module MAPL_IOMod
   integer, intent(out) :: nvars
   integer, intent(out), optional :: rc
 
-  integer :: status
   type(StringVariableMap), pointer :: vars
   type(StringVariableMapIterator) :: iter
   type(StringIntegerMap), pointer :: dims
@@ -8826,7 +8823,6 @@ module MAPL_IOMod
   type(FileMetadata), intent(inout) :: cf
   integer, intent(out), optional :: rc
 
-  integer :: status
   type(StringVector) :: nondim_vars
   type(StringVariableMap), pointer :: vars
   type(StringVariableMapIterator) :: iter

--- a/MAPL_Base/MAPL_IdentityRegridder.F90
+++ b/MAPL_Base/MAPL_IdentityRegridder.F90
@@ -106,6 +106,7 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_3d_real32'
 
       _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(rotate)
 
       u_out = u_in
       v_out = v_in
@@ -130,6 +131,7 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_3d_real32'
 
       _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(rotate)
 
       _ASSERT(size(u_in,3) == size(u_out,3))
       _ASSERT(size(v_in,3) == size(v_out,3))

--- a/MAPL_Base/MAPL_LatLonGridFactory.F90
+++ b/MAPL_Base/MAPL_LatLonGridFactory.F90
@@ -141,6 +141,8 @@ contains
       integer :: status
       character(*), parameter :: IAM = __FILE__
 
+      _UNUSED_DUMMY(unusable)
+
       factory%is_regular = .false.
       
       factory%grid_name = grid_name
@@ -336,6 +338,8 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
+      _UNUSED_DUMMY(unusable)
+
       longitudes = this%lon_centers
       _RETURN(_SUCCESS)
    end function get_longitudes
@@ -348,6 +352,8 @@ contains
       real(kind=REAL64), allocatable :: latitudes(:)
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
+
+      _UNUSED_DUMMY(unusable)
 
       latitudes = this%lat_centers
       _RETURN(_SUCCESS)
@@ -457,6 +463,8 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
+      _UNUSED_DUMMY(unusable)
+
       lon_corners = this%lon_corners
       _RETURN(_SUCCESS)
 
@@ -470,6 +478,8 @@ contains
       real(kind=REAL64), allocatable :: lat_corners(:)
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
+
+      _UNUSED_DUMMY(unusable)
 
       lat_corners = this%lat_corners
       _RETURN(_SUCCESS)
@@ -1379,6 +1389,8 @@ contains
       integer, optional, intent(out) :: rc
       logical :: can_decomp
       integer :: n
+      _UNUSED_DUMMY(unusable)
+
       can_decomp = .true.
       if (this%im_world==1 .and. this%jm_world==1) then
          _RETURN(_SUCCESS)
@@ -1396,6 +1408,8 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
       integer :: n
+
+      _UNUSED_DUMMY(unusable)
 
       n = this%im_world/this%nx
       if (n < 2) then
@@ -1663,6 +1677,7 @@ contains
       class (LatLonGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
+      _UNUSED_DUMMY(this)
 
       vars = 'lon,lat'
 
@@ -1671,6 +1686,8 @@ contains
    subroutine append_variable_metadata(this,var)
       class (LatLonGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(var)
    end subroutine append_variable_metadata
 
    subroutine generate_file_bounds(this,grid,local_start,global_start,global_count,rc)
@@ -1685,6 +1702,7 @@ contains
       integer :: status
       integer :: global_dim(3), i1,j1,in,jn
       character(len=*), parameter :: Iam = MOD_NAME // 'generate_file_bounds'
+      _UNUSED_DUMMY(this)
 
       call MAPL_GridGet(grid,globalCellCountPerDim=global_dim,rc=status)
       _VERIFY(status)
@@ -1702,6 +1720,7 @@ contains
       type(ArrayReference) :: ref
       class(LatLonGridFactory), intent(inout) :: this
       real, pointer, intent(in) :: fpointer(:,:)
+      _UNUSED_DUMMY(this)
       ref = ArrayReference(fpointer)
    end function generate_file_reference2D
       
@@ -1710,6 +1729,7 @@ contains
       type(ArrayReference) :: ref
       class(LatLonGridFactory), intent(inout) :: this
       real, pointer, intent(in) :: fpointer(:,:,:)
+      _UNUSED_DUMMY(this)
       ref = ArrayReference(fpointer)
    end function generate_file_reference3D
       

--- a/MAPL_Base/MAPL_LatLonToLatLonRegridder.F90
+++ b/MAPL_Base/MAPL_LatLonToLatLonRegridder.F90
@@ -284,6 +284,9 @@ contains
       real :: q, w, f
 
       real(kind=REAL32) :: undef
+
+      _UNUSED_DUMMY(rc)
+
       undef = -HUGE(1.)
 
       do j = 1, this%num_points_out(2)
@@ -344,6 +347,9 @@ contains
       real :: q, w, f
 
       real(kind=REAL64) :: undef
+
+      _UNUSED_DUMMY(rc)
+
       undef = -HUGE(1.d0)
 
       do j = 1, this%num_points_out(2)
@@ -479,14 +485,13 @@ contains
       type (RegridderSpec) :: spec
 
       logical :: cyclic_dim,hasPoles,stagger
-      integer :: dim,nsize,nin,j
+      integer :: dim,nsize,nin
       type(Weights), pointer :: WeightList(:) => null()
       real(kind=REAL64), allocatable :: xg_in(:),xg_out(:)
       real(kind=REAL32), allocatable :: xf_in(:),xf_out(:)
-      real(kind=REAL64) :: xMaxIn,xMaxOut,xMinIn,xMinOut,rngIn,rngOut,dx_in,dx_out
+      real(kind=REAL64) :: xMaxIn,xMaxOut,xMinIn,xMinOut,rngIn,rngOut
       type(dimensionSpec) :: dimspec
       character(len=ESMF_MAXSTR) :: grid_type
-      character(len=1024) :: error_msg
 
       _UNUSED_DUMMY(unusable)
 

--- a/MAPL_Base/MAPL_NUOPCWrapperMod.F90
+++ b/MAPL_Base/MAPL_NUOPCWrapperMod.F90
@@ -327,6 +327,8 @@ contains
     ! at the future stopTime, as it does its forward stepping from currentTime
     ! to stopTime.
 
+    _UNUSED_DUMMY(model)
+
     rc = ESMF_SUCCESS
 
   end subroutine CheckImport
@@ -338,10 +340,10 @@ contains
 
     type(ESMF_State) :: import_state, export_state
     type(ESMF_Clock) :: clock
-    type(ESMF_Field) :: field
+    !type(ESMF_Field) :: field
 
     integer :: num_items
-    character(len=ESMF_MAXSTR), allocatable :: item_names(:)
+    !character(len=ESMF_MAXSTR), allocatable :: item_names(:)
 
     call ESMF_GridCompGet(model, clock = clock, importState = import_state, &
          exportState = export_state, rc = rc)

--- a/MAPL_Base/MAPL_NewArthParser.F90
+++ b/MAPL_Base/MAPL_NewArthParser.F90
@@ -759,7 +759,6 @@ CONTAINS
     INTEGER                                     :: ParCnt, & ! Parenthesis counter
                                                    j,ib,in,lFunc
     LOGICAL                                     :: isUndef
-    INTEGER                                     :: status
     character(len=ESMF_MAXPATHLEN)              :: func
     integer, allocatable                        :: ipos(:)
     character(len=ESMF_MAXSTR), parameter       :: IAm="CheckSyntax"

--- a/MAPL_Base/MAPL_RegridderSpec.F90
+++ b/MAPL_Base/MAPL_RegridderSpec.F90
@@ -98,7 +98,6 @@ contains
    logical function less_than(a, b)
       class (RegridderTypeSpec), intent(in) :: a
       type (RegridderTypeSpec), intent(in) :: b
-      logical :: greater_than
 
       ! Compare methods
 
@@ -176,6 +175,8 @@ contains
 
       integer :: status
       character(len=*), parameter :: Iam = MOD_NAME//'get_grid_type'
+
+      _UNUSED_DUMMY(unusable)
 
       if (present(InputGridType)) then
          call ESMF_AttributeGet(this%grid_in,'GridType',InputGridType,rc=status)

--- a/MAPL_Base/MAPL_SimpleBundleMod.F90
+++ b/MAPL_Base/MAPL_SimpleBundleMod.F90
@@ -188,7 +188,7 @@ CONTAINS
     character(len=ESMF_MAXSTR) :: bundleName
     character(len=ESMF_MAXSTR) :: fieldName
 
-                                __Iam__('MAPL_SimpleBundleCreate')
+    integer :: status
 
     self%Bundle => Bundle ! remember where it came from
 
@@ -561,7 +561,7 @@ CONTAINS
     character(len=ESMF_MAXSTR) :: message
     type (ESMF_FieldBundle)    :: Bundle
 
-                   __Iam__('MAPL_SimpleBundleCreateFromState')
+    integer :: status
 
     call ESMF_StateGet(State, name=stateName, __RC__)
 
@@ -608,7 +608,7 @@ CONTAINS
 !EOP
 !-----------------------------------------------------------------------------
 
-    __Iam__('MAPL_SimpleBundleDestroy')
+    integer :: status
 
     deallocate(self%coords%Lons, self%coords%Lats, self%coords%Levs, __STAT__) 
     deallocate(self%r1, self%r2, self%r3, __STAT__)
@@ -655,7 +655,7 @@ CONTAINS
 !EOP
 !-----------------------------------------------------------------------------
 
-    __Iam__('MAPL_SimpleBundleRead')
+    integer :: status
     type(ESMF_FieldBundle),  pointer :: Bundle
 
     allocate(Bundle, stat=STATUS)
@@ -700,7 +700,7 @@ CONTAINS
 
 !                                ---
     type(MAPL_CFIO)            :: cfio
-    __Iam__ ('MAPL_SimpleBundleWrite0')
+    integer                    :: status
 
     call MAPL_CFIOCreate ( cfio, filename, clock, self%Bundle, __RC__)
     call MAPL_CFIOWrite  ( cfio, Clock, self%Bundle, verbose=verbose, __RC__)
@@ -738,7 +738,7 @@ CONTAINS
     type(ESMF_TimeInterval)    :: TimeStep 
     type(ESMF_Clock)           :: Clock
     type(MAPL_CFIO)            :: cfio
-    __Iam__ ('MAPL_SimpleBundleWrite1')
+    integer                    :: status
 
     call ESMF_TimeIntervalSet( TimeStep, h=0, m=30, s=0, __RC__ )
     CLOCK = ESMF_ClockCreate ( name="Clock", timeStep=TimeStep, startTime=Time, __RC__ )
@@ -863,8 +863,6 @@ end subroutine MAPL_SimpleBundlePrint
     character(len=ESMF_MAXSTR) :: message
     logical :: quiet_
     integer :: i
-
-                     _Iam_("MAPL_SimpleBundleGetIndex")
 
     if ( present(quiet) ) then
        quiet_ = quiet

--- a/MAPL_Base/MAPL_TimeMethods.F90
+++ b/MAPL_Base/MAPL_TimeMethods.F90
@@ -40,13 +40,13 @@ contains
     type(ESMF_TimeInterval) :: offset
     integer, optional, intent(Out) :: rc
 
-    integer :: status
-
     tdata%clock=clock
     tdata%ntime=ntime
     tdata%frequency=frequency
     tdata%offset=offset
     tdata%funits="minutes"
+
+    _RETURN(ESMF_SUCCESS)
 
   end function new_time_data
 
@@ -110,10 +110,11 @@ contains
     real, allocatable :: times(:)
     integer :: status
     
-    real :: scaleFactor
+    !real :: scaleFactor
     type(ESMF_Time) :: currTime,startTime
     type(ESMF_TimeInterval) :: tint
-    integer :: tindex,i
+    integer :: i
+    !integer :: tindex
     real(ESMF_KIND_R8) :: tint_s
     type(ESMFTimeVectorIterator) :: iter
     type(ESMF_Time), pointer :: tptr
@@ -216,6 +217,9 @@ contains
     class(Variable), pointer :: v
     type(Attribute), pointer :: attr
     class(*), pointer :: units
+
+    _UNUSED_DUMMY(this)
+
     v => metadata%get_variable('time',rc=status)
     _VERIFY(status)
     attr => v%get_attribute('units')

--- a/MAPL_Base/MAPL_TransposeRegridder.F90
+++ b/MAPL_Base/MAPL_TransposeRegridder.F90
@@ -73,6 +73,9 @@ contains
      class (KeywordEnforcer), optional, intent(in) :: unusable
      integer, optional, intent(out) :: rc
 
+     _UNUSED_DUMMY(this)
+     _UNUSED_DUMMY(unusable)
+
      ! This is a wrapper class and should not be directly
      ! initialized.
      _RETURN(_FAILURE)
@@ -149,6 +152,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real32'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%transpose_regrid(u_in, v_in, u_out, v_out, rc=status)
       _RETURN(status)
 
@@ -167,6 +173,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_2d_real64'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%transpose_regrid(u_in, v_in, u_out, v_out, rc=status)
       _RETURN(status)
 
@@ -184,6 +193,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_vector_3d_real32'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%transpose_regrid(u_in, v_in, u_out, v_out, rotate=rotate, rc=status)
       _RETURN(status)
 
@@ -321,6 +333,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real32'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%regrid(u_in, v_in, u_out, v_out, rc=status)
       _RETURN(status)
 
@@ -339,6 +354,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_2d_real64'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%regrid(u_in, v_in, u_out, v_out, rc=status)
       _RETURN(status)
 
@@ -358,6 +376,9 @@ contains
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_vector_3d_real32'
 
       integer :: status
+
+      _UNUSED_DUMMY(rotate)
+
       call this%reference%regrid(u_in, v_in, u_out, v_out, rotate=rotate, rc=status)
       _RETURN(status)
 
@@ -429,6 +450,7 @@ contains
    function isTranspose(this) result(amTranspose)
       logical :: amTranspose
       class (TransposeRegridder), intent(in) :: this
+      _UNUSED_DUMMY(this)
       amTranspose = .true.
    end function isTranspose
   

--- a/MAPL_Base/MAPL_TripolarGridFactory.F90
+++ b/MAPL_Base/MAPL_TripolarGridFactory.F90
@@ -248,9 +248,10 @@ contains
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam= MOD_NAME // 'initialize_from_file_metadata()'
-      integer :: status
 
+      _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(unusable)
+      _UNUSED_DUMMY(rc)
 
    end subroutine initialize_from_file_metadata
 
@@ -508,8 +509,8 @@ contains
       class (TripolarGridFactory), intent(in) :: this
 
       _UNUSED_DUMMY(this)
-      _UNUSED_DUMMY(name)
 
+      name = ''
       ! needs to be implemented
       error stop -1
 
@@ -870,6 +871,7 @@ contains
       class (TripolarGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
+      _UNUSED_DUMMY(this)
 
       vars = 'lon,lat'
 
@@ -878,6 +880,8 @@ contains
    subroutine append_variable_metadata(this,var)
       class (TripolarGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(var)
    end subroutine append_variable_metadata
 
    subroutine generate_file_bounds(this,grid,local_start,global_start,global_count,rc)
@@ -889,7 +893,12 @@ contains
       integer, allocatable, intent(inout) :: global_count(:)
       integer, optional, intent(out) :: rc
 
-      integer :: status
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(grid)
+      _UNUSED_DUMMY(local_start)
+      _UNUSED_DUMMY(global_start)
+      _UNUSED_DUMMY(global_count)
+      _UNUSED_DUMMY(rc)
 
    end subroutine generate_file_bounds
 
@@ -898,6 +907,7 @@ contains
       type(ArrayReference) :: ref
       class(TripolarGridFactory), intent(inout) :: this
       real, pointer, intent(in) :: fpointer(:,:)
+      _UNUSED_DUMMY(this)
       ref = ArrayReference(fpointer)
    end function generate_file_reference2D
 
@@ -906,6 +916,7 @@ contains
       type(ArrayReference) :: ref
       class(TripolarGridFactory), intent(inout) :: this
       real, pointer, intent(in) :: fpointer(:,:,:)
+      _UNUSED_DUMMY(this)
       ref = ArrayReference(fpointer)
    end function generate_file_reference3D
 

--- a/MAPL_Base/MAPL_VerticalMethods.F90
+++ b/MAPL_Base/MAPL_VerticalMethods.F90
@@ -62,8 +62,6 @@ module MAPL_VerticalDataMod
         character(len=*), optional, intent(in) :: vunit
         integer, optional, intent(Out) :: rc
 
-        integer :: status
-
         if (.not.present(levels)) then
            vdata%regrid_type = VERTICAL_METHOD_NONE
            _RETURN(ESMF_SUCCESS)

--- a/MAPL_Base/MAPL_ioClients.F90
+++ b/MAPL_Base/MAPL_ioClients.F90
@@ -51,6 +51,7 @@ contains
       i_Clients = ClientManager(n_client=n_i)
       o_Clients = ClientManager(n_client=n_o)
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(unusable)
    end subroutine
 

--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -86,8 +86,6 @@ module MAPL_newCFIOMod
         type(newCFIOitemVector), intent(in), optional :: items
         integer, intent(out), optional :: rc
 
-        integer :: status
-      
         if (present(metadata)) newCFIO%metadata=metadata 
         if (present(input_bundle)) newCFIO%input_bundle=input_bundle
         if (present(output_bundle)) newCFIO%output_bundle=output_bundle

--- a/MAPL_Base/MAPL_sun_uc.F90
+++ b/MAPL_Base/MAPL_sun_uc.F90
@@ -539,7 +539,6 @@ type(MAPL_SunOrbit) function MAPL_SunOrbitCreate(CLOCK,        &
 !EOP
 
        character(len=ESMF_MAXSTR), parameter :: IAm = "SunOrbitDestroy"
-       integer :: STATUS
 
        if(associated(ORBIT%TH)) deallocate(ORBIT%TH)
        if(associated(ORBIT%ZC)) deallocate(ORBIT%ZC)
@@ -575,7 +574,6 @@ type(MAPL_SunOrbit) function MAPL_SunOrbitCreate(CLOCK,        &
 !EOPI
 
        character(len=ESMF_MAXSTR), parameter :: IAm = "SunOrbitCreated"
-       integer :: STATUS
 
        MAPL_SunOrbitCreated = associated(ORBIT%TH)
        _RETURN(ESMF_SUCCESS)
@@ -892,9 +890,6 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
       type(MAPL_SunORBIT),  intent(IN ) :: ORBIT
       integer, optional,    intent(OUT) :: RC
 
-      character(len=ESMF_MAXSTR)      :: IAm = "GetIDAY"
-      integer                         :: STATUS
-
       real :: ANOMALY
 
       select case(TIME)
@@ -929,7 +924,6 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 
       integer    :: YY, DOY
       integer    :: STATUS
-      character(len=ESMF_MAXSTR) :: IAm = "MAPL_SunGetSolarConstantByTime"
 
       call ESMF_TimeGet (TIME, YY=YY, DayOfYear=DOY, RC=STATUS)
       _VERIFY(STATUS)
@@ -976,8 +970,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
    integer, optional, intent(OUT) :: rc
 
    real    :: F
-   integer :: i1,i2,Current, STATUS
-   character(len=ESMF_MAXSTR) :: IAm = "MAPL_SunGetSolarConstantByYearDoY"
+   integer :: i1,i2,Current
 
    integer, parameter :: firstYear = 1610
    integer, parameter :: finalYear = 2008
@@ -1799,9 +1792,8 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
       real, optional, intent(out)            :: JCALC4(:)
       integer, optional, intent(out)         :: rc
 
-      type(ESMF_VM)              :: VM
       type(ESMF_Time)            :: time
-      integer                    :: i, k, N
+      integer                    :: N
       integer                    :: begYear, endYear
       integer                    :: INDX1, INDX2
       integer                    :: MM, YY, DD, CCYY
@@ -1835,7 +1827,6 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
       real,    dimension(:,:), allocatable :: coef_jcalc4
       integer                              :: varid_coef_jcalc4
 
-      character(len=ESMF_MAXSTR) :: shortName
       character(len=ESMF_MAXSTR) :: IAm = "MAPL_SunGetSolarConstantFromNetcdfFile"
 
       ! Open the file
@@ -2190,8 +2181,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
       type(ESMF_Time)            :: startCycle23, startCycle24
       type(ESMF_TimeInterval)    :: timeSinceStartOfCycle24
 
-      integer :: currentYear, currentMon, currentDay, currentDOY, &
-                 prevDay, nextDay
+      integer :: currentYear, currentMon, currentDay, currentDOY
       integer :: prevDOY, nextDOY, prevNoonYear, nextNoonYear
       integer :: originalYear, originalMon, originalDay, origDOY
 
@@ -2219,8 +2209,6 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
       integer, save, allocatable, dimension(:) :: yearTable, doyTable
       real,    save, allocatable, dimension(:) :: tsi, mgindex, sbindex
       integer, save :: numlines
-
-      character(len=ESMF_MAXSTR) :: IAm = "MAPL_SunGetSolarConstantFromNRLFile"
 
       if (present(PersistSolar)) then
          PersistSolar_ = PersistSolar

--- a/MAPL_Base/Regrid_Functions_Mod.F90
+++ b/MAPL_Base/Regrid_Functions_Mod.F90
@@ -1,3 +1,5 @@
+#include "unused_dummy.H"
+
 !-----------------------------------------------------------------------
 !                 GEOS-Chem Global Chemical Transport Model            !
 !-----------------------------------------------------------------------
@@ -180,8 +182,6 @@
 !
 ! !LOCAL VARIABLES:
 !
-      Character(Len=255) :: OutMsg
-
       !=================================================================
       ! Set_fID starts here!
       !=================================================================
@@ -241,8 +241,6 @@
 !
 ! !LOCAL VARIABLES:
 !
-      Character(Len=255) :: OutMsg
-
       !=================================================================
       ! Cleanup starts here!
       !=================================================================
@@ -307,7 +305,7 @@
 !
 ! !LOCAL VARIABLES:
 !
-      Character(Len=255)        :: fName, errMsg
+      Character(Len=255)        :: fName
       Logical                   :: Found
       Integer                   :: status
 
@@ -354,7 +352,7 @@
 
 
       ! Expected grid sizes
-      Integer                   :: resIn(2), resOut(2)
+      !Integer                   :: resIn(2), resOut(2)
 
       ! Grid sizes on file
       integer                   :: resInFile(2), resOutFile(2)
@@ -567,6 +565,8 @@
          Integer                 :: JJ0(nVal)
          Integer                 :: I
 
+         _UNUSED_DUMMY(nY)
+
          ! Copy input
          II0 = II
          JJ0 = JJ
@@ -596,6 +596,8 @@
          Integer                 :: JJ0(nVal)
          Integer                 :: I
          Logical                 :: flipII, flipJJ
+
+         _UNUSED_DUMMY(nY)
 
          ! Copy input
          II0 = II
@@ -628,8 +630,9 @@
          Integer                 :: II0(nVal)
          Integer                 :: JJ0(nVal)
          Integer                 :: I
-         Logical                 :: flipII, flipJJ
          Integer, Parameter      :: faceMap(6) = (/4,5,1,2,6,3/)
+
+         _UNUSED_DUMMY(nY)
 
          ! Copy input
          II0 = II
@@ -922,6 +925,8 @@
       Logical                  :: isDE_
       Logical                  :: isPC_
 
+      _UNUSED_DUMMY(rc)
+
       !=================================================================
       ! genGridName starts here!
       !=================================================================
@@ -1169,7 +1174,7 @@
 !
       Integer     :: nX, nY
       Integer     :: I, RC_
-      Real(sp)    :: fTemp, fMin, fMax, fStride
+      Real(sp)    :: fMin, fStride
 
       !=================================================================
       ! nXYtoVec starts here!
@@ -1328,7 +1333,7 @@
 ! !LOCAL VARIABLES:
 !
       Integer                  :: I, iX, iY
-      Real(kind=sp)            :: wVal, inVal, outVal, rCount
+      Real(kind=sp)            :: wVal, inVal, outVal
       Real(kind=sp), Parameter :: missingVal=0.0
 
       !=================================================================
@@ -1406,9 +1411,9 @@
 !
 ! !LOCAL VARIABLES:
 !
-      Integer            :: fIDGCHP, RC_, IOS, nRead, I
+      Integer            :: fIDGCHP, RC_, I
       Integer            :: resTemp(2)
-      Character(Len=255) :: currLine, strRead, leftStr, rightStr
+      Character(Len=255) :: currLine, strRead 
       Logical            :: Found, logRead
 
       !=================================================================

--- a/MAPL_Base/Regrid_Util.F90
+++ b/MAPL_Base/Regrid_Util.F90
@@ -510,6 +510,9 @@ CONTAINS
       integer,                       intent(out)          :: rc
       integer :: i, j
       real(ESMF_KIND_R8)  :: renorm
+
+      _UNUSED_DUMMY(dynamicDstMaskValue)
+
       if (associated(dynamicMaskList)) then
         do i=1, size(dynamicMaskList)
           dynamicMaskList(i)%dstElement = 0.d0 ! set to zero
@@ -751,7 +754,6 @@ CONTAINS
        integer, optional, intent(out) :: rc
 
        integer :: status
-       character(len=ESMF_MAXSTR) :: Iam = "create_grid"
        type(LatLonGridFactory) :: ll_factory
 
        select case(grid_type)

--- a/MAPL_Base/read_parallel.H
+++ b/MAPL_Base/read_parallel.H
@@ -32,9 +32,9 @@ subroutine SUB_ ( layout, DATA, UNIT, FORMAT, arrdes, RC)
  integer                :: USABLE_UNIT
  integer                :: IOSTAT
  integer                :: status
- character(len=ESMF_MAXSTR) :: IAM='READ_PARALLEL'
 #if (RANK_ == 1 && VARTYPE_ == 4)
  integer                               :: nretries
+ character(len=ESMF_MAXSTR) :: IAM='READ_PARALLEL'
 #endif
 
  if(present(arrdes)) then

--- a/MAPL_Base/tests/MockGridFactory.F90
+++ b/MAPL_Base/tests/MockGridFactory.F90
@@ -30,6 +30,9 @@ module MockGridFactoryMod
 
       procedure :: append_metadata
       procedure :: append_variable_metadata
+      procedure :: generate_file_bounds
+      procedure :: generate_file_reference2D
+      procedure :: generate_file_reference3D
    end type MockGridFactory
 
    interface MockGridFactory
@@ -155,6 +158,10 @@ contains
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(file_metadata)
+      _UNUSED_DUMMY(unusable)
+      _UNUSED_DUMMY(rc)
    end subroutine initialize_from_file_metadata
 
 
@@ -162,7 +169,8 @@ contains
       class (MockGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
 
-      type (Variable) :: v
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(metadata)
       
 !!$      ! Horizontal grid dimensions
 !!$      call metadata%add_dimension('lon', this%im_world)
@@ -173,6 +181,7 @@ contains
       class (MockGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
+      _UNUSED_DUMMY(this)
 
       vars = 'lon,lat, mock'
 
@@ -181,7 +190,45 @@ contains
    subroutine append_variable_metadata(this,var)
       class (MockGridFactory), intent(inout) :: this
       type(Variable), intent(inout) :: var
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(var)
    end subroutine append_variable_metadata
 
+   subroutine generate_file_bounds(this,grid,local_start,global_start,global_count,rc)
+      use MAPL_BaseMod
+      use ESMF
+      class(MockGridFactory), intent(inout) :: this
+      type(ESMF_Grid),      intent(inout) :: grid
+      integer, allocatable, intent(inout) :: local_start(:)
+      integer, allocatable, intent(inout) :: global_start(:)
+      integer, allocatable, intent(inout) :: global_count(:)
+      integer, optional, intent(out) :: rc
+
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(grid)
+      _UNUSED_DUMMY(local_start)
+      _UNUSED_DUMMY(global_start)
+      _UNUSED_DUMMY(global_count)
+      _UNUSED_DUMMY(rc)
+
+   end subroutine generate_file_bounds
+
+   function generate_file_reference2D(this,fpointer) result(ref)
+      use pFIO
+      type(ArrayReference) :: ref
+      class(MockGridFactory), intent(inout) :: this
+      real, pointer, intent(in) :: fpointer(:,:)
+      _UNUSED_DUMMY(this)
+      ref = ArrayReference(fpointer)
+   end function generate_file_reference2D
+
+   function generate_file_reference3D(this,fpointer) result(ref)
+      use pFIO
+      type(ArrayReference) :: ref
+      class(MockGridFactory), intent(inout) :: this
+      real, pointer, intent(in) :: fpointer(:,:,:)
+      _UNUSED_DUMMY(this)
+      ref = ArrayReference(fpointer)
+   end function generate_file_reference3D
 
 end module MockGridFactoryMod

--- a/MAPL_Base/write_parallel.H
+++ b/MAPL_Base/write_parallel.H
@@ -27,7 +27,6 @@ subroutine SUB_ ( data, UNIT, ARRDES, format, RC)
   integer         ,    intent(  out),  optional :: RC
 
   character(len=ESMF_MAXSTR) :: FORMATTED
-  character(len=ESMF_MAXSTR) :: IAM='WRITE_PARALLEL'
   integer :: recl, status
 
  if(present(arrdes)) then

--- a/MAPL_cfio/ESMF_CFIOGridMod.F90
+++ b/MAPL_cfio/ESMF_CFIOGridMod.F90
@@ -191,7 +191,7 @@
 !------------------------------------------------------------------------------
        integer :: rtcode  = 0
        integer :: i, j
-       integer :: sz
+       !integer :: sz
 
        _UNUSED_DUMMY(sigma)
        _UNUSED_DUMMY(reduceGrid)

--- a/MAPL_cfio/ESMF_CFIOSdfMod.F90
+++ b/MAPL_cfio/ESMF_CFIOSdfMod.F90
@@ -106,11 +106,10 @@
 !EOP
 !------------------------------------------------------------------------------
        integer :: i, rtcode
-       integer :: maxLen
+       !integer :: maxLen
        character(len=MLEN) :: fNameTmp     ! file name 
        integer :: date, begTime
        character(len=MLEN) :: fName
-       character(len=MLEN) :: string
 
        call ESMF_CFIOGet(cfio, date=date, begTime=begTime, fName=fName, rc=rtcode)
        if (rtcode .ne. 0) print *, "Problems in ESMF_CFIOGet"
@@ -372,9 +371,7 @@
       integer :: nvatts           ! number of attributes
       real*4, pointer :: rtmp(:)
       integer, pointer :: itmp(:)
-      character(len=MVARLEN), pointer :: ctmp(:)
       logical :: esmf_file = .false.
-      logical :: tmpLog
       logical :: new_grid
       integer :: nDims, allVars, recdim
       integer :: im, jm, km
@@ -3802,7 +3799,7 @@ contains
       integer rtcode
       integer begDate, begTime, incSecs, timeIndex1, timeIndex2
       integer secs, secs1, secs2, nymd1, nymd2, nhms1, nhms2
-      integer i, j, k
+      integer i, j
       integer im, jm, km
                                                                                          
       real    alpha, amiss

--- a/MAPL_cfio/ESMF_CFIOUtilMod.F90
+++ b/MAPL_cfio/ESMF_CFIOUtilMod.F90
@@ -655,9 +655,11 @@
 !EOP
 !-------------------------------------------------------------------------
 
-      integer i, timeId, hour, min, sec, corner(1), timInc, incSecs
+      integer i, timeId, hour, min, sec, corner(1)
+      !integer incSecs
       integer year, month, day
-      character(len=MAXCHR) timeUnits, strTmp, dimUnits
+      character(len=MAXCHR) timeUnits, dimUnits
+      !character(len=MAXCHR) strTmp
 
       character*(MAXCHR) varName, dimName, stdName
       integer type, nvDims, vdims(MAXVDIMS), nvAtts, dimSize
@@ -668,10 +670,11 @@
       real*8    dtime, dtime_array(1)
       integer*2 itime, itime_array(1)
       integer*4 ltime, ltime_array(1)
-      integer   t1, t2, tMult, newDate, newTime
+      !integer   t1
+      integer   newDate, newTime
 
 !     We now have the possibility of a very large interval
-      integer(Kind=INT64) :: t1Long, t2Long, tMax, tMultLong, incSecsLong
+      integer(Kind=INT64) :: t1Long, t2Long, tMultLong, incSecsLong
       integer(Kind=INT64),allocatable :: incVecLong(:) ! Vector of offsets (seconds)
 
 !     Get the starting date and time
@@ -1325,8 +1328,6 @@
 !
 !EOP
 !-------------------------------------------------------------------------
-
-      integer i
 
       call ncclos (fid, rc)
       if (err("Close: error closing file",rc,-54) .NE. 0) return
@@ -2311,8 +2312,8 @@
  
       ! Local variables
  
-      integer ypos(2), mpos(2), dpos(2), hpos(2), minpos(2), spos(2)
-      integer inew, strlen
+      integer ypos(2), mpos(2), dpos(2), hpos(2), spos(2)
+      integer strlen
       integer firstdash, lastdash
       integer firstcolon, lastcolon
       integer lastspace
@@ -2865,7 +2866,7 @@
       integer corner(3), edges(3), timeIndex
       integer vid
       integer i,j,k
-      integer incSecs
+      !integer incSecs
       logical stationFile
       integer(INT64), allocatable :: incVec(:)
 
@@ -2878,7 +2879,7 @@
       integer dimSize, dimId
       integer nDims,nvars,ngatts
       integer varType, myIndex
-      integer timeShift
+      !integer timeShift
 
 ! Variables for dealing with precision
 
@@ -3240,11 +3241,11 @@
 !-------------------------------------------------------------------------
 
       integer begDate, begTime, seconds, minutes
-      integer timeShift
+      !integer timeShift
       integer corner(5), edges(5), timeIndex
       integer vid
       integer i,j,k
-      integer incSecs
+      !integer incSecs
       integer(INT64), allocatable :: incVec(:)
 
 ! Variables for working with dimensions
@@ -4049,10 +4050,9 @@
 !-------------------------------------------------------------------------
       integer year1,mon1,day1,hour1,min1,sec1
       integer year2,mon2,day2,hour2,min2,sec2
-      integer seconds1, seconds2
-      integer(kind=INT64) julian1, julian2
+      integer(kind=INT64) julian1
       integer(kind=INT64) julsec, remainder
-      character*8 dateString
+      !character*8 dateString
 
 ! Error checking.
 
@@ -4207,7 +4207,6 @@
       character*(MAXCHR) vnameTemp
       integer i
       logical surfaceOnly
-      logical noTimeInfo
       integer attType, attLen
       integer allVars            ! all variables - includes dimension vars
 

--- a/MAPL_pFUnit/ESMF_TestParameter.F90
+++ b/MAPL_pFUnit/ESMF_TestParameter.F90
@@ -1,3 +1,5 @@
+#include "unused_dummy.H"
+
 module ESMF_TestParameter_mod
    use pfunit, only: MpiTestParameter
    implicit none
@@ -67,6 +69,7 @@ contains
    function toString(this) result(string)
       class (ESMF_TestParameter), intent(in) :: this
       character(:), allocatable :: string
+      _UNUSED_DUMMY(this)
 
       string = ''
 

--- a/MAPL_pFUnit/unused_dummy.H
+++ b/MAPL_pFUnit/unused_dummy.H
@@ -1,0 +1,13 @@
+! The following macro causes a variable to appear to be "used"
+! according to the compiler.  This is a kludge to avoid excessive
+! warnings.  In most cases, a better fix would be to modify the the
+! procedure interface, but it is impractical in the short term.
+!
+! Note that the conditional is never satisfied and a reasonable
+! compiler will optimize the line away.  (Hopefully without
+! reintroducing the warning!)
+
+#ifdef _UNUSED_DUMMY
+#  undef _UNUSED_DUMMY
+#endif
+#define _UNUSED_DUMMY(x) if (.false.) print*,shape(x)

--- a/Tests/ExtDataDriverGridComp.F90
+++ b/Tests/ExtDataDriverGridComp.F90
@@ -63,7 +63,6 @@ contains
     type(MAPL_MetaComp_Wrapper) :: meta_comp_wrapper
 
     integer :: status, rc
-    character(len=ESMF_MAXSTR)   :: Iam="new_ExtData_DriverGridComp"
 
     cap%root_set_services => root_set_services
 
@@ -137,8 +136,6 @@ contains
 
     integer                      :: HEARTBEAT_DT
     character(len=ESMF_MAXSTR)   :: HIST_CF, ROOT_CF, EXTDATA_CF
-
-    character(len=ESMF_MAXSTR)   :: Iam="initialize_gc"
 
     type (MAPL_MetaComp), pointer :: MAPLOBJ
     procedure(), pointer :: root_set_services
@@ -436,7 +433,6 @@ contains
     integer, intent(out) :: RC     ! Error code:
 
     integer :: status
-    character(len=ESMF_MAXSTR)   :: Iam="MAPL_GridCompCap::run()"
 
     _UNUSED_DUMMY(import)
     _UNUSED_DUMMY(export)
@@ -456,7 +452,6 @@ contains
     integer, intent(out) :: rc
 
     integer :: status
-    character(len=ESMF_MAXSTR)   :: Iam = "CapGridComp_Finalize"
 
     type(ExtData_DriverGridComp), pointer :: cap
     type(MAPL_MetaComp), pointer :: MAPLOBJ
@@ -502,7 +497,6 @@ contains
     integer, intent(out) :: rc
 
     integer :: status
-    character(len=ESMF_MAXSTR)   :: Iam="set_services"
 
     call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, userRoutine = initialize_gc, rc = status)
     _VERIFY(status)
@@ -518,7 +512,6 @@ contains
   subroutine set_services(this, rc)
     class(ExtData_DriverGridComp), intent(inout) :: this
     integer, optional, intent(out) :: rc
-    character(*), parameter :: Iam = "set_services"
     integer :: status
 
     call ESMF_GridCompSetServices(this%gc, set_services_gc, rc = status)
@@ -532,7 +525,6 @@ contains
     integer, optional, intent(out) :: rc
     
     integer :: status
-    character(len=ESMF_MAXSTR)   :: Iam="Initialize"
     
     call ESMF_GridCompInitialize(this%gc, userRc = status)
     _VERIFY(status)
@@ -546,7 +538,6 @@ contains
 
     integer :: status
     integer :: userRc
-    character(len=ESMF_MAXSTR)   :: Iam="run"
 
     call ESMF_GridCompRun(this%gc, userRC=userRC,rc=status)
     _ASSERT(userRC==ESMF_SUCCESS .and. STATUS==ESMF_SUCCESS,'run failed')
@@ -560,7 +551,6 @@ contains
     integer, optional, intent(out) :: rc
     
     integer :: status    
-    character(len=ESMF_MAXSTR)   :: Iam="finalize"
     
     call ESMF_GridCompFinalize(this%gc, rc = status)
     _VERIFY(status)
@@ -571,8 +561,6 @@ contains
   function get_am_i_root(this, rc) result (amiroot)
     class (ExtData_DriverGridComp) :: this
     integer, optional, intent(out) :: rc
-
-    character(len=ESMF_MAXSTR)   :: Iam="get_am_i_root"
 
     logical :: amiroot
 
@@ -608,7 +596,6 @@ contains
     integer, optional, intent(out) :: rc
     
     integer :: n, status
-    character(len=ESMF_MAXSTR) :: Iam="run_MultipleTimes"
 
     type(ExtData_DriverGridComp), pointer :: cap
     type (MAPL_MetaComp), pointer :: MAPLOBJ
@@ -640,7 +627,6 @@ contains
   subroutine run_one_step(this, rc)
     class(ExtData_DriverGridComp), intent(inout) :: this
     integer, intent(out) :: rc
-    character(*), parameter :: Iam = "run_one_step"
     integer :: AGCM_YY, AGCM_MM, AGCM_DD, AGCM_H, AGCM_M, AGCM_S
     integer :: status
 
@@ -716,7 +702,6 @@ contains
     character(ESMF_MAXSTR)   :: CALENDAR
     integer                  :: status
     integer        :: datetime(2)
-    character(ESMF_MAXSTR)   :: IAM="MAPL_ClockInit"
     type(ESMF_Calendar) :: cal
     type(ESMF_Time)          :: CurrTime
     type(ESMF_TimeInterval) :: timeInterval, duration
@@ -789,7 +774,6 @@ contains
   subroutine parseTimes(this, rc)
     class(ExtData_DriverGridComp), intent(inout) :: this
     integer, intent(out), optional :: rc
-    character(*), parameter :: Iam = "parseTimes"
     integer :: comp_YY, comp_MM, comp_DD, comp_H, comp_M, comp_S,columnCount,lineCount,i,ctime(2)
     integer :: status
 
@@ -817,7 +801,6 @@ contains
     class(ExtData_DriverGridComp), intent(inout) :: this
     type(ESMF_Time), intent(inout) :: time
     integer, intent(out), optional :: rc
-    character(*), parameter :: Iam = "advanceClockToTime"
     integer :: status
 
     type(ESMF_Time) :: currTime

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -46,6 +46,9 @@ contains
       procedure() :: set_services
       class (KeywordEnforcer),  optional, intent(in) :: unusable
       class ( MAPL_CapOptions), optional, intent(in) :: cap_options
+     
+      _UNUSED_DUMMY(unusable)
+
       driver%name = name
       driver%set_services => set_services
       if (present(cap_options)) then
@@ -65,7 +68,6 @@ contains
 
 
       integer                      :: STATUS
-      character(len=ESMF_MAXSTR)   :: Iam="ExtData_Driver"
 
       integer                  :: CommCap
 

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -172,9 +172,10 @@ MODULE ExtDataUtRoot_GridCompMod
          integer                     :: status
          character(len=ESMF_MAXSTR)  :: comp_name
 
-         real(REAL64) :: ptop, pint
+         !real(REAL64) :: ptop, pint
          !real(REAL64), allocatable :: ak(:),bk(:)
-         integer :: ls,im,jm,lm,nx,ny,nrows, ncolumn,i
+         integer :: im,jm,lm,nx,ny,nrows, ncolumn,i
+         !integer :: ls
          type(ESMF_Grid) :: grid
          type(ESMF_Time) :: currTime
          type(SyntheticFieldSupportWrapper) :: synthWrap
@@ -279,7 +280,7 @@ MODULE ExtDataUtRoot_GridCompMod
          type (ESMF_State),         pointer  :: GEX(:)
 
          character(len=ESMF_MAXSTR)    :: Iam
-         integer                       :: STATUS,i
+         integer                       :: STATUS
          type(MAPL_MetaComp), pointer :: MAPL
          character(len=ESMF_MAXSTR)    :: comp_name
          type(SyntheticFieldSupportWrapper) :: synthWrap
@@ -518,9 +519,6 @@ MODULE ExtDataUtRoot_GridCompMod
       integer :: status
       character(len=*), parameter :: Iam=__FILE__//"::FillState"
       integer                             :: I
-      real, pointer                       :: IMptr3(:,:,:) => null()
-      real, pointer                       :: Exptr3(:,:,:) => null()
-      real, pointer                       :: IMptr2(:,:) => null()
       real, pointer                       :: Exptr2(:,:) => null()
       integer :: itemcount
       character(len=ESMF_MAXSTR), allocatable :: outNameList(:)

--- a/components.yaml
+++ b/components.yaml
@@ -7,7 +7,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./@cmake
   remote: git@github.com:GEOS-ESM/ESMA_cmake.git
-  tag: v2.1.1
+  tag: v2.1.2
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
Most of these fixes are adding `_UNUSED_DUMMY()` lines or just plain deleting variables that were never used.

The one exciting one was in MAPL_TripolarGridFactory where `name` was never set so Intel throws:

```
/discover/swdev/mathomp4/Models/MAPL-MAPL20-Cleanup/MAPL/MAPL_Base/MAPL_TripolarGridFactory.F90(507): warning #6178: The return value of this FUNCTION has not been defined.   [NAME]
   function generate_grid_name(this) result(name)
--------------------------------------------^
```

So we set name to a blank string and then the `error stop` will take care of everything still.

Finally, update to ESMA_cmake v2.1.2 to suppress long names warnings:
```
/discover/swdev/mathomp4/Models/GEOSgcm-MAPL20-MAPLCleanup/GEOSgcm/src/Shared/@MAPL/MAPL_Base/MAPL_TilingRegridder.F90: warning #5462: Global name too long, shortened from: mapl_tilingregriddermod_mp_copy_global_to_local_$blk.pfio_errorhandlingmod_mp_mpi_statuses_ignore_ to: pl_tilingregriddermod_mp_copy_global_to_local_$blk.pfio_errorhandlingmod_mp_mpi_statuses_ignore_
^
```

This adds a new `DISABLE_GLOBAL_NAME_WARNING` flag to suppress this output