### PR TITLE
Update changelog and version for 2.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [2.3.6] - 2020-11-12
+
+### Added
 
 - Added an external grid and clock setter (for NUOPC).
 
-### Changed
 ### Fixed
 
 - Fixed logic to allow proper termination of all imports except those specified
-
-### Removed
 
 ## [2.3.5] - 2020-11-06
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.3.5
+  VERSION 2.3.6
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)


### PR DESCRIPTION
Another trivial update to get the changelog and cmakelists version for a 2.3.6 release.