### PR TITLE
Feature/bmauer/restart for jedi

### DIFF
--- a/base/MAPL_Cap.F90
+++ b/base/MAPL_Cap.F90
@@ -44,6 +44,7 @@ module MAPL_CapMod
       procedure :: run_member
       procedure :: run_model
       procedure :: step_model
+      procedure :: rewind_model
 
       procedure :: create_member_subcommunicator
       procedure :: initialize_io_clients_servers
@@ -416,7 +417,14 @@ contains
      integer :: status
      call this%cap_gc%step(rc = status); _VERIFY(status)
    end subroutine step_model
-   
+  
+   subroutine rewind_model(this, time, rc)
+     class(MAPL_Cap), intent(inout) :: this
+     type(ESMF_Time), intent(inout) :: time
+     integer, intent(out) :: rc
+     integer :: status
+     call this%cap_gc%rewind_clock(time,rc = status); _VERIFY(status)
+   end subroutine rewind_model 
 
    integer function create_member_subcommunicator(this, comm, unusable, rc) result(subcommunicator)
       class (MAPL_Cap), intent(in) :: this

--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -1194,9 +1194,7 @@ contains
 
     call MAPL_GetObjectFromGC(this%gcs(this%root_id),maplobj,rc=status)
     _VERIFY(status)
