### PR TITLE
Fixes tripolar metadata ouput

### DIFF
--- a/base/MAPL_TripolarGridFactory.F90
+++ b/base/MAPL_TripolarGridFactory.F90
@@ -901,8 +901,20 @@ contains
       class (TripolarGridFactory), intent(inout) :: this
       type (FileMetadata), intent(inout) :: metadata
 
+      type (Variable) :: v
+
       call metadata%add_dimension('lon', this%im_world)
       call metadata%add_dimension('lat', this%jm_world)
+
+      v = Variable(PFIO_REAL32, dimensions='lon,lat')
+      call v%add_attribute('long_name','longitude')
+      call v%add_attribute('units','degrees_east')
+      call metadata%add_variable('lons',v)
+
+      v = Variable(PFIO_REAL32, dimensions='lon,lat')
+      call v%add_attribute('long_name','latitude')
+      call v%add_attribute('units','degrees_north')
+      call metadata%add_variable('lats',v)
 
 
    end subroutine append_metadata

--- a/base/MAPL_VerticalMethods.F90
+++ b/base/MAPL_VerticalMethods.F90
@@ -93,7 +93,7 @@ module MAPL_VerticalDataMod
            else
               vdata%interp_levels = vdata%scaled_levels
            endif
-        else
+        else 
            vdata%regrid_type = VERTICAL_METHOD_SELECT
         end if
      end function newVerticalData
@@ -291,7 +291,7 @@ module MAPL_VerticalDataMod
         integer                     :: ungrdsize
         real, allocatable           :: ungridded_coord(:)
         real, allocatable           :: ungridded_coords(:,:)
-        logical                     :: unGrdNameCheck, unGrdUnitCheck, unGrdCoordCheck, have_ungrd
+        logical                     :: unGrdNameCheck, unGrdUnitCheck, unGrdCoordCheck, have_ungrd, found_mixed_ce
       
         integer :: status
         type(Variable) :: v
@@ -368,45 +368,59 @@ module MAPL_VerticalDataMod
           end do
        end if
 
+        found_mixed_ce=.false.
         lm=1
         haveVert = any(varDims/=1)
         if (haveVert) then
-           if (this%regrid_type == VERTICAL_METHOD_NONE ) then
-              vlast=1
-              do i=1,numVars
-                 if (varDims(i)/=1) then
-                    if (vlast/=1) then
-                       if (vlast /= varDims(i)) then
-                          _ASSERT(.false.,"have mixed level/edge")
-                       end if
-                    else
-                       vlast=varDims(i)
-                       vloc=location(i)
+           vlast=1
+           do i=1,numVars
+              if (varDims(i)/=1) then
+                 if (vlast/=1) then
+                    if (vlast /= varDims(i)) then
+                       found_mixed_ce=.true.
                     end if
+                 else
+                    vlast=varDims(i)
+                    vloc=location(i)
                  end if
-              end do
-              lm=vlast
-              if (vloc == MAPL_VLocationCenter) then
-                 vlb = 1
-              else if (vloc == MAPL_VlocationEdge) then
-                 vlb = 0
-              else
-                 vlb = 1
-              end if         
-           else if (this%regrid_type == VERTICAL_METHOD_ETA2LEV .or. & 
-                    this%regrid_type == VERTICAL_METHOD_SELECT) then
-              lm = size(this%levs) 
+              end if
+           end do
+           lm=vlast
+           if (vloc == MAPL_VLocationCenter) then
               vlb = 1
+           else if (vloc == MAPL_VlocationEdge) then
+              vlb = 0
+           else
+              vlb = 1
+           end if         
+        end if
+
+        if (this%regrid_type == VERTICAL_METHOD_ETA2LEV) then
+           lm = size(this%levs)
+           vlb = 1
+        end if
+        if (this%regrid_type == VERTICAL_METHOD_SELECT) then
+           if (lm == size(this%levs)) then
+              this%regrid_type = VERTICAL_METHOD_NONE
+           else
+              lm = size(this%levs)
+              vlb=1
            end if
         end if
+        if (this%regrid_type == VERTICAL_METHOD_NONE) then
+           _ASSERT(.not.(found_mixed_ce),'have mixed level/edge')
+        end if
+           
 
         if (haveVert) then
            this%lm=lm
            if (this%regrid_type == VERTICAL_METHOD_NONE) then
-              allocate(this%levs(lm))
-              do i=1,lm
-                 this%levs(i)=vlb+i-1
-              enddo
+              if (.not.allocated(this%levs)) then
+                 allocate(this%levs(lm))
+                 do i=1,lm
+                    this%levs(i)=vlb+i-1
+                 enddo
+              end if
               if (have_ungrd) then
                  if (allocated(ungridded_coord)) then
                    this%levs=ungridded_coord


### PR DESCRIPTION
Fixes #527 
This will add 2D lons and lats if you are outputting on the native tripolar grid. (assuming the lons/lats in the grid are correct, but that is another issue being worked on, they should be good for at least MOM5, MOM6 maybe not until we do a little more work). This only addresses the requests in the issue Yuri opened.

In addition it restores the functionality that you can specify the vertical metadata even if not selecting a subset of levels or vertically regridding as the old History/CFIO could do.

This is bit a of a kluge, but then the behaivor in the old CFIO layer was just as klugy. 
Basically when creating the file vertical information you pass the levels. It was assuming that if you passed levels, but no vertical variable for interpolation you wanted to select levels. Of course this breaks the cases they were using in the tripolar output of passing in a file that has the level metadata.
In the old CFIO layer the Kluge was, if the values were negative the level array, don't use that as an index to do level selection.
The new kluge is this. If you just pass levels assume at first we want to select levels, that is the existing behaivour. However after we parse the bundle and if we find that the number of levels in the bundle fields matches the input level variable, don't do try to do level subsetting with the passed in level variable because why would you be trying to select levels if the number of levels passed in matches the size of the variable, makes no sense. Since at this point the levels have been written to the metadata we can obliterate them and go back to the no special vertical handling behavior and output all the levels.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
