### PR TITLE
Do all timer initialization in MAPL_GenericWrapper

### DIFF
--- a/MAPL_Base/MAPL_CapGridComp.F90
+++ b/MAPL_Base/MAPL_CapGridComp.F90
@@ -168,7 +168,6 @@ contains
 
 
     type (MAPL_MetaComp), pointer :: maplobj
-    type (MAPL_MetaComp), pointer :: CHILD_MAPLOBJ
     procedure(), pointer :: root_set_services
     type(MAPL_CapGridComp), pointer :: cap
     class(BaseProfiler), pointer :: t_p
@@ -546,14 +545,9 @@ contains
 
        call t_p%start('Initialize')
        call t_p%start(trim(root_name))
-       call MAPL_InternalStateRetrieve(cap%gcs(cap%root_id), CHILD_MAPLOBJ, RC=status)
-       call CHILD_MAPLOBJ%t_profiler%start()
-       call CHILD_MAPLOBJ%t_profiler%start('Intialize')
        call ESMF_GridCompInitialize(cap%gcs(cap%root_id), importState = cap%child_imports(cap%root_id), &
             exportState = cap%child_exports(cap%root_id), clock = cap%clock, userRC = status)
        _VERIFY(status)
-       call CHILD_MAPLOBJ%t_profiler%stop('Intialize')
-       call CHILD_MAPLOBJ%t_profiler%stop()
        call t_p%stop(trim(root_name))
 
        call t_p%start('HIST')
@@ -595,7 +589,6 @@ contains
     integer :: status
     type(HISTORY_ExchangeListWrap) :: lswrap
     integer*8, pointer             :: LSADDR(:) => null()
-    type (MAPL_MetaComp), pointer  :: CHILD_MAPLOBJ
 
     if (present(rc)) rc = ESMF_SUCCESS
     ! All the EXPORTS of the Hierachy are made IMPORTS of History
@@ -615,16 +608,9 @@ contains
     ! Initialize the History
     !------------------------
 
-    call MAPL_InternalStateRetrieve(cap%gcs(cap%history_id), CHILD_MAPLOBJ, RC=status)
-    call CHILD_MAPLOBJ%t_profiler%start()
-    call CHILD_MAPLOBJ%t_profiler%start('Intialize')
-
     call ESMF_GridCompInitialize (CAP%GCS(cap%history_id), importState=CAP%CHILD_IMPORTS(cap%history_id), &
          exportState=CAP%CHILD_EXPORTS(cap%history_id), clock=CAP%CLOCK_HIST, userRC=STATUS )
     _VERIFY(STATUS)
-
-    call CHILD_MAPLOBJ%t_profiler%stop('Intialize')
-    call CHILD_MAPLOBJ%t_profiler%stop()
 
     _RETURN(ESMF_SUCCESS)
   end subroutine initialize_history
@@ -643,7 +629,6 @@ contains
     integer :: i
     type(ESMF_State) :: state, root_imports, component_state
     character(len=:), allocatable :: component_name, field_name
-    type (MAPL_MetaComp), pointer :: CHILD_MAPLOBJ
 
     ! Prepare EXPORTS for ExtData
     ! ---------------------------
@@ -715,17 +700,10 @@ contains
     ! Initialize the ExtData
     !------------------------
 
-    call MAPL_InternalStateRetrieve(cap%gcs(cap%extdata_id), CHILD_MAPLOBJ, RC=status)
-    call CHILD_MAPLOBJ%t_profiler%start()
-    call CHILD_MAPLOBJ%t_profiler%start('Intialize')
-
     call ESMF_GridCompInitialize (cap%gcs(cap%extdata_id), importState = cap%child_imports(cap%extdata_id), &
          exportState = cap%child_exports(cap%extdata_id), & 
          clock = cap%clock, userRc = status)
     _VERIFY(status)
-
-    call CHILD_MAPLOBJ%t_profiler%stop('Intialize')
-    call CHILD_MAPLOBJ%t_profiler%stop()
 
     _RETURN(ESMF_SUCCESS)
 

--- a/MAPL_Base/MAPL_Generic.F90
+++ b/MAPL_Base/MAPL_Generic.F90
@@ -2029,7 +2029,6 @@ recursive subroutine MAPL_GenericFinalize ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! ---------------------
 
   t_p => get_global_time_profiler()
-  call t_p%start(trim(state%compname))
 
   call MAPL_GenericStateClockOn(STATE,"TOTAL")
   call MAPL_GenericStateClockOn(STATE,"GenFinalTot")

--- a/MAPL_Base/MAPL_Generic.F90
+++ b/MAPL_Base/MAPL_Generic.F90
@@ -1477,16 +1477,12 @@ endif
                t_p => get_global_time_profiler()
                call t_p%start(trim(CHILD_NAME))
                call MAPL_GenericStateClockOn (STATE,trim(CHILD_NAME))
