### PR TITLE
Update changelog-enforcer.yml

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -8,9 +8,9 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: dangoslen/changelog-enforcer@v1.2.0
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v1.4.0
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabel: '0 diff trivial'
+        skipLabel: 'Skip Changelog'
 


### PR DESCRIPTION
A minor update to use use a new 'Skip Changelog' label to skip the changelog need.

I think this might be better because in some cases, like `develop` to `main` merges, we might not need to change the changelog if it's already good in `develop`. Plus, since both are protected branches, things could get nutty potentially!