### PR TITLE
Fixes #443. Fix for CFMIP cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Removed
 
+## [2.2.4] - 2020-06-23
+
+### Fixed
+
+- Fix to `sun.H` to allow CFMIP SCM cases to run
+
 ## [2.2.3] - 2020-06-23
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.2.3
+  VERSION 2.2.4
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)

--- a/base/sun.H
+++ b/base/sun.H
@@ -309,17 +309,17 @@
          case(10)
             SLR = 0.3278
             ZTH = 0.6087247
-            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 10') 
+            ZTP = ZTH
 
          case(11)
             SLR = 0.3449
             ZTH = 0.5962
-            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 11') 
+            ZTP = ZTH
 
          case(12)
             SLR = 0.3461
             ZTH = 0.5884
-            _ASSERT(.not.present(ZTHP),'ZTHP not implemented for TIME_ == 12') 
+            ZTP = ZTH
 
          end select
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As all three SCM cases have positive `ZTH` values, it makes sense their `ZTP` would be equal to it as `ZTP` is the "below the horizon" zenith that isn't forced to be positive definite.


## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#443 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Allows MAPL 2.2 to run CFMIP cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I compared a run of scm_cfmip2-p6 SCM from MAPL 2.1 to one with this fix and they seem to be zero-diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
