### PR TITLE
Feature/wjiang/frontend backend distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- For MultiGroupServer, the backend and frontend share each node
 ### Fixed
 
 ### Removed

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -79,11 +79,11 @@ module pFIO_MultiGroupServerMod
 
 contains
 
-   function new_MultiGroupServer(server_comm, port_name, nwriter, rc) result(s)
+   function new_MultiGroupServer(server_comm, port_name, nwriter_per_node, rc) result(s)
       type (MultiGroupServer) :: s
       integer, intent(in) :: server_comm
       character(*), intent(in) :: port_name
-      integer, intent (in) :: nwriter
+      integer, intent (in) :: nwriter_per_node
       integer, optional, intent(out) :: rc
       integer :: s_rank, s_size
       integer :: ierror, status, local_rank
@@ -92,18 +92,21 @@ contains
       character(len=:), allocatable :: s_name
       integer :: MPI_STAT(MPI_STATUS_SIZE)
       type (MpiSocket), target :: dummy_socket
-      integer :: server_group, tmp_group, n
+      integer :: server_group, tmp_group, n, nwriter
       integer, allocatable :: ranks(:)
+      integer, allocatable :: node_sizes(:)
 
       call MPI_Comm_dup(server_comm, s%server_comm, ierror)
       call MPI_Comm_size(s%server_comm, s_size , ierror)
 
       splitter = SimpleCommsplitter(s%server_comm)
-      call splitter%add_group(npes = s_size-nwriter, name="o_server_front", isolate_nodes=.false.)
-      call splitter%add_group(npes = nwriter,        name="o_server_back",  isolate_nodes=.false.)
+      node_sizes = splitter%get_node_sizes()
+      call splitter%add_group(npes_per_node = node_sizes(1)-nwriter_per_node, name="o_server_front", isolate_nodes=.false.)
+      call splitter%add_group(npes_per_node = nwriter_per_node,               name="o_server_back",  isolate_nodes=.false.)
  
       s_comm = splitter%split(rc=status); _VERIFY(status)
 
+      nwriter = nwriter_per_node*size(node_sizes)
       s%front_comm = MPI_COMM_NULL
       s%back_comm  = MPI_COMM_NULL
       s%nwriter    = nwriter

--- a/shared/CommGroupDescription.F90
+++ b/shared/CommGroupDescription.F90
@@ -86,7 +86,7 @@ contains
            do i_rank = start_rank_, nodes_sizes(i_node)-1
 
               if( my_node == i_node .and. my_rank == i_rank) then
-                  _ASSERT( .not. IamInGroup, "I have been inluded in the other group")
+                  _ASSERT( .not. IamInGroup, "I have been included in the other group")
                   IamInGroup = .true.
               endif
 
@@ -110,7 +110,7 @@ contains
          next_node = start_node_ + this%nnodes 
          next_rank = 0
          if (start_node_ <= my_node .and. my_node < next_node) then
-            _ASSERT( .not. IamInGroup, "I have been inluded in the other group")
+            _ASSERT( .not. IamInGroup, "I have been included in the other group")
             IamInGroup = .true.
          endif
       endif
@@ -121,7 +121,7 @@ contains
          next_rank  = start_rank + this%npes_per_node
          next_node  = 0 ! no used
          if (start_rank <=my_rank .and. my_rank < next_rank) then
-            _ASSERT( .not. IamInGroup, "I have been inluded in the other group")
+            _ASSERT( .not. IamInGroup, "I have been included in the other group")
             IamInGroup = .true.
          endif
       endif

--- a/shared/CommGroupDescription.F90
+++ b/shared/CommGroupDescription.F90
@@ -9,6 +9,7 @@ module MAPL_CommGroupDescriptionMod
    public :: CommGroupDescription
    
    type :: CommGroupDescription
+      integer :: npes_per_node
       integer :: npes
       integer :: nnodes
       logical :: isolate_nodes
@@ -23,17 +24,18 @@ end interface
 
 contains
 
-   function new_CommGroupDescription( npes, nnodes, isolate_nodes, name, unusable, rc) result(CommGroup)
+   function new_CommGroupDescription( npes, nnodes, isolate_nodes, name, unusable, npes_per_node, rc) result(CommGroup)
       type(CommGroupDescription) :: CommGroup
       integer, intent(in) :: npes
       integer, intent(in) :: nnodes
       logical, intent(in) :: isolate_nodes
       character(*), intent(in) :: name
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(in)  :: npes_per_node
       integer, optional, intent(out) :: rc
 
       _UNUSED_DUMMY(unusable)
-      _ASSERT(npes*nnodes ==0, "npes and nnodes are exclusive")
+      _ASSERT(npes*nnodes == 0, "npes and nnodes are exclusive")
 
       if (nnodes > 0) then
          _ASSERT( isolate_nodes, " nnodes should be isolated")
@@ -43,6 +45,13 @@ contains
       CommGroup%nnodes = nnodes
       CommGroup%isolate_nodes = isolate_nodes 
       CommGroup%name = name
+      CommGroup%npes_per_node = 0
+
+      if ( present(npes_per_node)) then
+         CommGroup%npes_per_node = npes_per_node
+         CommGroup%npes   = 0
+         CommGroup%nnodes = 0
+      endif
 
       _RETURN(_SUCCESS)
    end function new_CommGroupDescription
@@ -97,6 +106,7 @@ contains
 
       ! case 2, group is divided by nnodes
       if (this%nnodes > 0) then
+
          next_node = start_node_ + this%nnodes 
          next_rank = 0
          if (start_node_ <= my_node .and. my_node < next_node) then
@@ -105,8 +115,19 @@ contains
          endif
       endif
 
-      ! case 3, empty group
-      if (this%npes == 0 .and. this%nnodes ==0) then
+      ! case 3, npes per node
+      if (this%npes_per_node > 0) then
+         _ASSERT( all(nodes_sizes == nodes_sizes(1)) , " all nodes should have the same amount of cores")
+         next_rank  = start_rank + this%npes_per_node
+         next_node  = 0 ! no used
+         if (start_rank <=my_rank .and. my_rank < next_rank) then
+            _ASSERT( .not. IamInGroup, "I have been inluded in the other group")
+            IamInGroup = .true.
+         endif
+      endif
+
+      ! case 4, empty group
+      if (this%npes == 0 .and. this%nnodes ==0 .and. this%npes_per_node ==0) then
         next_node = start_node
         next_rank = start_rank
       endif


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
The backend (writers) of oservers were concentrated to the last nodes. Now they are distributed across all the oserver nodes, i.e., frontend and backend share each node. 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
