### PR TITLE
Set return value when variable not found

### DIFF
--- a/base/FileMetadataUtilities.F90
+++ b/base/FileMetadataUtilities.F90
@@ -253,7 +253,6 @@ module MAPL_FileMetadataUtilsMod
       isPresent = var%is_attribute_present(trim(attr_name))
       if (isPresent) then
          attr => var%get_attribute(trim(attr_name))
-      !if (associated(attr)) then
          vunits => attr%get_value()
          select type(vunits)
          type is (character(*))
@@ -261,6 +260,8 @@ module MAPL_FileMetadataUtilsMod
          class default
             _ASSERT(.false.,'units must be string')
          end select
+      else
+         units => null()
       end if
       _RETURN(_SUCCESS)
 


### PR DESCRIPTION
Fixes a bug found my Mike Manyin with gcc. This routine in FileMetadataUtilities.F90 was not setting the return value if the attribute was not found. The calling program that was using this had set the pointer to null before calling this function. Apparently intel was leaving the pointer null but with gcc the result was becoming associated causing an error in the calling layer. This sets the return value to null if not found.