### PR TITLE
AT: eliminated errors in the ESMF PET log files due to esmf_usercompg…

### DIFF
--- a/MAPL_Base/MAPL_CapGridComp.F90
+++ b/MAPL_Base/MAPL_CapGridComp.F90
@@ -179,7 +179,7 @@ contains
     _UNUSED_DUMMY(clock)
 
     cap => get_CapGridComp_from_gc(gc)
-    call MAPL_GetObjectFromGC(gc, maplobj, rc=status)
+    call MAPL_InternalStateCreate(gc, maplobj, rc=status)
     _VERIFY(status)
 
     t_p => get_global_time_profiler()

--- a/MAPL_Base/MAPL_Generic.F90
+++ b/MAPL_Base/MAPL_Generic.F90
@@ -359,6 +359,26 @@ type MAPL_GenericRecordType
    integer                                  :: INT_LEN
 end type  MAPL_GenericRecordType
 
+type MAPL_Connectivity
+   type (MAPL_VarConn), pointer :: CONNECT(:)       => null()
+   type (MAPL_VarConn), pointer :: DONOTCONN(:)     => null()
+end type MAPL_Connectivity
+
+type MAPL_LinkType
+   type (ESMF_GridComp) :: GC
+   integer              :: StateType
+   integer              :: SpecId
+end type MAPL_LinkType
+
+type MAPL_LinkForm
+   type (MAPL_LinkType) :: FROM
+   type (MAPL_LinkType) :: TO
+end type MAPL_LinkForm
+
+type MAPL_Link
+   type (MAPL_LinkForm), pointer :: PTR
+end type MAPL_Link
+
 !BOP
 !BOC
 type  MAPL_MetaComp
@@ -392,6 +412,7 @@ type  MAPL_MetaComp
    character(len=ESMF_MAXSTR)               :: COMPNAME
    type (MAPL_GenericRecordType)  , pointer :: RECORD           => null()
    type (ESMF_State)                        :: FORCING
+   type (MAPL_Connectivity)                 :: connectList
    integer                        , pointer :: phase_init (:)    => null()
    integer                        , pointer :: phase_run  (:)    => null()
    integer                        , pointer :: phase_final(:)    => null()
@@ -407,30 +428,6 @@ type  MAPL_MetaComp
 end type MAPL_MetaComp
 !EOC
 !EOP
-
-type MAPL_Connectivity
-   type (MAPL_VarConn), pointer :: CONNECT(:)       => null()
-   type (MAPL_VarConn), pointer :: DONOTCONN(:)     => null()
-end type MAPL_Connectivity
-
-type MAPL_ConnectivityWrap
-   type(MAPL_Connectivity), pointer :: PTR
-end type MAPL_ConnectivityWrap
-
-type MAPL_LinkType
-   type (ESMF_GridComp) :: GC
-   integer              :: StateType
-   integer              :: SpecId
-end type MAPL_LinkType
-
-type MAPL_LinkForm
-   type (MAPL_LinkType) :: FROM
-   type (MAPL_LinkType) :: TO
-end type MAPL_LinkForm
-
-type MAPL_Link
-   type (MAPL_LinkForm), pointer :: PTR
-end type MAPL_Link
 
 type MAPL_MetaPtr
    type(MAPL_MetaComp), pointer  :: PTR
@@ -526,7 +523,6 @@ type(ESMF_FieldBundle), pointer   :: BUNDLE
 type(ESMF_State), pointer         :: STATE
 type(ESMF_VM)                     :: VM
 
-type (MAPL_ConnectivityWrap)      :: connwrap
 type (MAPL_VarConn),      pointer :: CONNECT(:)
 type (MAPL_VarSpec),      pointer :: IM_SPECS(:)
 type (MAPL_VarSpec),      pointer :: EX_SPECS(:)
@@ -594,13 +590,8 @@ type(ESMF_GridComp)               :: rootGC
 
 ! Relax connectivity for non-existing imports
       if (NC > 0) then
