### PR TITLE
Feature/tclune/#387 support logical in python acg

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -16,14 +16,28 @@ class MAPL_DataSpec:
                    'refresh_interval', 'averaging_interval', 'halowidth',
                    'precision','default','restart', 'ungridded_dims',
                    'field_type', 'staggering', 'rotation',
-                   'friendlyto']
+                   'friendlyto', 'add2export']
 
     # The following arguments are skipped if value is empty string
     optional_options = [ 'dims', 'vlocation', 'num_subtiles',
                          'refresh_interval', 'averaging_interval', 'halowidth',
                          'precision','default','restart', 'ungridded_dims',
                          'field_type', 'staggering', 'rotation',
-                         'friendlyto']
+                         'friendlyto', 'add2export']
+
+    entry_aliases = {'dims': {'z'  : 'MAPL_DimsVertOnly',
+                              'xy' : 'MAPL_DimsHorzOnly',
+                              'xyz': 'MAPL_DimsHorzVert'},
+                     'vlocation': {'C': 'MAPL_VlocationCenter',
+                                   'E': 'MAPL_VlocationEdge',
+                                   'N': 'MAPL_VlocationNone'},
+                     'restart': {'OPT'  : 'MAPL_RestartOptional',
+                                 'SKIP' : 'MAPL_RestartSkip',
+                                 'REQ'  : 'MAPL_RestartRequired',
+                                 'BOOT' : 'MAPL_RestartBoot',
+                                 'SKIPI': 'MAPL_RestartSkipInitial'},
+                     'add2export': {'T': '.true.', 'F': '.false.'}
+                 }
 
     # The following options require quotes in generated code
     stringlike_options = ['short_name', 'long_name', 'units', 'friendlyto']
@@ -108,6 +122,12 @@ class MAPL_DataSpec:
                 value = "'" + value + "'"
             elif option in MAPL_DataSpec.arraylike_options:
                 value = '[' + value + ']' # convert to Fortran 1D array
+            else:
+                if (option in MAPL_DataSpec.entry_aliases) and (
+                        self.args[option] in MAPL_DataSpec.entry_aliases[option]):
+                    value = MAPL_DataSpec.entry_aliases[option][self.args[option]]
+                else:
+                    value = self.args[option]
             text = text + value + ", " + self.continue_line()
         return text
 
@@ -149,7 +169,8 @@ def read_specs(specs_filename):
         'COND'       : 'condition',
         'DEFAULT'    : 'default',
         'RESTART'    : 'restart',
-        'FRIENDLYTO' : 'friendlyto'
+        'FRIENDLYTO' : 'friendlyto',
+        'ADD2EXPORT' : 'add2export'
     }
 
     specs = {}
@@ -175,23 +196,10 @@ def read_specs(specs_filename):
             except StopIteration:
                 break
 
-    entry_aliases = {'z'     : 'MAPL_DimsVertOnly',
-                     'xy'    : 'MAPL_DimsHorzOnly',
-                     'xyz'   : 'MAPL_DimsHorzVert',
-                     'C'     : 'MAPL_VlocationCenter',
-                     'E'     : 'MAPL_VlocationEdge',
-                     'N'     : 'MAPL_VlocationNone',
-                     'OPT'   : 'MAPL_RestartOptional',
-                     'SKIP'  : 'MAPL_RestartSkip',
-                     'REQ'   : 'MAPL_RestartRequired',
-                     'BOOT'  : 'MAPL_RestartBoot',
-                     'SKIPI' : 'MAPL_RestartSkipInitial'
 
-    }
-
-    specs['IMPORT'].replace(entry_aliases,inplace=True)
-    specs['EXPORT'].replace(entry_aliases,inplace=True)
-    specs['INTERNAL'].replace(entry_aliases,inplace=True)
+#    specs['IMPORT'].replace(entry_aliases,inplace=True)
+#    specs['EXPORT'].replace(entry_aliases,inplace=True)
+#    specs['INTERNAL'].replace(entry_aliases,inplace=True)
 
     return specs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Added support for sampling along a 1-D timeseries in History
 
 ### Changed
+
+- Refactored aliases in python automatic code generator.  Now aliases
+  are tailored per column.  This allows T/F to be safely used as
+  aliases for .true./.false. without risking things like the short
+  name of Temperature.
+
 ### Fixed
 ### Removed
 


### PR DESCRIPTION
## Description
Refactored alias dictionary for the ACG so that the aliases are now tied to particular columns.   Otherwise, adding an alias for T to mean .true. would have also resulted in short names being .true.
Compiler would have caught it, but not useful.


## Motivation and Context
Motivation was for simple entries in add2export columns in GridComp Spec files.

## How Has This Been Tested?
Tested manually on modification of existing spec input
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
