### PR TITLE
Update Regrid_Util.x to use MAPL/ESMF regridding machinery, other improvements as well.

### DIFF
--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -596,6 +596,7 @@ contains
       if ( (this%target_lon /= UNDEFINED_REAL) .and. &
            (this%target_lat /= UNDEFINED_REAL) .and. &
            (this%stretch_factor /= UNDEFINED_REAL) ) then
+         _ASSERT( (this%target_lat >= -90.0) .and. (this%target_lat <= 90) )
          this%stretched_cube = .true.
          this%target_lon=this%target_lon*pi/180.d0
          this%target_lat=this%target_lat*pi/180.d0

--- a/base/Regrid_Util.F90
+++ b/base/Regrid_Util.F90
@@ -4,6 +4,7 @@
 
    use ESMF
    use ESMFL_Mod
+   use MAPL_Profiler
    use MAPL_BaseMod
    use MAPL_MemUtilsMod
    use MAPL_CFIOMod
@@ -12,20 +13,24 @@
    use ESMF_CFIOMod
    use ESMF_CFIOUtilMod
    use ESMF_CFIOFileMod
-   use MAPL_LatLonGridFactoryMod
+   use MAPL_RegridderManagerMod
+   use MAPL_AbstractRegridderMod
+   use MAPL_RegridderSpecMod
+   use MAPL_GridManagerMod
+   use MAPL_LatLonGridFactoryMod, only: LatLonGridFactory
+   use MAPL_CubedSphereGridFactoryMod, only: CubedSphereGridFactory
+   use MAPL_TripolarGridFactoryMod, only: TripolarGridFactory
    use MAPL_ConstantsMod, only: MAPL_PI_R8
    use MAPL_ExceptionHandling
    use MAPL_ApplicationSupport
+
  
    implicit NONE
 
-   type(ESMF_RouteHandle) :: regrid_rh
-   type(ESMF_DynamicMask) :: dynamicMask
-   logical :: createdHandle
-
-   integer, parameter :: grid_ll = 1
-   integer, parameter :: grid_cs = 2
-   integer, parameter :: grid_tp = 3
+   class(AbstractRegridder), pointer :: regridder_esmf=>null()
+   real, parameter :: cs_stretch_uninit = -1.0
+   type(DistributedProfiler), target :: t_prof
+   type (ProfileReporter) :: reporter
 
    include "mpif.h"
 
@@ -41,8 +46,6 @@ CONTAINS
 !  ---------------------------------------------
    type(ESMF_Grid)     :: grid_old, grid_new
    type(ESMF_VM)       :: vm             ! ESMF Virtual Machine
-
-   real(kind=ESMF_KIND_R8) :: itime_end, itime_beg
 
    character(len=ESMF_MAXPATHLEN) ::  Filename,OutputFile,tp_filein,tp_fileout
 
@@ -88,7 +91,10 @@ CONTAINS
    character(len=ESMF_MAXSTR) :: gridname
    character(len=ESMF_MAXPATHLEN) :: str,astr
    real, pointer :: lonsfile(:), latsfile(:)
-   integer :: inGrid, outGrid
+   character(len=:), allocatable :: tripolar_file_in,tripolar_file_out,old_gridname
+   type(ESMF_CONFIG) :: cfinput,cfoutput
+   integer :: regridMethod
+   real :: cs_stretch_param(3)
  
     Iam = "ut_ReGridding"
 
@@ -99,16 +105,15 @@ CONTAINS
     _VERIFY(STATUS)
     call ESMF_VMGet(vm, localPET=myPET, petCount=nPet)
     call MAPL_Initialize(__RC__)
+    t_prof=DistributedProfiler('Regrid_Util',MpiTimerGauge(),MPI_COMM_WORLD)
  
-    createdHandle=.false.
     nx=1
     ny=6
     onlyvars=.false.
     alltimes=.true.
     regridMth='bilinear'
     newCube=.true.
-    inGrid = grid_ll
-    outGrid = grid_ll
+    cs_stretch_param=cs_stretch_uninit
     nargs = command_argument_count()
     do i=1,nargs
       call get_command_argument(i,str)
