### PR TITLE
Adds a mpeu StrTemplate Replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added routine to finalize the ioservers so that it can be called by another application using cap, like JEDI
 - Re-added CircleCI with FV3 standalone test
 - Add ability to run multiple forward time integrations within one execution for JEDI (#529)
+- Added mpeu `StrTemplate` replacement to MAPL
 
 ### Changed
 

--- a/base/StringTemplate.F90
+++ b/base/StringTemplate.F90
@@ -15,6 +15,7 @@ character(len=2), parameter :: valid_tokens(13) = ["y4","y2","m1","m2","mc","Mc"
 character(len=3),parameter :: mon_lc(12) = [&
    'jan','feb','mar','apr','may','jun',   &
    'jul','aug','sep','oct','nov','dec']
+integer, parameter :: uninit_time = -999999
 
 contains
    subroutine StrTemplate(str, tmpl, class, xid, nymd, nhms, stat, preserve)
@@ -31,14 +32,10 @@ contains
       _UNUSED_DUMMY(class)
 
       call fill_grads_template(str, tmpl, &
-            experiment_id=xid, nymd=nymd, nhms=nhms,rc=stat)
-
-      if (present(preserve)) then
-         if (preserve) stat = 1
-      end if
+            experiment_id=xid, nymd=nymd, nhms=nhms,preserve=preserve, rc=stat)
    end subroutine StrTemplate
 
-   subroutine fill_grads_template(output_string,template,unusable,experiment_id,nymd,nhms,time,rc)
+   subroutine fill_grads_template(output_string,template,unusable,experiment_id,nymd,nhms,time,preserve,rc)
       character(len=*), intent(out) :: output_string
       character(len=*), intent(in)  :: template
       class(keywordEnforcer), optional, intent(in) :: unusable
@@ -46,22 +43,28 @@ contains
       integer, intent(in), optional :: nymd
       integer, intent(in), optional :: nhms
       type(ESMF_Time), intent(in), optional :: time
+      logical, intent(in), optional :: preserve
       integer, intent(out), optional :: rc
 
       integer :: year,month,day,hour,minute,second,tmpl_length,output_length
       integer  :: i, m, istp, k, kstp, i1, i2
       character(len=1) :: c0,c1,c2
       character(len=4) :: sbuf
-      logical :: valid_token
+      logical :: valid_token,preserve_
       integer :: status
      
       _UNUSED_DUMMY(unusable)
-      year=-1
-      month=-1
-      day=-1
-      hour=-1
-      minute=-1
-      second=-1
+      if (present(preserve)) then
+         preserve_=preserve
+      else
+         preserve_=.false.
+      end if
+      year=uninit_time
+      month=uninit_time
+      day=uninit_time
+      hour=uninit_time
+      minute=uninit_time
+      second=uninit_time
       if (present(time)) then
          _ASSERT(.not.present(nymd),'can not specify an ESMF_Time and an integer time')
          _ASSERT(.not.present(nhms),'can not specify an ESMF_Time and an integer time')
@@ -103,6 +106,9 @@ contains
                   output_string(k:m)=experiment_id
                   k=m+1
                   cycle
+               else if (preserve_) then
+                  output_string(k:k+1)="%s"
+                  k=k+1
                else
                   _ASSERT(.false.,"Using %s token with no experiment id")
                end if
@@ -118,8 +124,10 @@ contains
                valid_token = check_token(c1//c2) 
                if (valid_token) then
                   istp=3
-                  _ASSERT(present(nymd) .or. present(nhms) .or. present(time),'Using token with no time')
-                  sbuf = evaluate_token(c1//c2,year,month,day,hour,minute)
+                  if (.not.preserve_) then
+                     _ASSERT(present(nymd) .or. present(nhms) .or. present(time),'Using token with no time')
+                  end if
+                  sbuf = evaluate_token(c1//c2,year,month,day,hour,minute,preserve_)
                   kstp = len_trim(sbuf)
                   m=k+kstp-1
                   output_string(k:m)=sbuf
@@ -150,57 +158,90 @@ contains
       enddo
    end function check_token
 
-   function evaluate_token(token,year,month,day,hour,minute) result(buffer)
+   function evaluate_token(token,year,month,day,hour,minute,preserve) result(buffer)
       character(len=2), intent(in) :: token
       integer, intent(in) :: year,month,day,hour,minute
+      logical, intent(in) :: preserve
       character(len=4) :: buffer
       character(len=1) :: c1,c2
       c1=token(1:1)
       c2=token(2:2)
       select case(c1)
       case("y")
-         if (c2 == "2" ) then
-            write(buffer,'(i2.2)')mod(year,100)
-         else if (c2 == "4" ) then
-            write(buffer,'(i4.4)')year
+         if (.not.skip_token(year,preserve)) then
+            if (c2 == "2" ) then
+               write(buffer,'(i2.2)')mod(year,100)
+            else if (c2 == "4" ) then
+               write(buffer,'(i4.4)')year
+            end if
+         else
+            buffer="%"//token
          end if
       case("m")
-         if (c2 == "c") then
-            buffer = mon_lc(month)
-         else if (c2 == "1") then
-            if (day < 10) then
-               write(buffer,'(i1)')month
-            else
-               write(buffer,'(i2)')month
+         if (.not.skip_token(month,preserve)) then
+            if (c2 == "c") then
+               buffer = mon_lc(month)
+            else if (c2 == "1") then
+               if (day < 10) then
+                  write(buffer,'(i1)')month
+               else
+                  write(buffer,'(i2)')month
+               end if
+            else if (c2 == "2") then
+               write(buffer,'(i2.2)')month 
             end if
-         else if (c2 == "2") then
-            write(buffer,'(i2.2)')month 
+         else
+            buffer="%"//token
          end if
       case("d")
-         if (c2 == "2") then
-            write(buffer,'(i2.2)')day
-         else if (c1 == "1") then
-            if (day < 10) then
-               write(buffer,'(i1)')day
-            else
-               write(buffer,'(i2)')day
+         if (.not.skip_token(day,preserve)) then
+            if (c2 == "2") then
+               write(buffer,'(i2.2)')day
+            else if (c1 == "1") then
+               if (day < 10) then
+                  write(buffer,'(i1)')day
+               else
+                  write(buffer,'(i2)')day
+               end if
             end if
+         else
+            buffer="%"//token
          end if
       case("h")
-         if (c2 == "3") then
-            write(buffer,'(i3.3)')hour
-         else if (c2 == "2") then
-            write(buffer,'(i2.2)')hour
-         else if (c1 == "1") then
-            if (day < 10) then
-               write(buffer,'(i1)')hour
-            else
-               write(buffer,'(i2)')hour
+         if (.not.skip_token(hour,preserve)) then
+            if (c2 == "3") then
+               write(buffer,'(i3.3)')hour
+            else if (c2 == "2") then
+               write(buffer,'(i2.2)')hour
+            else if (c1 == "1") then
+               if (day < 10) then
+                  write(buffer,'(i1)')hour
+               else
+                  write(buffer,'(i2)')hour
+               end if
             end if
+         else
+            buffer="%"//token
          end if
       case("n")
-         write(buffer,'(i2.2)')minute
+         if (.not.skip_token(minute,preserve)) then
+            write(buffer,'(i2.2)')minute
+         else
+            buffer="%"//token
+         end if
       end select
 
    end function evaluate_token
+
+   function skip_token(val,preserve) result(skip)
+      integer :: val
+      logical :: preserve
+
+      logical :: skip
+
+      skip = .false.
+      if (val==uninit_time .and. preserve) skip = .true.
+
+   end function skip_token
+
 end module MAPL_StringTemplate

--- a/base/StringTemplate.F90
+++ b/base/StringTemplate.F90
@@ -9,6 +9,7 @@ implicit none
 private
 
 public fill_grads_template
+public StrTemplate
 
 character(len=2), parameter :: valid_tokens(13) = ["y4","y2","m1","m2","mc","Mc","MC","d1","d2","h1","h2","h3","n2"]
 character(len=3),parameter :: mon_lc(12) = [&
@@ -16,6 +17,20 @@ character(len=3),parameter :: mon_lc(12) = [&
    'jul','aug','sep','oct','nov','dec']
 
 contains
+   subroutine StrTemplate(str, tmpl, class, xid, nymd, nhms, stat, preserve)
+      character(len=*), intent(out) :: str
+      character(len=*), intent(in ) :: tmpl
+
+      character(len=*), optional, intent(in ) :: class
+      character(len=*), optional, intent(in ) :: xid
+      integer,          optional, intent(in ) :: nymd
+      integer,          optional, intent(in ) :: nhms
+      integer,          optional, intent(out) :: stat
+      logical,          optional, intent(in ) :: preserve
+
+      call fill_grads_template(str, tmpl, &
+            experiment_id=xid, nymd=nymd, nhms=nhms,rc=stat)
+   end subroutine StrTemplate
 
    subroutine fill_grads_template(output_string,template,unusable,experiment_id,nymd,nhms,time,rc)
       character(len=*), intent(out) :: output_string

--- a/base/StringTemplate.F90
+++ b/base/StringTemplate.F90
@@ -28,6 +28,11 @@ contains
       integer,          optional, intent(out) :: stat
       logical,          optional, intent(in ) :: preserve
 
+      _UNUSED_DUMMY(class)
+
+      ! This option is not currently supported
+      _UNUSED_DUMMY(preserve)
+
       call fill_grads_template(str, tmpl, &
             experiment_id=xid, nymd=nymd, nhms=nhms,rc=stat)
    end subroutine StrTemplate

--- a/base/StringTemplate.F90
+++ b/base/StringTemplate.F90
@@ -30,11 +30,12 @@ contains
 
       _UNUSED_DUMMY(class)
 
-      ! This option is not currently supported
-      _UNUSED_DUMMY(preserve)
-
       call fill_grads_template(str, tmpl, &
             experiment_id=xid, nymd=nymd, nhms=nhms,rc=stat)
+
+      if (present(preserve)) then
+         if (preserve) stat = 1
+      end if
    end subroutine StrTemplate
 
    subroutine fill_grads_template(output_string,template,unusable,experiment_id,nymd,nhms,time,rc)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

Adds a wrapper for `fill_grads_template` which allows MAPL to provide the same interface (name and arguments) as the `StrTemplate` from `GMAO_Shared/GMAO_mpeu` (see [`m_StrTemplate.F90`](https://github.com/GEOS-ESM/GMAO_Shared/blob/main/GMAO_mpeu/m_StrTemplate.F90)). 

## Description
<!--- Describe your changes in detail -->

Replicates all the functionality of the mpeu version except for true support of the `preserve` option.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
GOCART2G should be independent of the `GMAO_Shared`, but it currently needs the mpeu provided `StrTemplate`. Since GOCART2G relies on MAPL, it makes sense to provide this functionality directly from MAPL.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
