### PR TITLE
Add simple checking that the restart file matches the grid for at lea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add stretching factors to file if applicable in cubed-sphere output via History and uptick to cube version 2.91
 - Ability to register protoype (non-ESMF) regridders in NewRegridderManager
 - Make the default clobber rather than no clobber in NetCDF formatter in PFIO
-
+- Add basic check that the restart files match the application grid
 
 ### Changed
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -7336,7 +7336,9 @@ module MAPL_IOMod
     integer                            :: MAPL_DIMS
     integer, pointer                   :: MASK(:) => null()
     type(Netcdf4_Fileformatter)        :: formatter
+    type(FileMetaData)                 :: metadata
     character(len=:), allocatable      :: fname_by_face
+    logical :: grid_file_match
 
     call ESMF_FieldBundleGet(Bundle,FieldCount=nVars,rc=STATUS)
     _VERIFY(STATUS)
@@ -7362,6 +7364,13 @@ module MAPL_IOMod
              _VERIFY(STATUS)
           endif
        end if
+       metadata=formatter%read(rc=status)
+       _VERIFY(status)
+       call ESMF_FieldBundleGet(bundle,grid=grid,rc=status)
+       _VERIFY(status)
+       grid_file_match=compare_grid_file(metadata,grid,rc=status)
+       _VERIFY(status)
+       _ASSERT(grid_file_match,"File grid dimensions in "//trim(filename)//" do not match grid")
     endif
 
     do l=1,nVars
@@ -7407,6 +7416,38 @@ module MAPL_IOMod
     _RETURN(ESMF_SUCCESS)
 
   end subroutine MAPL_BundleReadNCPar
+
+  function compare_grid_file(metadata,grid,rc) result(match)
+     type(FileMetaData), intent(in) :: metadata
+     type(ESMF_Grid), intent(in) :: grid
+     integer, optional, intent(out) :: rc
+
+     integer :: status
+     logical :: match
+
+     integer :: file_lev_size, file_lat_size, file_lon_size, file_tile_size
+     integer :: grid_dims(3)
+
+     match = .false.
+     call MAPL_GridGet(grid,globalCellCountPerDim=grid_dims,rc=status)
+     _VERIFY(status)
+     file_lon_size = metadata%get_dimension("lon")
+     file_lat_size = metadata%get_dimension("lat")
+     file_lev_size = metadata%get_dimension("lev")
+     file_tile_size = metadata%get_dimension("tile")
+     if (file_tile_size > 0) then
+        match = (file_tile_size == grid_dims(1))
+     else
+        if (file_lev_size > 0) then
+
+            match = (file_lon_size == grid_dims(1)) .and. (file_lat_size == grid_dims(2)) &
+                    .and. (file_lev_size==grid_dims(3))
+        else
+            match = (file_lon_size == grid_dims(1)) .and. (file_lat_size == grid_dims(2))
+        end if
+     end if
+     _RETURN(_SUCCESS)
+  end function compare_grid_file
 
   subroutine MAPL_StateVarReadNCPar(filename, STATE, arrdes, bootstrapable, NAME, RC)
     character(len=*)            , intent(IN   ) :: filename


### PR DESCRIPTION

Fixes #643

This is a simple check that the restart matches the grid. The elegant way would be to create a grid from the file and check they match but the tiles, the fact that the restarts are not on the "new" cube format, vertical levels etc ... make that not practical. 

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