-               call CHLDMAPL(I)%ptr%t_profiler%start()
-               call CHLDMAPL(I)%ptr%t_profiler%start('Initialize')
                call ESMF_GridCompInitialize (STATE%GCS(I), &
                     importState=STATE%GIM(I), &
                     exportState=STATE%GEX(I), &
                     clock=CLOCK, PHASE=CHLDMAPL(I)%PTR%PHASE_INIT(PHASE), &
                     userRC=userRC, RC=STATUS )
                _ASSERT(userRC==ESMF_SUCCESS .and. STATUS==ESMF_SUCCESS,'needs informative message')
-               call CHLDMAPL(I)%ptr%t_profiler%stop('Initialize')
-               call CHLDMAPL(I)%ptr%t_profiler%stop()
                call MAPL_GenericStateClockOff(STATE,trim(CHILD_NAME))
                call t_p%stop(trim(CHILD_NAME))
             end if
@@ -1803,17 +1799,10 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
   endif MethodBlock
 
 ! TIMERS on
-  if (method == ESMF_METHOD_RUN ) then
-    call t_p%start(trim(state%compname))
-    call state%t_profiler%start()
-    call state%t_profiler%start(trim(sbrtn))
-  endif
+  call t_p%start(trim(state%compname))
+  call state%t_profiler%start()
+  call state%t_profiler%start(trim(sbrtn))
 
-  if (method == ESMF_METHOD_FINALIZE ) then
-    call t_p%start(trim(state%compname))
-    call state%t_profiler%start()
-    call state%t_profiler%start('Finalize')
-  endif
 
 
   if (associated(timers)) then
@@ -1845,7 +1834,8 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
      end do
   end if
 
-  if (method == ESMF_METHOD_RUN) then 
+  !if (method == ESMF_METHOD_RUN) then 
+  if (method /= ESMF_METHOD_FINALIZE) then 
      call state%t_profiler%stop(trim(sbrtn))
      call state%t_profiler%stop()
      call t_p%stop(trim(state%compname))
@@ -2039,9 +2029,7 @@ recursive subroutine MAPL_GenericFinalize ( GC, IMPORT, EXPORT, CLOCK, RC )
 ! ---------------------
 
   t_p => get_global_time_profiler()
-  !call t_p%start(trim(state%compname))
-  !call state%t_profiler%start()
-  !call state%t_profiler%start('Final')
+  call t_p%start(trim(state%compname))
 
   call MAPL_GenericStateClockOn(STATE,"TOTAL")
   call MAPL_GenericStateClockOn(STATE,"GenFinalTot")
@@ -2300,7 +2288,6 @@ end subroutine MAPL_GenericFinalize
 
   t_p => get_global_time_profiler()
   call t_p%start(trim(state%compname))
-  call state%t_profiler%start()
   call state%t_profiler%start('Record')
 
 
@@ -2398,7 +2385,6 @@ end subroutine MAPL_GenericFinalize
   call MAPL_GenericStateClockOff(STATE,"TOTAL")
 
   call state%t_profiler%stop('Record')
-  call state%t_profiler%stop()
   call t_p%stop(trim(state%compname))
 
   _RETURN(ESMF_SUCCESS)
@@ -2525,7 +2511,6 @@ end subroutine MAPL_StateRecord
 
   t_p => get_global_time_profiler()
   call t_p%start(trim(state%compname))
-  call state%t_profiler%start()
   call state%t_profiler%start('Refresh')
 
   call MAPL_GenericStateClockOn(STATE,"TOTAL")
@@ -2611,7 +2596,6 @@ end subroutine MAPL_StateRecord
 
   call state%t_profiler%stop('Refresh_self')
   call state%t_profiler%stop('Refresh')
-  call state%t_profiler%stop()
   call t_p%stop(trim(state%compname))
 
   _RETURN(ESMF_SUCCESS)


### PR DESCRIPTION
This is a very minor cleanup. In MAPL_CapGridComp there was some lines of code that were turning on/off the child timers just for the initialization but not run or finalize. I believe this is unnecessary as all the method registration  in the grid comps are now using MAPL_GridCompSetEntryPoint which uses MAPL_GenericWrapper which routes all init/run/record/write/finalize through this. This includes the initialization.
I removed the code in CapGridComp and now in MAPL_GenericWrapper I start and stop the component timer for all methods, not just run and finalize since everyone goes thru here anyway. 
As far as I could tell the timers were were working identically by doing this.
This is some help as now other executables not using the cap don't have to bother doing this extra step before and after calling the initialization.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
