### PR TITLE
Cap reorganization part 2

### DIFF
--- a/MAPL_Base/ApplicationSupport.F90
+++ b/MAPL_Base/ApplicationSupport.F90
@@ -1,0 +1,156 @@
+#include "MAPL_ErrLog.h"
+module MAPL_ApplicationSupport
+ use MPI
+ use MAPL_ExceptionHandling
+ use pflogger, only: logging
+ use pflogger, only: Logger
+ use MAPL_Profiler
+
+ public initialize_pflogger
+ public finalize_pflogger
+ public start_global_profiler
+ public stop_global_profiler
+ public report_global_profiler
+
+ contains
+
+   subroutine finalize_pflogger()
+      call logging%free()
+   end subroutine finalize_pflogger
+
+   subroutine initialize_pflogger(comm,logging_config,rc)
+      use pflogger, only: pfl_initialize => initialize
+      use pflogger, only: StreamHandler, FileHandler, HandlerVector
+      use pflogger, only: MpiLock, MpiFormatter
+      use pflogger, only: INFO, WARNING
+      use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
+
+      integer, optional, intent(in) :: comm
+      character(len=*), optional,intent(in) :: logging_config
+      integer, optional, intent(out) :: rc
+
+      type (HandlerVector) :: handlers
+      type (StreamHandler) :: console
+      type (FileHandler) :: file_handler
+      integer :: level,rank,status
+      character(:), allocatable :: logging_configuration_file
+      integer :: comm_world
+      type(Logger), pointer :: lgr
+
+      if (present(logging_config)) then
+         logging_configuration_file=logging_config
+      else
+         logging_configuration_file=''
+      end if
+      if (present(comm)) then
+         comm_world=comm
+      else
+         comm_world=MPI_COMM_WORLD
+      end if
+
+      call pfl_initialize()
+
+      if (logging_configuration_file /= '') then
+         call logging%load_file(logging_configuration_file)
+      else
+
+         call MPI_COMM_Rank(comm_world,rank,status)
+         console = StreamHandler(OUTPUT_UNIT)
+         call console%set_level(INFO)
+         call console%set_formatter(MpiFormatter(comm_world, fmt='%(short_name)a10~: %(message)a'))
+         call handlers%push_back(console)
+
+         file_handler = FileHandler('warnings_and_errors.log')
+         call file_handler%set_level(WARNING)
+         call file_handler%set_formatter(MpiFormatter(comm_world, fmt='pe=%(mpi_rank)i5.5~: %(short_name)a~: %(message)a'))
+         call file_handler%set_lock(MpiLock(comm_world))
+         call handlers%push_back(file_handler)
+
+         if (rank == 0) then
+            level = INFO
+         else
+            level = WARNING
+         end if
+
+         call logging%basic_config(level=level, handlers=handlers, rc=status)
+         _VERIFY(status)
+
+         if (rank == 0) then
+            lgr => logging%get_logger('MAPL')
+            call lgr%warning('No configure file specified for logging layer.  Using defaults.')            
+         end if
+
+      end if
+
+   end subroutine initialize_pflogger
+
+   subroutine start_global_profiler(comm)
+      integer, optional, intent(in) :: comm
+      class (BaseProfiler), pointer :: t_p
+      integer :: world_comm
+
+      if (present(comm)) then
+         world_comm=comm
+      else
+         world_comm=MPI_COMM_WORLD
+      end if
+      t_p => get_global_time_profiler()
+      t_p = TimeProfiler('All', comm_world = world_comm)
+      call t_p%start()
+   end subroutine start_global_profiler
+
+   subroutine stop_global_profiler()
+      class (BaseProfiler), pointer :: t_p
+
+      t_p => get_global_time_profiler()
+      call t_p%stop()
+   end subroutine stop_global_profiler
+
+   subroutine report_global_profiler(comm,rc)
+      integer, optional, intent(in) :: comm
+      integer, optional, intent(out) :: rc
+      type (ProfileReporter) :: reporter
+      integer :: i, world_comm
+      character(:), allocatable :: report_lines(:)
+      type (MultiColumn) :: inclusive
+      type (MultiColumn) :: exclusive
+      integer :: npes, my_rank, ierror
+      character(1) :: empty(0)
+      class (BaseProfiler), pointer :: t_p
+
+      if (present(comm)) then
+         world_comm=comm
+      else
+         world_comm=MPI_COMM_WORLD
+      end if
+      t_p => get_global_time_profiler()
+
+      reporter = ProfileReporter(empty)
+      call reporter%add_column(NameColumn(50, separator= " "))
+      call reporter%add_column(FormattedTextColumn('#-cycles','(i5.0)', 5, NumCyclesColumn(),separator='-'))
+
+      inclusive = MultiColumn(['Inclusive'], separator='=')
+      call inclusive%add_column(FormattedTextColumn(' T (sec) ','(f9.3)', 9, InclusiveColumn(), separator='-'))
+      call inclusive%add_column(FormattedTextColumn('   %  ','(f6.2)', 6, PercentageColumn(InclusiveColumn(),'MAX'),separator='-'))
+      call reporter%add_column(inclusive)
+
+      exclusive = MultiColumn(['Exclusive'], separator='=')
+      call exclusive%add_column(FormattedTextColumn(' T (sec) ','(f9.3)', 9, ExclusiveColumn(), separator='-'))
+      call exclusive%add_column(FormattedTextColumn('   %  ','(f6.2)', 6, PercentageColumn(ExclusiveColumn()), separator='-'))
+      call reporter%add_column(exclusive)
+
+      call MPI_Comm_size(world_comm, npes, ierror)
+      call MPI_Comm_Rank(world_comm, my_rank, ierror)
+
+      if (my_rank == 0) then
+            report_lines = reporter%generate_report(t_p)
+            write(*,'(a,1x,i0)')'Report on process: ', my_rank
+            do i = 1, size(report_lines)
+               write(*,'(a)') report_lines(i)
+            end do
+       end if
+       call MPI_Barrier(world_comm, ierror)
+
+   end subroutine report_global_profiler
+
+end module MAPL_ApplicationSupport

