### PR TITLE
Hotfix/esherman/mapl acg python2

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -72,12 +72,14 @@ class MAPL_DataSpec:
         dims = MAPL_DataSpec.entry_aliases['dims'][self.args['dims']]
         return ranks[dims] + extra_rank
 
+    @staticmethod
     def internal_name(name):
         if name[-1] == '*':
             return name[:-1]
         else:
             return name
 
+    @staticmethod
     def mangled_name(name):
         if name[-1] == '*':
             return "'" + name[:-1] + "'//trim(comp_name)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Python ACG to work with Python 2.x
+
+### Fixed
+
 - Fixed logger creation (similar fix was already applied to develop branch to fix issue #397)
 
 ## [2.1.4] - 2020-05-21


### PR DESCRIPTION
The changes in MAPL_GridCompSpecs_ACG.py will allow MAPL_GridCompSpecs_ACG.py to be used by python 2.x which is what is used in g5_modules.