### PR TITLE
Bugfix/wjamieso/arrdescr uninitialized

### DIFF
--- a/MAPL_Base/MAPL_IO.F90
+++ b/MAPL_Base/MAPL_IO.F90
@@ -375,6 +375,23 @@ module MAPL_IOMod
          _VERIFY(STATUS)
          arrdes%jn=jn
 
+         ArrDes%NX0 = NY0
+         ArrDes%NY0 = NX0
+
+         ArrDes%offset = 0
+
+         ArrDes%romio_cb_read  = "automatic"
+         ArrDes%cb_buffer_size = "16777216"
+         ArrDes%romio_cb_write = "enable"
+
+         ArrDes%face_readers_comm = 0
+         ArrDes%face_writers_comm = 0
+         ArrDes%face_index        = 0
+
+         ArrDes%tile = .false.
+
+         ArrDes%filename = ''
+
          _RETURN(ESMF_SUCCESS)
 
       end subroutine ArrDescrInit

--- a/MAPL_Base/MAPL_IO.F90
+++ b/MAPL_Base/MAPL_IO.F90
@@ -384,8 +384,8 @@ module MAPL_IOMod
          ArrDes%cb_buffer_size = "16777216"
          ArrDes%romio_cb_write = "enable"
 
-         ArrDes%face_readers_comm = 0
-         ArrDes%face_writers_comm = 0
+         ArrDes%face_readers_comm = MPI_COMM_NULL
+         ArrDes%face_writers_comm = MPI_COMM_NULL
          ArrDes%face_index        = 0
 
          ArrDes%tile = .false.


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `ArrDescr` type initialize subroutine `ArrDescrInit` fails to initialize some variables. Normally these are initialized by other routines. The online-ctm project does not run some of these other routines ultimately resulting in an MPI error. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

During initialization of of the online-ctm model openmpi encounters an error with an `MPI_Info_set` call. It was determined that an uninitialized string originating in an `ArrDescr` type object was the cause of the error. Note that when iMPI is used the same `MPI_Info_set` call also receives the same uninitialized string, but it does not raise any errors and the code proceeds.

Further investigation of the uninitialized string found that the `ArrDescrInit` subroutine does not initialize all the variables in the derived type `ArrDescr`. Under normal circumstances most of these variables are initialized later by other subroutines, and/or hidden by the lack of an error being raised by iMPI builds.

Consequentially, an effort has been made to initialize all the variables associated with the `ArrDescr` derived type within the `ArrDescrInit` subroutine to prevent further uninitialized variable errors in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The change has only been tested with regards to the online-ctm project, wherein it resolves the aforementioned issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