@@ -133,6 +138,13 @@ CONTAINS
          read(astr,*)itime(1)
          call get_command_argument(i+2,astr)
          read(astr,*)itime(2)
+      case('-stretch_factor')
+         call get_command_argument(i+1,astr)
+         read(astr,*)cs_stretch_param(1)
+         call get_command_argument(i+2,astr)
+         read(astr,*)cs_stretch_param(2)
+         call get_command_argument(i+2,astr)
+         read(astr,*)cs_stretch_param(3)
       case('-method')
          call get_command_argument(i+1,RegridMth)
       case('-cubeFormat')
@@ -141,10 +153,10 @@ CONTAINS
          if (trim(astr) == 'old') newCube=.false.
       case('-tp_in')
          call get_command_argument(i+1,tp_filein)
-         inGrid=grid_tp
+         tripolar_file_in = tp_filein
       case('-tp_out')
          call get_command_argument(i+1,tp_fileout)
-         outGrid=grid_tp
+         tripolar_file_out = tp_fileout
       case('--help')
          if (mapl_am_I_root()) then
          
@@ -158,6 +170,18 @@ CONTAINS
          trim(regridMth).ne.'patch') then
        if (MAPL_AM_I_Root()) write(*,*)'invalid regrid method choose bilinear or conservative'
        _ASSERT(.false.,'needs informative message')
+    end if
+    if (trim(regridMth) == 'bilinear') then
+       regridMethod = REGRID_METHOD_BILINEAR
+    end if
+    if (trim(regridMth) == 'patch') then
+       regridMethod = REGRID_METHOD_PATCH
+    end if
+    if (trim(regridMth) == 'conservative') then
+       regridMethod = REGRID_METHOD_CONSERVE
+    end if
+    if (trim(regridMth) == 'conservative2') then
+       regridMethod = REGRID_METHOD_CONSERVE_2ND
     end if
 
     call MAPL_GetNodeInfo (comm=MPI_COMM_WORLD, rc=status)
@@ -173,6 +197,7 @@ CONTAINS
     call ESMF_CFIOGet       (LCFIO,     grid=CFIOGRID, __RC__)
     call ESMF_CFIOGridGet   (CFIOGRID, IM=IM_WORLD0, JM=JM_WORLD0, KM=LM_WORLD, Lon=lonsfile,lat=latsfile, __RC__)
     call guesspole_and_dateline(lonsfile,latsfile,dateline_old,pole_old)
+    old_gridname = create_gridname(im_world0,jm_world0,dateline_old,pole_old)
     if (.not.allTimes) then
        tSteps=1
        call UnpackDateTIme(itime,year,month,day,hour,minute,second)
@@ -208,20 +233,16 @@ CONTAINS
     _VERIFY(STATUS)
 
     call UnpackGridName(Gridname,im_world_new,jm_world_new,dateline_new,pole_new)
-!   Lat lon or cubed sphere?
-!   ------------------------
-    if ( JM_World0 == 6*IM_World0 ) then
-       inGrid = grid_cs
-    end if
-
-    if ( JM_World_new == 6*IM_World_new ) then
-       outGrid = grid_cs
-    end if
-
 
     if (mapl_am_i_root()) write(*,*)'going to make grid',im_world0,jm_world0,im_world_new,jm_world_new
