### PR TITLE
Add external grid and clock setters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added an external grid and clock setter (for NUOPC).
+
 ### Changed
 ### Fixed
 
@@ -20,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added fixture entry to `components.yaml` (requires mepo v1.23.0 or higher)
-- Added an external grid and clock setter (for NUOPC).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added fixture entry to `components.yaml` (requires mepo v1.23.0 or higher)
+- Added an external grid and clock setter (for NUOPC).
 
 ### Changed
 ### Fixed

--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -22,6 +22,7 @@ module MAPL_CapGridCompMod
   use MAPL_CFIOServerMod
   use MAPL_ConfigMod
   use MAPL_DirPathMod
+  use MAPL_KeywordEnforcerMod
   use pFIO
   use gFTL_StringVector
   use pflogger, only: logging, Logger
@@ -74,6 +75,8 @@ module MAPL_CapGridCompMod
      procedure :: destroy_state
      procedure :: get_field_from_import
      procedure :: get_field_from_internal
+     procedure :: set_grid
+     procedure :: set_clock
   end type MAPL_CapGridComp
 
   type :: MAPL_CapGridComp_Wrapper
@@ -1271,6 +1274,36 @@ contains
     _RETURN(_SUCCESS)
 
   end subroutine get_field_from_internal
+
+  subroutine set_grid(this, grid, unusable, rc)
+     class(MAPL_CapGridComp),          intent(inout) :: this
+     type(ESMF_Grid),                  intent(in   ) :: grid
+     class(KeywordEnforcer), optional, intent(in   ) :: unusable
+     integer,                optional, intent(  out) :: rc
+
+     integer :: status
+
+     _UNUSED_DUMMY(unusable)
+
+     call ESMF_GridCompSet(this%gc, grid=grid, __RC__)
+
+     _RETURN(_SUCCESS)
+  end subroutine set_grid
+
+  subroutine set_clock(this, clock, unusable, rc)
+     class(MAPL_CapGridComp),          intent(inout) :: this
+     type(ESMF_Clock),                 intent(in   ) :: clock
+     class(KeywordEnforcer), optional, intent(in   ) :: unusable
+     integer,                optional, intent(  out) :: rc
+
+     integer :: status
+
+     _UNUSED_DUMMY(unusable)
+
+     call ESMF_GridCompSet(this%gc, clock=clock, __RC__)
+
+     _RETURN(_SUCCESS)
+  end subroutine set_clock
 
   subroutine destroy_state(this, rc)
     class(MAPL_CapGridComp), intent(inout) :: this


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides setting API for external grids and clocks as suggested by @rmontouro for the UFS GOCART component

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows a NUOPC cap to set the grid and clock instead of relying MAPL to create a grid and clock.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This works for the UFS NUOPC component
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
