### PR TITLE
Make clobber default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `ExternalGridManager`, to allow MAPL to have knowledge of external grids (for NUOPC).
 - Added command line interface option `--isolate_nodes`. By default it is `.true.`
 - Add stretching factors to file if applicable in cubed-sphere output via History and uptick to cube version 2.91
+- Make the default clobber rather than no clobber in NetCDF formatter in PFIO
 
 ### Changed
 

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -139,16 +139,23 @@ module pFIO_NetCDF4_FileFormatterMod
 
 contains
 
-   subroutine create(this, file, unusable, rc)
+   subroutine create(this, file, unusable, mode, rc)
       class (NetCDF4_FileFormatter), intent(inout) :: this
       character(len=*), intent(in) :: file
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(in) :: mode
       integer, optional, intent(out) :: rc
 
       integer :: status
+      integer :: mode_
 
+      if (present(mode)) then
+         mode_=mode
+      else
+         mode_=NF90_CLOBBER
+      end if
       !$omp critical
-      status = nf90_create(file, IOR(NF90_NOCLOBBER, NF90_NETCDF4), this%ncid)
+      status = nf90_create(file, IOR(mode_, NF90_NETCDF4), this%ncid)
       !$omp end critical
       _VERIFY(status)
 
@@ -157,10 +164,11 @@ contains
    end subroutine create
 
 
-   subroutine create_par(this, file, unusable, comm, info, rc)
+   subroutine create_par(this, file, unusable, mode, comm, info, rc)
       class (NetCDF4_FileFormatter), intent(inout) :: this
       character(len=*), intent(in) :: file
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(in) :: mode
       integer, optional, intent(in) :: comm
       integer, optional, intent(in) :: info
       integer, optional, intent(out) :: rc
@@ -168,7 +176,13 @@ contains
       integer :: comm_
       integer :: info_
       integer :: status
-      integer :: mode
+      integer :: mode_
+
+      if (present(mode)) then
+         mode_=mode
+      else
+         mode_=NF90_CLOBBER
+      end if
 
       if (present(comm)) then
          comm_ = comm
@@ -186,13 +200,12 @@ contains
       this%comm = comm_
       this%info = info_
 
-      mode = NF90_NOCLOBBER
-      mode = IOR(mode, NF90_NETCDF4)
-      mode = IOR(mode, NF90_SHARE)
-      mode = IOR(mode, NF90_MPIIO)
+      mode_ = IOR(mode_, NF90_NETCDF4)
+      mode_ = IOR(mode_, NF90_SHARE)
+      mode_ = IOR(mode_, NF90_MPIIO)
 
       !$omp critical
-      status = nf90_create(file, mode, comm=comm_, info=info_, ncid=this%ncid)
+      status = nf90_create(file, mode_, comm=comm_, info=info_, ncid=this%ncid)
       !$omp end critical
       _VERIFY(status)
 


### PR DESCRIPTION
Fixes #640
This is a very simple PR that changes the default behavior when creating NetCDF files with pfio from NOCLOBBER to CLOBBER (although I did add a new argument so if we need someday we can override).
This was requested by the GEOS-Chem developers. I can find no harm in doing this for GEOS. We must not be trying clobber files in the first place with our workflow as we would not be able to run. Hence changing to NOCLOBBER should have no effect.
Making this user configurable is difficult since the places the "create" is called are so low level they don't have access to any resource file so no ability for the user to change this for now.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
