### PR TITLE
add new type of cos(ZA) diagnostic, ZTHP, for Luke Oman and Michael Manyin of GMI Chemistry group. 

### DIFF
--- a/MAPL_Base/MAPL_sun_uc.F90
+++ b/MAPL_Base/MAPL_sun_uc.F90
@@ -919,6 +919,10 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 ! interval (ZTHB,ZTHD) and the values at the beginning and end of the interval
 ! (ZTH1,ZTHN) are also optionally available. The last two are supported only for
 ! first two (non-ESMF) overloads.
+! PMN Jun 2020: Added optional ZTHP, like ZTHB a pure average of the cosine of the
+! solar zenith angle, except that for ZTHP the value averaged is allowed to be
+! negative (below the horizon). It will be used for Photolysis calculations.
+! Not implemented for ESMF overload.
 !
 ! If the interval is not specified, the values are instantaneous values valid at
 ! the reference time.
@@ -948,7 +952,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 ! !INTERFACE:
 
 !   subroutine MAPL_SunGetInsolation(LONS, LATS, ORBIT,ZTH,SLR,INTV,CLOCK, &
-!                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN, &
+!                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN,ZTHP, &
 !                                    RC)
 
 ! !ARGUMENTS:
@@ -967,6 +971,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 !      TYPE             ,        optional, intent(OUT) :: ZTHD
 !      TYPE             ,        optional, intent(OUT) :: ZTH1
 !      TYPE             ,        optional, intent(OUT) :: ZTHN
+!      TYPE             ,        optional, intent(OUT) :: ZTHP
 !      integer,                  optional, intent(OUT) :: RC
 !\end{verbatim}
 ! where we currently support three overloads for {\tt TYPE} : 
@@ -980,7 +985,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 #define DIMENSIONS (:)
 #define THE_SIZE   (size(LONS,1))
       recursive subroutine SOLAR_1D(LONS, LATS, ORBIT,ZTH,SLR,INTV,CLOCK, &
-                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN,&
+                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN,ZTHP,&
                                     STEPSIZE,RC)
 #include "sun.H"
       end subroutine SOLAR_1D
@@ -992,7 +997,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 #define DIMENSIONS (:,:)
 #define THE_SIZE   (size(LONS,1),size(LONS,2))
       recursive subroutine SOLAR_2D(LONS, LATS, ORBIT,ZTH,SLR,INTV,CLOCK, &
-                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN,&
+                                    TIME,currTime,DIST,ZTHB,ZTHD,ZTH1,ZTHN,ZTHP,&
                                     STEPSIZE,RC)
 #include "sun.H"
       end subroutine SOLAR_2D

--- a/MAPL_Base/sun.H
+++ b/MAPL_Base/sun.H
@@ -14,6 +14,7 @@
       real,                    optional, intent(OUT) :: ZTHD DIMENSIONS
       real,                    optional, intent(OUT) :: ZTH1 DIMENSIONS
       real,                    optional, intent(OUT) :: ZTHN DIMENSIONS
+      real,                    optional, intent(OUT) :: ZTHP DIMENSIONS
       real,                    optional, intent(IN)  :: STEPSIZE
       integer,                 optional, intent(OUT) :: RC
 
@@ -34,7 +35,7 @@
       type (ESMF_Time)  :: CURRENTTIME
       type (ESMF_Clock) :: MYCLOCK
       type (ESMF_TimeInterval)  :: ts
-      real, dimension THE_SIZE :: ZTT, SLT, Y, ZTB, ZTD, NCC
+      real, dimension THE_SIZE :: ZTT, SLT, Y, NCC, ZTP
 
       real(ESMF_KIND_R8) :: days
       real :: ECC, OBQ, LAMBDAP
@@ -70,6 +71,9 @@
          call WRITE_PARALLEL('--- WARNING --- sun.H --- Doubly Periodic Using Daily Mean Solar Insolation')
          TIME_=MAPL_SunDailyMean
       end if
+
+      ! default value for ZTP since not fully implemented for some options
+      ZTP = 0.
 
       ! analytic two-body currently only works with TIME_=0 currently
       _ASSERT(.NOT.(ORBIT%ANAL2B.AND.TIME_/=0),'analytic two-body orbit currently requires TIME_=0') 
@@ -135,6 +139,8 @@
                ZTH = 0.0
             endwhere
 
+            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for SunDailyMean') 
+
          case(MAPL_SunAnnualMean)
 
             !pmn: consistent with above (and erroneous) SunDailyMean,
