### PR TITLE
Fixes #324 and fixes #325

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
    gcc-build-env:
       docker:
-         - image: gmao/geos-build-env-gcc-source:6.0.10
+         - image: gmao/geos-build-env-gcc-source:6.0.11
       environment:
          OMPI_ALLOW_RUN_AS_ROOT: 1
          OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   build_mapl:
     runs-on: ubuntu-latest
-    container: gmao/geos-build-env-gcc-source:6.0.10
+    container: gmao/geos-build-env-gcc-source:6.0.11
     env:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [2.1.1]  2020-04-20
 ## [2.1.0]  2020-04-16
+	
+### Fixed
+- Added a default initialization clause for pFlogger
+  so that INFO messages go to console.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ## [2.1.1]  2020-04-20
-## [2.1.0]  2020-04-16
-	
+
 ### Fixed
+
 - Added a default initialization clause for pFlogger
   so that INFO messages go to console.
+
+## [2.1.0]  2020-04-16
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.1.0
+  VERSION 2.1.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -129,7 +129,7 @@ contains
           type (FileHandler) :: file_handler
           integer :: level
           
-          call pfl_initialize_pflogger()
+          call pfl_initialize()
 
           if (cap%cap_options%logging_config /= '') then
              call logging%load_file(cap%cap_options%logging_config)

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -119,14 +119,17 @@ contains
     contains
 
        subroutine initialize_pflogger()
-          use pflogger
+          use pflogger, only: pfl_initialize => initialize
+          use pflogger, only: StreamHandler, FileHandler, HandlerVector
+          use pflogger, only: MpiLock, MpiFormatter
+          use pflogger, only: INFO, WARNING
           use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
           type (HandlerVector) :: handlers
           type (StreamHandler) :: console
           type (FileHandler) :: file_handler
           integer :: level
           
-          call initialize()
+          call pfl_initialize_pflogger()
 
           if (cap%cap_options%logging_config /= '') then
              call logging%load_file(cap%cap_options%logging_config)

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -14,7 +14,7 @@ module MAPL_CapMod
    use MAPL_BaseMod
    use MAPL_ErrorHandlingMod
    use pFIO
-   use MAPL_Profiler
+   use MAPL_Profiler, only: get_global_time_profiler, BaseProfiler, TimeProfiler
    use MAPL_ioClientsMod
    use MAPL_CapOptionsMod
    use pflogger, only: logging
@@ -540,6 +540,7 @@ contains
       end subroutine report_throughput
 
       subroutine report_profiling(rc)
+         use MAPL_Profiler
          integer, optional, intent(out) :: rc
          type (ProfileReporter) :: reporter
          integer :: i

--- a/components.yaml
+++ b/components.yaml
@@ -1,7 +1,7 @@
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v2.1.0
+  tag: v2.1.1
   develop: master
 
 cmake:


### PR DESCRIPTION
 - Added a default initialization clause for pFlogger
  so that INFO messages go to console.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Runs of GEOSgcm with and without logging.yaml on command line

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
