### PR TITLE
Fixes mapl comm bug for NUOPC_Wrapper introduced with MAPL 2.2

### DIFF
--- a/base/MAPL_Cap.F90
+++ b/base/MAPL_Cap.F90
@@ -52,6 +52,8 @@ module MAPL_CapMod
       procedure :: initialize_mpi
       procedure :: finalize_mpi
 
+      procedure :: nuopc_fill_mapl_comm
+
 
       !getters
       procedure :: get_npes_model
@@ -214,6 +216,23 @@ contains
       end select
                   
    end subroutine run_member
+
+   subroutine nuopc_fill_mapl_comm(this, rc)
+      class(MAPL_Cap),         intent(inout) :: this
+      integer, optional,       intent(  out) :: rc
+
+      type(SplitCommunicator) :: split_comm
+      integer                 :: subcommunicator, status
+
+      subcommunicator = this%create_member_subcommunicator(this%comm_world, rc=status); _VERIFY(status)
+      if (subcommunicator /= MPI_COMM_NULL) then
+         call this%initialize_io_clients_servers(subcommunicator, rc = status); _VERIFY(status)
+         call this%cap_server%get_splitcomm(split_comm)
+         call fill_mapl_comm(split_comm, subcommunicator, .false., this%mapl_comm, rc=status); _VERIFY(status)
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine nuopc_fill_mapl_comm
 
 
     subroutine fill_mapl_comm(split_comm, gcomm, running_old_o_server, mapl_comm, unusable, rc)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes errors encountered when running newer versions of MAPL using NUOPC.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #500

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes MPI issue encountered when trying to run MAPL through NUOPC using newer versions of MAPL by providing a method that allows the NUOPC_wrapper to call `fill_mapl_comm` which was moved to a portion of MAPL that the NUOPC_wrapper avoids.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested with MAPL NUOPC test applications and appears to solve the bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
