### PR TITLE
Feature/restart by oserver refactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to ESMA_cmake v3.1.2
 - Update GitHub Actions to use Ubuntu 20/GCC 10 image
 - Updated CircleCI image to use 6.0.16 Baselibs
+- Refactor the option WRITE_RESTART_BY_OSERVER
+- Change the writing rank calculation in ServerThread.F90
 
 ### Fixed
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -2907,8 +2907,9 @@ module MAPL_IOMod
                    lMemRef = LocalMemReference(pFIO_REAL32,[0])
                    call c_f_pointer(lMemRef%base_address, gvar_1d, shape=[0])
                 endif
-                
-                call ArrayGather(var_1d, gvar_1d, grid, mask=mask, rc=status)
+                if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then 
+                   call ArrayGather(var_1d, gvar_1d, grid, mask=mask, rc=status)
+                endif
                 call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1], &
                              global_start=[1], global_count=[size_1d])
              else
@@ -2945,7 +2946,9 @@ module MAPL_IOMod
                    call c_f_pointer(lMemRef%base_address, gvr8_1d, shape=[0])
                 endif
 
-                call ArrayGather(vr8_1d, gvr8_1d, grid, mask=mask, rc=status)
+                if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then 
+                   call ArrayGather(vr8_1d, gvr8_1d, grid, mask=mask, rc=status)
+                endif
                 call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1], &
                              global_start=[1], global_count=[size_1d])
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -2903,6 +2903,7 @@ module MAPL_IOMod
                 if( MAPL_AM_I_ROOT())  then
                    lMemRef = LocalMemReference(pFIO_REAL32,[size_1d])
                    call c_f_pointer(lMemRef%base_address, gvar_1d, shape=[size_1d])
+                   if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) gvar_1d = var_1d
                 else
                    lMemRef = LocalMemReference(pFIO_REAL32,[0])
                    call c_f_pointer(lMemRef%base_address, gvar_1d, shape=[0])
@@ -2941,6 +2942,7 @@ module MAPL_IOMod
                 if(MAPL_AM_I_ROOT()) then
                    lMemRef = LocalMemReference(pFIO_REAL64,[size_1d])
                    call c_f_pointer(lMemRef%base_address, gvr8_1d, shape=[size_1d])
+                   if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) gvr8_1d = vr8_1d
                 else
                    lMemRef = LocalMemReference(pFIO_REAL64,[0])
                    call c_f_pointer(lMemRef%base_address, gvr8_1d, shape=[0])

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -2900,28 +2900,30 @@ module MAPL_IOMod
              endif
  
              if (arrdes%write_restart_by_oserver) then
-                if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                if( MAPL_AM_I_ROOT())  then
                    lMemRef = LocalMemReference(pFIO_REAL32,[size_1d])
                    call c_f_pointer(lMemRef%base_address, gvar_1d, shape=[size_1d])
                 else
                    lMemRef = LocalMemReference(pFIO_REAL32,[0])
                    call c_f_pointer(lMemRef%base_address, gvar_1d, shape=[0])
                 endif
-             endif
-
-             if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
-                call MAPL_VarWrite(formatter, name, var_1d, layout=layout, arrdes=arrdes, mask=mask, gvar_out = gvar_1d, rc=status)
-             else if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) then
-                call MAPL_VarWrite(formatter, name, var_1d, layout=layout, arrdes=arrdes,gvar_out = gvar_1d, rc=status)
-             else
-                _RETURN(ESMF_FAILURE)
-             end if
-
-             if (arrdes%write_restart_by_oserver) then
+                
+                call ArrayGather(var_1d, gvar_1d, grid, mask=mask, rc=status)
                 call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1], &
                              global_start=[1], global_count=[size_1d])
-             endif
+             else
 
+                if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
+                   call MAPL_VarWrite(formatter, name, var_1d, layout=layout, arrdes=arrdes, mask=mask, rc=status)
+                else if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) then
+                   call MAPL_VarWrite(formatter, name, var_1d, layout=layout, arrdes=arrdes, rc=status)
+                else
+                   _RETURN(ESMF_FAILURE)
+                end if
+
+             endif
+          else
+             _ASSERT(.false., "Cannot write unassociated var-1d")
           end if
        else
           call ESMF_ArrayGet(array, localDE=0, farrayptr=vr8_1d, rc=status)