--- a/MAPL_Base/ApplicationSupport.F90
+++ b/MAPL_Base/ApplicationSupport.F90
@@ -83,7 +83,8 @@ module MAPL_ApplicationSupport
          logging_configuration_file=''
       end if
       if (present(comm)) then
-         comm_world=comm
+         call MPI_Comm_dup(comm,comm_world,status)
+         _VERIFY(status)
       else
          comm_world=MPI_COMM_WORLD
       end if
@@ -121,16 +122,19 @@ module MAPL_ApplicationSupport
          end if
 
       end if
+      _RETURN(_SUCCESS)
 
    end subroutine initialize_pflogger
 
-   subroutine start_global_profiler(comm)
+   subroutine start_global_profiler(comm,rc)
       integer, optional, intent(in) :: comm
+      integer, optional, intent(out) :: rc
       class (BaseProfiler), pointer :: t_p
-      integer :: world_comm
+      integer :: world_comm,status
 
       if (present(comm)) then
-         world_comm=comm
+         call MPI_Comm_dup(comm,world_comm,status)
+         _VERIFY(status)
       else
          world_comm=MPI_COMM_WORLD
       end if
@@ -143,7 +147,7 @@ module MAPL_ApplicationSupport
       class (BaseProfiler), pointer :: t_p
 
       t_p => get_global_time_profiler()
-      call t_p%stop()
+      call t_p%stop('All')
    end subroutine stop_global_profiler
 
    subroutine report_global_profiler(comm,rc)
@@ -159,7 +163,8 @@ module MAPL_ApplicationSupport
       class (BaseProfiler), pointer :: t_p
 
       if (present(comm)) then
-         world_comm=comm
+         call MPI_comm_dup(comm,world_comm,ierror)
+         _VERIFY(ierror)
       else
          world_comm=MPI_COMM_WORLD
       end if

--- a/MAPL_Base/CMakeLists.txt
+++ b/MAPL_Base/CMakeLists.txt
@@ -39,7 +39,7 @@ MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           Simple
 MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
 MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
 MAPL_LocStreamFactoryMod.F90          MAPL_HistoryTrajectoryMod.F90       MAPL_LocstreamRegridder.F90
