### PR TITLE
Update changelog and version for 2.5.0 release [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [2.5.0] - 2021-01-08
+
+### Added
+
 - Added an `ExternalGridManager`, to allow MAPL to have knowledge of external grids (for NUOPC).
 - Added command line interface option `--isolate_nodes`. By default it is `.true.`
 - Add stretching factors to file if applicable in cubed-sphere output via History and uptick to cube version 2.91
@@ -28,10 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_env v3.1.3
   - ESMA_cmake v3.3.5
 - Update CI image to use Baselibs v6.0.27
-	
-### Fixed
-	
-### Removed
 
 ## [2.4.0] - 2020-11-20
 
@@ -324,7 +330,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected Python code generator scripts for component import/export specs.
 - Add directories to `.gitignore` for building with `mepo`
 - Bug building with mixed Intel/GCC compilers
-- Implemented workaround to cmake error that happens when building tests in parallel.	
+- Implemented workaround to cmake error that happens when building tests in parallel.
 - Set correct ESMA_env tag in `components.yaml`
 - Updated `components.yaml` to be inline with GEOSgcm
 - Minor problem in GMAO_pFIO Cmakelists (consistency with PRIVATE)
@@ -343,7 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Builds and runs `pFIO_tests` and `MAPL_Base_tests`
 - Add precession of equinox (not on by default)
 - Imported Python/MAPL subdir (old, but never imported to GitHub)
-- Python automatic code generator for grid comp include files	
+- Python automatic code generator for grid comp include files
 - Added support to use pFlogger for logging
   - Command line option: `--logging_config=<file>`
 - Added ability for History to do monthly mean. This also involves reading and writing MAPL_GenericCpl checkpoints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.4.0
+  VERSION 2.5.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)


### PR DESCRIPTION
Simply updating `CHANGELOG.md` and `CMakeLists.txt` for a release of MAPL 2.5.0.

Also got rid of some "tab" characters in the Changelog. Because Tabs Are Evil™