### PR TITLE
Fix vertical flipping for 0-indexed arrays

### DIFF
--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -4506,7 +4506,7 @@ CONTAINS
       type(ESMF_Field) :: Field,field1,field2
       real, pointer    :: ptr(:,:,:)
       real, allocatable :: ptemp(:,:,:)
-      integer :: lm
+      integer :: ls, le
 
       if (item%isVector) then
 
@@ -4522,13 +4522,14 @@ CONTAINS
          _VERIFY(STATUS)
          allocate(ptemp,source=ptr,stat=status)
          _VERIFY(status)
-         lm = size(ptr,3)
-         ptr(:,:,lm:1:-1) = ptemp(:,:,1:lm:+1)
+         ls = lbound(ptr,3)
+         le = ubound(ptr,3)
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
          call ESMF_FieldGet(Field2,0,farrayPtr=ptr,rc=status)
          _VERIFY(STATUS)
          ptemp=ptr
-         ptr(:,:,lm:1:-1) = ptemp(:,:,1:lm:+1)
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
          deallocate(ptemp)
 
@@ -4544,8 +4545,9 @@ CONTAINS
          _VERIFY(STATUS)
          allocate(ptemp,source=ptr,stat=status)
          _VERIFY(status)
-         lm = size(ptr,3)
-         ptr(:,:,lm:1:-1) = ptemp(:,:,1:lm:+1)
+         ls = lbound(ptr,3)
+         le = ubound(ptr,3)
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
          deallocate(ptemp)
       end if
 


### PR DESCRIPTION
## Description
When flipping vertical arrays, ExtData is implicitly assuming that the array indexing starts from 1. However, 3-D arrays which are defined at the grid edges (e.g. cloud mass flux) are indexed beginning at 0 (i.e. TOA or surface). This commit makes the routine robust by explicitly flipping the arrays based on lbound:ubound, rather than 1:size.

## Related Issue
Resolves https://github.com/GEOS-ESM/MAPL/issues/301.

## Motivation and Context
Fixes a bug when reading in meteorological data which is specified as positive=up.

## How Has This Been Tested?
Simulation in GCHP.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
