### PR TITLE
Handmerge main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed duplicate `Python` directory
 - Removed CircleCI
 
+## [2.1.6] - 2020-07-08
+
+### Changed
+
+- Updates for JEDI/ecbuild compatibility
+  - Updates to CMake to use `NOINSTALL`
+  - Updates to `components.yaml` to support use of `NOINSTALL`
+
 ## [2.1.5] - 2020-06-11
 
 ### Changed


### PR DESCRIPTION
Github is acting weird, so let's handmerge the updates for changelog from `main` to `develop` 