### PR TITLE
Bypass the majority of MAPL_FlapCapOptions.F90 if not using FLAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- USE_FLAP ifdef within MAPL_FlapCapOptions module
+
 ### Changed
 
 - Updated Github Actions to not build GCM if trivial PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMake option BUILD_WITH_FLAP which is default ON.  When set to OFF, the build
   skips layers that require FLAP.  (Supports GCHP)
   
-	
-- USE_FLAP ifdef within MAPL_FlapCapOptions module
-
 ### Changed
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- CMake option BUILD_WITH_FLAP which is default ON.  When set to OFF, the build
+  skips layers that require FLAP.  (Supports GCHP)
+  
+	
 - USE_FLAP ifdef within MAPL_FlapCapOptions module
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ else ()
   endif()
 endif()
 
+option(BUILD_WITH_FLAP "Use FLAP for command line processing" ON)
+
 ecbuild_declare_project()
 
 find_package(PFLOGGER REQUIRED)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -8,12 +8,12 @@ set (srcs
 
 include_directories (${INC_ESMF})
 
-#add_executable (ExtDataDriver.x ${srcs})
-ecbuild_add_executable (TARGET ExtDataDriver.x SOURCES ${srcs})
+if (BUILD_WITH_FLAP)
+  ecbuild_add_executable (TARGET ExtDataDriver.x SOURCES ${srcs})
+  target_link_libraries (ExtDataDriver.x MAPL FLAP::FLAP ${MKL_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
+  set_target_properties(ExtDataDriver.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
+endif ()
 
 #install(PROGRAMS ExtDataDriver.x DESTINATION bin)
-
-target_link_libraries (ExtDataDriver.x MAPL ${MKL_LIBRARIES} ${OpenMP_Fortran_LIBRARIES})
-set_target_properties(ExtDataDriver.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
 #install(TARGETS ExtDataDriver.x DESTINATION bin)
     

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -7,7 +7,6 @@ module ExtDataDriverMod
    use MAPL
    use ExtData_DriverGridCompMod, only: ExtData_DriverGridComp, new_ExtData_DriverGridComp
    use ExtDataUtRoot_GridCompMod, only:  ROOT_SetServices => SetServices
-   use FLAP
    use gFTL_StringVector
    use MAPL_ApplicationSupport
    use MAPL_ServerManager

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -13,7 +13,7 @@ set (srcs
   AbstractCommSplitter.F90              MAPL_ExtData_IOBundleMod.F90        MAPL_Profiler.F90
   CFIOCollection.F90                    MAPL_ExtData_IOBundleVectorMod.F90  MAPL_RegridderManager.F90
   CommGroupDescription.F90              MAPL_RegridderSpec.F90
-  MAPL_FractionalRegridder.F9  0        MAPL_RegridderTypeSpecRegridderMap.F90
+  MAPL_FractionalRegridder.F90          MAPL_RegridderTypeSpecRegridderMap.F90
   ESMF_CFIOPtrVectorMod.F90             MAPL_GenericCplComp.F90             MAPL_RegridderVector.F90
   ESMFL_Mod.F90                         MAPL_Generic.F90                    MAPL_SatVapor.F90
   FileMetadataUtilities.F90             MAPL_GetLatLonCoord.F90             MAPL_SimpleAlarm.F90

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -10,54 +10,63 @@ endif()
 
 
 set (srcs
-AbstractCommSplitter.F90              MAPL_ExtData_IOBundleMod.F90        MAPL_Profiler.F90
-CFIOCollection.F90                    MAPL_ExtData_IOBundleVectorMod.F90  MAPL_RegridderManager.F90
-CommGroupDescription.F90              MAPL_FlapCapOptions.F90             MAPL_RegridderSpec.F90
-MAPL_FractionalRegridder.F90        MAPL_RegridderTypeSpecRegridderMap.F90
-ESMF_CFIOPtrVectorMod.F90             MAPL_GenericCplComp.F90             MAPL_RegridderVector.F90
-ESMFL_Mod.F90                         MAPL_Generic.F90                    MAPL_SatVapor.F90
-FileMetadataUtilities.F90             MAPL_GetLatLonCoord.F90             MAPL_SimpleAlarm.F90
-FileMetadataUtilitiesVector.F90       MAPL_GridManager.F90                MAPL_SimpleBundleMod.F90
-MAPL_AbstractGridFactory.F90          MAPL_GridSpec.F90                   MAPL_StringGridFactoryMap.F90
-MAPL_GridType.F90                   MAPL_StringGridMap.F90
-MAPL_AbstractRegridder.F90            MAPL_HistoryCollection.F90          
-MAPL_Base.F90                         MAPL_HistoryGridComp.F90            MAPL_StringRouteHandleMap.F90
-MAPL_Cap.F90                          MAPL_IdentityRegridder.F90          MAPL_stubs.F90
-MAPL_CapGridComp.F90                  MAPL_Integer64GridFactoryMap.F90    MAPL_sun_uc.F90
-MAPL_CapOptions.F90                   MAPL_ioClients.F90                  MAPL_TilingRegridder.F90
-MAPL_CFIO.F90                         MAPL_IO.F90                         MAPL_TimeMethods.F90
-MAPL_CFIOServer.F90                   MAPL_LatLonGridFactory.F90          MAPL_TransposeRegridder.F90
-MAPL_Comms.F90                        MAPL_LatLonToLatLonRegridder.F90    MAPL_TripolarGridFactory.F90
-MAPL_LlcGridFactory.F90
-MAPL_Config.F90                       MAPL_LocStreamMod.F90               MAPL_VarSpecMod.F90
-MAPL_ConservativeRegridder.F90        MAPL_MaxMinMod.F90                  MAPL_VerticalInterpMod.F90
-MAPL_CubedSphereGridFactory.F90       MAPL_MemUtils.F90                   MAPL_VerticalMethods.F90
-MAPL_DefGridName.F90                  MAPL_Mod.F90                        MAPL_VotingRegridder.F90
-MAPL_EsmfRegridder.F90                MAPL_NewArthParser.F90              
-MAPL_ESMFTimeVectorMod.F90            MAPL_newCFIO.F90                    Regrid_Functions_Mod.F90
-MAPL_EtaHybridVerticalCoordinate.F90  MAPL_newCFIOitem.F90                
-MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           SimpleCommSplitter.F90
-MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
-MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
-MAPL_LocStreamFactoryMod.F90          MAPL_HistoryTrajectoryMod.F90       MAPL_LocstreamRegridder.F90
-ServerManager.F90 ApplicationSupport.F90
-regex_module.F90 StringTemplate.F90
-regex_F.c
-c_mapl_locstream_F.c  getrss.c  memuse.c
-)
+  AbstractCommSplitter.F90              MAPL_ExtData_IOBundleMod.F90        MAPL_Profiler.F90
+  CFIOCollection.F90                    MAPL_ExtData_IOBundleVectorMod.F90  MAPL_RegridderManager.F90
+  CommGroupDescription.F90              MAPL_RegridderSpec.F90
+  MAPL_FractionalRegridder.F9  0        MAPL_RegridderTypeSpecRegridderMap.F90
+  ESMF_CFIOPtrVectorMod.F90             MAPL_GenericCplComp.F90             MAPL_RegridderVector.F90
+  ESMFL_Mod.F90                         MAPL_Generic.F90                    MAPL_SatVapor.F90
+  FileMetadataUtilities.F90             MAPL_GetLatLonCoord.F90             MAPL_SimpleAlarm.F90
+  FileMetadataUtilitiesVector.F90       MAPL_GridManager.F90                MAPL_SimpleBundleMod.F90
+  MAPL_AbstractGridFactory.F90          MAPL_GridSpec.F90                   MAPL_StringGridFactoryMap.F90
+  MAPL_GridType.F90                     MAPL_StringGridMap.F90
+  MAPL_AbstractRegridder.F90            MAPL_HistoryCollection.F90          
+  MAPL_Base.F90                         MAPL_HistoryGridComp.F90            MAPL_StringRouteHandleMap.F90
+  MAPL_Cap.F90                          MAPL_IdentityRegridder.F90          MAPL_stubs.F90
+  MAPL_CapGridComp.F90                  MAPL_Integer64GridFactoryMap.F90    MAPL_sun_uc.F90
+  MAPL_CapOptions.F90                   MAPL_ioClients.F90                  MAPL_TilingRegridder.F90
+  MAPL_CFIO.F90                         MAPL_IO.F90                         MAPL_TimeMethods.F90
+  MAPL_CFIOServer.F90                   MAPL_LatLonGridFactory.F90          MAPL_TransposeRegridder.F90
+  MAPL_Comms.F90                        MAPL_LatLonToLatLonRegridder.F90    MAPL_TripolarGridFactory.F90
+  MAPL_LlcGridFactory.F90
+  MAPL_Config.F90                       MAPL_LocStreamMod.F90               MAPL_VarSpecMod.F90
+  MAPL_ConservativeRegridder.F90        MAPL_MaxMinMod.F90                  MAPL_VerticalInterpMod.F90
+  MAPL_CubedSphereGridFactory.F90       MAPL_MemUtils.F90                   MAPL_VerticalMethods.F90
+  MAPL_DefGridName.F90                  MAPL_Mod.F90                        MAPL_VotingRegridder.F90
+  MAPL_EsmfRegridder.F90                MAPL_NewArthParser.F90              
+  MAPL_ESMFTimeVectorMod.F90            MAPL_newCFIO.F90                    Regrid_Functions_Mod.F90
+  MAPL_EtaHybridVerticalCoordinate.F90  MAPL_newCFIOitem.F90                
+  MAPL_ExtDataCollection.F90            MAPL_NominalOrbitsMod.F90           SimpleCommSplitter.F90
+  MAPL_ExtDataCollectionManager.F90     MAPL_NUOPCWrapperMod.F90            SplitCommunicator.F90
+  MAPL_ExtDataGridCompMod.F90           MAPL_OrbGridCompMod.F90             tstqsat.F90
+  MAPL_LocStreamFactoryMod.F90          MAPL_HistoryTrajectoryMod.F90       MAPL_LocstreamRegridder.F90
+  ServerManager.F90 ApplicationSupport.F90
+  regex_module.F90 StringTemplate.F90
+  regex_F.c
+  c_mapl_locstream_F.c  getrss.c  memuse.c
+  )
 
+if (BUILD_WITH_FLAP)
+  list (APPEND srcs MAPL_FlapCapOptions.F90)
+endif()
 
 esma_add_library(
   ${this} SRCS ${srcs}
-  DEPENDENCIES MAPL.shared MAPL.profiler MAPL.pfio MAPL_cfio_r4 pflogger gftl-shared FLAP::FLAP MPI::MPI_Fortran)
+  DEPENDENCIES MAPL.shared MAPL.profiler MAPL.pfio MAPL_cfio_r4 pflogger gftl-shared MPI::MPI_Fortran)
+
 target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 if(DISABLE_GLOBAL_NAME_WARNING)
-   target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${DISABLE_GLOBAL_NAME_WARNING}>)
+  target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${DISABLE_GLOBAL_NAME_WARNING}>)
 endif()
 target_compile_definitions (${this} PRIVATE TWO_SIDED_COMM MAPL_MODE)
-#target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
+
 target_include_directories (${this} PUBLIC
-          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+  $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+
+if (BUILD_WITH_FLAP)
+  target_link_libraries(${this} PRIVATE FLAP::FLAP)
+  target_compile_definitions (${this} PRIVATE USE_FLAP)
+endif()
 
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...
 foreach(dir ${OSX_EXTRA_LIBRARY_PATH})

--- a/base/MAPL_Cap.F90
+++ b/base/MAPL_Cap.F90
@@ -5,7 +5,6 @@
 module MAPL_CapMod
    use MPI
    use ESMF
-   use FLAP
    use MAPL_SimpleCommSplitterMod
    use MAPL_SplitCommunicatorMod
    use MAPL_KeywordEnforcerMod

--- a/base/MAPL_FlapCapOptions.F90
+++ b/base/MAPL_FlapCapOptions.F90
@@ -251,6 +251,5 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine set_esmf_logging_mode
-#endif
 
 end module MAPL_FlapCapOptionsMod

--- a/base/MAPL_FlapCapOptions.F90
+++ b/base/MAPL_FlapCapOptions.F90
@@ -4,6 +4,7 @@
 module MAPL_FlapCapOptionsMod
    use MPI
    use ESMF
+#ifdef USE_FLAP
    use FLAP
    use MAPL_KeywordEnforcerMod
    use MAPL_ExceptionHandling
@@ -251,5 +252,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine set_esmf_logging_mode
+#endif
 
 end module MAPL_FlapCapOptionsMod

--- a/base/MAPL_FlapCapOptions.F90
+++ b/base/MAPL_FlapCapOptions.F90
@@ -4,7 +4,6 @@
 module MAPL_FlapCapOptionsMod
    use MPI
    use ESMF
-#ifdef USE_FLAP
    use FLAP
    use MAPL_KeywordEnforcerMod
    use MAPL_ExceptionHandling

--- a/base/MAPL_Mod.F90
+++ b/base/MAPL_Mod.F90
@@ -25,7 +25,9 @@ module MAPL_Mod
   use MAPL_HeapMod
   use MAPL_SatVaporMod
   use MAPL_CapOptionsMod
+#ifdef USE_FLAP
   use MAPL_FlapCapOptionsMod
+#endif
   use MAPL_CapMod
   use MAPL_MemUtilsMod
   use MAPL_HashMod


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Nearly the entire MAPL_FlapCapOptions module in enclosed with an USE_FLAP ifdef to avoid compile errors when not using FLAP.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See issue https://github.com/GEOS-ESM/MAPL/issues/451.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using MAPL 2.2 in GCHP, which does not use FLAP, there are compiler errors in MAPL_FlapCapOptions.F90 due to the FLAP dependency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I am testing only in the context of building GCHP without FLAP.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
