### PR TITLE
Fixes #272. Use IOR() for netcdf modes

### DIFF
--- a/GMAO_pFIO/NetCDF4_FileFormatter.F90
+++ b/GMAO_pFIO/NetCDF4_FileFormatter.F90
@@ -133,7 +133,7 @@ contains
       integer :: status
 
       !$omp critical
-      status = nf90_create(file, NF90_NOCLOBBER + NF90_NETCDF4, this%ncid)
+      status = nf90_create(file, IOR(NF90_NOCLOBBER, NF90_NETCDF4), this%ncid)
       !$omp end critical
       _VERIFY(status)
 
@@ -153,6 +153,7 @@ contains
       integer :: comm_
       integer :: info_
       integer :: status
+      integer :: mode
 
       if (present(comm)) then
          comm_ = comm
@@ -170,8 +171,13 @@ contains
       this%comm = comm_
       this%info = info_
 
+      mode = NF90_NOCLOBBER
+      mode = IOR(mode, NF90_NETCDF4)
+      mode = IOR(mode, NF90_SHARE)
+      mode = IOR(mode, NF90_MPIIO)
+
       !$omp critical
-      status = nf90_create(file, NF90_NOCLOBBER + NF90_NETCDF4 + NF90_SHARE + NF90_MPIIO, comm=comm_, info=info_, ncid=this%ncid)
+      status = nf90_create(file, mode, comm=comm_, info=info_, ncid=this%ncid)
       !$omp end critical
       _VERIFY(status)
 
@@ -214,12 +220,12 @@ contains
 
       if (this%parallel) then
          !$omp critical
-         status = nf90_open(file, omode + NF90_MPIIO, comm=this%comm, info=this%info, ncid=this%ncid)
+         status = nf90_open(file, IOR(omode, NF90_MPIIO), comm=this%comm, info=this%info, ncid=this%ncid)
          !$omp end critical
          _VERIFY(status)
       else
          !$omp critical
-         status = nf90_open(file, omode + NF90_SHARE, this%ncid)
+         status = nf90_open(file, IOR(omode, NF90_SHARE), this%ncid)
          !$omp end critical
          _VERIFY(status)
       end if


### PR DESCRIPTION
As the subject says, this PR uses IOR() to "combine" netCDF modes.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes us from adding NF90 constants to using `IOR()`.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#272 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Per [netcdf-fortran advice](https://github.com/Unidata/netcdf-fortran/issues/241), there could be issues with adding NF90 mode flags.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
