### PR TITLE
Add return to MAPL_Intialize

### DIFF
--- a/MAPL_Base/ApplicationSupport.F90
+++ b/MAPL_Base/ApplicationSupport.F90
@@ -40,6 +40,7 @@ module MAPL_ApplicationSupport
       _VERIFY(status)
       call start_global_profiler(comm=comm_world,rc=status)
       _VERIFY(status)
+      _RETURN(_SUCCESS)
 
    end subroutine MAPL_Initialize
 

--- a/Tests/ExtDataDriver.F90
+++ b/Tests/ExtDataDriver.F90
@@ -1,3 +1,5 @@
+#define I_AM_MAIN
+
 #include "MAPL_Generic.h"
 
 program ExtData_Driver
@@ -18,8 +20,8 @@ program ExtData_Driver
 
   cap_options=MAPL_FlapCapOptions(description='extdata driver',authors='gmao')
 
-  driver = ExtDataDriver('ExtDataApp',Root_SetServices,cap_options=cap_options)
-  call driver%run(rc=STATUS)
+  driver = ExtDataDriver('ExtDataApp',Root_SetServices,cap_options=cap_options,_RC)
+  call driver%run(_RC)
 
   call exit(0)
 


### PR DESCRIPTION
Adds an _RETURN to the new MAPL_Initialize function. For whatever reason the model gets lucky and the RC must be coming back as 0 but when I was examining my ExtData tester it was not. Of course I was not checking the RC status in my main properly so I missed this the first time around when testing with my ExtDataTester.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
