### PR TITLE
Use Ubuntu20 GCC10 image

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
   build_test_mapl:
     name: Build and Test MAPL
     runs-on: ubuntu-latest
-    container: gmao/geos-build-env-gcc-source:6.0.13-openmpi_4.0.3-gcc_9.3.0
+    container: gmao/ubuntu20-geos-env-mkl:6.0.13-openmpi_4.0.4-gcc_10.2.0
     env:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved more code to use pFlogger
 - Update to ESMA_cmake v3.1.2
+- Update GitHub Actions to use Ubuntu 20/GCC 10 image
 
 ### Fixed
 


### PR DESCRIPTION
Update the GitHub Actions CI to use an Ubuntu 20/GCC 10 image.

Note: I'll probably soon be looking at moving the GEOSgcm (and MAPL?) tests back to CircleCI now that we have a paid plan. A 10-minute GEOSgcm build is not as bad as a 30-minute one.