-         call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-              connwrap, status)
-         if (STATUS == ESMF_FAILURE) then
-            NULLIFY(CONNECT)
-         else
-            CONNECT => connwrap%ptr%CONNECT
-         end if
+         
+         CONNECT => MAPLOBJ%connectList%CONNECT
 
          allocate (ImSpecPtr(NC), ExSpecPtr(NC), stat=status)
          _VERIFY(STATUS)
@@ -2784,8 +2775,6 @@ end subroutine MAPL_DateStampGet
 #if defined(ABSOFT) || defined(sysIRIX64)
     WRAP%MAPLOBJ => DUMMY
 #endif
-    call ESMF_UserCompGetInternalState(GC, "MAPL_GenericInternalState", WRAP, STATUS)
-    _ASSERT(STATUS == ESMF_FAILURE,'needs informative message')
 
 ! Allocate this instance of the internal state and put it in wrapper.
 ! -------------------------------------------------------------------
@@ -4625,22 +4614,11 @@ end function MAPL_AddChildFromGC
 
     character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_AddConnectivity"
     integer                               :: STATUS
-    type (MAPL_ConnectivityWrap)          :: connwrap
     type (MAPL_Connectivity), pointer     :: conn
 
 
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       allocate(conn, STAT=STATUS)
-       _VERIFY(STATUS)
-       connwrap%ptr => conn
-       call ESMF_UserCompSetInternalState(gc, 'MAPL_Connectivity', &
-                                          connwrap, status)
-       _VERIFY(STATUS)
-    else
-       conn => connwrap%ptr
-    end if
+    call MAPL_ConnectivityGet(gc, connectivityPtr=conn, RC=status)
+    _VERIFY(STATUS)
 
     call MAPL_VarConnCreate(CONN%CONNECT, SHORT_NAME, TO_NAME=TO_NAME,        &
                             FROM_IMPORT=FROM_IMPORT, FROM_EXPORT=FROM_EXPORT, &
@@ -4661,22 +4639,10 @@ end function MAPL_AddChildFromGC
 
     character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_AddConnectivityE2E"
     integer                               :: STATUS
-    type (MAPL_ConnectivityWrap)          :: connwrap
     type (MAPL_Connectivity), pointer     :: conn
 
-
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       allocate(conn, STAT=STATUS)
-       _VERIFY(STATUS)
-       connwrap%ptr => conn
-       call ESMF_UserCompSetInternalState(gc, 'MAPL_Connectivity', &
-                                          connwrap, status)
-       _VERIFY(STATUS)
-    else
-       conn => connwrap%ptr
-    end if
+    call MAPL_ConnectivityGet(gc, connectivityPtr=conn, RC=status)
+    _VERIFY(STATUS)
 
     call MAPL_VarConnCreate(CONN%CONNECT, SHORT_NAME, &
                             FROM_EXPORT=SRC_ID, &
@@ -4707,22 +4673,12 @@ end function MAPL_AddChildFromGC
 
     character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_AddConnectivityRename"
     integer                               :: STATUS
-    type (MAPL_ConnectivityWrap)          :: connwrap
+
     type (MAPL_Connectivity), pointer     :: conn
 
 
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       allocate(conn, STAT=STATUS)
-       _VERIFY(STATUS)
-       connwrap%ptr => conn
-       call ESMF_UserCompSetInternalState(gc, 'MAPL_Connectivity', &
-                                          connwrap, status)
-       _VERIFY(STATUS)
-    else
-       conn => connwrap%ptr
-    end if
+    call MAPL_ConnectivityGet(gc, connectivityPtr=conn, RC=status)
+    _VERIFY(STATUS)
 
     call MAPL_VarConnCreate(CONN%CONNECT, SHORT_NAME=SRC_NAME, TO_NAME=DST_NAME,        &
                             FROM_EXPORT=SRC_ID, TO_IMPORT=DST_ID, RC=STATUS  )
@@ -4808,22 +4764,10 @@ end function MAPL_AddChildFromGC
 
     character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_DoNotConnect"
     integer                               :: STATUS
-    type (MAPL_ConnectivityWrap)          :: connwrap
     type (MAPL_Connectivity), pointer     :: conn
 
-
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       allocate(conn, STAT=STATUS)
-       _VERIFY(STATUS)
-       connwrap%ptr => conn
-       call ESMF_UserCompSetInternalState(gc, 'MAPL_Connectivity', &
-                                          connwrap, status)
-       _VERIFY(STATUS)
-    else
-       conn => connwrap%ptr
-    end if
+    call MAPL_ConnectivityGet(gc, connectivityPtr=conn, RC=status)
+    _VERIFY(STATUS)
 
     call MAPL_VarConnCreate(CONN%DONOTCONN, SHORT_NAME, &
        FROM_IMPORT=CHILD, RC=STATUS  )
@@ -6443,7 +6387,6 @@ recursive subroutine MAPL_WireComponent(GC, RC)
     integer                                     :: STAT
     logical                                     :: SATISFIED
     logical                                     :: PARENTIMPORT
-    type (MAPL_ConnectivityWrap)                :: connwrap
     type (MAPL_Connectivity), pointer           :: conn
     type (MAPL_VarConn), pointer                :: CONNECT(:)
     type (MAPL_VarConn), pointer                :: DONOTCONN(:)
@@ -6475,16 +6418,11 @@ recursive subroutine MAPL_WireComponent(GC, RC)
        _RETURN(ESMF_SUCCESS)
     end if
 
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       NULLIFY(CONNECT)
-       NULLIFY(DONOTCONN)
-    else
-       conn => connwrap%ptr
-       CONNECT => CONN%CONNECT
-       DONOTCONN => CONN%DONOTCONN
-    end if
+    call MAPL_ConnectivityGet(gc, connectivityPtr=conn, RC=status)
+    _VERIFY(STATUS)
+
+    CONNECT => CONN%CONNECT
+    DONOTCONN => CONN%DONOTCONN
 
     NC = size(GCS)
 
@@ -7677,9 +7615,7 @@ recursive subroutine MAPL_WireComponent(GC, RC)
 
     integer                                     :: I
     logical                                     :: err
-    type (MAPL_ConnectivityWrap)          :: connwrap
-    type (MAPL_Connectivity), pointer     :: conn
-
+    type (MAPL_Connectivity), pointer           :: conn
 
 
 !EOP
@@ -7697,19 +7633,8 @@ recursive subroutine MAPL_WireComponent(GC, RC)
     call MAPL_InternalStateRetrieve ( GC, STATE, RC=STATUS )
     _VERIFY(STATUS)
 
-    call ESMF_UserCompGetInternalState(gc, 'MAPL_Connectivity', &
-                                       connwrap, status)
-    if (STATUS == ESMF_FAILURE) then
-       allocate(conn, STAT=STATUS)
-       _VERIFY(STATUS)
-       connwrap%ptr => conn
-       call ESMF_UserCompSetInternalState(gc, 'MAPL_Connectivity', &
-                                          connwrap, status)
-       _VERIFY(STATUS)
-    else
-       conn => connwrap%ptr
-    end if
-
+    conn => state%connectList
+      
     err = .false.
     if (.not. MAPL_ConnCheckUnused(CONN%CONNECT)) then
        err = .true.
@@ -10406,5 +10331,21 @@ end subroutine MAPL_READFORCINGX
       lgr => meta%lgr
       _RETURN(_SUCCESS)
    end subroutine MAPL_GetLogger
+
+   subroutine MAPL_ConnectivityGet(gc, connectivityPtr, RC)
+      type(ESMF_GridComp), intent(inout) :: gc
+      integer, optional, intent(out) :: rc
+      type (MAPL_Connectivity), pointer :: connectivityPtr
+
+      type (MAPL_MetaComp), pointer :: meta
+      integer                       :: status
+      
+      call MAPL_GetObjectFromGC(gc, meta, rc=status)
+      _VERIFY(status)
+
+      connectivityPtr => meta%connectList
+      
+      _RETURN(_SUCCESS)
+   end subroutine MAPL_ConnectivityGet
 
 end module MAPL_GenericMod


### PR DESCRIPTION
…et querries for objects that were not created yet. Aslo eliminated similar calls to get MAPL_Connectivity object, which has been moved to MAPL itself

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
