### PR TITLE
Inject external grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added ability to inject grid into root child GridComp (for NUOPC).
 ### Changed
 ### Fixed
 ### Removed

--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -76,6 +76,7 @@ module MAPL_CapGridCompMod
      procedure :: get_field_from_import
      procedure :: get_field_from_internal
      procedure :: set_grid
+     procedure :: inject_external_grid
      procedure :: set_clock
   end type MAPL_CapGridComp
 
@@ -547,6 +548,12 @@ contains
 
     call MAPL_Get(MAPLOBJ, gcs = cap%gcs, gim = cap%child_imports, gex = cap%child_exports, rc = status)
     _VERIFY(status)
+
+
+    !  Inject grid to root child if grid has been set externally
+    !-----------------------------------------------------------
+
+    call cap%inject_external_grid(__RC__)
 
     ! Run as usual unless PRINTSPEC> 0 as set in CAP.rc. If set then
     ! model will not run completely and instead it will simply run MAPL_SetServices
@@ -1289,6 +1296,40 @@ contains
 
      _RETURN(_SUCCESS)
   end subroutine set_grid
+
+  subroutine inject_external_grid(this, unusable, rc)
+     class(MAPL_CapGridComp),          intent(inout) :: this
+     class(KeywordEnforcer), optional, intent(in   ) :: unusable
+     integer,                optional, intent(  out) :: rc
+
+     type(ESMF_GridMatch_Flag) :: grid_match
+     type(ESMF_Grid)           :: cap_grid,            root_grid
+     logical                   :: cap_grid_is_present, root_grid_is_present
+     integer                   :: status
+
+     _UNUSED_DUMMY(unusable)
+
+     call ESMF_GridCompGet(this%gc, gridIsPresent=cap_grid_is_present, __RC__)
+
+     if (cap_grid_is_present) then
+        call ESMF_GridCompGet(this%gc, grid=cap_grid, __RC__)
+        call ESMF_GridValidate(cap_grid, __RC__)
+
+        call ESMF_GridCompGet(this%gcs(this%root_id), gridIsPresent=root_grid_is_present, __RC__)
+
+        if (root_grid_is_present) then
+           call ESMF_GridCompGet(this%gcs(this%root_id), grid=root_grid, __RC__)
+           call ESMF_GridValidate(root_grid, __RC__)
+
+           grid_match = ESMF_GridMatch(cap_grid, root_grid, __RC__)
+           _ASSERT(grid_match == ESMF_GRIDMATCH_EXACT, "Attempting to override root grid with non-matching external grid")
+        else
+            call ESMF_GridCompSet(this%gcs(this%root_id), grid=root_grid, __RC__)
+        end if
+     end if
+
+     _RETURN(_SUCCESS)
+  end subroutine inject_external_grid
 
   subroutine set_clock(this, clock, unusable, rc)
      class(MAPL_CapGridComp),          intent(inout) :: this


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
Completes system to bring an external grid into a MAPL based NUOPC component by providing a method to take a grid from the `Cap_GridComp` and set it into the `root_child`'s GridComp.

## Description
<!--- Describe your changes in detail -->
At the request of @rmontuoro, we have extended the external grid set API to automatically set the external grid into the `root_child` GridComp in addition to the `Cap_GridComp`.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since this change involves code that will always be run, I performed a 3 day C12 run, which was zero diff with a run with no changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