-ServerManager.F90
+ServerManager.F90 ApplicationSupport.F90
 c_mapl_locstream_F.c  getrss.c  memuse.c
 )
 

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -106,9 +106,9 @@ contains
       call cap%initialize_mpi(rc=status)
       _VERIFY(status)
 
-      call initialize_pflogger(comm=cap%comm_world, &
-                               logging_config=cap%cap_options%logging_config, &
-                               rc=status)
+      call MAPL_Initialize(comm=cap%comm_world, &
+                           logging_config=cap%cap_options%logging_config, &
+                           rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)     
@@ -311,8 +311,6 @@ contains
 
       _UNUSED_DUMMY(unusable)
 
-      call start_global_profiler(comm=mapl_comm%esmf%comm)
-
       call start_timer()
       call ESMF_Initialize (vm=vm, logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=mapl_comm%esmf%comm, rc=status)
       _VERIFY(status)
@@ -332,8 +330,6 @@ contains
       !_VERIFY(status)
       call stop_timer()
 
-      call stop_global_profiler
-      call report_global_profiler(comm=mapl_comm%esmf%comm)
       ! W.J note : below reporting will be remove soon
       call report_throughput()
 
@@ -478,8 +474,7 @@ contains
       _UNUSED_DUMMY(unusable)
 
       if (.not. this%mpi_already_initialized) then
-         call finalize_pflogger()
-         !call logging%free()
+         call MAPL_Finalize(this%comm_world)
          call MPI_Finalize(ierror)
          _VERIFY(ierror)
       end if

--- a/MAPL_Base/MAPL_Cap.F90
+++ b/MAPL_Base/MAPL_Cap.F90
@@ -14,12 +14,10 @@ module MAPL_CapMod
    use MAPL_BaseMod
    use MAPL_ExceptionHandling
    use pFIO
-   use MAPL_Profiler, only: get_global_time_profiler, BaseProfiler, TimeProfiler
    use MAPL_ioClientsMod
    use MAPL_CapOptionsMod
    use MAPL_ServerManager
-   use pflogger, only: logging
-   use pflogger, only: Logger
+   use MAPL_ApplicationSupport
    implicit none
    private
 
@@ -88,7 +86,6 @@ contains
       class ( MAPL_CapOptions), optional, intent(in) :: cap_options
       integer, optional, intent(out) :: rc
       integer :: status
-      type(Logger), pointer :: lgr
 
       cap%name = name
       cap%set_services => set_services
@@ -109,59 +106,14 @@ contains
       call cap%initialize_mpi(rc=status)
       _VERIFY(status)
 
-      call initialize_pflogger()
+      call initialize_pflogger(comm=cap%comm_world, &
+                               logging_config=cap%cap_options%logging_config, &
+                               rc=status)
+      _VERIFY(status)
 
       _RETURN(_SUCCESS)     
       _UNUSED_DUMMY(unusable)
 
-    contains
-
-       subroutine initialize_pflogger()
-          use pflogger, only: pfl_initialize => initialize
-          use pflogger, only: StreamHandler, FileHandler, HandlerVector
-          use pflogger, only: MpiLock, MpiFormatter
-          use pflogger, only: INFO, WARNING
-          use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
-          type (HandlerVector) :: handlers
-          type (StreamHandler) :: console
-          type (FileHandler) :: file_handler
-          integer :: level
-          
-          call pfl_initialize()
-
-          if (cap%cap_options%logging_config /= '') then
-             call logging%load_file(cap%cap_options%logging_config)
-          else
-
-             console = StreamHandler(OUTPUT_UNIT)
-             call console%set_level(INFO)
-             call console%set_formatter(MpiFormatter(cap%comm_world, fmt='%(short_name)a10~: %(message)a'))
-             call handlers%push_back(console)
-
-             file_handler = FileHandler('warnings_and_errors.log')
-             call file_handler%set_level(WARNING)
-             call file_handler%set_formatter(MpiFormatter(cap%comm_world, fmt='pe=%(mpi_rank)i5.5~: %(short_name)a~: %(message)a'))
-             call file_handler%set_lock(MpiLock(cap%comm_world))
-             call handlers%push_back(file_handler)
-             
-             if (cap%rank == 0) then
-                level = INFO
-             else
-                level = WARNING
-             end if
-
-             call logging%basic_config(level=level, handlers=handlers, rc=status)
-             _VERIFY(status)
-             
-             if (cap%rank == 0) then
-                lgr => logging%get_logger('MAPL')
-                call lgr%warning('No configure file specified for logging layer.  Using defaults.')
-             end if
-
-          end if
-
-       end subroutine initialize_pflogger
-     
     end function new_MAPL_Cap
 
    
