### PR TITLE
Fixes #234. Update ASSERT in MAPL_ExtDataGridComp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Corrected handling of Equation of Time in orbit (off by default)
-	
+- Made ASSERT in ExtData more explicit in case of missing variables.
+
 ### Fixed
 
 - Corrected Python code generator scripts for component import/export specs.

--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -2227,13 +2227,13 @@ CONTAINS
         var => null()
         if (item%isVector) then
            var=>metadata%get_variable(trim(item%fcomp1))
-           _ASSERT(associated(var),"Variable not found in file")
+           _ASSERT(associated(var),"Variable "//TRIM(item%fcomp1)//" not found in file "//TRIM(item%file))
            var => null()
            var=>metadata%get_variable(trim(item%fcomp2))
-           _ASSERT(associated(var),"Variable not found in file")
+           _ASSERT(associated(var),"Variable "//TRIM(item%fcomp2)//" not found in file "//TRIM(item%file))
         else
            var=>metadata%get_variable(trim(item%var))
-           _ASSERT(associated(var),"Variable not found in file")
+           _ASSERT(associated(var),"Variable "//TRIM(item%var)//" not found in file "//TRIM(item%file))
         end if
    
         levName = metadata%get_level_name(rc=status)


### PR DESCRIPTION
## Description

I am not sure if I got this right. @mmanyin had:
```fortran
_ASSERT(associated(var),"Variable "//TRIM(item%var)//" not found in file "//TRIM(file))
```
but I'm pretty sure it should be `item%file` given some of the other `_ASSERT()` in this module.

Also, I changed the `_ASSERT()` in three places since the message looked to be generic. But, I might not have gotten the variable name variables correct. @bena-nasa can double-check

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#234 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

In the change to MAPL 2.0, ExtData became case-sensitive. This better `_ASSERT()` will allow tracking down needed changes more easily.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not tested yet as this change was made in-browser. Will test soon...though I'm not sure how to cause it to break in all three cases. Might need @bena-nasa to do this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
