### PR TITLE
Feature/move/ioserver logic

### DIFF
--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -39,7 +39,7 @@ MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           Simple
 MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
 MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
 MAPL_LocStreamFactoryMod.F90          MAPL_HistoryTrajectoryMod.F90       MAPL_LocstreamRegridder.F90
-IOServers.F90
+ServerManager.F90
 c_mapl_locstream_F.c  getrss.c  memuse.c
 )
 

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -39,6 +39,7 @@ MAPL_EtaHybridVerticalCoordinate.F90  MAPL_newCFIOitem.F90
 MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           SimpleCommSplitter.F90
 MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
 MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
+IOServers.F90
 c_mapl_locstream_F.c  getrss.c  memuse.c
 )
 

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -38,7 +38,6 @@ MAPL_EtaHybridVerticalCoordinate.F90  MAPL_newCFIOitem.F90
 MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           SimpleCommSplitter.F90
 MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
 MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
-IOServers.F90
 MAPL_LocStreamFactoryMod.F90          MAPL_HistoryTrajectoryMod.F90       MAPL_LocstreamRegridder.F90
 IOServers.F90
 c_mapl_locstream_F.c  getrss.c  memuse.c

--- a/MAPL_Base/IOServers.F90
+++ b/MAPL_Base/IOServers.F90
@@ -1,0 +1,218 @@
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
+
+module MAPL_ioServer
+
+   use MAPL_ExceptionHandling
+   use MAPL_KeywordEnforcerMod
+   use pFIO_ClientManagerMod
+   use PFIO
+   use MAPL_ioClientsMod
+   use MAPL_SimpleCommSplitterMod
+   use MAPL_SplitCommunicatorMod
+   implicit none
+   private
+
+
+   type, public :: io_server
+      type(SplitCommunicator)  :: split_comm
+      type(MpiServer), pointer :: i_server=>null()
+      type(MpiServer), pointer :: o_server=>null()
+      type(DirectoryService) :: directory_service
+      contains
+         procedure :: init_io_server
+         procedure :: finalize_io_server
+         procedure :: get
+   end type
+
+contains
+
+   subroutine get(this, unusable, split_comm, rc)
+      class (io_server), intent(inout) :: this
+      class (KeywordEnforcer),  optional, intent(in) :: unusable
+      type(SplitCommunicator), intent(out), optional :: split_comm
+      integer, intent(out), optional :: rc
+
+      _UNUSED_DUMMY(unusable)
+
+      if (present(split_comm)) split_comm=this%split_comm
+      _RETURN(_SUCCESS)
+
+   end subroutine get
+
+   subroutine init_io_server(this, comm, unusable, application_size, nodes_input_server, nodes_output_server, npes_input_server,npes_output_server, rc)
+      class (io_server), intent(inout) :: this
+      integer, intent(in) :: comm
+      class (KeywordEnforcer),  optional, intent(in) :: unusable
+      integer, optional, intent(in) :: application_size
+      integer, optional, intent(in) :: nodes_input_server(:),nodes_output_server(:)
+      integer, optional, intent(in) :: npes_input_server(:),npes_output_server(:)
+      integer, optional, intent(out) :: rc
+      integer, allocatable :: npes_in(:),npes_out(:),nodes_in(:),nodes_out(:)
+
+      type (SimpleCommSplitter) :: splitter
+      integer :: status, i, rank,npes_model,n_oserver_group, n_iserver_group
+      character(len=:), allocatable :: s_name
+      type(ClientThread), pointer :: clientPtr
+
+      _UNUSED_DUMMY(unusable)
+
+      if (present(application_size)) then
+         npes_model = application_size
+      else
+         call MPI_COMM_Size(comm,npes_model,status)
+         _VERIFY(status)
+      end if
+      if (present(npes_input_server)) then
+         npes_in = npes_input_server
+      else
+         npes_in = [0]
+      end if
+
+      if (present(npes_output_server)) then
+         npes_out = npes_output_server
+      else
+         npes_out = [0]
+      end if
+
+      if (present(nodes_input_server)) then
+         nodes_in = nodes_input_server
+      else
+         nodes_in = [0]
+      end if
+
+      if (present(nodes_output_server)) then
+         nodes_out = nodes_output_server
+      else
+         nodes_out = [0]
+      end if
+
+     n_iserver_group = max(size(npes_in),size(nodes_in))
+     n_oserver_group = max(size(npes_out),size(nodes_out))
+     this%directory_service = DirectoryService(comm)
+     splitter = SimpleCommSplitter(comm)
+     call splitter%add_group(npes=npes_model, name='model', isolate_nodes=.true.)
+
+     if (npes_in(1) > 0) then
+        do i = 1, size(npes_in)
+           s_name ='i_server'//trim(i_to_string(i))
+           call splitter%add_group(npes=npes_in(i), name=s_name, isolate_nodes=.true.)
+        enddo
+     elseif (nodes_in(1) > 0) then
+        do i = 1, size(nodes_in)
+           s_name ='i_server'//trim(i_to_string(i))
+           call splitter%add_group(nnodes=nodes_in(i), name=s_name, isolate_nodes=.true.)
+        enddo
+     end if
+
+     if (npes_out(1) > 0 ) then
+        do i = 1, size(npes_out)
+          s_name ='o_server'//trim(i_to_string(i))
+          call splitter%add_group(npes=npes_out(i), name=s_name, isolate_nodes=.true.)
+        enddo
+     else if(nodes_out(1) > 0) then
+        do i = 1, size(nodes_out)
+          s_name ='o_server'//trim(i_to_string(i))
+          call splitter%add_group(nnodes=nodes_out(i), name=s_name, isolate_nodes=.true.)
+        enddo
+     endif
+
+     this%split_comm = splitter%split(rc=status); _VERIFY(status)
+
+     s_name = this%split_comm%get_name()
+
+     if ( index(s_name, 'model') /=0 ) then
+        if (npes_in(1) == 0 .and. nodes_in(1) == 0) then
+           allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'i_server'//trim(i_to_string(1))))
+           call this%directory_service%publish(PortInfo('i_server'//trim(i_to_string(1)), this%i_server), this%i_server)
+        end if
+        if (npes_out(1) == 0 .and. nodes_out(1) == 0) then
+           allocate(this%o_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'o_server'//trim(i_to_string(1))))
+           call this%directory_service%publish(PortInfo('o_server'//trim(i_to_string(1)), this%o_server), this%o_server)
+        end if
+        call io_client%init_io_clients(ni = n_oserver_group, no = n_iserver_group )
+     endif
+
+     ! establish i_server group one by one
+     do i = 1, n_iserver_group
+
+        if ( trim(s_name) =='i_server'//trim(i_to_string(i)) ) then
+           allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), s_name))
+           call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
+           call this%directory_service%connect_to_client(s_name, this%i_server)
+           call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
+           if (rank == 0 .and. nodes_in(i) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO input server on ",nodes_in(i)," nodes"
+           else if (rank==0 .and. npes_in(i) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO input server on ",npes_in(i)," pes"
+           end if
+        endif
+
+        if ( index(s_name, 'model') /=0 ) then
+           clientPtr => i_Clients%current()
+           call this%directory_service%connect_to_server('i_server'//trim(i_to_string(i)), clientPtr, this%split_comm%get_subcommunicator())
+           call i_Clients%next()
+        endif
+
+        call mpi_barrier(comm, status)
+
+     enddo
+
+     ! establish o_server group one by one
+     do i = 1, n_oserver_group
+
+        if ( trim(s_name) =='o_server'//trim(i_to_string(i)) ) then
+           allocate(this%o_server, source = MpiServer(this%split_comm%get_subcommunicator(), s_name))
+           call this%directory_service%publish(PortInfo(s_name,this%o_server), this%o_server)
+           call this%directory_service%connect_to_client(s_name, this%o_server)
+           call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
+           if (rank == 0 .and. nodes_out(i) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO output server on ",nodes_out," nodes"
+           else if (rank==0 .and. npes_out(i) /=0 ) then
+              write(*,'(A,I0,A)')"Starting pFIO output server on ",npes_out," pes"
+           end if
+        endif
+
+        if ( index(s_name, 'model') /=0 ) then
+           clientPtr => o_Clients%current()
+           call this%directory_service%connect_to_server('o_server'//trim(i_to_string(i)), clientPtr, this%split_comm%get_subcommunicator())
+           call o_Clients%next()
+        endif
+
+        call mpi_barrier(comm, status)
+
+     enddo
+
+     if ( index(s_name, 'o_server') /=0 ) then
+        call this%o_server%start()
+     endif
+
+     if ( index(s_name, 'i_server') /=0 ) then
+        call this%i_server%start()
+     endif
+
+     if ( index(s_name, 'model') /=0 ) then
+        call i_Clients%set_current(1) ! set current to be the first
+        call o_Clients%set_current(1) ! set current to be the first
+        if (npes_out(1) >0) then
+           call io_client%set_size(no = npes_out,rc=status)
+        else if (nodes_out(1)>0) then
+           call io_client%set_size(no = nodes_out,rc=status)
+        endif
+        _VERIFY(status)
+     end if
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(unusable)
+   end subroutine init_io_server
+
+   subroutine finalize_io_server(this,rc)
+      class(io_server), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+ 
+      call this%directory_service%free_directory_resources()
+      _RETURN(_SUCCESS)
+   end subroutine finalize_io_server
+
+end module MAPL_ioServer

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -17,7 +17,7 @@ module MAPL_CapMod
    use MAPL_Profiler, only: get_global_time_profiler, BaseProfiler, TimeProfiler
    use MAPL_ioClientsMod
    use MAPL_CapOptionsMod
-   use MAPL_ioServer
+   use MAPL_ServerManager
    use pflogger, only: logging
    use pflogger, only: Logger
    implicit none
@@ -39,7 +39,7 @@ module MAPL_CapMod
 
       type(MAPL_CapGridComp), public :: cap_gc
       type(MAPL_Communicators) :: mapl_comm
-      type(io_server) :: cap_server
+      type(ServerManager) :: cap_server
 
    contains
       procedure :: run
@@ -204,7 +204,7 @@ contains
          call this%cap_server%get(split_comm=split_comm)
          call fill_mapl_comm(split_comm, subcommunicator, .false., this%mapl_comm, rc=status)
          call this%run_member(rc=status); _VERIFY(status)
-         call this%cap_server%finalize_io_server()
+         call this%cap_server%finalize()
       end if
 
       _RETURN(_SUCCESS)
@@ -220,7 +220,7 @@ contains
      integer :: status
 
      _UNUSED_DUMMY(unusable)
-     call this%cap_server%init_io_server(comm, &
+     call this%cap_server%initialize(comm, &
          application_size=this%cap_options%npes_model, &
          nodes_input_server=this%cap_options%nodes_input_server, &
          nodes_output_server=this%cap_options%nodes_output_server, &

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -17,6 +17,7 @@ module MAPL_CapMod
    use MAPL_Profiler, only: get_global_time_profiler, BaseProfiler, TimeProfiler
    use MAPL_ioClientsMod
    use MAPL_CapOptionsMod
+   use MAPL_ioServer
    use pflogger, only: logging
    use pflogger, only: Logger
    implicit none
@@ -37,11 +38,8 @@ module MAPL_CapMod
       logical :: mpi_already_initialized = .false.
 
       type(MAPL_CapGridComp), public :: cap_gc
-      type(SplitCommunicator)  :: split_comm
       type(MAPL_Communicators) :: mapl_comm
-      type(MpiServer), pointer :: i_server=>null()
-      type(MpiServer), pointer :: o_server=>null()
-      type(DirectoryService) :: directory_service
+      type(io_server) :: cap_server
 
    contains
       procedure :: run
@@ -196,14 +194,17 @@ contains
 
       integer :: status
       integer :: subcommunicator
+      type(SplitCommunicator) :: split_comm
 
       _UNUSED_DUMMY(unusable)
       
       subcommunicator = this%create_member_subcommunicator(this%comm_world, rc=status); _VERIFY(status)
       if (subcommunicator /= MPI_COMM_NULL) then
          call this%initialize_io_clients_servers(subcommunicator, rc = status); _VERIFY(status)
+         call this%cap_server%get(split_comm=split_comm)
+         call fill_mapl_comm(split_comm, subcommunicator, .false., this%mapl_comm, rc=status)
          call this%run_member(rc=status); _VERIFY(status)
-         call this%directory_service%free_directory_resources()
+         call this%cap_server%finalize_io_server()
       end if
 
       _RETURN(_SUCCESS)
@@ -212,144 +213,24 @@ contains
 
 
    subroutine initialize_io_clients_servers(this, comm, unusable, rc)
-     use MAPL_CFIOMod
      class (MAPL_Cap), target, intent(inout) :: this
      integer, intent(in) :: comm
      class (KeywordEnforcer), optional, intent(in) :: unusable
      integer, optional, intent(out) :: rc
-
-     type (SimpleCommSplitter) :: splitter
-     integer :: status, i, rank
-     logical :: running_old_o_server ! relevant only for "old" o-server
-     character(len=:), allocatable :: s_name
-
-     type(ClientThread), pointer :: clientPtr
+     integer :: status
 
      _UNUSED_DUMMY(unusable)
-
-     this%directory_service = DirectoryService(comm)
-     splitter = SimpleCommSplitter(comm)
-     call splitter%add_group(npes=this%cap_options%npes_model, name='model', isolate_nodes=.true.)
-
-     if (this%cap_options%npes_input_server(1) > 0) then
-        do i = 1, this%cap_options%n_iserver_group
-           s_name ='i_server'//trim(i_to_string(i))
-           call splitter%add_group(npes=this%cap_options%npes_input_server(i), name=s_name, isolate_nodes=.true.)
-        enddo
-     elseif (this%cap_options%nodes_input_server(1) > 0) then
-        do i = 1, this%cap_options%n_iserver_group
-           s_name ='i_server'//trim(i_to_string(i))
-           call splitter%add_group(nnodes=this%cap_options%nodes_input_server(i), name=s_name, isolate_nodes=.true.)
-        enddo
-     end if
-
-     running_old_o_server = .false.
-
-     if (this%cap_options%npes_output_server(1) > 0 ) then
-        running_old_o_server = (this%cap_options%n_oserver_group ==1) ! otherwise need to combine all the o-server groups to form a group used by old_server
-        do i = 1, this%cap_options%n_oserver_group
-          s_name ='o_server'//trim(i_to_string(i))
-          call splitter%add_group(npes=this%cap_options%npes_output_server(i), name=s_name, isolate_nodes=.true.)
-        enddo
-     else if(this%cap_options%nodes_output_server(1) > 0) then
-        running_old_o_server = (this%cap_options%n_oserver_group ==1) ! otherwise need to combine all the o-server groups to form a group used by old_server
-        do i = 1, this%cap_options%n_oserver_group
-          s_name ='o_server'//trim(i_to_string(i))
-          call splitter%add_group(nnodes=this%cap_options%nodes_output_server(i), name=s_name, isolate_nodes=.true.)
-        enddo
-     endif
-
-     this%split_comm = splitter%split(rc=status); _VERIFY(status)
-
-     call fill_mapl_comm(this%split_comm, comm, running_old_o_server, this%mapl_comm, rc=status)
+     call this%cap_server%init_io_server(comm, &
+         application_size=this%cap_options%npes_model, &
+         nodes_input_server=this%cap_options%nodes_input_server, &
+         nodes_output_server=this%cap_options%nodes_output_server, &
+         npes_input_server=this%cap_options%npes_input_server, &
+         npes_output_server=this%cap_options%npes_output_server, &
+         rc=status)
      _VERIFY(status)
-     
-     s_name = this%split_comm%get_name()
 
-     if ( index(s_name, 'model') /=0 ) then
-        if (this%cap_options%npes_input_server(1) == 0 .and. this%cap_options%nodes_input_server(1) == 0) then
-           allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'i_server'//trim(i_to_string(1))))
-           call this%directory_service%publish(PortInfo('i_server'//trim(i_to_string(1)), this%i_server), this%i_server)
-        end if
-        if (this%cap_options%npes_output_server(1) == 0 .and. this%cap_options%nodes_output_server(1) == 0) then
-           allocate(this%o_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'o_server'//trim(i_to_string(1))))
-           call this%directory_service%publish(PortInfo('o_server'//trim(i_to_string(1)), this%o_server), this%o_server)
-        end if
-        call io_client%init_io_clients(ni = this%cap_options%n_iserver_group, no = this%cap_options%n_oserver_group )
-     endif
-
-     ! establish i_server group one by one
-     do i = 1, this%cap_options%n_iserver_group
-        
-        if ( trim(s_name) =='i_server'//trim(i_to_string(i)) ) then
-           allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), s_name))
-           call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
-           call this%directory_service%connect_to_client(s_name, this%i_server)
-           call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. this%cap_options%nodes_input_server(i) /=0 ) then
-              write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%nodes_input_server(i)," nodes"
-           else if (rank==0 .and. this%cap_options%npes_input_server(i) /=0 ) then
-              write(*,'(A,I0,A)')"Starting pFIO input server on ",this%cap_options%npes_input_server(i)," pes"
-           end if
-        endif
-
-        if ( index(s_name, 'model') /=0 ) then
-           clientPtr => i_Clients%current()
-           call this%directory_service%connect_to_server('i_server'//trim(i_to_string(i)), clientPtr, this%split_comm%get_subcommunicator())
-           call i_Clients%next()
-        endif 
-
-        call mpi_barrier(comm, status) 
-
-     enddo
-
-     ! establish o_server group one by one
-     do i = 1, this%cap_options%n_oserver_group
-        
-        if ( trim(s_name) =='o_server'//trim(i_to_string(i)) ) then
-           allocate(this%o_server, source = MpiServer(this%split_comm%get_subcommunicator(), s_name))
-           call this%directory_service%publish(PortInfo(s_name,this%o_server), this%o_server)
-           call this%directory_service%connect_to_client(s_name, this%o_server)
-           call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. this%cap_options%nodes_output_server(i) /=0 ) then
-              write(*,'(A,I0,A)')"Starting pFIO output server on ",this%cap_options%nodes_output_server(i)," nodes"
-           else if (rank==0 .and. this%cap_options%npes_output_server(i) /=0 ) then
-              write(*,'(A,I0,A)')"Starting pFIO output server on ",this%cap_options%npes_output_server(i)," pes"
-           end if
-        endif
-
-        if ( index(s_name, 'model') /=0 ) then
-           clientPtr => o_Clients%current()
-           call this%directory_service%connect_to_server('o_server'//trim(i_to_string(i)), clientPtr, this%split_comm%get_subcommunicator())
-           call o_Clients%next()
-        endif 
-
-        call mpi_barrier(comm, status) 
-
-     enddo
-
-     if ( index(s_name, 'o_server') /=0 ) then
-        call this%o_server%start()
-     endif
-
-     if ( index(s_name, 'i_server') /=0 ) then
-        call this%i_server%start()
-     endif
-
-     if ( index(s_name, 'model') /=0 ) then
-        call i_Clients%set_current(1) ! set current to be the first
-        call o_Clients%set_current(1) ! set current to be the first
-        if (this%cap_options%npes_output_server(1) >0) then
-           call io_client%set_size(no = this%cap_options%npes_output_server,rc=status)
-        else if (this%cap_options%nodes_output_server(1)>0) then
-           call io_client%set_size(no = this%cap_options%nodes_output_server,rc=status)
-        endif
-        _VERIFY(status)
-     end if
-     
    end subroutine initialize_io_clients_servers
-
-   
+     
    ! This layer splits the communicator to support separate i/o servers
    ! and runs the model via a CapGridComp.
    subroutine run_member(this, rc)
@@ -358,8 +239,10 @@ contains
       integer, optional, intent(out) :: rc
       
       integer :: status
+      type(SplitCommunicator) :: split_comm
 
-      select case(this%split_comm%get_name())
+      call this%cap_server%get(split_comm=split_comm)
+      select case(split_comm%get_name())
       case('model')
          call this%run_model(this%mapl_comm, rc=status); _VERIFY(status)
          call i_Clients%terminate()

--- a/MAPL_Base/ServerManager.F90
+++ b/MAPL_Base/ServerManager.F90
@@ -1,7 +1,7 @@
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
-module MAPL_ioServer
+module MAPL_ServerManager
 
    use MAPL_ExceptionHandling
    use MAPL_KeywordEnforcerMod
@@ -14,21 +14,21 @@ module MAPL_ioServer
    private
 
 
-   type, public :: io_server
+   type, public :: ServerManager
       type(SplitCommunicator)  :: split_comm
       type(MpiServer), pointer :: i_server=>null()
       type(MpiServer), pointer :: o_server=>null()
       type(DirectoryService) :: directory_service
       contains
-         procedure :: init_io_server
-         procedure :: finalize_io_server
+         procedure :: initialize
+         procedure :: finalize
          procedure :: get
    end type
 
 contains
 
    subroutine get(this, unusable, split_comm, rc)
-      class (io_server), intent(inout) :: this
+      class (ServerManager), intent(inout) :: this
       class (KeywordEnforcer),  optional, intent(in) :: unusable
       type(SplitCommunicator), intent(out), optional :: split_comm
       integer, intent(out), optional :: rc
@@ -40,8 +40,8 @@ contains
 
    end subroutine get
 
-   subroutine init_io_server(this, comm, unusable, application_size, nodes_input_server, nodes_output_server, npes_input_server,npes_output_server, rc)
-      class (io_server), intent(inout) :: this
+   subroutine initialize(this, comm, unusable, application_size, nodes_input_server, nodes_output_server, npes_input_server,npes_output_server, rc)
+      class (ServerManager), intent(inout) :: this
       integer, intent(in) :: comm
       class (KeywordEnforcer),  optional, intent(in) :: unusable
       integer, optional, intent(in) :: application_size
@@ -205,14 +205,14 @@ contains
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(unusable)
-   end subroutine init_io_server
+   end subroutine initialize
 
-   subroutine finalize_io_server(this,rc)
-      class(io_server), intent(inout) :: this
+   subroutine finalize(this,rc)
+      class(ServerManager), intent(inout) :: this
       integer, optional, intent(out) :: rc
  
       call this%directory_service%free_directory_resources()
       _RETURN(_SUCCESS)
-   end subroutine finalize_io_server
+   end subroutine finalize
 
-end module MAPL_ioServer
+end module MAPL_ServerManager


### PR DESCRIPTION
This is part 1 of some reorganization I was instructed to do at the last meeting to move stuff out of the MAPL_Cap to make it easier for applications that do not use our cap but still need to use MAPL features.

This pull request for moves the IO server logic (initialize IO servers, split the communicator) out of CAP into it's own module.

All options go thru subroutine arguments since we don't want to tie this to any one command line options (previously in CAP it could just pull these from the cap options).

Anyone have an idea for a better name for this module?

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
