### PR TITLE
Fix for mixed compiler build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected Python code generator scripts for component import/export specs.
 - Add directories to `.gitignore` for building with `mepo`
+- Bug building with mixed Intel/GCC compilers
 	
 ## [2.0.0] - 2019-02-07
 

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -66,7 +66,7 @@ set (srcs
 esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4 gftl-shared FLAP::FLAP MPI::MPI_Fortran)
 target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 if(DISABLE_GLOBAL_NAME_WARNING)
-   set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${DISABLE_GLOBAL_NAME_WARNING})
+   target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${DISABLE_GLOBAL_NAME_WARNING}>)
 endif()
 target_compile_definitions (${this} PRIVATE TWO_SIDED_COMM MAPL_MODE)
 


### PR DESCRIPTION
On the GMAO desktop, an Intel Fortran flag was leaking into GCC. This
fixes it for me by passing that flag only to Fortran files.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is a bugfix for mixed compiler builds with `develop`. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #228.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built and ran on desktop. Zerodiff to v2.0.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
