### PR TITLE
Update Changelog and version for 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
-
-- Updated Github Actions to not build GCM if trivial PR
-
 ### Fixed
 ### Removed
+
+## [2.2.2] - 2020-06-22
+
+### Changed
+
+- Updated Github Actions to not build GCM if trivial PR
 
 ## [2.2.1] - 2020-06-22
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.2.1
+  VERSION 2.2.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)


### PR DESCRIPTION
So. I just learned you don't enable superpowers on Github because it can merge `develop` into `main` for you automatically. Bad @mathomp4 for doing that. 

But if there was a day to do it, today's the day.

This update just pulls down my CI changes. If all works, this should only build the MAPL tests and not the GCM.