### PR TITLE
Added missing stretched-grid support to MAPL_ExtDataGridChangeLev()

### DIFF
--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -33,7 +33,7 @@
    use ESMF_CFIOUtilMod
    use MAPL_CFIOMod
    use MAPL_NewArthParserMod
-   use MAPL_ConstantsMod, only: MAPL_PI,MAPL_PI_R8
+   use MAPL_ConstantsMod, only: MAPL_PI,MAPL_PI_R8,MAPL_RADIANS_TO_DEGREES
    use MAPL_IOMod, only: MAPL_NCIOParseTimeUnits
    use MAPL_regridderSpecMod
    use, intrinsic :: iso_fortran_env, only: REAL64
@@ -4286,6 +4286,7 @@ CONTAINS
      type(ESMF_Grid)           :: newGrid
      type(ESMF_Config)         :: cflocal
      character(len=*), parameter :: CF_COMPONENT_SEPARATOR = '.'
+     real :: temp_real
 
      IAM = "MAPL_ExtDataGridChangeLev"
 
@@ -4313,6 +4314,21 @@ CONTAINS
         _VERIFY(status)
         call MAPL_ConfigSetAttribute(cflocal,value=trim(gname), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"GRIDNAME:",rc=status)
         _VERIFY(status)
+        call ESMF_AttributeGet(grid, name='STRETCH_FACTOR', value=temp_real, rc=status)
+        if (status == ESMF_SUCCESS) then
+           call MAPL_ConfigSetAttribute(cflocal,value=temp_real, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"STRETCH_FACTOR:",rc=status)
+           _VERIFY(status)
+        endif
+        call ESMF_AttributeGet(grid, name='TARGET_LON', value=temp_real, rc=status)
+        if (status == ESMF_SUCCESS) then
+           call MAPL_ConfigSetAttribute(cflocal,value=temp_real*MAPL_RADIANS_TO_DEGREES, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"TARGET_LON:",rc=status)
+           _VERIFY(status)
+        endif
+        call ESMF_AttributeGet(grid, name='TARGET_LAT', value=temp_real, rc=status)
+        if (status == ESMF_SUCCESS) then
+           call MAPL_ConfigSetAttribute(cflocal,value=temp_real*MAPL_RADIANS_TO_DEGREES, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"TARGET_LAT:",rc=status)
+           _VERIFY(status)
+        endif
      else
         call MAPL_ConfigSetAttribute(cflocal,value=counts(1), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"IM_WORLD:",rc=status)
         _VERIFY(status)


### PR DESCRIPTION
Hi everyone,

I've been testing stretched-grid in GCHPctm and saw that some of emissions we're being regridded properly. The affected emissions were 3D emissions that *did not* have 72 vertical layers. These emissions were regridded onto a cubed-sphere that was missing the stretching transformation (i.e. the grid they were regridded onto was otherwise correct).

I tracked this down to the `MAPL_ExtDataGridChangeLev()` subroutine in `MAPL_ExtDataGridCompMod.F90`. It appears this subroutine is missing stretched-grid support. This PR adds stretched-grid support to `MAPL_ExtDataGridChangeLev()`.


Below are some plots of before and after this PR. Sorry they are a bit hard to see--I pulled them out of a benchmark file which auto-generates a bunch of plots. I'm just trying to show the difference between the LHS and RHS before and after this PR.

## Before
Below are some figures comparing a C48 simulation (Ref) to a C32 simulation with a stretch factor of 1.5 (Dev). These simulations were both ran with GCHPctm 13.0.0-alpha.0.

![image](https://user-images.githubusercontent.com/12772306/74043799-a8d67780-498f-11ea-9d28-0e698e4c45f5.png)

Note that if I undid the Dev simulation's stretch transformation before plotting, the emissions were in good agreement.

## After

Below are simulations ran with GCHPctm 13.0.0-alpha.0 + this PR.

![image](https://user-images.githubusercontent.com/12772306/74043755-952b1100-498f-11ea-8c3a-e0f02fc05c3b.png)

Thanks,

Liam