### PR TITLE
Add MAPL_Profiler to CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,12 @@ jobs:
                cd build
                make -j2 MAPL_Base_tests
                ctest -R 'MAPL_Base_tests$' --output-on-failure
+         - run:
+            name: Run MAPL_Profiler Unit tests
+            command: |
+               cd build
+               make -j2 MAPL_Profiler_tests
+               ctest -R 'MAPL_Profiler_tests$' --output-on-failure
 
 workflows:
    version: 2.1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,3 +47,8 @@ jobs:
           cd build
           make -j4 MAPL_Base_tests
           ctest -R 'MAPL_Base_tests$' --output-on-failure
+      - name: Run MAPL_Profiler Unit tests
+        run: |
+          cd build
+          make -j4 MAPL_Profiler_tests
+          ctest -R 'MAPL_Profiler_tests$' --output-on-failure


### PR DESCRIPTION
With the fixes to the MAPL_Profiler unit tests, this should add them. Let us see if the CI tests work...