### PR TITLE
Feature/ewl/rename profiler demo exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `components.yaml` to use `NOINSTALL`
     - ESMA_cmake v3.0.6
     - ecbuild geos/v1.0.5
+- Renamed MAPL_Profiler executable demo.x to profiler.x
 - Renamed directories.   Sub-libraries now named MAPL.<sub>
   
   - `./MAPL_Base` => `./base` (`MAPL.base`)

--- a/profiler/demo/CMakeLists.txt
+++ b/profiler/demo/CMakeLists.txt
@@ -2,4 +2,4 @@ add_executable(profiler_demo.x demo.F90)
 target_link_libraries(profiler_demo.x MAPL_Profiler)
 
 add_executable(mpi_demo.x mpi_demo.F90)
-target_link_libraries(mpi_demo.x MAPL_Profiler MPI::MPI_Fortran)
+target_link_libraries(mpi_demo.x MAPL.profiler MPI::MPI_Fortran)

--- a/profiler/demo/CMakeLists.txt
+++ b/profiler/demo/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable(demo.x demo.F90)
-target_link_libraries(demo.x MAPL_Profiler)
+add_executable(profiler_demo.x demo.F90)
+target_link_libraries(profiler_demo.x MAPL_Profiler)
 
 add_executable(mpi_demo.x mpi_demo.F90)
 target_link_libraries(mpi_demo.x MAPL_Profiler MPI::MPI_Fortran)


### PR DESCRIPTION


<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Change MAPL_Profiler executable name from demo.x to profiler_demo.x.

## Related Issue
See also https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/issues/22.

## Motivation and Context
This update prevents a CMake name conflict for executable demo.x if building gFTL-shared within the source same tree as MAPL, such as in GCHPctm.

## How Has This Been Tested?
This update has not been tested in the context of GEOSgcm. I am not sure how demo.x is used outside of MAPL. I am assuming it is a trivial update, and that is reflected in my checked boxes below.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
