### PR TITLE
Handmerge master into develop 2020-Apr-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Imported Python/MAPL subdir (old, but never imported to GitHub)
  - Python automatic code generator for grid comp include files	
 	
+## [2.0.5] - 2020-04-13
+
+### Fixed
+
+- Fixes an issue with a too-large MPI tag.
+
+## [2.0.4] - 2020-04-03 
+
+### Fixed
+
+- Fixes an issue when regridding thru the locstream in the history component.
+
+## [2.0.3] - 2020-03-19
+
+### Fixed
+
+- Fixed a logic bug in the MAPL Profilers that make affect certain runs when using NUOPC.
+
 ## [2.0.2] - 2020-03-10
 
 ### Fixed

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -318,7 +318,7 @@ contains
 
       integer :: comm
       integer :: status
-      integer, parameter :: MAPL_TAG_GLOBAL_IOROOT_RANK = 987654
+      integer, parameter :: MAPL_TAG_GLOBAL_IOROOT_RANK = 987
       character(len=:), allocatable :: s_name
 
       _UNUSED_DUMMY(unusable)


### PR DESCRIPTION
Hand merge of `master` into `develop` due to conflicts.