### PR TITLE
Properly set external grid into root GridComp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to inject grid into root child GridComp (for NUOPC).
 ### Changed
 ### Fixed
+- Bug in injecting grid into root child GridComp (for NUOPC).
 ### Removed
 
 ## [2.3.6] - 2020-11-12

--- a/base/MAPL_CapGridComp.F90
+++ b/base/MAPL_CapGridComp.F90
@@ -1324,7 +1324,7 @@ contains
            grid_match = ESMF_GridMatch(cap_grid, root_grid, __RC__)
            _ASSERT(grid_match == ESMF_GRIDMATCH_EXACT, "Attempting to override root grid with non-matching external grid")
         else
-            call ESMF_GridCompSet(this%gcs(this%root_id), grid=root_grid, __RC__)
+            call ESMF_GridCompSet(this%gcs(this%root_id), grid=cap_grid, __RC__)
         end if
      end if
 


### PR DESCRIPTION
This PR fixes a bug in the recently added `inject_external_grid` API (see PR #608).

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set external grid into `root_child` GridComp if no grid was previously set.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change addresses a bug present in the `Cap_GridComp` method `inject_external_grid` by replacing an uninitialized grid object with the proper external grid object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested within NOAA's UFS-GOCART application.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