@@ -201,7 +153,7 @@ contains
       subcommunicator = this%create_member_subcommunicator(this%comm_world, rc=status); _VERIFY(status)
       if (subcommunicator /= MPI_COMM_NULL) then
          call this%initialize_io_clients_servers(subcommunicator, rc = status); _VERIFY(status)
-         call this%cap_server%get(split_comm=split_comm)
+         call this%cap_server%get_splitcomm(split_comm)
          call fill_mapl_comm(split_comm, subcommunicator, .false., this%mapl_comm, rc=status)
          call this%run_member(rc=status); _VERIFY(status)
          call this%cap_server%finalize()
@@ -241,7 +193,7 @@ contains
       integer :: status
       type(SplitCommunicator) :: split_comm
 
-      call this%cap_server%get(split_comm=split_comm)
+      call this%cap_server%get_splitcomm(split_comm)
       select case(split_comm%get_name())
       case('model')
          call this%run_model(this%mapl_comm, rc=status); _VERIFY(status)
@@ -356,16 +308,10 @@ contains
       type (ESMF_VM) :: vm
       integer :: start_tick, stop_tick, tick_rate
       integer :: status
-!
-!     profiler
-!  
-      class (BaseProfiler), pointer :: t_p
 
       _UNUSED_DUMMY(unusable)
 
-      t_p => get_global_time_profiler()
-      t_p = TimeProfiler('All', comm_world = mapl_comm%esmf%comm)
-      call t_p%start()
+      call start_global_profiler(comm=mapl_comm%esmf%comm)
 
       call start_timer()
       call ESMF_Initialize (vm=vm, logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=mapl_comm%esmf%comm, rc=status)
@@ -386,8 +332,8 @@ contains
       !_VERIFY(status)
       call stop_timer()
 
-      call t_p%stop()
-      call report_profiling()
+      call stop_global_profiler
+      call report_global_profiler(comm=mapl_comm%esmf%comm)
       ! W.J note : below reporting will be remove soon
       call report_throughput()
 
@@ -422,56 +368,6 @@ contains
          end if
          
       end subroutine report_throughput