@@ -169,6 +175,8 @@
             ZTH = ZTH / float(ORBIT%DAYS_PER_CYCLE)
 
             if(present(DIST)) DIST = 1.0
+
+            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for SunAnnualMean') 
 
          case (0,                       &
                MAPL_SunAutumnalEquinox, & 
@@ -271,6 +279,9 @@
 
             end if
 
+            ! copy ZTH to ZTP before above horizon enforcement
+            ZTP = ZTH
+
             ! enforce zero insolation for sun below horizon
             ZTH = max(ZTH, 0.0)
 
@@ -298,14 +309,17 @@
          case(10)
             SLR = 0.3278
             ZTH = 0.6087247
+            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 10') 
 
          case(11)
             SLR = 0.3449
             ZTH = 0.5962
+            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 11') 
 
          case(12)
             SLR = 0.3461
             ZTH = 0.5884
+            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 12') 
 
          end select
 
@@ -313,6 +327,7 @@
          if(present(ZTHD)) ZTHD = ZTH
          if(present(ZTH1)) ZTH1 = ZTH
          if(present(ZTHN)) ZTHN = ZTH
+         if(present(ZTHP)) ZTHP = ZTP
 
        else ! Return Time-Interval-Mean present(INTV)
 
@@ -346,9 +361,10 @@
 
          if(present(ZTHB)) ZTHB = 0.0
          if(present(DIST)) DIST = 0.0
+         if(present(ZTHP)) ZTHP = 0.0
 
          call MAPL_SunGetInsolation( LONS, LATS, ORBIT, ZTT, SLT, &
-              CLOCK=MYCLOCK, TIME=TIME, DIST=DD, &
+              CLOCK=MYCLOCK, TIME=TIME, DIST=DD, ZTHP=ZTP, &
               RC=STATUS)
          _VERIFY(STATUS)
 
@@ -359,6 +375,7 @@
             ZTH = ZTH + ZTT*SLT*0.5
 
             if(present(ZTHB)) ZTHB = ZTHB + 0.5*ZTT
+            if(present(ZTHP)) ZTHP = ZTHP + 0.5*ZTP
             if(present(ZTHD)) then
                where(ZTT>0.0)
                   ZTHD = ZTHD + 0.5*ZTT
@@ -372,7 +389,7 @@
             _VERIFY(STATUS)
 
             call MAPL_SunGetInsolation( LONS, LATS, ORBIT, ZTT, SLT, &
-                 CLOCK=MYCLOCK, TIME=TIME, ZTHB=ZTB, ZTHD=ZTD, DIST=DD, &
+                 CLOCK=MYCLOCK, TIME=TIME, DIST=DD, ZTHP=ZTP, &
                  RC=STATUS)
             _VERIFY(STATUS)
 
@@ -380,6 +397,7 @@
             ZTH = ZTH + ZTT*SLT*0.5
 
             if(present(ZTHB)) ZTHB = ZTHB + 0.5*ZTT
+            if(present(ZTHP)) ZTHP = ZTHP + 0.5*ZTP
             if(present(ZTHD)) then
                where(ZTT>0.0)
                   ZTHD = ZTHD + 0.5*ZTT
@@ -402,6 +420,7 @@
          end where
 
          if(present(ZTHB)) ZTHB = ZTHB/dble(NT)
+         if(present(ZTHP)) ZTHP = ZTHP/dble(NT)
 
          if(present(ZTHD)) then
             where(NCC>0.0)


### PR DESCRIPTION
Add a new type of cos(ZA) diagnostic, ZTHP, for Luke Oman and Michael Manyin of GMI Chemistry group. It is another one of the many optional outputs from MAPL_SunGetInsolation().

## Description
A change to @MAPL/MAPL_Base/ MAPL_sun_uc.F90 and sun.H
The new diagnostic is a straight average like the ZTHB (cf insolation-weighted average like ZTH), but it works on an instantaneous cos(SZA) (internally ZTP) which has not been zeroed if it goes negative. Its because the photolysis calculations want a solar zenith angle below the horizon.
It should be zero-diff because it just adds functionality.

## Related Issue
MAPL issue #403 

## Motivation and Context
Because the GMI photolysis calculations want a solar zenith angle below the horizon because some light still reaches elevated locations from there..

## How Has This Been Tested?
I have compiled and run the GEOSgcm and verified that the new diagnostic (through related GEOSgcm issue #290) 'PCOSZ' of solar looks like it should. I also verified it was zero diff in fvcore and solar internal restarts, and that several standard solar history outputs were identical.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
