### PR TITLE
Update CHANGELOG and version for 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [Unreleased]
+## [2.1.3] - 2020-05-04
 
 ### Changed
 
@@ -32,14 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove `MPI_comm_set_errhandler` workaround
 
-## [2.1.2]  2020-04-24
+## [2.1.2] - 2020-04-24
 
 ### Fixed
 
 - Fixed bug when output fields on tripolar grid in History
 - Fixed bug during replay when the refresh template in ExtData is a time interval
 
-## [2.1.1]  2020-04-20
+## [2.1.1] - 2020-04-20
 
 ### Fixed
 
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround for MPT 2.17 build bug with `MPI_Comm_set_errhandler`
 
 
-## [2.1.0]  2020-04-16
+## [2.1.0] - 2020-04-16
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+### Fixed
+### Removed
+### Added
 
-- Update CI to use Baselibs 6.0.12
-- Update `components.yaml`
-  - ESMA_env v2.1.2
-  - ESMA_cmake v3.0.2
+## [Unreleased]
+
+### Changed
+
+- MAPL now requires Baselibs 6.0.12 (pFlogger v1.4.1)
+  - Update CI to use Baselibs 6.0.12
+  - Update `components.yaml`
+    - ESMA_env v2.1.2
+    - ESMA_cmake v3.0.2
 
 ### Fixed
 
 - Fix for `MPI_Finalize` error with Intel MPI
+- Fix `ArrDescrInit` routine
+- Fixes for ESMF logging (when run with MULTI)
 
 ### Removed
 
 - Remove `MPI_comm_set_errhandler` workaround
-
-### Added
 
 ## [2.1.2]  2020-04-24
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.1.1
+  VERSION 2.1.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)


### PR DESCRIPTION
Simply getting the `CHANGELOG.md` and `CMakeLists.txt` ready for release