### PR TITLE
Fixes #563. Fixes for Leap Year Extrapolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.2] - 2020-10-09
 
+### Fixed
+
+- Fixed a bug in ExtData when extrapolating on a Leap Day (#563)
+
 ### Added
 
 - Added a deflate and bit shaving option to Regrid_Util.x

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -2416,7 +2416,7 @@ CONTAINS
                  ! Convert year offset to the future value
                  yrOffset = iYr - cYearOff
                  ! Determine the template time
-                 call ESMF_TimeSet(newTime,yy=iYr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                 call OffsetTimeYear(cTime,yrOffset,newTime,__RC__)
                  ftime = item%reff_time
                  n = 0
                  do while (.not.found)
@@ -2452,8 +2452,8 @@ CONTAINS
                  ! yrOffset: Number of years added from current time to get file time
                  Do While ((.not.found).and.(abs(yrOffset).lt.maxOffset))
                     yrOffset = yrOffset - 1
-                    iYr = refYear + yrOffset
-                    call ESMF_TimeSet(newTime,yy=iyr,mm=imm,dd=idd,h=ihr,m=imn,s=isc,__RC__)
+                    call OffsetTimeYear(cTime,yrOffset,newTime,__RC__)
+
                     ! Error check - if the new time is before the first file time,
                     ! all is lost
                     If (newTime.lt.xTSeries(1)) exit


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the issue with leap year extrapolations where the code could look for, say, 2019-02-29.

## Related Issue

<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #563 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If you try and extrapolate during leap years, badness happens.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran GEOS, but:

1. My usual test is in Y2000, so no extrapolation is done. Even if there is extrapolation, by default it's not on (but since the run didn't crash, must not be used).
2. This does let the 2020-02-27 21z run referenced in #563 work, but...is it right?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