@@ -2935,28 +2937,31 @@ module MAPL_IOMod
              endif
 
              if (arrdes%write_restart_by_oserver) then
-                if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                if(MAPL_AM_I_ROOT()) then
                    lMemRef = LocalMemReference(pFIO_REAL64,[size_1d])
                    call c_f_pointer(lMemRef%base_address, gvr8_1d, shape=[size_1d])
                 else
                    lMemRef = LocalMemReference(pFIO_REAL64,[0])
                    call c_f_pointer(lMemRef%base_address, gvr8_1d, shape=[0])
                 endif
-             endif
 
-             if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
-                call MAPL_VarWrite(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, mask=mask, gvar_out = gvr8_1d, rc=status)
-             else if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) then
-                call MAPL_VarWrite(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, gvar_out = gvr8_1d, rc=status)
-             else
-                _RETURN(ESMF_FAILURE)
-             end if
-
-             if (arrdes%write_restart_by_oserver) then
+                call ArrayGather(vr8_1d, gvr8_1d, grid, mask=mask, rc=status)
                 call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1], &
                              global_start=[1], global_count=[size_1d])
-             endif
 
+             else
+
+                if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
+                   call MAPL_VarWrite(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, mask=mask, rc=status)
+                else if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) then
+                   call MAPL_VarWrite(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, rc=status)
+                else
+                   _RETURN(ESMF_FAILURE)
+                end if
+
+             endif
+          else
+             _ASSERT(.false., "Cannot write unassociated var8-1d")
           end if
        endif
     else if (rank == 2) then
@@ -2967,27 +2972,31 @@ module MAPL_IOMod
              if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
 
                 if (arrdes%write_restart_by_oserver) then