-
-      subroutine report_profiling(rc)
-         use MAPL_Profiler
-         integer, optional, intent(out) :: rc
-         type (ProfileReporter) :: reporter
-         integer :: i
-         character(:), allocatable :: report_lines(:)
-         type (MultiColumn) :: inclusive
-         type (MultiColumn) :: exclusive
-         integer :: npes, my_rank, rank, ierror
-         character(1) :: empty(0)
-
-         reporter = ProfileReporter(empty)
-         call reporter%add_column(NameColumn(50, separator= " "))
-         call reporter%add_column(FormattedTextColumn('#-cycles','(i5.0)', 5, NumCyclesColumn(),separator='-'))
-
-         inclusive = MultiColumn(['Inclusive'], separator='=')
-         call inclusive%add_column(FormattedTextColumn(' T (sec) ','(f9.3)', 9, InclusiveColumn(), separator='-'))
-         call inclusive%add_column(FormattedTextColumn('   %  ','(f6.2)', 6, PercentageColumn(InclusiveColumn(),'MAX'),separator='-'))
-         call reporter%add_column(inclusive)
-
-         exclusive = MultiColumn(['Exclusive'], separator='=')
-         call exclusive%add_column(FormattedTextColumn(' T (sec) ','(f9.3)', 9, ExclusiveColumn(), separator='-'))
-         call exclusive%add_column(FormattedTextColumn('   %  ','(f6.2)', 6, PercentageColumn(ExclusiveColumn()), separator='-'))
-         call reporter%add_column(exclusive)
-
-!!$      call reporter%add_column(FormattedTextColumn('  std. dev ','(f12.4)', 12, StdDevColumn()))
-!!$      call reporter%add_column(FormattedTextColumn('  rel. dev ','(f12.4)', 12, StdDevColumn(relative=.true.)))
-!!$      call reporter%add_column(FormattedTextColumn('  max cyc ','(f12.8)', 12, MaxCycleColumn()))
-!!$      call reporter%add_column(FormattedTextColumn('  min cyc ','(f12.8)', 12, MinCycleColumn()))
-!!$      call reporter%add_column(FormattedTextColumn(' mean cyc','(f12.8)', 12, MeanCycleColumn()))
-!!$         call mem_reporter%add_column(NameColumn(50,separator='-'))
-!!$         call mem_reporter%add_column(MemoryTextColumn(['RSS'],'(i10,1x,a2)',13, InclusiveColumn(),separator='-'))
-!!$         call mem_reporter%add_column(MemoryTextColumn(['Cyc RSS'],'(i10,1x,a2)',13, MeanCycleColumn(),separator='-'))
-
-!!$         report_lines = reporter%generate_report(get_global_time_profiler())
-
-         call MPI_Comm_size(mapl_comm%esmf%comm, npes, ierror)
-         call MPI_Comm_Rank(mapl_comm%esmf%comm, my_rank, ierror)
-
-         if (my_rank == 0) then
-               report_lines = reporter%generate_report(t_p)
-               write(*,'(a,1x,i0)')'Report on process: ', my_rank
-               do i = 1, size(report_lines)
-                  write(*,'(a)') report_lines(i)
-               end do
-          end if
-          call MPI_Barrier(mapl_comm%esmf%comm, ierror)
-
-      end subroutine report_profiling
 
    end subroutine run_model
    
@@ -582,7 +478,8 @@ contains
       _UNUSED_DUMMY(unusable)
 
       if (.not. this%mpi_already_initialized) then
-         call logging%free()
+         call finalize_pflogger()
+         !call logging%free()
          call MPI_Finalize(ierror)
          _VERIFY(ierror)
       end if

--- a/MAPL_Base/MAPL_Mod.F90
+++ b/MAPL_Base/MAPL_Mod.F90
@@ -48,6 +48,7 @@ module MAPL_Mod
   use MAPL_SimpleCommSplitterMod
   use MAPL_SplitCommunicatorMod
   use MAPL_EtaHybridVerticalCoordinateMod
+  use MAPL_ApplicationSupport
   logical, save, private :: mapl_is_initialized = .false.
 
 end module MAPL_Mod

--- a/MAPL_Base/ServerManager.F90
+++ b/MAPL_Base/ServerManager.F90
@@ -22,23 +22,21 @@ module MAPL_ServerManager
       contains
          procedure :: initialize
          procedure :: finalize
-         procedure :: get
+         procedure :: get_splitcomm
    end type
 
 contains
 
-   subroutine get(this, unusable, split_comm, rc)
+   subroutine get_splitcomm(this, split_comm, rc)
       class (ServerManager), intent(inout) :: this
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      type(SplitCommunicator), intent(out), optional :: split_comm
+      type(SplitCommunicator), intent(out) :: split_comm
       integer, intent(out), optional :: rc
 
-      _UNUSED_DUMMY(unusable)
 
-      if (present(split_comm)) split_comm=this%split_comm
+      split_comm=this%split_comm
       _RETURN(_SUCCESS)
 
-   end subroutine get
+   end subroutine get_splitcomm
 
    subroutine initialize(this, comm, unusable, application_size, nodes_input_server, nodes_output_server, npes_input_server,npes_output_server, rc)
       class (ServerManager), intent(inout) :: this

--- a/MAPL_Profiler/MemoryProfiler.F90
+++ b/MAPL_Profiler/MemoryProfiler.F90
@@ -80,14 +80,14 @@ module MAPL_MemoryProfiler
    public :: MemoryProfiler
    public :: MemoryProfilerIterator
    public :: get_global_memory_profiler
