### PR TITLE
Fixes #258. Suppress MPI_Finalize errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6] - 2020-04-15
+
+### Fixed
+
+- Added code to suppress (seemingly) spurious MPI_Finalize errors at end
+  of model run. Suppression does not happen if built with
+  `-DCMAKE_BUILD_TYPE=Debug`
+
 ## [2.0.5] - 2020-04-13
 
 ### Fixed

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -67,6 +67,10 @@ esma_add_library(${this} SRCS ${srcs} DEPENDENCIES GMAO_pFIO MAPL_cfio_r4 gftl-s
 target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 target_compile_definitions (${this} PRIVATE TWO_SIDED_COMM MAPL_MODE)
 
+if (NOT (CMAKE_BUILD_TYPE MATCHES Debug))
+   target_compile_definitions(${this} PRIVATE NOT_BUILD_TYPE_IS_DEBUG)
+endif ()
+
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...
 foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
   target_link_libraries(${this} PUBLIC "-Xlinker -rpath -Xlinker ${dir}")

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -68,7 +68,7 @@ target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_F
 target_compile_definitions (${this} PRIVATE TWO_SIDED_COMM MAPL_MODE)
 
 if (NOT (CMAKE_BUILD_TYPE MATCHES Debug))
-   target_compile_definitions(${this} PRIVATE NOT_BUILD_TYPE_IS_DEBUG)
+   target_compile_definitions(${this} PRIVATE BUILD_TYPE_IS_NOT_DEBUG)
 endif ()
 
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -582,6 +582,13 @@ contains
       _UNUSED_DUMMY(unusable)
 
       if (.not. this%mpi_already_initialized) then
+#ifdef NOT_BUILD_TYPE_IS_DEBUG
+         ! Intel MPI at NCCS seems to have spurious MPI_Finalize errors that do
+         ! not affect the answer or even the finalize step. This call suppresses
+         ! the errors.
+         call MPI_Comm_set_errhandler(this%comm_world,MPI_ERRORS_RETURN,ierror)
+         _VERIFY(ierror)
+#endif
          call MPI_Finalize(ierror)
          _VERIFY(ierror)
       end if

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -582,7 +582,7 @@ contains
       _UNUSED_DUMMY(unusable)
 
       if (.not. this%mpi_already_initialized) then
-#ifdef NOT_BUILD_TYPE_IS_DEBUG
+#ifdef BUILD_TYPE_IS_NOT_DEBUG
          ! Intel MPI at NCCS seems to have spurious MPI_Finalize errors that do
          ! not affect the answer or even the finalize step. This call suppresses
          ! the errors.


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit suppresses MPI_Finalize errors when built as anything but
Debug. We don't want to do this if we are actually debugging things!

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#258 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Occasionally at NCCS with Intel MPI, the model throws errors at MPI_Finalize, though the errors don't seem to actually affect anything. The model ends successfully and `EGRESS` is written.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Well, I ran the model...and it didn't throw errors at the end. But then again I don't really get them that often.

Was zero-diff, though, which is nice.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
