### PR TITLE
fix so cubed sphere input can be read in when it has the corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+
+- Fixed bug with reading in cubed-sphere files that have the corners
+
 ### Removed
 
 ## [2.3.3] - 2020-10-14

--- a/MAPL_cfio/ESMF_CFIOSdfMod.F90
+++ b/MAPL_cfio/ESMF_CFIOSdfMod.F90
@@ -505,6 +505,8 @@
            if(vnameTemp == 'contacts') cycle
            if(vnameTemp == 'orientation') cycle
            if(vnameTemp == 'anchor') cycle
+           if(vnameTemp == 'corner_lons') cycle
+           if(vnameTemp == 'corner_lats') cycle
         end if
         if (nvDims .EQ. 1) cycle
         nVars = nVars + 1
@@ -528,6 +530,8 @@
               if (dimName(iv)=='nf') cycle
               if (dimName(iv)=='orientationStrLen') cycle
               if (dimName(iv)=='ncontact') cycle
+              if (dimName(iv)=='XCdim') cycle
+              if (dimName(iv)=='YCdim') cycle
            end if
            rtcode = NF90_INQ_VARID(fid,dimName(iv),varId)
            dimUnits(iv) = ' '

--- a/MAPL_cfio/ESMF_CFIOUtilMod.F90
+++ b/MAPL_cfio/ESMF_CFIOUtilMod.F90
@@ -495,12 +495,15 @@
       integer tmpNvar
       logical :: cs_found
       integer :: vdir_
+      integer :: found_xc, found_yc,vid
 
 ! Initialize variables
 
       surfaceOnly = .FALSE.
       stationFile = .false.
       vdir_       = -1 ! Assume 3D and same orientation
+      found_xc = 0
+      found_yc = 0
 
 ! Check FID here.
 
@@ -534,7 +537,13 @@
            tmpNvar = tmpNvar - 1
         end if
       enddo
-      if (cs_found) tmpNvar = tmpNvar - 3
+      if (cs_found) then
+         tmpNvar = tmpNvar - 3
+         found_xc = NF90_INQ_VARID(fid,"corner_lons",vid)
+         if (found_xc ==0) tmpNvar = tmpNvar - 1
+         found_yc = NF90_INQ_VARID(fid,"corner_lats",vid)
+         if (found_yc ==0) tmpNvar = tmpNvar - 1
+      end if
       nvars = tmpNvar
 
 ! Extract dimension information
@@ -550,7 +559,9 @@
         end if
         if (trim(dimName) .eq. 'nv') cycle 
         if (trim(dimName) .eq. 'nf') cycle 
-        if (trim(dimName) .eq. 'ncontact') cycle 
+        if (trim(dimName) .eq. 'ncontact') cycle
+        if (trim(dimName) .eq. 'XCdim') cycle 
+        if (trim(dimName) .eq. 'YCdim') cycle 
         if (trim(dimName) .eq. 'orientationStrLen') cycle 
 
         rc = NF90_INQ_VARID (fid, dimName, dimId)
@@ -602,6 +613,7 @@
       enddo
 
       if (cs_found .and. nDims == 6) surfaceOnly = .TRUE.
+      if (cs_found .and. nDims == 8) surfaceOnly = .TRUE.
       if (nDims .EQ. 3 .and. .NOT. stationFile) then
         surfaceOnly = .TRUE.
       endif
@@ -695,6 +707,8 @@
         if (trim(dimName) .eq. 'nv') cycle
         if (trim(dimName) .eq. 'nf') cycle
         if (trim(dimName) .eq. 'ncontact') cycle
+        if (trim(dimName) .eq. 'XCdim') cycle 
+        if (trim(dimName) .eq. 'YCdim') cycle 
         if (trim(dimName) .eq. 'orientationStrLen') cycle
 
         rc = NF90_INQ_VARID (fid, dimName, dimId)
@@ -890,6 +904,8 @@
         if (dimName=='nf') cycle
         if (dimName=='orientationStrLen') cycle
         if (dimName=='ncontact') cycle
+        if (trim(dimName) .eq. 'XCdim') cycle 
+        if (trim(dimName) .eq. 'YCdim') cycle 
         rc = NF90_INQ_VARID (fid, dimName, dimId)
         if (err("GetBegDateTime: NF90_INQ_VARID failed",rc,-40) .NE. 0) return
         ! If it has the standard_name attribute, use that instead
@@ -3316,6 +3332,8 @@
         if (dimName=='nf') cycle
         if (dimName=='orientationStrLen') cycle
         if (dimName=='ncontact') cycle
+        if (trim(dimName) .eq. 'XCdim') cycle 
+        if (trim(dimName) .eq. 'YCdim') cycle 
         rc = NF90_INQ_VARID (fid, dimName, dimId)
         if (err("DimInqure: NF90_INQ_VARID failed",rc,-40) .NE. 0) return
         rc = NF90_GET_ATT(fid,dimId,'units',dimUnits)


### PR DESCRIPTION
Fixes #581 

This fixes a bug that was discovered when reading cubed sphere files that have the corners. History/pfio is now outputting the native cubed sphere output with the corners but the "little" cfio layer that is still used by making things like Regrid_Util.x to read files was breaking because of this change in the file format. The little cfio layer was modified to skip reading these variables as this was causing problems. In addition it ignores the xcdim/ycdim that are now in the files.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