-    grid_old = create_grid(inGrid,"unknown",im_world0,jm_world0,lm_world,nx,ny,dateline_old,pole_old,tp_filein,__RC__)
-    grid_new = create_grid(outGrid,gridname,im_world_new,jm_world_new,lm_world,nx,ny,dateline_new,pole_new,tp_fileout,__RC__)
+    cfinput = create_cf(old_gridname,im_world0,jm_world0,nx,ny,lm_world,cs_stretch_param,__RC__)
+    cfoutput = create_cf(gridname,im_world_new,jm_world_new,nx,ny,lm_world,cs_stretch_param,__RC__)
+    grid_old=grid_manager%make_grid(cfinput,prefix=trim(old_gridname)//".",__RC__)
+    grid_new=grid_manager%make_grid(cfoutput,prefix=trim(gridname)//".",__RC__)
+    call t_prof%start("GenRegrid")
+    regridder_esmf => new_regridder_manager%make_regridder(grid_old,grid_new,regridMethod,__RC__)
+    call t_prof%stop("GenRegrid")
+
     if (mapl_am_i_root()) write(*,*)'done making grid'
 
     bundle_cfio=ESMF_FieldBundleCreate(name="cfio_bundle",rc=status)
@@ -233,6 +254,7 @@ CONTAINS
     do i=1,tsteps
 
        
+       call t_prof%start("Read")
        if (mapl_am_i_root()) write(*,*)'processing timestep ',i
        time = tSeries(i)
        if (onlyvars) then
@@ -245,18 +267,20 @@ CONTAINS
        if (Mapl_AM_I_Root()) write(*,*)'done reading file ',trim(filename)
 
        if (.not.fileCreated) bundle_esmf = BundleClone(bundle_cfio,grid_new,__RC__)
+       call t_prof%stop("Read")
 
        call MPI_BARRIER(MPI_COMM_WORLD,STATUS)
        _VERIFY(STATUS)
-       itime_beg = MPI_Wtime(STATUS)
        _VERIFY(STATUS)
 
-       call RunESMFRegridding(regridMth,bundle_cfio,bundle_esmf,__RC__)
+       call t_prof%start("regrid")
+       call RunESMFRegridding(bundle_cfio,bundle_esmf,__RC__)
+       call t_prof%stop("regrid")
 
        call MPI_BARRIER(MPI_COMM_WORLD,STATUS)
        _VERIFY(STATUS)
-       itime_end = MPI_Wtime(STATUS)
-       if (mapl_am_I_root()) write(*,*)'MAPL TIME: ',itime_end-itime_beg
+ 
+       call t_prof%start("write")
 
 
        if (mapl_am_I_root()) write(*,*) "moving on to writing the file"
@@ -272,6 +296,7 @@ CONTAINS
        call MAPL_CFIOWrite(cfio_esmf,clock,bundle_esmf,created=fileCreated,rc=status)
        _VERIFY(STATUS)
        if (.not.fileCreated) fileCreated=.true.
+       call t_prof%stop("write")
  
     end do
     call MAPL_CFIOClose(cfio_esmf,rc=status)
@@ -281,6 +306,9 @@ CONTAINS
 !   --------
     call ESMF_VMBarrier(VM,__RC__)
 
+    call t_prof%finalize()
+    call t_prof%reduce()
+    call generate_report()
     call MAPL_Finalize(__RC__)
     call MPI_Finalize(status)
 !    call ESMF_Finalize ( rc=status )
@@ -391,9 +419,8 @@ CONTAINS
 
     end subroutine BundleCopy
 
-    subroutine RunESMFRegridding(regridMth,bundle_old,bundle_new,rc)
+    subroutine RunESMFRegridding(bundle_old,bundle_new,rc)
 
-    character(len=*),           intent(in   ) :: regridMth
     type(ESMF_FieldBundle),     intent(inout) :: bundle_old
     type(ESMF_FieldBundle),     intent(inout) :: bundle_new
 
@@ -402,65 +429,17 @@ CONTAINS
     character(len=ESMF_MAXSTR) :: Iam
     integer :: status
 
-    type(ESMF_Field) :: field_old, field_new, srcField,dstField
-    type(ESMF_Grid) :: grid_old, grid_new
-    integer :: bcount,i,l
+    type(ESMF_Field) :: field_old, field_new
+    integer :: bcount,i
     real(ESMF_KIND_R4), pointer  :: ptr3d_old(:,:,:) => null()
     real(ESMF_KIND_R4), pointer  :: ptr3d_new(:,:,:) => null()
-    real(ESMF_KIND_R4), pointer  :: srcPtr(:,:) => null()
-    real(ESMF_KIND_R4), pointer  :: dstPtr(:,:) => null()
-    type(ESMF_RegridMethod_Flag) :: regridMethod
-    type(ESMF_PoleMethod_Flag)   :: PoleMethod
-    integer                 :: oldRank, newRank,srcterm
-    real(kind=ESMF_KIND_R4), pointer :: ptr2d(:,:)
+    real(ESMF_KIND_R4), pointer  :: ptr2d_old(:,:) => null()
+    real(ESMF_KIND_R4), pointer  :: ptr2d_new(:,:) => null()
+    integer                 :: oldRank, newRank
 
     Iam = "RunESMFRegridding"
 
-    if (trim(regridMth) == 'bilinear') then
-       regridMethod = ESMF_REGRIDMETHOD_BILINEAR
-       PoleMethod = ESMF_POLEMETHOD_TEETH
-    end if
-    if (trim(regridMth) == 'patch') then
-       regridMethod = ESMF_REGRIDMETHOD_PATCH
-       PoleMethod = ESMF_POLEMETHOD_TEETH
-    end if
-    if (trim(regridMth) == 'conservative') then
-       regridMethod = ESMF_REGRIDMETHOD_CONSERVE
-       PoleMethod = ESMF_POLEMETHOD_NONE
-    end if
-    if (trim(regridMth) == 'conservative2') then
-       regridMethod = ESMF_REGRIDMETHOD_CONSERVE_2ND
-       PoleMethod = ESMF_POLEMETHOD_NONE
-    end if
-
-    call ESMF_FieldBundleGet(bundle_old,grid=grid_old,__RC__)
-    call ESMF_FieldBundleGet(bundle_new,grid=grid_new,__RC__)
-
-    srcField = MAPL_FieldCreateEmpty(name="srcField",grid=grid_old,__RC__)
-    call MAPL_FieldAlloccommit(srcField,dims=MAPL_DimsHorzOnly,location=MAPL_VLocationNone, &
-        typekind=kind(0.0),hw=0,__RC__)
-    call ESMF_FieldGet(srcField,localDE=0,farrayPtr=ptr2d,__RC__)
-    ptr2d = 0.0
-
-    dstField = MAPL_FieldCreateEmpty(name="dstField",grid=grid_new,__RC__)
-    call MAPL_FieldAlloccommit(dstField,dims=MAPL_DimsHorzOnly,location=MAPL_VLocationNone, &
-        typekind=kind(0.0),hw=0,__RC__)
-    call ESMF_FieldGet(dstField,localDE=0,farrayPtr=ptr2d,__RC__)
-    ptr2d = 0.0
-
-    srcTerm=0
-    if (.not.createdHandle) then
-       call ESMF_FieldRegridStore(srcField, dstField, &
-              & regridmethod=regridMethod, lineType=ESMF_LINETYPE_GREAT_CIRCLE, &
-              & srcTermProcessing=srcTerm, &
-              & srcMaskValues = [0], &
-              & unmappedAction=ESMF_UNMAPPEDACTION_IGNORE, &
-              & routehandle=regrid_rh, __RC__)
-       createdHandle=.true.
-       call ESMF_DynamicMaskSetR4R8R4(dynamicMask,simpleDynMaskProc,dynamicSrcMaskValue=MAPL_UNDEF,__RC__)
-    end if
-
-    call ESMF_FieldBundleGet(bundle_old,fieldcount=bcount,__RC__)
+   call ESMF_FieldBundleGet(bundle_old,fieldcount=bcount,__RC__)
    do i=1,bcount
 
        call ESMF_FieldBundleGet(bundle_old,i,field=field_old,__RC__)
@@ -474,79 +453,24 @@ CONTAINS
        if (oldRank == 3) then
 
           call ESMF_FieldGet(field_old,0,farrayPtr=ptr3D_old,__RC__)
-          call ESMF_FieldGet(srcfield,0,farrayPtr=srcPtr,__RC__)
           call ESMF_FieldGet(field_new,0,farrayPtr=ptr3D_new,__RC__)
-          call ESMF_FieldGet(dstfield,0,farrayPtr=dstPtr,__RC__)
-          do l=1,size(ptr3D_old,3)
-
-             srcPtr = ptr3d_old(:,:,l)
-             call ESMF_FieldRegrid(srcField,dstField,routehandle=regrid_rh, &
-                  termorderflag=ESMF_TERMORDER_SRCSEQ, dynamicMask=dynamicMask,__RC__)
-             ptr3d_new(:,:,l) = dstPtr
-
-          end do
-
+          call regridder_esmf%regrid(ptr3d_old,ptr3d_new,__RC__)
           nullify(ptr3d_old)
           nullify(ptr3d_new)
-          nullify(srcPtr)
-          nullify(dstPtr)
 
        else if (oldRank == 2) then
 
-          call ESMF_FieldRegrid(field_old,field_new,routehandle=regrid_rh, &
-               termorderflag=ESMF_TERMORDER_SRCSEQ, &
-               zeroregion=ESMF_REGION_SELECT, dynamicMask=dynamicMask, __RC__)
-
+          call ESMF_FieldGet(field_old,0,farrayPtr=ptr2D_old,__RC__)
+          call ESMF_FieldGet(field_new,0,farrayPtr=ptr2D_new,__RC__)
+          call regridder_esmf%regrid(ptr2d_old,ptr2d_new,__RC__)
+          nullify(ptr2d_old)
+          nullify(ptr2d_new)
        end if
     end do
 
     _RETURN(ESMF_SUCCESS)
 
     end subroutine RunESMFRegridding
-
-   subroutine simpleDynMaskProc(dynamicMaskList, dynamicSrcMaskValue, &
-      dynamicDstMaskValue, rc)
-      type(ESMF_DynamicMaskElementR4R8R4), pointer        :: dynamicMaskList(:)
-      real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
-      real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
-      integer,                       intent(out)          :: rc
-      integer :: i, j
-      real(ESMF_KIND_R8)  :: renorm
-
-      _UNUSED_DUMMY(dynamicDstMaskValue)
-
-      if (associated(dynamicMaskList)) then
-        do i=1, size(dynamicMaskList)
-          dynamicMaskList(i)%dstElement = 0.d0 ! set to zero
-          renorm = 0.d0 ! reset
-          do j=1, size(dynamicMaskList(i)%factor)
-            !if (.not. &
-              !match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j))) then
-              !dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement &
-                !+ dynamicMaskList(i)%factor(j) &
-                !* dynamicMaskList(i)%srcElement(j)
-              !renorm = renorm + dynamicMaskList(i)%factor(j)
-            !endif
-            if (dynamicSrcMaskValue /= dynamicMaskList(i)%srcElement(j)) then
-              dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement &
-                + dynamicMaskList(i)%factor(j) &
-                * dynamicMaskList(i)%srcElement(j)
-              renorm = renorm + dynamicMaskList(i)%factor(j)
-            endif
-          enddo
-          if (renorm > 0.d0) then
-            dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
-          else if (present(dynamicSrcMaskValue)) then
-            dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
-          else
-            rc = ESMF_RC_ARG_BAD  ! error detected
-            return
-          endif
-        enddo
-      endif
-      ! return successfully
-      rc = ESMF_SUCCESS
-    end subroutine
 
    subroutine UnpackDateTime(DATETIME, YY, MM, DD, H, M, S)
      integer, intent(IN   ) :: DATETIME(:)
