### PR TITLE
Update changelog and version for 2.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [2.3.5] - 2020-11-06
+
+### Added
 
 - Added fixture entry to `components.yaml` (requires mepo v1.23.0 or higher)
 
-### Changed
 ### Fixed
 
 - Fixed integer overflow in memutils for big memory systems
-
-### Removed
 
 ## [2.3.4] - 2020-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed integer overflow in memutils for big memory systems
-- Fix bug with segment alarm whenn processing a monthly mean collection
+- Fix bug with segment alarm when processing a monthly mean collection
 
 
 ## [2.3.4] - 2020-10-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fix bug with segment alarm whem processing a monthly mean collectiom
 
 ### Added
 ### Changed
@@ -22,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed integer overflow in memutils for big memory systems
+- Fix bug with segment alarm whenn processing a monthly mean collection
+
 
 ## [2.3.4] - 2020-10-20
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.3.4
+  VERSION 2.3.5
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)


### PR DESCRIPTION
This is a preparatory change for pulling `develop` into `main` for a 2.3.5 release.