### PR TITLE
Fix spelling in CHANGELOG [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an `ExternalGridManager`, to allow MAPL to have knowledge of external grids (for NUOPC).
-- Added command line interface option "--isolate_nodes .false. " , by default it is .ture.
+- Added command line interface option `--isolate_nodes`. By default it is `.true.`
 
 ### Changed
 


### PR DESCRIPTION
An insanely trivial PR. Just changed some spelling in the `CHANGELOG.md` and added some markdown. 