-    call MAPL_AddSaveState(maplobj,MAPL_Write2Ram,rc=status)
-    _VERIFY(status)
-    call MAPL_GenericSaveState(this%gcs(this%root_id),this%child_imports(this%root_id), &
+    call MAPL_GenericStateSave(this%gcs(this%root_id),this%child_imports(this%root_id), &
            this%child_exports(this%root_id),this%clock,rc=status)
 
     call ESMF_ClockGet(this%clock,alarmCount=nalarms,rc=status)
@@ -1222,7 +1220,7 @@ contains
     integer :: status
 
     integer :: i 
-    call MAPL_GenericRestore(this%gcs(this%root_id),this%child_imports(this%root_id), &
+    call MAPL_GenericStateRestore(this%gcs(this%root_id),this%child_imports(this%root_id), &
              this%child_exports(this%root_id),this%clock,rc=status)
     _VERIFY(status)
     DO I = 1, size(this%alarm_list)

--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -53,6 +53,9 @@ module MAPL_CapGridCompMod
      type(ESMF_VM) :: vm
      real(kind=real64) :: loop_start_timer
      type(ESMF_Time) :: cap_restart_time
+     type(ESMF_Alarm), allocatable :: alarm_list(:)
+     type(ESMF_Time),  allocatable :: AlarmRingTime(:)
+     logical,          allocatable :: ringingState(:)
    contains
      procedure :: set_services
      procedure :: initialize
@@ -64,6 +67,10 @@ module MAPL_CapGridCompMod
      procedure :: get_model_duration
      procedure :: get_am_i_root
      procedure :: get_heartbeat_dt
+     procedure :: get_current_time
+     procedure :: rewind_clock
+     procedure :: record_state
+     procedure :: refresh_state
   end type MAPL_CapGridComp
 
   type :: MAPL_CapGridComp_Wrapper
@@ -915,6 +922,18 @@ contains
 
   end function get_heartbeat_dt
 
+  function get_current_time(this, rc) result (current_time)
+    class (MAPL_CapGridComp) :: this
+    type(ESMF_Time) :: current_time
+    integer, optional, intent(out) :: rc
+    integer :: status
+    call ESMF_ClockGet(this%clock,currTime=current_time,rc=status)
+    _VERIFY(status)
+
+    _RETURN(ESMF_SUCCESS)
+
+  end function get_current_time
+
 
   function get_CapGridComp_from_gc(gc) result(cap)
     type(ESMF_GridComp), intent(inout) :: gc
@@ -1097,7 +1116,6 @@ contains
 
     ! Advance the Clock before running History and Record
     ! ---------------------------------------------------
-
     call ESMF_ClockAdvance(this%clock, rc = status)
     _VERIFY(STATUS)
     call ESMF_ClockAdvance(this%clock_hist, rc = status)
@@ -1163,9 +1181,101 @@ contains
     1000 format(1x,'AGCM Date: ',i4.4,'/',i2.2,'/',i2.2,2x,'Time: ',i2.2,':',i2.2,':',i2.2, &
                 2x,'Throughput(days/day)[Avg Tot Run]: ',f6.1,1x,f6.1,1x,f6.1,2x,'TimeRemaining(Est) ',i3.3,':'i2.2,':',i2.2,2x, &
                 f5.1,'% : ',f5.1,'% Mem Comm:Used')
-
     _RETURN(ESMF_SUCCESS)
   end subroutine step
+
+  subroutine record_state(this, rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    integer, intent(out) :: rc
+    integer :: status
+    type(MAPL_MetaComp), pointer :: maplobj
+
+    integer :: nalarms,i
+
+    call MAPL_GetObjectFromGC(this%gcs(this%root_id),maplobj,rc=status)
+    _VERIFY(status)
+    call MAPL_AddSaveState(maplobj,MAPL_Write2Ram,rc=status)
+    _VERIFY(status)
+    call MAPL_GenericSaveState(this%gcs(this%root_id),this%child_imports(this%root_id), &
+           this%child_exports(this%root_id),this%clock,rc=status)
+
+    call ESMF_ClockGet(this%clock,alarmCount=nalarms,rc=status)
+    _VERIFY(status)
+
+    allocate(this%alarm_list(nalarms),this%ringingState(nalarms),this%alarmRingTime(nalarms),stat=status)
+    _VERIFY(status)
+    call ESMF_ClockGetAlarmList(this%clock, alarmListFlag=ESMF_ALARMLIST_ALL, &
+         alarmList=this%alarm_list, rc=status)
+    _VERIFY(status)
+    do i = 1, nalarms
+       call ESMF_AlarmGet(this%alarm_list(I), ringTime=this%alarmRingTime(I), ringing=this%ringingState(I), rc=status)
+       VERIFY_(STATUS)
+    end do
+
+    _RETURN(_SUCCESS)
+
+  end subroutine record_state
+
+  subroutine refresh_state(this, rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    integer, intent(out) :: rc
+    integer :: status
+
+    integer :: i 
+    call MAPL_GenericRestore(this%gcs(this%root_id),this%child_imports(this%root_id), &
+             this%child_exports(this%root_id),this%clock,rc=status)
+    _VERIFY(status)
+    DO I = 1, size(this%alarm_list)
+       call ESMF_AlarmSet(this%alarm_list(I), ringTime=this%alarmRingTime(I), ringing=this%ringingState(I), rc=status)
+       _VERIFY(STATUS)
+    END DO
+
+    _RETURN(_SUCCESS)
+
+  end subroutine refresh_state
+
+  subroutine rewind_clock(this, time, rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    type(ESMF_Time), intent(inout) :: time
+    integer, intent(out) :: rc
+    integer :: status
+    type(ESMF_Time) :: current_time,ct
+
+    call ESMF_ClockGet(this%clock,currTime=current_time,rc=status)
+    _VERIFY(status)
+    if (current_time >  time) then
+       call ESMF_ClockSet(this%clock,direction=ESMF_DIRECTION_REVERSE,rc=status)
+       _VERIFY(status)
+       do 
+          call ESMF_ClockAdvance(this%clock,rc=status)
+          _VERIFY(status)
+          call ESMF_ClockGet(this%clock,currTime=ct,rc=status)
+          _VERIFY(status)
+          if (ct==time) exit
+       enddo
+       call ESMF_ClockSet(this%clock,direction=ESMF_DIRECTION_FORWARD,rc=status)
+       _VERIFY(status)
+    end if
+      
+    call ESMF_ClockGet(this%clock_hist,currTime=current_time,rc=status)
+    _VERIFY(status)
+    if (current_time >  time) then
+       call ESMF_ClockSet(this%clock_hist,direction=ESMF_DIRECTION_REVERSE,rc=status)
+       _VERIFY(status)
+       do 
+          call ESMF_ClockAdvance(this%clock_hist,rc=status)
+          _VERIFY(status)
+          call ESMF_ClockGet(this%clock_hist,currTime=ct,rc=status)
+          _VERIFY(status)
+          if (ct==time) exit
+       enddo
+       call ESMF_ClockSet(this%clock_hist,direction=ESMF_DIRECTION_FORWARD,rc=status)
+       _VERIFY(status)
+    end if
+      
+       
+    _RETURN(_SUCCESS)
+  end subroutine rewind_clock
 
 
   ! !IROUTINE: MAPL_ClockInit -- Sets the clock

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -41,12 +41,13 @@ module MAPL_CapOptionsMod
 
 contains
 
-   function new_CapOptions(unusable, cap_rc_file, egress_file, ensemble_subdir_prefix, rc) result (cap_options)
+   function new_CapOptions(unusable, cap_rc_file, egress_file, ensemble_subdir_prefix, esmf_logging_mode, rc) result (cap_options)
       type (MAPL_CapOptions) :: cap_options
       class (KeywordEnforcer), optional, intent(in) :: unusable
       character(*), optional, intent(in) :: cap_rc_file
       character(*), optional, intent(in) :: egress_file
       character(*), optional, intent(in) :: ensemble_subdir_prefix 
+      type(ESMF_LogKind_Flag), optional, intent(in) :: esmf_logging_mode
 
       integer, optional, intent(out) :: rc
 
@@ -64,6 +65,7 @@ contains
       if (present(cap_rc_file)) cap_options%cap_rc_file = cap_rc_file
       if (present(egress_file)) cap_options%egress_file = egress_file
       if (present(ensemble_subdir_prefix)) cap_options%ensemble_subdir_prefix = ensemble_subdir_prefix
+      if (present(esmf_logging_mode)) cap_options%esmf_logging_mode = esmf_logging_mode
 
       _RETURN(_SUCCESS)
 

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -207,6 +207,11 @@ module MAPL_GenericMod
   public MAPL_ESMFStateReadFromFile
   public MAPL_InternalStateRetrieve
   public :: MAPL_GetLogger
+  public MAPL_AddSaveState
+  public MAPL_GenericSaveState
+  public MAPL_StateSave 
+  public MAPL_GenericRestore
+  public MAPL_StateRecord
 !BOP  
   ! !PUBLIC TYPES:
 
@@ -365,6 +370,13 @@ type MAPL_GenericRecordType
    integer                                  :: INT_LEN
 end type  MAPL_GenericRecordType
 
+type MAPL_GenericSaveType
+   integer                                  :: FILETYPE
+   character(len=:), allocatable            :: IMP_FNAME
+   character(len=:), allocatable            :: INT_FNAME
+end type  MAPL_GenericSaveType
+
+
 type MAPL_Connectivity
    type (MAPL_VarConn), pointer :: CONNECT(:)       => null()
    type (MAPL_VarConn), pointer :: DONOTCONN(:)     => null()
@@ -417,6 +429,7 @@ type  MAPL_MetaComp
    type (MAPL_LocStream)                    :: LOCSTREAM
    character(len=ESMF_MAXSTR)               :: COMPNAME
    type (MAPL_GenericRecordType)  , pointer :: RECORD           => null()
+   type (MAPL_GenericSaveType)              :: savestate
    type (ESMF_State)                        :: FORCING
    type (MAPL_Connectivity)                 :: connectList
    integer                        , pointer :: phase_init (:)    => null()
@@ -5424,7 +5437,7 @@ end function MAPL_AddChildFromGC
 
     nwrgt1 = (mpl%grid%num_readers > 1) 
 
-    
+   
     if(INDEX(FNAME,'*') == 0) then
        if (AmIRoot) then
           block
@@ -9765,6 +9778,317 @@ end subroutine MAPL_READFORCINGX
 
     _RETURN(ESMF_SUCCESS)
   end function MAPL_AddMethod
+
+
+  recursive subroutine MAPL_AddSaveState(state,filetype,rc)
+    type(MAPL_MetaComp), intent(inout) :: state
+    integer,             intent(in ) :: filetype
+    integer, optional,   intent(out) :: rc
+    type(MAPL_MetaComp), pointer :: CMAPL => null()
+    integer :: k, status
+    character(len=ESMF_MAXSTR) :: filename
+
+    if (associated(state%gcs)) then
+       do k=1,size(state%GCS)
+          call MAPL_GetObjectFromGC ( state%GCS(K), CMAPL, RC=STATUS)
+          _VERIFY(STATUS)
+          call MAPL_AddSaveState(CMAPL,filetype,RC=STATUS)
+          _VERIFY(STATUS)
+       enddo
+    end if
+
+    state%savestate%filetype = filetype
+   call MAPL_GetResource( STATE, FILENAME,         &
+                          LABEL="IMPORT_CHECKPOINT_FILE:", &
+                          RC=STATUS)
+   if(STATUS==ESMF_SUCCESS) then
+      STATE%savestate%IMP_FNAME = FILENAME
+   end if
+   call MAPL_GetResource( STATE   , filename,  &
+                        LABEL="INTERNAL_CHECKPOINT_FILE:", &
+                        RC=STATUS)
+   if(STATUS==ESMF_SUCCESS) then
+      STATE%savestate%INT_FNAME = FILENAME
+   end if
+
+  end subroutine MAPL_AddSaveState
+
+  recursive subroutine MAPL_GenericSaveState( GC, IMPORT, EXPORT, CLOCK, RC )
+    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
+    type(ESMF_State),    intent(inout) :: IMPORT ! import state
+    type(ESMF_State),    intent(inout) :: EXPORT ! export state
+    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
+    integer, optional,   intent(  out) :: RC     ! Error code:
+
+    type(mapl_metacomp), pointer :: state
+    integer :: i, k, filetype
+
+ character(len=14)                           :: datestamp
+  character(len=1)                            :: separator
+
+  character(len=ESMF_MAXSTR)                  :: filetypechar
+  character(len=4)                            :: extension
+  integer                                     :: hdr
+   integer :: status
+  character(len=:), allocatable :: tmpstr
+
+  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
+  _VERIFY(STATUS)
+
+  if(associated(STATE%GCS)) then
+     do I=1,size(STATE%GCS)
+        call MAPL_GenericSaveState (STATE%GCS(I), &
+             STATE%GIM(I), &
+             STATE%GEX(I), &
+             CLOCK, RC=STATUS )
+        _VERIFY(status)
+     enddo
+  endif
+
+  call MAPL_DateStampGet(clock, datestamp, rc=status)
+  _VERIFY(STATUS)
+  filetype=state%savestate%filetype
+  if (FILETYPE /= MAPL_Write2Disk) then
+     separator = '*'
+  else
+     separator = '.'
+  end if
+
+  if (allocated(state%savestate%imp_fname)) then
+     call    MAPL_GetResource( STATE, filetypechar, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
+     if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
+    call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+                    _VERIFY(STATUS)
+   end if
+    filetypechar = ESMF_UtilStringLowerCase(filetypechar,rc=STATUS)
+      _VERIFY(STATUS)
+     if (filetypechar == 'pnc4') then
+        extension = '.nc4'
+    else
+       extension = '.bin'
+     end if
+      tmpstr=trim(state%savestate%imp_fname)
+      deallocate(state%savestate%imp_fname)
+      STATE%savestate%IMP_FNAME = tmpstr // separator // DATESTAMP // extension
+      deallocate(tmpstr)
+    end if
+
+     if (allocated(state%savestate%int_fname)) then
+        call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
+        _VERIFY(STATUS)
+        call    MAPL_GetResource( STATE, filetypechar, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
+        if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
+           call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+           _VERIFY(STATUS)
+        end if
+        filetypechar = ESMF_UtilStringLowerCase(filetypechar,rc=STATUS)
+        _VERIFY(STATUS)
+        if (filetypechar == 'pnc4') then
+           extension = '.nc4'
+        else
+           extension = '.bin'
+        end if
+        tmpstr=trim(state%savestate%int_fname)
+        deallocate(state%savestate%int_fname)
+        STATE%savestate%INT_FNAME = tmpstr // separator // DATESTAMP // extension
+        deallocate(tmpstr)
+     end if
+
+     ! call the actual record method
+     call MAPL_StateSave (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
+     _VERIFY(STATUS)
+
+  end subroutine MAPL_GenericSaveState
+
+subroutine MAPL_StateSave( GC, IMPORT, EXPORT, CLOCK, RC )
+
+    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
+    type(ESMF_State),    intent(inout) :: IMPORT ! import state
+    type(ESMF_State),    intent(inout) :: EXPORT ! export state
+    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
+    integer, optional,   intent(  out) :: RC     ! Error code:
+
+  character(len=ESMF_MAXSTR)                  :: IAm
+  character(len=ESMF_MAXSTR)                  :: COMP_NAME
+  integer                                     :: STATUS
+
+  type (MAPL_MetaComp), pointer               :: STATE
+  integer                                     :: hdr
+  character(len=ESMF_MAXSTR)                  :: FILETYPE
+
+  _UNUSED_DUMMY(EXPORT)
+
+  Iam = "MAPL_StateSave"
+  call ESMF_GridCompGet(GC, name=COMP_NAME, RC=STATUS )
+  _VERIFY(STATUS)
+  Iam = trim(COMP_NAME) // Iam
+
+  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
+  _VERIFY(STATUS)
+
+  if (allocated(state%savestate%imp_fname)) then
+     call    MAPL_GetResource( STATE, FILETYPE, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
+     if ( STATUS/=ESMF_SUCCESS  .or.  FILETYPE == "default" ) then
+        call MAPL_GetResource( STATE, FILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+        _VERIFY(STATUS)
+     end if
+     call MAPL_ESMFStateWriteToFile(IMPORT, CLOCK, &
+                                    STATE%savestate%IMP_FNAME, &
+                                    FILETYPE, STATE, .FALSE., oClients = o_Clients, &
+                                    RC=STATUS)
+     _VERIFY(STATUS)
+  end if
+
+  if (allocated(state%savestate%int_fname)) then
+     call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
+     _VERIFY(STATUS)
+     call    MAPL_GetResource( STATE, FILETYPE, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
+     if ( STATUS/=ESMF_SUCCESS  .or.  FILETYPE == "default" ) then
+        call MAPL_GetResource( STATE, FILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+        _VERIFY(STATUS)
+     end if
+     call MAPL_ESMFStateWriteToFile(STATE%INTERNAL, CLOCK, &
+                                    STATE%savestate%INT_FNAME, &
+                                    FILETYPE, STATE, hdr/=0, oClients = o_Clients, &
+                                    RC=STATUS)
+     _VERIFY(STATUS)
+  end if
+
+  _RETURN(ESMF_SUCCESS)
+end subroutine MAPL_StateSave
+
+
+  recursive subroutine MAPL_GenericRestore ( GC, IMPORT, EXPORT, CLOCK, RC )
+
+! !ARGUMENTS:
+
+    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
+    type(ESMF_State),    intent(inout) :: IMPORT ! import state
+    type(ESMF_State),    intent(inout) :: EXPORT ! export state
+    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
+    integer, optional,   intent(  out) :: RC     ! Error code:
+                                                 ! = 0 all is well
+                                                 ! otherwise, error
+!EOPI
+
+! LOCAL VARIABLES
+
+  character(len=ESMF_MAXSTR)                  :: IAm
+  character(len=ESMF_MAXSTR)                  :: COMP_NAME
+  character(len=ESMF_MAXSTR)                  :: CHILD_NAME
+  character(len=14)                           :: datestamp ! YYYYMMDD_HHMMz
+  integer                                     :: STATUS
+  integer                                     :: I
+  type (MAPL_MetaComp), pointer               :: STATE
+  character(len=1)                            :: separator
+  character(len=ESMF_MAXSTR)                  :: filetypechar
+  character(len=4)                            :: extension
+  integer                                     :: hdr
+  class(BaseProfiler), pointer                :: t_p
+!=============================================================================
+
+!  Begin...
+
+  Iam = "MAPL_GenericRestore"
+  call ESMF_GridCompGet(GC, name=COMP_NAME, RC=STATUS )
+  _VERIFY(STATUS)
+  Iam = trim(COMP_NAME) // Iam
+
+! Retrieve the pointer to the state
+!----------------------------------
+
+  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
+  _VERIFY(STATUS)
+
+  call MAPL_GenericStateClockOn(STATE,"TOTAL")
+! Refresh the children
+! ---------------------
+  if(associated(STATE%GCS)) then
+     do I=1,size(STATE%GCS)
+        call ESMF_GridCompGet( STATE%GCS(I), NAME=CHILD_NAME, RC=STATUS )
+        _VERIFY(STATUS)
+        call MAPL_GenericRestore (STATE%GCS(I), STATE%GIM(I), STATE%GEX(I), CLOCK, &
+             RC=STATUS )
+        _VERIFY(STATUS)
+     enddo
+  endif
+! Do my "own" refresh
+! ------------------
+  call MAPL_GenericStateClockOn(STATE,"--GenRefreshMine")
+
+     call MAPL_StateRestore (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
+     _VERIFY(STATUS)
+
+  _RETURN(ESMF_SUCCESS)
+end subroutine MAPL_GenericRestore
+
+subroutine MAPL_StateRestore( GC, IMPORT, EXPORT, CLOCK, RC )
+
+! !ARGUMENTS:
+
+    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
+    type(ESMF_State),    intent(inout) :: IMPORT ! import state
+    type(ESMF_State),    intent(inout) :: EXPORT ! export state
+    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
+    integer, optional,   intent(  out) :: RC     ! Error code:
+                                                 ! = 0 all is well
+                                                 ! otherwise, error
+!EOPI
+
+! LOCAL VARIABLES
+
+  character(len=ESMF_MAXSTR)                  :: IAm
+  character(len=ESMF_MAXSTR)                  :: COMP_NAME
+  integer                                     :: STATUS
+
+  type (MAPL_MetaComp), pointer               :: STATE
+  integer                                     :: hdr, unit
+  _UNUSED_DUMMY(EXPORT)
+
+!  Begin...
+
+  Iam = "MAPL_StateRefresh"
+  call ESMF_GridCompGet(GC, name=COMP_NAME, RC=STATUS )
+  _VERIFY(STATUS)
+  Iam = trim(COMP_NAME) // Iam
+
+
+! Retrieve the pointer to the state
+!----------------------------------
+
+  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
+  _VERIFY(STATUS)
+
+
+  if (allocated(STATE%savestate%imp_fname)) then
+     call MAPL_ESMFStateReadFromFile(IMPORT, CLOCK, &
+                                     STATE%savestate%IMP_FNAME, &
+                                     STATE, .FALSE., RC=STATUS)
+     _VERIFY(STATUS)
+     UNIT = GETFILE(STATE%savestate%IMP_FNAME, RC=STATUS)
+     _VERIFY(STATUS)
+     call MAPL_DestroyFile(unit = UNIT, rc=STATUS)
+     _VERIFY(STATUS)
+  end if
+
+  if (allocated(state%savestate%int_fname)) then
+     call MAPL_GetResource( STATE   , hdr,         &
+                            default=0, &
+                            LABEL="INTERNAL_HEADER:", &
+                            RC=STATUS)
+     _VERIFY(STATUS)
+     call MAPL_ESMFStateReadFromFile(STATE%INTERNAL, CLOCK, &
+                                     STATE%savestate%INT_FNAME, &
+                                     STATE, hdr/=0, RC=STATUS)
+     _VERIFY(STATUS)
+     UNIT = GETFILE(STATE%savestate%INT_FNAME, RC=STATUS)
+     _VERIFY(STATUS)
+     call MAPL_DestroyFile(unit = UNIT, rc=STATUS)
+     _VERIFY(STATUS)
+  end if
+
+  _RETURN(ESMF_SUCCESS)
+end subroutine MAPL_StateRestore
 
   subroutine MAPL_AddRecord(MAPLOBJ, ALARM, FILETYPE, RC)
     type(MAPL_MetaComp), intent(inout) :: MAPLOBJ

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -371,7 +371,7 @@ type MAPL_GenericRecordType
 end type  MAPL_GenericRecordType
 
 type MAPL_InitialState
-   integer                                  :: FILETYPE
+   integer                                  :: FILETYPE = MAPL_Write2Ram
    character(len=:), allocatable            :: IMP_FNAME
    character(len=:), allocatable            :: INT_FNAME
 end type  MAPL_InitialState
@@ -9823,7 +9823,6 @@ end subroutine MAPL_READFORCINGX
     call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
     _VERIFY(STATUS)
 
-    state%initial_state%filetype = MAPL_Write2Ram
     call MAPL_GetResource( STATE, FILENAME,         &
                           LABEL="IMPORT_CHECKPOINT_FILE:", &
                           RC=STATUS)

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -9780,7 +9780,7 @@ end subroutine MAPL_READFORCINGX
   end function MAPL_AddMethod
 
 
-  recursive subroutine MAPL_Setstatesave(state,filetype,rc)
+  recursive subroutine MAPL_SetStateSave(state,filetype,rc)
     type(MAPL_MetaComp), intent(inout) :: state
     integer,             intent(in ) :: filetype
     integer, optional,   intent(out) :: rc
@@ -9798,9 +9798,9 @@ end subroutine MAPL_READFORCINGX
 
     state%initial_state%filetype = filetype
 
-  end subroutine MAPL_Setstatesave
+  end subroutine MAPL_SetStateSave
 
-  recursive subroutine MAPL_Genericstatesave( GC, IMPORT, EXPORT, CLOCK, RC )
+  recursive subroutine MAPL_GenericStateSave( GC, IMPORT, EXPORT, CLOCK, RC )
     type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
     type(ESMF_State),    intent(inout) :: IMPORT ! import state
     type(ESMF_State),    intent(inout) :: EXPORT ! export state
@@ -9810,18 +9810,18 @@ end subroutine MAPL_READFORCINGX
     type(mapl_metacomp), pointer :: state
     integer :: i,filetype
 
- character(len=14)                           :: datestamp
-  character(len=1)                            :: separator
+    character(len=14)                           :: datestamp
+    character(len=1)                            :: separator
 
-  character(len=ESMF_MAXSTR)                  :: filetypechar
-  character(len=4)                            :: extension
-  integer                                     :: hdr
-   integer :: status
-  character(len=:), allocatable :: tmpstr
-  character(len=ESMF_MAXSTR) :: filename
+    character(len=ESMF_MAXSTR)                  :: filetypechar
+    character(len=4)                            :: extension
+    integer                                     :: hdr
+    integer :: status
+    character(len=:), allocatable :: tmpstr
+    character(len=ESMF_MAXSTR) :: filename
 
-  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
-  _VERIFY(STATUS)
+    call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
+    _VERIFY(STATUS)
 
     state%initial_state%filetype = MAPL_Write2Ram
     call MAPL_GetResource( STATE, FILENAME,         &
@@ -9839,35 +9839,35 @@ end subroutine MAPL_READFORCINGX
        STATE%initial_state%INT_FNAME = FILENAME
     end if
 
-  if(associated(STATE%GCS)) then
-     do I=1,size(STATE%GCS)
-        call MAPL_Genericstatesave (STATE%GCS(I), &
-             STATE%GIM(I), &
-             STATE%GEX(I), &
-             CLOCK, RC=STATUS )
-        _VERIFY(status)
-     enddo
-  endif
+    if(associated(STATE%GCS)) then
+       do I=1,size(STATE%GCS)
+          call MAPL_GenericStateSave (STATE%GCS(I), &
+               STATE%GIM(I), &
+               STATE%GEX(I), &
+               CLOCK, RC=STATUS )
+          _VERIFY(status)
+       enddo
+    endif
 
-  call MAPL_DateStampGet(clock, datestamp, rc=status)
-  _VERIFY(STATUS)
-  filetype=state%initial_state%filetype
-  if (FILETYPE /= MAPL_Write2Disk) then
-     separator = '*'
-  else
-     separator = '.'
-  end if
+    call MAPL_DateStampGet(clock, datestamp, rc=status)
+    _VERIFY(STATUS)
+    filetype=state%initial_state%filetype
+    if (FILETYPE /= MAPL_Write2Disk) then
+       separator = '*'
+    else
+       separator = '.'
+    end if
 
-  if (allocated(state%initial_state%imp_fname)) then
-     call    MAPL_GetResource( STATE, filetypechar, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
-     if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
-    call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+    if (allocated(state%initial_state%imp_fname)) then
+       call    MAPL_GetResource( STATE, filetypechar, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
+       if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
+      call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
                     _VERIFY(STATUS)
-   end if
+    end if
     filetypechar = ESMF_UtilStringLowerCase(filetypechar,rc=STATUS)
-      _VERIFY(STATUS)
-     if (filetypechar == 'pnc4') then
-        extension = '.nc4'
+    _VERIFY(STATUS)
+    if (filetypechar == 'pnc4') then
+       extension = '.nc4'
     else
        extension = '.bin'
      end if
@@ -9877,33 +9877,33 @@ end subroutine MAPL_READFORCINGX
       deallocate(tmpstr)
     end if
 
-     if (allocated(state%initial_state%int_fname)) then
-        call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
-        _VERIFY(STATUS)
-        call    MAPL_GetResource( STATE, filetypechar, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
-        if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
-           call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
-           _VERIFY(STATUS)
-        end if
-        filetypechar = ESMF_UtilStringLowerCase(filetypechar,rc=STATUS)
-        _VERIFY(STATUS)
-        if (filetypechar == 'pnc4') then
-           extension = '.nc4'
-        else
-           extension = '.bin'
-        end if
-        tmpstr=trim(state%initial_state%int_fname)
-        deallocate(state%initial_state%int_fname)
-        STATE%initial_state%INT_FNAME = tmpstr // separator // DATESTAMP // extension
-        deallocate(tmpstr)
-     end if
+    if (allocated(state%initial_state%int_fname)) then
+       call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
+       _VERIFY(STATUS)
+       call    MAPL_GetResource( STATE, filetypechar, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
+       if ( STATUS/=ESMF_SUCCESS  .or.  filetypechar == "default" ) then
+          call MAPL_GetResource( STATE, filetypechar, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+          _VERIFY(STATUS)
+       end if
+       filetypechar = ESMF_UtilStringLowerCase(filetypechar,rc=STATUS)
+       _VERIFY(STATUS)
+       if (filetypechar == 'pnc4') then
+          extension = '.nc4'
+       else
+          extension = '.bin'
+       end if
+       tmpstr=trim(state%initial_state%int_fname)
+       deallocate(state%initial_state%int_fname)
+       STATE%initial_state%INT_FNAME = tmpstr // separator // DATESTAMP // extension
+       deallocate(tmpstr)
+    end if
 
-     ! call the actual record method
-     call MAPL_StateSave (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
-     _VERIFY(STATUS)
-     _RETURN(_SUCCESS)
+    ! call the actual record method
+    call MAPL_StateSave (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
+    _VERIFY(STATUS)
+    _RETURN(_SUCCESS)
 
-  end subroutine MAPL_Genericstatesave
+  end subroutine MAPL_GenericStateSave
 
 subroutine MAPL_StateSave( GC, IMPORT, EXPORT, CLOCK, RC )
 


### PR DESCRIPTION
This is adding new functionality requested by the Jedi developers.
They have the requirement to be able to run multiple forward time integrations within one execution, restoring the initial state in between of whatever model is hooked into the Jedi Framework. This has been done for the FV3 standalone case, and UFS, waiting for us.

Jedi currently uses hooks into our Cap and CapGridComp utilizing the work Kyle did with a custom driver that implements the abstract model phases Jedi has in the framework.  So essentially for the first step they want to initialize GEOS, integrate GEOS forward in time (this has been implemented), but now rewind, start again from the same state, and make sure on the second integration they get back to the same state at the end. Similar to replay but not quite the same. Since this is being driven from outside, rather than say in replay where the extra time looping is controlled inside GCM, I could not use the Record feature we currently have. This works by doing a MAPL_AddRecord, but that is not a recursively routine so it relies on doing this in the component set services, then all the record states get replicated in the children as part of generic initialize. In addition the GenericRecord feature uses alarms to control when the record happens which I do not trust to use until ESMF fixes them. Indeed, I tried hardcoding an addrecord in the CapGridComp set to record at the model start time just to see if the underlying machinery would work. This caused a hang in the alarms after the rewind, so that is a no go.

Instead I added simple functions in MAPL_Generic that can be directly invoked by the driver by calls in Cap and CapGridComp to rewind the clock, checkpoint the state to memory, and restore the state. It is basically generic/record/refresh without all the alarm complication in there. I also added a new type to the MAPL state to store the filenames, whether memory or on disk as the existing record structure is all convoluted with the alarms. By default it will do memory checkpointing but I did add a set so that you could do disk if you really wanted to.

With this Jedi can choose to memory checkpoint the state, rewind the cap clocks, restore the saved state as it sees fit. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