@@ -603,173 +527,103 @@ CONTAINS
      else
         pole='PC'
      end if
-    end subroutine guesspole_and_dateline  
- 
-    function cs_gridcreate(grid_name,im_world,nx,lm,rc) result(grid)
-       type(ESMF_Grid)              :: grid
-       character(len=*), intent(in) :: grid_name
-       integer, intent(in)          :: im_world
-       integer, intent(in)          :: nx
-       integer, intent(in)          :: lm
-       integer, optional, intent(out) :: rc
+    end subroutine guesspole_and_dateline 
 
-       character(len=*),parameter :: Iam = "cs_gridcreate"
-       integer :: i
-       integer :: ijms(2,6)
-       integer :: status
-
-       ijms(1,1)=nx
-       ijms(2,1)=nx
-       do i=2,6
-          ijms(:,i)=ijms(:,1)
-       enddo
-       grid = ESMF_GridCreateCubedSPhere(im_world,regDecompPTile=ijms,name=grid_name, &
-                staggerLocList=[ESMF_STAGGERLOC_CENTER,ESMF_STAGGERLOC_CORNER], coordSys=ESMF_COORDSYS_SPH_RAD, rc=status)
-      _VERIFY(status)
-
-      call ESMF_AttributeSet(grid, name='GRID_LM', value=lm, rc=status)
-      _VERIFY(status)
-
-      call ESMF_AttributeSet(grid, 'GridType', 'Cubed-Sphere', rc=status)
-      _VERIFY(status)
-      call ESMF_AttributeSet(grid, name='NEW_CUBE', value=1,rc=status)
-      _VERIFY(status)
-      _RETURN(ESMF_SUCCESS)
-
-     end function cs_gridcreate
- 
-    function tripolar_gridcreate(grid_name,im_world,jm_world,nx,ny,lm,gridspec,rc) result(grid)
-       type(ESMF_Grid)              :: grid
+    function create_cf(grid_name,im_world,jm_world,nx,ny,lm,cs_stretch_param,rc) result(cf)
+       use MAPL_ConfigMod
+       type(ESMF_Config)              :: cf
        character(len=*), intent(in) :: grid_name
        integer, intent(in)          :: im_world,jm_world
        integer, intent(in)          :: nx,ny
        integer, intent(in)          :: lm
