### PR TITLE
Destroy saved state for Jedi

### DIFF
--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -71,6 +71,7 @@ module MAPL_CapGridCompMod
      procedure :: rewind_clock
      procedure :: record_state
      procedure :: refresh_state
+     procedure :: destroy_state
   end type MAPL_CapGridComp
 
   type :: MAPL_CapGridComp_Wrapper
@@ -770,7 +771,7 @@ contains
     call t_p%start('Finalize')
 
     if (.not. cap%printspec > 0) then
-       
+
        call ESMF_GridCompFinalize(cap%gcs(cap%root_id), importstate = cap%child_imports(cap%root_id), &
             exportstate=cap%child_exports(cap%root_id), clock = cap%clock, userrc = status)
        _VERIFY(status)
@@ -1231,6 +1232,22 @@ contains
     _RETURN(_SUCCESS)
 
   end subroutine refresh_state
+
+  subroutine destroy_state(this, rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    integer, intent(out) :: rc
+    integer :: status
+
+    call MAPL_DestroyStateSave(this%gcs(this%root_id),rc=status)
+    _VERIFY(status)
+   
+     if (allocated(this%alarm_list)) deallocate(this%alarm_list)
+     if (allocated(this%AlarmRingTime)) deallocate(this%alarmRingTime)
+     if (allocated(this%ringingState)) deallocate(this%ringingState)
+
+    _RETURN(_SUCCESS)
+
+  end subroutine destroy_state
 
   subroutine rewind_clock(this, time, rc)
     class(MAPL_CapGridComp), intent(inout) :: this


### PR DESCRIPTION
This is a follow up to the previous PR about the memory checkpointing for JEDI. The previous PR destroyed the memory checkpointed state right after reading. However, it should persist until it is explicitly destroyed as I may need to be reused more than once. This removes the deletion of the memory checkpointed state from the restore call, adds a call in generic that can be called to free it, and hook in cap to accomplish allow JEDI to make the call.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