-                   if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                   if(MAPL_AM_I_ROOT()) then
                       lMemRef = LocalMemReference(pFIO_REAL32,[arrdes%im_world, size(var_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvar_2d, shape=[arrdes%im_world, size(var_2d,2)])
                    else
                       lMemRef = LocalMemReference(pFIO_REAL32,[0,size(var_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvar_2d, shape=[0, size(var_2d,2)])
                    endif
-                endif
 
-                do J = 1,size(var_2d,2)
-                   call MAPL_VarWrite(formatter, name, var_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, gvar_out=gvar_2d(:,j), rc=status)
-                end do
+                   call ArrayGather(var_2d, gvar_2d, grid, mask=mask, rc=status)
+                   call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
+                                global_start=[1,1], global_count=[arrdes%im_world,size(var_2d,2)])
 
-                if (arrdes%write_restart_by_oserver) then
-                     call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
-                                 global_start=[1,1], global_count=[arrdes%im_world,size(var_2d,2)])
+                else
+
+                   do J = 1,size(var_2d,2)
+                      call MAPL_VarWrite(formatter, name, var_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, rc=status)
+                   end do
+
                 endif
 
              else
                call MAPL_VarWrite(formatter, name, var_2d, arrdes=arrdes, oClients=oClients, rc=status)
              endif ! dims
+          else
+             _ASSERT(.false., "Cannot write unassociated var-2d")
           endif ! associated 
        else
           call ESMF_ArrayGet(array, localDE=0, farrayptr=vr8_2d, rc=status)
@@ -2996,27 +3005,30 @@ module MAPL_IOMod
              if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
 
                 if (arrdes%write_restart_by_oserver) then
-                   if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                   if( MAPL_AM_I_ROOT() ) then
                       lMemRef = LocalMemReference(pFIO_REAL64,[arrdes%im_world,size(vr8_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvr8_2d, shape=[arrdes%im_world,size(vr8_2d,2)])
                    else
                       lMemRef = LocalMemReference(pFIO_REAL64,[0,size(vr8_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvr8_2d, shape=[0,size(vr8_2d,2)])
                    endif
-                endif
 
-                do J = 1,size(vr8_2d,2)
-                   call MAPL_VarWrite(formatter, name, vr8_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, gvar_out=gvr8_2d(:,j), rc=status)
-                end do
-
-                if (arrdes%write_restart_by_oserver) then
-                     call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
+                   call ArrayGather(vr8_2d, gvr8_2d, grid, mask=mask, rc=status) 
+                   call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
                                  global_start=[1,1], global_count=[arrdes%im_world,size(vr8_2d,2)])
+                else
+
+                   do J = 1,size(vr8_2d,2)
+                      call MAPL_VarWrite(formatter, name, vr8_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, rc=status)
+                   end do
+
                 endif
 
              else
                 call MAPL_VarWrite(formatter, name, vr8_2d, arrdes=arrdes, oClients=oClients, rc=status)
              end if
+          else
+             _ASSERT(.false., "Cannot write unassociated var8-2d")
           end if
        endif
     else if (rank == 3) then
@@ -3027,30 +3039,34 @@ module MAPL_IOMod
              if (DIMS == MAPL_DimsTileOnly) then
 
                 if (arrdes%write_restart_by_oserver) then
-                   if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                   if( MAPL_Am_I_Root() ) then
                       lMemRef = LocalMemReference(pFIO_REAL32,[arrdes%im_world, size(var_3d,2), size(var_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvar_3d, shape=[arrdes%im_world, size(var_3d,2), size(var_3d,3)])
                    else
                       lMemRef = LocalMemReference(pFIO_REAL32,[0,size(var_3d,2), size(var_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvar_3d, shape=[0, size(var_3d,2), size(var_3d,3)])
                    endif
-                endif
-
-                do J = 1,size(var_3d,2)
-                   do K = 1,size(var_3d,3)
-                      call MAPL_VarWrite(formatter, name, var_3d(:,J,K), layout=layout, arrdes=arrdes, mask=mask, &
-                           & offset1=j, offset2=k, gvar_out=gvar_3d(:,J,K), rc=status)
-                   end do
-                end do
-
-                if (arrdes%write_restart_by_oserver) then
+                   do k = 1, size(var_3d,3)
+                      call ArrayGather(var_3d(:,:,k), gvar_3d(:,:,k), grid, mask=mask, rc=status)
+                   enddo
                    call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1,1], &
                                  global_start=[1,1,1], global_count=[arrdes%im_world,size(var_3d,2),size(var_3d,3)])
+                else
+
+                   do J = 1,size(var_3d,2)
+                      do K = 1,size(var_3d,3)
+                         call MAPL_VarWrite(formatter, name, var_3d(:,J,K), layout=layout, arrdes=arrdes, mask=mask, &
+                           & offset1=j, offset2=k, rc=status)
+                      end do
+                   end do
+
                 endif
 
              else
                 call MAPL_VarWrite(formatter, name, var_3d, arrdes=arrdes, oClients=oClients, rc=status)
              endif
+          else
+             _ASSERT(.false., "Cannot write unassociated var-3d")
           end if
        else
           call ESMF_ArrayGet(array, localDE=0, farrayptr=vr8_3d, rc=status)
@@ -3059,33 +3075,36 @@ module MAPL_IOMod
              if (DIMS == MAPL_DimsTileOnly) then
 
                 if (arrdes%write_restart_by_oserver) then
-                   if(arrdes%writers_comm /= MPI_COMM_NULL) then
+                   if( MAPL_Am_I_Root() ) then
                       lMemRef = LocalMemReference(pFIO_REAL64,[arrdes%im_world,size(vr8_3d,2), size(vr8_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvr8_3d, shape=[arrdes%im_world,size(vr8_3d,2), size(vr8_3d,3)])
                    else
                       lMemRef = LocalMemReference(pFIO_REAL64,[0,size(vr8_3d,2), size(vr8_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvr8_3d, shape=[0,size(vr8_3d,2), size(vr8_3d,3)])
                    endif
-                endif
-
-                do J = 1,size(vr8_3d,2)
-                   do K = 1,size(vr8_3d,3)
-                      call MAPL_VarWrite(formatter, name, vr8_3d(:,J,K), layout=layout, arrdes=arrdes, mask=mask, &
-                           & offset1=j, offset2=k, gvar_out=gvr8_3d(:,J,K), rc=status)
-                   end do
-                end do
-
-                if (arrdes%write_restart_by_oserver) then
-                     call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1,1], &
+                   do k = 1, size(vr8_3d,3)
+                      call ArrayGather(vr8_3d(:,:,k), gvr8_3d(:,:,k), grid, mask=mask, rc=status)
+                   enddo
+                   call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1,1], &
                                  global_start=[1,1,1], global_count=[arrdes%im_world, size(vr8_3d,2), size(vr8_3d,3)])
+                else
+
+                   do J = 1,size(vr8_3d,2)
+                      do K = 1,size(vr8_3d,3)
+                         call MAPL_VarWrite(formatter, name, vr8_3d(:,J,K), layout=layout, arrdes=arrdes, mask=mask, &
+                           & offset1=j, offset2=k, rc=status)
+                      end do
+                   end do
+                
                 endif
 
              else
                 call MAPL_VarWrite(formatter, name, vr8_3d, arrdes=arrdes, oClients=oClients, rc=status)
              end if
+          else
+             _ASSERT(.false., "Cannot write unassociated var8-3d")
           end if
        endif
-
     else if (rank == 4) then
        if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
           _ASSERT(.false., "Unsupported tile/ungrid variable")
@@ -3096,14 +3115,13 @@ module MAPL_IOMod
           if (.not.associated(var_4d)) then
              _ASSERT(.false., "Cannot write unassociated vars")
           end if
-             call MAPL_VarWrite(formatter, name, var_4d, arrdes=arrdes, oClients=oClients, rc=status)
+          call MAPL_VarWrite(formatter, name, var_4d, arrdes=arrdes, oClients=oClients, rc=status)
        else
           call ESMF_ArrayGet(array, localDE=0, farrayptr=vr8_4d, rc=status)
           _VERIFY(STATUS)
           if (.not.associated(vr8_4d)) then
              _ASSERT(.false., "Cannot write unassociated vars")
           end if
-
           call MAPL_VarWrite(formatter, name, vr8_4d, arrdes=arrdes, oClients=oClients, rc=status)
        endif
     else
@@ -5733,7 +5751,7 @@ module MAPL_IOMod
 
 !---------------------------
 
-  subroutine MAPL_VarWriteNCpar_R4_1d(formatter, name, A, layout, ARRDES, MASK, offset1, offset2,gvar_out, RC)
+  subroutine MAPL_VarWriteNCpar_R4_1d(formatter, name, A, layout, ARRDES, MASK, offset1, offset2, RC)
 
     type(Netcdf4_Fileformatter)           , intent(IN   ) :: formatter
     character(len=*)            , intent(IN   ) :: name
@@ -5743,7 +5761,6 @@ module MAPL_IOMod
     integer,           optional , intent(IN   ) :: MASK(:)
     integer,           optional,  intent(IN   ) :: offset1
     integer,           optional,  intent(IN   ) :: offset2
-    real(kind=ESMF_KIND_R4),optional, intent(inout  ) :: gvar_out(:)
     integer,           optional , intent(  OUT) :: RC
 
 ! Local variables
@@ -5979,21 +5996,12 @@ module MAPL_IOMod
 !          print*,'start values are ',start
 !          print*,'count values are ',cnt
 
-          if (arrdes%write_restart_by_oserver) then
-             if(present(gvar_out)) then
-               gvar_out = gvar
-             else
-               _ASSERT(.false., "gvar_out should be present")
-             endif
-          else
-             call formatter%put_var(trim(name),gvar,start=start,count=cnt,rc=status)
-             if(status /= nf_noerr) then
-                print*,'Error writing variable ', status
-                print*, NF_STRERROR(status)
-                _VERIFY(STATUS)
-             endif
-          endif ! write_restart_by_oserver
-
+          call formatter%put_var(trim(name),gvar,start=start,count=cnt,rc=status)
+          if(status /= nf_noerr) then
+             print*,'Error writing variable ', status
+             print*, NF_STRERROR(status)
+             _VERIFY(STATUS)
+          endif
        endif
 
        call MPI_GROUP_FREE (GROUP, STATUS)
@@ -6035,21 +6043,12 @@ module MAPL_IOMod
              endif
 
              if (io_rank == 0) then
-
-                if (arrdes%write_restart_by_oserver) then
-                   if(present(gvar_out)) then
-                      gvar_out = A
-                   else
-                      _ASSERT(.false., "gvar_out should be present")
-                   endif
-                else
-                   call formatter%put_var(trim(name),A,start=start,count=cnt,rc=status)
-                   if(status /= nf_noerr) then
-                      print*,trim(IAm),'Error writing variable ',status
-                      print*, NF_STRERROR(status)
-                      _VERIFY(STATUS)
-                   endif
-                endif !write_restart_by_oserver
+                call formatter%put_var(trim(name),A,start=start,count=cnt,rc=status)
+                if(status /= nf_noerr) then
+                   print*,trim(IAm),'Error writing variable ',status
+                   print*, NF_STRERROR(status)
+                   _VERIFY(STATUS)
+                endif
              endif ! io_rank = 0
           endif ! arrdes%writers_comm/=MPI_COMM_NULL
        else ! not present(arrdes)
@@ -6068,7 +6067,7 @@ module MAPL_IOMod
     _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_VarWriteNCpar_R4_1d
 
-  subroutine MAPL_VarWriteNCpar_R8_1d(formatter, name, A, layout, ARRDES, MASK, offset1, offset2, gvar_out, RC)
+  subroutine MAPL_VarWriteNCpar_R8_1d(formatter, name, A, layout, ARRDES, MASK, offset1, offset2, RC)
 
     type(Netcdf4_Fileformatter)           , intent(IN   ) :: formatter
     character(len=*)            , intent(IN   ) :: name
@@ -6078,7 +6077,6 @@ module MAPL_IOMod
     integer,           optional , intent(IN   ) :: MASK(:)
     integer,           optional,  intent(IN   ) :: offset1
     integer,           optional,  intent(IN   ) :: offset2
-    real(kind=ESMF_KIND_R8), optional, intent(INOUT  ) :: gvar_out(:)
     integer,           optional , intent(  OUT) :: RC
 
 ! Local variables
@@ -6314,22 +6312,12 @@ module MAPL_IOMod
 !          print*,'start values are ',start
 !          print*,'count values are ',cnt
  
-          if (arrdes%write_restart_by_oserver) then
-             ! WJ note: only one writer, so size(gvar) == size(gvar_out)  
-             if (present(gvar_out)) then
-                gvar_out = gvar
-             else
-                _ASSERT(.false., "gvar_out should be present")
-             endif
-          else
-             call formatter%put_var(trim(name),gvar,start=start,count=cnt,rc=status)
-             if(status /= nf_noerr) then
-                print*,'Error writing variable ', status
-                print*, NF_STRERROR(status)
-                _VERIFY(STATUS)
-             endif
-          endif !write_restart_by_oserver
-
+          call formatter%put_var(trim(name),gvar,start=start,count=cnt,rc=status)
+          if(status /= nf_noerr) then
+             print*,'Error writing variable ', status
+             print*, NF_STRERROR(status)
+             _VERIFY(STATUS)
+          endif
        endif
 
        call MPI_GROUP_FREE (GROUP, STATUS)
@@ -6371,21 +6359,12 @@ module MAPL_IOMod
              endif
 
              if (io_rank == 0) then
-                if (arrdes%write_restart_by_oserver) then
-                   ! WJ note: only one writer, so size(gvar) == size(gvar_out)  
-                   if (present(gvar_out)) then
-                      gvar_out = A
-                   else
-                      _ASSERT(.false., "gvar_out should be present")
-                  endif
-               else
-                  call formatter%put_var(trim(name),A,start=start,count=cnt,rc=status)
-                  if(status /= nf_noerr) then
-                     print*,trim(IAm),'Error writing variable ',status
-                     print*, NF_STRERROR(status)
-                     _VERIFY(STATUS)
-                  endif
-               endif ! write_restart_by_oserver
+                call formatter%put_var(trim(name),A,start=start,count=cnt,rc=status)
+                if(status /= nf_noerr) then
+                   print*,trim(IAm),'Error writing variable ',status
+                   print*, NF_STRERROR(status)
+                   _VERIFY(STATUS)
+                endif
              endif ! io_rank
            endif
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -2979,8 +2979,9 @@ module MAPL_IOMod
                       lMemRef = LocalMemReference(pFIO_REAL32,[0,size(var_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvar_2d, shape=[0, size(var_2d,2)])
                    endif
-
-                   call ArrayGather(var_2d, gvar_2d, grid, mask=mask, rc=status)
+                   do J = 1,size(var_2d,2)
+                      call ArrayGather(var_2d(:,J), gvar_2d(:,J), grid, mask=mask, rc=status)
+                   enddo
                    call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
                                 global_start=[1,1], global_count=[arrdes%im_world,size(var_2d,2)])
 
@@ -3012,8 +3013,9 @@ module MAPL_IOMod
                       lMemRef = LocalMemReference(pFIO_REAL64,[0,size(vr8_2d,2)])
                       call c_f_pointer(lMemRef%base_address, gvr8_2d, shape=[0,size(vr8_2d,2)])
                    endif
-
-                   call ArrayGather(vr8_2d, gvr8_2d, grid, mask=mask, rc=status) 
+                   do J = 1,size(vr8_2d,2)
+                      call ArrayGather(vr8_2d(:,J), gvr8_2d(:,J), grid, mask=mask, rc=status) 
+                   enddo
                    call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1], &
                                  global_start=[1,1], global_count=[arrdes%im_world,size(vr8_2d,2)])
                 else
@@ -3046,9 +3048,12 @@ module MAPL_IOMod
                       lMemRef = LocalMemReference(pFIO_REAL32,[0,size(var_3d,2), size(var_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvar_3d, shape=[0, size(var_3d,2), size(var_3d,3)])
                    endif
-                   do k = 1, size(var_3d,3)
-                      call ArrayGather(var_3d(:,:,k), gvar_3d(:,:,k), grid, mask=mask, rc=status)
+                   do K = 1, size(var_3d,3)
+                      do J = 1,size(var_3d,2)
+                         call ArrayGather(var_3d(:,J,K), gvar_3d(:,J,K), grid, mask=mask, rc=status)
+                      enddo
                    enddo
+
                    call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1,1], &
                                  global_start=[1,1,1], global_count=[arrdes%im_world,size(var_3d,2),size(var_3d,3)])
                 else
@@ -3082,8 +3087,10 @@ module MAPL_IOMod
                       lMemRef = LocalMemReference(pFIO_REAL64,[0,size(vr8_3d,2), size(vr8_3d,3)])
                       call c_f_pointer(lMemRef%base_address, gvr8_3d, shape=[0,size(vr8_3d,2), size(vr8_3d,3)])
                    endif
-                   do k = 1, size(vr8_3d,3)
-                      call ArrayGather(vr8_3d(:,:,k), gvr8_3d(:,:,k), grid, mask=mask, rc=status)
+                   do K = 1, size(vr8_3d,3)
+                      do J = 1, size(vr8_3d,2)
+                         call ArrayGather(vr8_3d(:,J,K), gvr8_3d(:,J,K), grid, mask=mask, rc=status)
+                      enddo
                    enddo
                    call oClients%collective_stage_data(arrdes%collection_id, trim(arrdes%filename), name, lMemRef, start=[1,1,1], &
                                  global_start=[1,1,1], global_count=[arrdes%im_world, size(vr8_3d,2), size(vr8_3d,3)])

--- a/pfio/ServerThread.F90
+++ b/pfio/ServerThread.F90
@@ -639,7 +639,7 @@ contains
       ! (3) allocate the memory
       msize_words = offsets
       do collection_counter = 1, collection_total
-         rank = this%containing_server%get_writing_PE(collection_counter)
+         rank = this%containing_server%get_writing_PE(collection_counter-1)
          msize_word = msize_words(collection_counter) 
          call this%containing_server%stage_offset%insert(i_to_string(MSIZE_ID + collection_counter ),msize_word)
          allocate(remotePtr, source  = RDMAReference(pFIO_INT32,msize_word, this%containing_server%comm, rank ))


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactoring the option WRITE_RESTART_BY_OSERVER
There is one minor but important change to get the rank of the writer in ServerThread.F90. When SimpleSocket is used, The writer rank should be 0 which is the same as the ArrayGather. That avoids data movement across the process. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