-   public :: initialize
-   public :: finalize
-   public :: start
-   public :: stop
+   public :: initialize_global_memory_profiler
+   public :: finalize_global_memory_profiler
+   public :: start_global_memory_profiler
+   public :: stop_global_memory_profiler
 
 contains
 
-   subroutine initialize(name)
+   subroutine initialize_global_memory_profiler(name)
       character(*), optional, intent(in) :: name
 
       type(MemoryProfiler), pointer :: memory_profiler
@@ -102,20 +102,20 @@ contains
       memory_profiler => get_global_memory_profiler()
       memory_profiler = MemoryProfiler(name_)
 
-   end subroutine initialize
+   end subroutine initialize_global_memory_profiler
 
 
-   subroutine finalize()
+   subroutine finalize_global_memory_profiler()
 
       type(MemoryProfiler), pointer :: memory_profiler
 
       memory_profiler => get_global_memory_profiler()
       call memory_profiler%finalize()
 
-   end subroutine finalize
+   end subroutine finalize_global_memory_profiler
 
 
-   subroutine start(name)
+   subroutine start_global_memory_profiler(name)
       character(*), intent(in) :: name
       
       type(MemoryProfiler), pointer :: memory_profiler
@@ -123,10 +123,10 @@ contains
       memory_profiler => get_global_memory_profiler()
       call memory_profiler%start(name)
 
-   end subroutine start
+   end subroutine start_global_memory_profiler
 
    
-   subroutine stop(name)
+   subroutine stop_global_memory_profiler(name)
       character(*), intent(in) :: name
 
       type(MemoryProfiler), pointer :: memory_profiler
@@ -134,7 +134,7 @@ contains
       memory_profiler => get_global_memory_profiler()
       call memory_profiler%stop(name)
 
-   end subroutine stop
+   end subroutine stop_global_memory_profiler
 
 
 

--- a/MAPL_Profiler/TimeProfiler.F90
+++ b/MAPL_Profiler/TimeProfiler.F90
@@ -76,14 +76,14 @@ module MAPL_TimeProfiler
    public :: TimeProfiler
    public :: TimeProfilerIterator
    public :: get_global_time_profiler
-   public :: initialize
-   public :: finalize
-   public :: start
-   public :: stop
+   public :: initialize_global_time_profiler
+   public :: finalize_global_time_profiler
+   public :: start_global_time_profiler
+   public :: stop_global_time_profiler
 
 contains
 
-   subroutine initialize(name)
+   subroutine initialize_global_time_profiler(name)
       character(*), optional, intent(in) :: name
 
       type(TimeProfiler), pointer :: time_profiler
@@ -98,20 +98,20 @@ contains
       time_profiler => get_global_time_profiler()
       time_profiler = TimeProfiler(name_)
 
-   end subroutine initialize
+   end subroutine initialize_global_time_profiler
 
 
-   subroutine finalize()
+   subroutine finalize_global_time_profiler()
 
       type(TimeProfiler), pointer :: time_profiler
 
       time_profiler => get_global_time_profiler()
       call time_profiler%finalize()
 
-   end subroutine finalize
+   end subroutine finalize_global_time_profiler
 
 
-   subroutine start(name)
+   subroutine start_global_time_profiler(name)
       character(*), intent(in) :: name
       
       type(TimeProfiler), pointer :: time_profiler
@@ -119,10 +119,10 @@ contains
       time_profiler => get_global_time_profiler()
       call time_profiler%start(name)
 
-   end subroutine start
+   end subroutine start_global_time_profiler
 
    
-   subroutine stop(name)
+   subroutine stop_global_time_profiler(name)
       character(*), intent(in) :: name
 
       type(TimeProfiler), pointer :: time_profiler
@@ -130,7 +130,7 @@ contains
       time_profiler => get_global_time_profiler()
       call time_profiler%stop(name)
 
-   end subroutine stop
+   end subroutine stop_global_time_profiler
 
 
 end module MAPL_TimeProfiler


### PR DESCRIPTION
Part 2 of moving stuff out of the cap. Now the logging and profiler stuff has been moved to a support module. Now mkiau, gsi, and other programs can use these. I could not think of something better than ApplicationSupport for the name. Other things like ProfilerAndLoggerSupport seemed too long.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