-       character(len=*), intent(in) :: gridspec
+       real, intent(in)             :: cs_stretch_param(3)
        integer, optional, intent(out) :: rc
 
-       character(len=*),parameter :: Iam = "cs_gridcreate"
+       character(len=ESMF_MAXSTR),parameter :: Iam = "create_cf"
        integer :: status
+       character(len=2) :: pole,dateline
+       integer :: nn
 
-       integer, allocatable :: ims(:),jms(:)
-       integer :: i_1,i_n,j_1,j_n, ncid, varid, ic, jc
-       real, allocatable :: centers(:,:), corners(:,:,:)
-       real(ESMF_KIND_R8), pointer :: fptr(:,:)
+       nn = len_trim(grid_name)
+       dateline=grid_name(nn-1:nn)
+       pole=grid_name(1:2)
 
-       allocate(ims(0:nx-1),jms(0:ny-1))
-       call MAPL_DecomposeDim(im_world,ims,nx)
-       call MAPL_DecomposeDim(jm_world,jms,ny)
-
-       grid = ESMF_GridCreate1PeriDim( &
-            name=trim(grid_name) ,&
-            countsPerDEDim1=ims, &
-            countsPerDEDim2=jms, &
-            indexFlag=ESMF_INDEX_DELOCAL, &
-            gridEdgeLWidth=[0,0], &
-            gridEdgeUWidth=[0,1], &
-            coordDep1=[1,2], &
-            coordDep2=[1,2], &
-            poleKindFlag=[ESMF_POLEKIND_MONOPOLE,ESMF_POLEKIND_BIPOLE], &
-            coordSys=ESMF_COORDSYS_SPH_RAD, &
-            __RC__)
-
-       deallocate(ims,jms)
-
-       call ESMF_GridAddCoord(grid, __RC__)
-       call ESMF_GridAddCoord(grid, staggerloc=ESMF_STAGGERLOC_CORNER,__RC__)
-       call MAPL_Grid_Interior(grid, i_1, i_n, j_1, j_n)
-       status = nf90_open(gridspec,NF90_NOWRITE,ncid)
-       _VERIFY(status)
-
-       allocate(centers(im_world,jm_world),__STAT__)
-
-       ! do longitudes
-       status = nf90_inq_varid(ncid,'x_T',varid)
-       _VERIFY(status)
-       status = nf90_get_var(ncid,varid,centers)
-       _VERIFY(status)
-       centers=centers*MAPL_PI_R8/180.d0
-       call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
-          staggerloc=ESMF_STAGGERLOC_CENTER, &
-          farrayPtr=fptr, rc=status)
-       fptr=centers(i_1:i_n,j_1:j_n)
-       ! do latitudes
-       status = nf90_inq_varid(ncid,'y_T',varid)
-       _VERIFY(status)
-       status = nf90_get_var(ncid,varid,centers)
-       _VERIFY(status)
-       centers=centers*MAPL_PI_R8/180.d0
-       call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
-          staggerloc=ESMF_STAGGERLOC_CENTER, &
-          farrayPtr=fptr, rc=status)
-       fptr=centers(i_1:i_n,j_1:j_n)
-       deallocate(centers)
-       ! now repeat for corners
-       allocate(corners(im_world,jm_world,4),__STAT__)
-
-       ! do longitudes
-       status = nf90_inq_varid(ncid,'x_vert_T',varid)
-       _VERIFY(status)
-       status = nf90_get_var(ncid,varid,corners)
-       _VERIFY(status)
-       corners=corners*MAPL_PI_R8/180.d0
-       call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
-          staggerloc=ESMF_STAGGERLOC_CORNER, &
-          farrayPtr=fptr, __RC__)
-       ic = size(fptr,1)
-       jc = size(fptr,2)
-       if (j_n == jm_world) then
-          fptr(:,1:jc-1)=corners(i_1:i_n,j_1:j_n,1)
-          fptr(:,jc)=corners(i_1:i_n,j_n,4)
+       cf = MAPL_ConfigCreate(__RC__)
+       call MAPL_ConfigSetAttribute(cf,value=NX, label=trim(grid_name)//".NX:",rc=status)
+       VERIFY_(status)
+       call MAPL_ConfigSetAttribute(cf,value=lm, label=trim(grid_name)//".LM:",rc=status)
+       VERIFY_(status)
+       if (jm_world==6*im_world) then
+          call MAPL_ConfigSetAttribute(cf,value="Cubed-Sphere", label=trim(grid_name)//".GRID_TYPE:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=6, label=trim(grid_name)//".NF:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=im_world,label=trim(grid_name)//".IM_WORLD:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=ny/6, label=trim(grid_name)//".NY:",rc=status)
+          VERIFY_(status)
+          if (any(cs_stretch_param/=cs_stretch_uninit)) then
+             call MAPL_ConfigSetAttribute(cf,value=cs_stretch_param(1),label=trim(grid_name)//".STRETCH_FACTOR:",rc=status)
+             VERIFY_(status)
+             call MAPL_ConfigSetAttribute(cf,value=cs_stretch_param(2),label=trim(grid_name)//".TARGET_LON:",rc=status)
+             call MAPL_ConfigSetAttribute(cf,value=cs_stretch_param(3),label=trim(grid_name)//".TARGET_LAT:",rc=status)
+          end if
+     
        else
-          fptr=corners(i_1:i_n,j_1:j_n,1)
+          call MAPL_ConfigSetAttribute(cf,value="LatLon", label=trim(grid_name)//".GRID_TYPE:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=im_world,label=trim(grid_name)//".IM_WORLD:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=jm_world,label=trim(grid_name)//".JM_WORLD:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=ny, label=trim(grid_name)//".NY:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=pole, label=trim(grid_name)//".POLE:",rc=status)
+          VERIFY_(status)
+          call MAPL_ConfigSetAttribute(cf,value=dateline, label=trim(grid_name)//".DATELINE:",rc=status)
+          VERIFY_(status)
        end if
-       ! do latitudes
-       status = nf90_inq_varid(ncid,'y_vert_T',varid)
-       _VERIFY(status)
-       status = nf90_get_var(ncid,varid,corners)
-       _VERIFY(status)
-       corners=corners*MAPL_PI_R8/180.d0
-       call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
-          staggerloc=ESMF_STAGGERLOC_CORNER, &
-          farrayPtr=fptr, __RC__)
-       if (j_n == jm_world) then
-          fptr(:,1:jc-1)=corners(i_1:i_n,j_1:j_n,1)
-          fptr(:,jc)=corners(i_1:i_n,j_n,4)
-       else
-          fptr=corners(i_1:i_n,j_1:j_n,1)
-       end if
-       deallocate(corners)
 
-       call ESMF_AttributeSet(grid,name='GRID_LM',value=lm,__RC__)
 
-       _RETURN(ESMF_SUCCESS)
+     end function create_cf 
 
-     end function tripolar_gridcreate 
+    function create_gridname(im,jm,date,pole) result(gridname)
+     integer, intent(in) :: im
+     integer, intent(in) :: jm
+     character(len=2), intent(in) :: date
+     character(len=2), intent(in) :: pole
+     character(len=ESMF_MAXSTR) :: gridname
+     character(len=16) :: imstr,jmstr
+     write(imstr,*) im
+     write(jmstr,*) jm
+     gridname =  pole // trim(adjustl(imstr))//'x'//&
+                 trim(adjustl(jmstr))//'-'//date
 
-    function create_grid(grid_type,gname,im_world,jm_world,lm,nx,ny,dateline,pole,tp_file,rc) result(grid)
-       type(ESMF_Grid) :: grid
-       integer, intent(in) :: grid_type
-       character(len=*), intent(in) :: gname
-       integer, intent(in) :: im_world,jm_world,lm,nx,ny
-       character(len=2), intent(in) :: dateline,pole
-       character(len=*), intent(in) :: tp_file
-       integer, optional, intent(out) :: rc
+    end function create_gridname
 
-       integer :: status
-       type(LatLonGridFactory) :: ll_factory
+    subroutine generate_report()
 
-       select case(grid_type)
-          case(grid_ll)
-             ll_factory = LatLonGridFactory(grid_name=gname,im_world=im_world,jm_world=jm_world,lm=lm, &
-                                            nx=nx,ny=ny,pole=pole,dateline=dateline,__RC__)
-             grid=ll_factory%make_grid(__RC__)
-          case(grid_cs)
-             grid = cs_gridcreate(gname,im_world,nx,lm,__RC__)
-          case(grid_tp)
-             grid = tripolar_gridcreate(gname,im_world,jm_world,nx,ny,lm,tp_file,__RC__)
-       end select
-       
-       _RETURN(ESMF_SUCCESS)
-    end function create_grid
-        
+         character(:), allocatable :: report_lines(:)
+         integer :: i
+   
+         call reporter%add_column(NameColumn(20))
+         call reporter%add_column(FormattedTextColumn('Inclusive','(f9.6)', 9, InclusiveColumn('MEAN')))
+         call reporter%add_column(FormattedTextColumn('% Incl','(f6.2)', 6, PercentageColumn(InclusiveColumn('MEAN'),'MAX')))
+         call reporter%add_column(FormattedTextColumn('Exclusive','(f9.6)', 9, ExclusiveColumn('MEAN')))
+         call reporter%add_column(FormattedTextColumn('% Excl','(f6.2)', 6, PercentageColumn(ExclusiveColumn('MEAN'))))   
+         call reporter%add_column(FormattedTextColumn(' Max Excl)','(f9.6)', 9, ExclusiveColumn('MAX')))
+         call reporter%add_column(FormattedTextColumn(' Min Excl)','(f9.6)', 9, ExclusiveColumn('MIN')))
+         call reporter%add_column(FormattedTextColumn('Max PE)','(1x,i4.4,1x)', 6, ExclusiveColumn('MAX_PE')))
+         call reporter%add_column(FormattedTextColumn('Min PE)','(1x,i4.4,1x)', 6, ExclusiveColumn('MIN_PE'))) 
+        report_lines = reporter%generate_report(t_prof)
+         if (mapl_am_I_root()) then 
+            write(*,'(a)')'Final profile'
+            write(*,'(a)')'============='
+            do i = 1, size(report_lines)
+               write(*,'(a)') report_lines(i)
+            end do
+            write(*,'(a)') ''
+         end if
+    end subroutine generate_report
+ 
     end program ut_ReGridding 

--- a/base/Regrid_Util.F90
+++ b/base/Regrid_Util.F90
@@ -143,7 +143,7 @@ CONTAINS
          read(astr,*)cs_stretch_param(1)
          call get_command_argument(i+2,astr)
          read(astr,*)cs_stretch_param(2)
-         call get_command_argument(i+2,astr)
+         call get_command_argument(i+3,astr)
          read(astr,*)cs_stretch_param(3)
       case('-method')
          call get_command_argument(i+1,RegridMth)


### PR DESCRIPTION
This PR only affects the Regrid_Util.x code in MAPL which is a code I created for regridding History output a long time ago due to repeated user requests. I have modified this utility to use the grid/regridder managers and grid factories in MAPL. When this was first created the cubed-sphere grid factory was still in FV3 so if I wanted this to be self contained to MAPL so I could not use the factory. Now that the cubed-sphere factory is in MAPL I was able to clean this up.

I have modified the code to now use all our grid/regridder manager framework to create the grids, regridders, and applying the regridders. I have also added the options to pass in cubed-sphere stretch parameters if the output grid is a cubed-sphere. Finally I have instrumented it with the MAPL_Profiling layer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
