### PR TITLE
Changed memtot (and associated variables) to 64-bit integers. Otherwi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+
+- Fixed integer overflow in memutils for big memory systems
+
 ### Removed
 
 ## [2.3.4] - 2020-10-20

--- a/base/MAPL_MemUtils.F90
+++ b/base/MAPL_MemUtils.F90
@@ -572,7 +572,7 @@ integer, optional, intent(OUT  ) :: RC
 character(len=32) :: proc_self = '/proc/self/status'
 character(len=32) :: meminfo   = '/proc/meminfo'
 character(len=32) :: string
-integer :: memtot, memfree, swaptot, swapfree
+integer(kind=INT64) :: memtot, memfree, swaptot, swapfree
 integer :: mem_unit
 real    :: multiplier
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
MAPL crashes on systems that report >2.147 TB of memory because `memtot` in MAPL_MemUtils.F90 overflows. This PR changes `memtot` to a 64-bit integer to avoid this overflow.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/geoschem/GCHPctm/issues/14

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This came up when I was trying to run GCHP on Compute1. Some of the nodes' `/proc/meminfo` report several TB of memory (I think they're for genomics maybe?) which causes GCHP to crash in MAPL_MemUtils.F90.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I checked that GCHP compiles with this update. Unfortunately, I haven't been able to test anything else (and I don't have access to those large-memory nodes anymore).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
