### PR TITLE
Allow cap driver to retrieve GEOS state

### DIFF
--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -72,6 +72,8 @@ module MAPL_CapGridCompMod
      procedure :: record_state
      procedure :: refresh_state
      procedure :: destroy_state
+     procedure :: get_field_from_import
+     procedure :: get_field_from_internal
   end type MAPL_CapGridComp
 
   type :: MAPL_CapGridComp_Wrapper
@@ -1232,6 +1234,43 @@ contains
     _RETURN(_SUCCESS)
 
   end subroutine refresh_state
+
+  subroutine get_field_from_import(this,field_name,state_name,field,rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    character(len=*), intent(in) :: field_name
+    character(len=*), intent(in) :: state_name
+    type(ESMF_Field), intent(inout) :: field
+    integer, intent(out) :: rc
+    integer :: status
+
+    type(ESMF_State) :: state
+
+    call MAPL_ImportStateGet(this%gcs(this%root_id),this%child_imports(this%root_id),&
+         state_name,state,rc=status)
+    _VERIFY(status)
+    call ESMF_StateGet(state,trim(field_name),field,rc=status)
+    _VERIFY(status)
+    _RETURN(_SUCCESS)
+
+  end subroutine get_field_from_import
+
+  subroutine get_field_from_internal(this,field_name,state_name,field,rc)
+    class(MAPL_CapGridComp), intent(inout) :: this
+    character(len=*), intent(in) :: field_name
+    character(len=*), intent(in) :: state_name
+    type(ESMF_field), intent(inout) :: field
+    integer, intent(out) :: rc
+    integer :: status
+
+    type(ESMF_State) :: state
+
+    call MAPL_InternalESMFStateGet(this%gcs(this%root_id),state_name,state,rc=status)
+    _VERIFY(status)
+    call ESMF_StateGet(state,trim(field_name),field,rc=status)
+    _VERIFY(status)
+    _RETURN(_SUCCESS)
+
+  end subroutine get_field_from_internal
 
   subroutine destroy_state(this, rc)
     class(MAPL_CapGridComp), intent(inout) :: this

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -188,6 +188,7 @@ module MAPL_GenericMod
   public MAPL_ExchangeGridGet
   public MAPL_ExchangeGridSet
   public MAPL_ImportStateGet
+  public MAPL_InternalESMFStateGet
   public MAPL_ExportStateGet
   public MAPL_GetChildLocstream
   public MAPL_CopyFriendliness
@@ -210,9 +211,7 @@ module MAPL_GenericMod
   public MAPL_SetStateSave
   public MAPL_DestroyStateSave
   public MAPL_GenericStateSave
-  public MAPL_StateSave 
   public MAPL_GenericStateRestore
-  public MAPL_StateRestore
 !BOP  
   ! !PUBLIC TYPES:
 
@@ -8534,6 +8533,53 @@ recursive subroutine MAPL_WireComponent(GC, RC)
    return
  end subroutine MAPL_ImportStateGet
 
+ recursive subroutine MAPL_InternalESMFStateGet ( GC, name, result, rc )
+    type(ESMF_GridComp), intent(INout)  :: GC
+    character(len=*),  intent(IN   ) :: name
+    type (ESMF_State), intent(  OUT) :: result
+    integer,           intent(  OUT) :: rc
+    
+    character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_InternalESMFStateGet"
+    integer                               :: status 
+    integer                               :: I
+    logical                               :: have_ens
+    character(len=ESMF_MAXSTR)            :: sname
+    type (MAPL_MetaComp),pointer          :: STATE 
+    type(ESMF_State)                      :: internal
+    
+
+    have_ens = index(name,":") /= 0
+   
+    call MAPL_InternalStateGet ( GC, STATE, RC=STATUS)
+    _VERIFY(STATUS)
+    call MAPL_Get(STATE,INTERNAL_ESMF_STATE=internal,rc=status)
+    _VERIFY(status)
+    call ESMF_StateGet(internal, name=sname, rc=status)
+    _VERIFY(STATUS)
+    if (have_ens) then
+       if (sname == trim(name) // '_INTERNAL') then
+          result = internal
+          _RETURN(ESMF_SUCCESS)
+       end if
+    else
+       if (sname(index(sname,":")+1:) == trim(name) // '_INTERNAL') then
+          result = internal
+          _RETURN(ESMF_SUCCESS)
+       end if
+    end if
+
+    if (associated(STATE%GCS)) then
+       do I = 1, size(STATE%GCS)
+          call MAPL_InternalESMFStateGet(STATE%GCS(I), name, result, RC=STATUS)
+          if (status == ESMF_SUCCESS) then
+             _RETURN(ESMF_SUCCESS)
+          end if
+       end do
+    end if
+   rc = ESMF_FAILURE
+   return
+ end subroutine MAPL_InternalESMFStateGet
+
  recursive subroutine MAPL_GetChildLocstream(GC, result, name, rc)
     type(ESMF_GridComp),   intent(INout) :: GC
     type (MAPL_LocStream), intent(  OUT) :: result
@@ -9820,6 +9866,7 @@ end subroutine MAPL_READFORCINGX
     integer :: status
     character(len=:), allocatable :: tmpstr
     character(len=ESMF_MAXSTR) :: filename
+    character(len=ESMF_MAXSTR)                  :: CFILETYPE
 
     call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
     _VERIFY(STATUS)
@@ -9898,69 +9945,36 @@ end subroutine MAPL_READFORCINGX
        deallocate(tmpstr)
     end if
 
-    ! call the actual record method
-    call MAPL_StateSave (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
-    _VERIFY(STATUS)
-    _RETURN(_SUCCESS)
+    if (allocated(state%initial_state%imp_fname)) then
+       call    MAPL_GetResource( STATE, CFILETYPE, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
+       if ( STATUS/=ESMF_SUCCESS  .or.  CFILETYPE == "default" ) then
+          call MAPL_GetResource( STATE, CFILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+          _VERIFY(STATUS)
+       end if
+       call MAPL_ESMFStateWriteToFile(IMPORT, CLOCK, &
+                                      STATE%initial_state%IMP_FNAME, &
+                                      CFILETYPE, STATE, .FALSE., oClients = o_Clients, &
+                                    RC=STATUS)
+       _VERIFY(STATUS)
+    end if
 
+    if (allocated(state%initial_state%int_fname)) then
+       call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
+       _VERIFY(STATUS)
+       call    MAPL_GetResource( STATE, CFILETYPE, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
+       if ( STATUS/=ESMF_SUCCESS  .or.  CFILETYPE == "default" ) then
+          call MAPL_GetResource( STATE, CFILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
+          _VERIFY(STATUS)
+       end if
+       call MAPL_ESMFStateWriteToFile(STATE%INTERNAL, CLOCK, &
+                                      STATE%initial_state%INT_FNAME, &
+                                      CFILETYPE, STATE, hdr/=0, oClients = o_Clients, &
+                                    RC=STATUS)
+       _VERIFY(STATUS)
+    end if
+
+    _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_GenericStateSave
-
-subroutine MAPL_StateSave( GC, IMPORT, EXPORT, CLOCK, RC )
-
-    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
-    type(ESMF_State),    intent(inout) :: IMPORT ! import state
-    type(ESMF_State),    intent(inout) :: EXPORT ! export state
-    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
-    integer, optional,   intent(  out) :: RC     ! Error code:
-
-  character(len=ESMF_MAXSTR)                  :: IAm
-  character(len=ESMF_MAXSTR)                  :: COMP_NAME
-  integer                                     :: STATUS
-
-  type (MAPL_MetaComp), pointer               :: STATE
-  integer                                     :: hdr
-  character(len=ESMF_MAXSTR)                  :: FILETYPE
-
-  _UNUSED_DUMMY(EXPORT)
-
-  Iam = "MAPL_StateSave"
-  call ESMF_GridCompGet(GC, name=COMP_NAME, RC=STATUS )
-  _VERIFY(STATUS)
-  Iam = trim(COMP_NAME) // Iam
-
-  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
-  _VERIFY(STATUS)
-
-  if (allocated(state%initial_state%imp_fname)) then
-     call    MAPL_GetResource( STATE, FILETYPE, LABEL="IMPORT_CHECKPOINT_TYPE:",                  RC=STATUS )
-     if ( STATUS/=ESMF_SUCCESS  .or.  FILETYPE == "default" ) then
-        call MAPL_GetResource( STATE, FILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
-        _VERIFY(STATUS)
-     end if
-     call MAPL_ESMFStateWriteToFile(IMPORT, CLOCK, &
-                                    STATE%initial_state%IMP_FNAME, &
-                                    FILETYPE, STATE, .FALSE., oClients = o_Clients, &
-                                    RC=STATUS)
-     _VERIFY(STATUS)
-  end if
-
-  if (allocated(state%initial_state%int_fname)) then
-     call    MAPL_GetResource( STATE, hdr,      LABEL="INTERNAL_HEADER:",         default=0,      RC=STATUS )
-     _VERIFY(STATUS)
-     call    MAPL_GetResource( STATE, FILETYPE, LABEL="INTERNAL_CHECKPOINT_TYPE:",                RC=STATUS )
-     if ( STATUS/=ESMF_SUCCESS  .or.  FILETYPE == "default" ) then
-        call MAPL_GetResource( STATE, FILETYPE, LABEL="DEFAULT_CHECKPOINT_TYPE:", default='pnc4', RC=STATUS )
-        _VERIFY(STATUS)
-     end if
-     call MAPL_ESMFStateWriteToFile(STATE%INTERNAL, CLOCK, &
-                                    STATE%initial_state%INT_FNAME, &
-                                    FILETYPE, STATE, hdr/=0, oClients = o_Clients, &
-                                    RC=STATUS)
-     _VERIFY(STATUS)
-  end if
-
-  _RETURN(ESMF_SUCCESS)
-end subroutine MAPL_StateSave
 
 
   recursive subroutine MAPL_GenericStateRestore ( GC, IMPORT, EXPORT, CLOCK, RC )
@@ -9987,6 +10001,7 @@ end subroutine MAPL_StateSave
   character(len=ESMF_MAXSTR)                  :: filetypechar
   character(len=4)                            :: extension
   class(BaseProfiler), pointer                :: t_p
+  integer                                     :: hdr, unit
 !=============================================================================
 
 !  Begin...
@@ -10018,50 +10033,6 @@ end subroutine MAPL_StateSave
 ! ------------------
   call MAPL_GenericStateClockOn(STATE,"--GenRefreshMine")
 
-     call MAPL_StateRestore (GC, IMPORT, EXPORT, CLOCK, RC=STATUS )
-     _VERIFY(STATUS)
-
-  _RETURN(ESMF_SUCCESS)
-end subroutine MAPL_GenericStateRestore
-
-subroutine MAPL_StateRestore( GC, IMPORT, EXPORT, CLOCK, RC )
-
-! !ARGUMENTS:
-
-    type(ESMF_GridComp), intent(inout) :: GC     ! composite gridded component
-    type(ESMF_State),    intent(inout) :: IMPORT ! import state
-    type(ESMF_State),    intent(inout) :: EXPORT ! export state
-    type(ESMF_Clock),    intent(inout) :: CLOCK  ! the clock
-    integer, optional,   intent(  out) :: RC     ! Error code:
-                                                 ! = 0 all is well
-                                                 ! otherwise, error
-!EOPI
-
-! LOCAL VARIABLES
-
-  character(len=ESMF_MAXSTR)                  :: IAm
-  character(len=ESMF_MAXSTR)                  :: COMP_NAME
-  integer                                     :: STATUS
-
-  type (MAPL_MetaComp), pointer               :: STATE
-  integer                                     :: hdr, unit
-  _UNUSED_DUMMY(EXPORT)
-
-!  Begin...
-
-  Iam = "MAPL_StateRefresh"
-  call ESMF_GridCompGet(GC, name=COMP_NAME, RC=STATUS )
-  _VERIFY(STATUS)
-  Iam = trim(COMP_NAME) // Iam
-
-
-! Retrieve the pointer to the state
-!----------------------------------
-
-  call MAPL_InternalStateRetrieve(GC, STATE, RC=STATUS)
-  _VERIFY(STATUS)
-
-
   if (allocated(STATE%initial_state%imp_fname)) then
      call MAPL_ESMFStateReadFromFile(IMPORT, CLOCK, &
                                      STATE%initial_state%IMP_FNAME, &
@@ -10084,7 +10055,7 @@ subroutine MAPL_StateRestore( GC, IMPORT, EXPORT, CLOCK, RC )
   end if
 
   _RETURN(ESMF_SUCCESS)
-end subroutine MAPL_StateRestore
+end subroutine MAPL_GenericStateRestore
 
   recursive subroutine MAPL_DestroyStateSave(gc,rc)
     type(ESMF_GridComp), intent(inout) :: GC    


### PR DESCRIPTION
This satisfies another request by the JEDI developers. Since they will ultimately be doing DA from one executable they want to be able to modify the GEOS state, i.e. maybe JEDI does a forecast, then an analysis, then backup, rerun this time doing something like IAU where you will have to perturb the model state. 

I've added a new call in Generic to retrieve the internal state of a named component, just like we already have for the import state of a component in a MAPL hierarchy.

Then I added two hooks in the CapGridComp so whatever is driving the Cap JEDI, or something else can reach in and pull the fields from the appropriate components it needs to act on.

Finally I cleaned up the memory checkpointing and simplified it into one routine each for the checkpoint and restore. There was no reason it needed to be broken up as the initial implementation was.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
