### PR TITLE
Additional CMake Updates for JEDI Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed duplicate `Python` directory
-- Removed CircleCI
+- Removed CircleC
+
+## [2.1.6] - 2020-07-08
+
+### Changed
+
+- Updates for JEDI/ecbuild compatibility
+  - Updates to CMake to use `NOINSTALL`
+  - Updates to `components.yaml` to support use of `NOINSTALL`
 
 ## [2.1.5] - 2020-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed duplicate `Python` directory
-- Removed CircleC
+- Removed CircleCI
 
 ## [2.1.6] - 2020-07-08
 


### PR DESCRIPTION
This adds the v2.1.6 changelog entry into `main`