### PR TITLE
Improving use of external clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug in pfio tests when compiled with Debug flag
 - Bug in injecting grid into root child GridComp (for NUOPC).
+- Bug preventing components from advancing when an external clock is used
 ### Removed
 
 ## [2.3.6] - 2020-11-12


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
Improve changes enabling use of an external clock in MAPL, introduced with PR #610 

## Description
<!--- Describe your changes in detail -->
This change improves MAPL's ability to use an externally-provided clock by:
- Creating a copy of the external clock to protect it from local state changes. For instance, the clock is advanced by MAPL internally and this will change the external clock's state, too, if a reference is used instead of a copy
- Setting the heartbeat to the external clock's time interval, and ignoring settings from the cap's resource file

This PR also sets the number of time steps to 1 when MAPL is driven by an external clock, addressing an issue preventing MAPL from advancing its components. Advancing MAPL components by one time step at the time allows an external driver to more precisely control MAPL's time-dependent state.

_NOTE_: This PR adds to the latest changes introduced with PR #611, and should be merged _after_ PR #611. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes a bug in the earlier implementation of MAPL's ability to use an externally provided clock (see PR #610).
It also improves the overall reliability and behavior of the previous implementation in UFS applications.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change was tested within NOAA's UFS-GOCART application

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
