### PR TITLE
fixes #280

### DIFF
--- a/MAPL_Base/MAPL_HistoryGridComp.F90
+++ b/MAPL_Base/MAPL_HistoryGridComp.F90
@@ -288,7 +288,7 @@ contains
     character(len=ESMF_MAXSTR)     :: tmpstring
     character(len=ESMF_MAXSTR)     :: tilefile
     character(len=ESMF_MAXSTR)     :: gridname
-    character(len=ESMF_MAXSTR), pointer :: gnames(:)
+    character(len=MAPL_TileNameLength), pointer :: gnames(:)
     integer                        :: L, LM
     integer                        :: NG
     integer                        :: NGRIDS


### PR DESCRIPTION
This is a zero-diff change, but fixes a bug that was affect certain history configurations that are only exercised by the coupled ocean.
