### PR TITLE
Fixes #260. The logic in timermodeset is just wrong.

### DIFF
--- a/MAPL_Base/MAPL_Profiler.F90
+++ b/MAPL_Base/MAPL_Profiler.F90
@@ -352,8 +352,8 @@
       character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_ProfModeSet"
 
       ! Sanity check
-      _ASSERT(timerMode >= MAPL_TimerModeOld .and. timerMode <= MAPL_TimerModeMax,'needs informative message')
       timerMode = mode
+      _ASSERT(timerMode >= MAPL_TimerModeOld .and. timerMode <= MAPL_TimerModeMinMax,'needs informative message')
 
       _RETURN(ESMF_SUCCESS)
       


### PR DESCRIPTION
Fixes #260 

This is a zero diff change. No effect on the model, just incorrect logic running the GCM/CTM sequentially through NUOPC uncovered.
