### PR TITLE
Fixes #269. Use NF90_NETCDF4

### DIFF
--- a/GMAO_pFIO/NetCDF4_FileFormatter.F90
+++ b/GMAO_pFIO/NetCDF4_FileFormatter.F90
@@ -133,7 +133,7 @@ contains
       integer :: status
 
       !$omp critical
-      status = nf90_create(file, NF90_NOCLOBBER + NF90_HDF5, this%ncid)
+      status = nf90_create(file, NF90_NOCLOBBER + NF90_NETCDF4, this%ncid)
       !$omp end critical
       _VERIFY(status)
 


### PR DESCRIPTION

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes pFIO to use `NF90_NETCDF4` instead of `NF90_HDF5` as the latter is deprecated.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#269 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Keeps us current. Don't want to have MAPL fall apart if netCDF removes `NF90_HDF5`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran c24 GEOSgcm, was zero-diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
