### PR TITLE
Clean up CHANGELOG and update CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
-/@cmake/
-/@env/
+/ESMA_cmake/
+/ESMA_env/
 /BUILD/
 /build*/
 /install*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added LLC grid factory
 - Added support for wildcard expansions (using regex)
 - Added "public" for 2 interfaces: ESMFL_Diff, and ESMFL_statistics
-
 - Added support for sampling along a 1-D timeseries in History
 - Introduced generic subdirectory
 - String.F90 - encapsulates deferred length strings
 - Added target "build-tests" that will build all tests.  This will enable
   ctest to be more selective about which tests.
-
-- Added ability of MAPL_GridCompGetFriendlies to recurse its children 
+- Added ability of MAPL_GridCompGetFriendlies to recurse its children
+- Added `add_subdirectory(@env)` to `CMakeLists.txt` to allow
+  installation of various files to the `bin` and `etc` directories under
+  install prefix
 
 ### Changed
+
 - Refactored aliases in python automatic code generator.  Now aliases
   are tailored per column.  This allows T/F to be safely used as
   aliases for .true./.false. without risking things like the short
@@ -51,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new CI test for building GCM on pull request
-- 
+
 ## [2.1.5] - 2020-06-11
 
 ### Changed
@@ -139,7 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Imported Python/MAPL subdir (old, but never imported to GitHub)
 - Python automatic code generator for grid comp include files	
 - Added support to use pFlogger for logging
-  - Command line option: --logging_config=<file>
+  - Command line option: `--logging_config=<file>`
 - Added ability for History to do monthly mean. This also involves reading and writing MAPL_GenericCpl checkpoints
 
 ## [2.0.6] - 2020-04-15
@@ -174,13 +177,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix for handling coarse grids at high-resolution in ExtData
 
-## [2.0.1] - 2019-03-02
+## [2.0.1] - 2020-03-02
 
 ### Fixed
 
 - Restoring functionality with the tripolar grid that was lost when the develop branch was merged into master for version 2.0.0
 
-## [2.0.0] - 2019-02-07
+## [2.0.0] - 2020-02-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `./GMAO_pFIO` => `./pfio`
   - `./MAPL_Profiler` => `./profiler`
   - `./MAPL_Shared` => `./shared`  
+    
+- Updated `components.yaml` to use `ESMA_env` and `ESMA_cmake` if
+  building MAPL as standalone
 
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added target "build-tests" that will build all tests.  This will enable
   ctest to be more selective about which tests.
 - Added ability of MAPL_GridCompGetFriendlies to recurse its children
-- Added `add_subdirectory(@env)` to `CMakeLists.txt` to allow
+- Added `esma_add_subdirectory(ESMA_env)` to `CMakeLists.txt` to allow
   installation of various files to the `bin` and `etc` directories under
   install prefix
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project (
   VERSION 2.2.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
-if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)
-  list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)
+  list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake")
   include (esma)
 else ()
   if (NOT COMMAND esma) # build as standalone project
@@ -28,7 +28,7 @@ else ()
     endif()
     option (SKIP_MEPO "Set to skip mepo steps" ON)
 
-    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")
+    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake")
     include (esma)
   endif()
 endif()
@@ -62,9 +62,7 @@ add_subdirectory (Apps)
 add_subdirectory (Tests)
 
 # @env will exist here if MAPL is built as itself but not as part of, say, GEOSgcm
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/@env)
-   add_subdirectory (@env)
-endif ()
+esma_add_subdirectory (ESMA_env FOUND ESMA_env_FOUND)
 
 # Install the Python directory
 install (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.1.5
+  VERSION 2.2.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/@cmake)
@@ -60,6 +60,8 @@ include(mapl_create_stub_component)
 add_subdirectory (Apps)
 
 add_subdirectory (Tests)
+
+add_subdirectory (@env)
 
 # Install the Python directory
 install (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,10 @@ add_subdirectory (Apps)
 
 add_subdirectory (Tests)
 
-add_subdirectory (@env)
+# @env will exist here if MAPL is built as itself but not as part of, say, GEOSgcm
+if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/@env)
+   add_subdirectory (@env)
+endif ()
 
 # Install the Python directory
 install (

--- a/components.yaml
+++ b/components.yaml
@@ -1,16 +1,16 @@
 env:
-  local: ./@env
+  local: ./ESMA_env
   remote: ../ESMA_env.git
   tag: v2.1.5
   develop: master
 
 cmake:
-  local: ./@cmake
+  local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
   tag: v3.0.6
   develop: develop
 
 ecbuild:
-  local: ./@cmake/@ecbuild
+  local: ./ESMA_cmake/ecbuild
   remote: ../ecbuild.git
   tag: geos/v1.0.5

--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
-env:
+ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
   tag: v2.1.5
   develop: master
 
-cmake:
+ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
   tag: v3.0.6


### PR DESCRIPTION
* Fix incorrect dates in `CHANGELOG.md`
* Clean up some blank lines
* Add `@env` as a subdirectory so files like `g5_modules` are installed in `install/bin` and some rc files get installed in `install/etc` (that's all @env `CMakeLists.txt` does)
* Update the version to 2.2.0 in `CMakeLists.txt` preemptively so we don't forget.