### PR TITLE
add option that waits before using oserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Add option fast_oclient that waits before using oserver. It would not wait after done message are sent 
 ### Changed
 
 - For MultiGroupServer, the backend and frontend share each node

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -26,6 +26,9 @@ module MAPL_CapOptionsMod
       integer, allocatable :: nodes_output_server(:)
       ! whether or not the nodes are padding with idle when mod(model total npes , each node npes) /=0
       logical              :: isolate_nodes = .true.
+      ! whether or not copy the data before isend to the oserver
+      ! it is faster but demands more memory if it is true 
+      logical              :: fast_oclient  = .false.
       ! server groups
       integer :: n_iserver_group = 1
       integer :: n_oserver_group = 1

--- a/base/MAPL_FlapCapOptions.F90
+++ b/base/MAPL_FlapCapOptions.F90
@@ -196,6 +196,14 @@ contains
            error=status)
       _VERIFY(status)
 
+      call options%add(switch='--fast_oclient', &
+           help='Copying data before isend. Client would wait until it is re-used', &
+           required=.false., &
+           def='.false.', &
+           act='store', &
+           error=status)
+      _VERIFY(status)
+
       _RETURN(_SUCCESS)
 
    end subroutine add_command_line_options
@@ -228,6 +236,7 @@ contains
  
       call this%cli_options%get(val=this%npes_model, switch='--npes_model', error=status); _VERIFY(status)
       call this%cli_options%get(val=this%isolate_nodes, switch='--isolate_nodes', error=status); _VERIFY(status)
+      call this%cli_options%get(val=this%fast_oclient, switch='--fast_oclient', error=status); _VERIFY(status)
       call this%cli_options%get_varying(val=this%npes_input_server, switch='--npes_input_server', error=status); _VERIFY(status)
       call this%cli_options%get_varying(val=this%npes_output_server, switch='--npes_output_server', error=status); _VERIFY(status)
       call this%cli_options%get_varying(val=this%nodes_input_server, switch='--nodes_input_server', error=status); _VERIFY(status)

--- a/base/MAPL_HistoryGridComp.F90
+++ b/base/MAPL_HistoryGridComp.F90
@@ -3567,9 +3567,10 @@ ENDDO PARSER
 
    enddo POSTLOOP
 
-   call o_Clients%done_collective_stage()
-   call o_Clients%wait() 
-
+   if (any(writing)) then
+      call o_Clients%done_collective_stage()
+      call o_Clients%post_wait()
+   endif
    call MAPL_TimerOff(GENSTATE,"-----IO Post")
    call MAPL_TimerOff(GENSTATE,"----IO Write")
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -8467,7 +8467,7 @@ module MAPL_IOMod
     
     if (arrdes%write_restart_by_oserver) then
        call oClients%done_collective_stage()
-       call oClients%wait()
+       call oClients%post_wait()
        call MPI_Info_free(info, status)
        _VERIFY(STATUS)
     elseif (arrdes%writers_comm/=MPI_COMM_NULL) then

--- a/base/ServerManager.F90
+++ b/base/ServerManager.F90
@@ -37,7 +37,8 @@ contains
    end subroutine get_splitcomm
 
    subroutine initialize(this, comm, unusable, application_size, nodes_input_server, nodes_output_server,&
-                         npes_input_server,npes_output_server, oserver_type, npes_output_backend, isolate_nodes, rc)
+                         npes_input_server,npes_output_server, oserver_type, npes_output_backend, isolate_nodes, &
+                         fast_oclient, rc)
       class (ServerManager), intent(inout) :: this
       integer, intent(in) :: comm
       class (KeywordEnforcer),  optional, intent(in) :: unusable
@@ -47,12 +48,14 @@ contains
       character(*), optional, intent(in) :: oserver_type
       integer, optional, intent(in) :: npes_output_backend
       logical, optional, intent(in) :: isolate_nodes
- 
+      logical, optional, intent(in) :: fast_oclient
+      
       integer, optional, intent(out) :: rc
       integer, allocatable :: npes_in(:),npes_out(:),nodes_in(:),nodes_out(:)
       integer :: npes_out_backend, server_size
 
       type (SimpleCommSplitter) :: splitter
+      integer :: client_comm
       integer :: status, i, rank,npes_model,n_oserver_group, n_iserver_group
       character(len=:), allocatable :: s_name
       character(len=:), allocatable :: oserver_type_
@@ -143,15 +146,16 @@ contains
      s_name = this%split_comm%get_name()
 
      if ( index(s_name, 'model') /=0 ) then
+        client_comm = this%split_comm%get_subcommunicator()
         if (npes_in(1) == 0 .and. nodes_in(1) == 0) then
-           allocate(this%i_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'i_server'//trim(i_to_string(1))))
+           allocate(this%i_server, source = MpiServer(client_comm, 'i_server'//trim(i_to_string(1))))
            call this%directory_service%publish(PortInfo('i_server'//trim(i_to_string(1)), this%i_server), this%i_server)
         end if
         if (npes_out(1) == 0 .and. nodes_out(1) == 0) then
-           allocate(this%o_server, source = MpiServer(this%split_comm%get_subcommunicator(), 'o_server'//trim(i_to_string(1))))
+           allocate(this%o_server, source = MpiServer(client_comm, 'o_server'//trim(i_to_string(1))))
            call this%directory_service%publish(PortInfo('o_server'//trim(i_to_string(1)), this%o_server), this%o_server)
         end if
-        call init_IO_ClientManager(n_i = n_iserver_group, n_o = n_oserver_group, rc = status)
+        call init_IO_ClientManager(client_comm, n_i = n_iserver_group, n_o = n_oserver_group, fast_oclient=fast_oclient, rc = status)
         _VERIFY(status)
      endif
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -194,6 +194,7 @@ contains
          oserver_type=this%cap_options%oserver_type, &
          npes_output_backend=this%cap_options%npes_output_backend, &
          isolate_nodes = this%cap_options%isolate_nodes, &
+         fast_oclient  = this%cap_options%fast_oclient, &
          rc=status)
      _VERIFY(status)
 

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -70,6 +70,7 @@ set (srcs
   ServerThreadVector.F90
   BaseThread.F90
   ClientThread.F90
+  FastClientThread.F90
   ClientThreadVector.F90
   ClientManager.F90
   ExtDataCollection.F90

--- a/pfio/ClientThread.F90
+++ b/pfio/ClientThread.F90
@@ -72,6 +72,7 @@ module pFIO_ClientThreadMod
       procedure :: done_collective_stage
       procedure :: wait
       procedure :: wait_all
+      procedure :: post_wait_all
       procedure :: terminate
 
       procedure :: handle_Id
@@ -449,6 +450,12 @@ contains
       !call this%shake_hand()
 
    end subroutine wait_all
+
+   subroutine post_wait_all(this)
+      use pFIO_AbstractRequestHandleMod
+      class (ClientThread), target, intent(inout) :: this
+      call this%wait_all()
+   end subroutine post_wait_all
 
    integer function get_unique_request_id(this) result(request_id)
       class (ClientThread), intent(inout) :: this

--- a/pfio/ClientThreadVector.F90
+++ b/pfio/ClientThreadVector.F90
@@ -1,7 +1,7 @@
 module pFIO_ClientThreadVectorMod
    use pFIO_ClientThreadMod
 
-#define _type type (ClientThread)
+#define _type class (ClientThread)
 #define _pointer
 #define _vector ClientThreadVector
 #define _iterator ClientThreadVectorIterator

--- a/pfio/FastClientThread.F90
+++ b/pfio/FastClientThread.F90
@@ -1,0 +1,167 @@
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
+
+module pFIO_FastClientThreadMod
+   use MAPL_ExceptionHandling
+   use pFIO_AbstractMessageMod
+   use pFIO_AbstractSocketMod
+   use pFIO_AbstractDataReferenceMod
+   use pFIO_LocalMemReferenceMod
+   use pFIO_KeywordEnforcerMod
+   use pFIO_ClientThreadMod
+   use pFIO_StageDataMessageMod
+   use pFIO_CollectiveStageDataMessageMod
+   implicit none
+   private
+
+   public :: FastClientThread
+
+   type, extends(ClientThread) :: FastClientThread
+   contains
+      procedure :: stage_data
+      procedure :: collective_stage_data 
+      procedure :: stage_nondistributed_data
+      procedure :: post_wait_all
+   end type FastClientThread
+
+
+   interface FastClientThread
+      module procedure new_FastClientThread
+   end interface FastClientThread
+
+contains
+
+   function new_FastClientThread(sckt) result(c)
+      class(AbstractSocket),optional,intent(in) :: sckt
+      type (FastClientThread),target :: c
+      if (present(sckt)) call c%set_connection(sckt)
+   end function new_FastClientThread
+
+   function stage_data(this, collection_id, file_name, var_name, data_reference, &
+        & unusable, start, rc) result(request_id)
+      class (FastClientThread), intent(inout) :: this
+      integer, intent(in) :: collection_id
+      character(len=*), intent(in) :: file_name
+      character(len=*), intent(in) :: var_name
+      class (AbstractDataReference), intent(in) :: data_reference
+      class (KeywordEnforcer), optional, intent(out) :: unusable
+      integer, optional, intent(in)  :: start(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: request_id, status
+      class (AbstractMessage), pointer :: handshake_msg
+      class(AbstractSocket),pointer :: connection
+      type (LocalMemReference) :: mem_data_reference 
+
+      request_id = this%get_unique_request_id()
+      connection=>this%get_connection()
+      call connection%send(StageDataMessage( &
+           request_id, &
+           collection_id, &
+           file_name, &
+           var_name, &
+           data_reference,unusable=unusable,start=start))
+
+      handshake_msg => connection%receive()
+      deallocate(handshake_msg)
+      associate (id => request_id)
+         mem_data_reference = LocalMemReference(data_reference%type_kind, data_reference%shape)
+         ! copy data out so the client can move on after done message is send
+         call data_reference%copy_data_to(mem_data_reference, rc=status)
+         _VERIFY(status) 
+         ! put calls iSend
+         call this%insert_RequestHandle(id, connection%put(id, mem_data_reference))
+      end associate
+      _RETURN(_SUCCESS)
+   end function stage_data
+
+   function collective_stage_data(this, collection_id, file_name, var_name, data_reference, &
+        & unusable, start,global_start,global_count, rc) result(request_id)
+      class (FastClientThread), intent(inout) :: this
+      integer, intent(in) :: collection_id
+      character(len=*), intent(in) :: file_name
+      character(len=*), intent(in) :: var_name
+      class (AbstractDataReference), intent(in) :: data_reference
+      class (KeywordEnforcer), optional, intent(out) :: unusable
+      integer, optional, intent(in) :: start(:)
+      integer, optional, intent(in) :: global_start(:)
+      integer, optional, intent(in) :: global_count(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: request_id, status
+
+      class (AbstractMessage), pointer :: handshake_msg
+      class(AbstractSocket),pointer :: connection
+      type (LocalMemReference) :: mem_data_reference
+
+      request_id = this%get_unique_collective_request_id()
+      connection => this%get_connection()
+
+      call connection%send(CollectiveStageDataMessage( &
+           request_id, &
+           collection_id, &
+           file_name, &
+           var_name, &
+           data_reference,unusable=unusable, start=start,&
+           global_start=global_start,global_count=global_count))
+
+      handshake_msg => connection%receive()
+      deallocate(handshake_msg)
+      associate (id => request_id)
+         mem_data_reference = LocalMemReference(data_reference%type_kind, data_reference%shape)
+         ! copy data out so the client can move on after done message is send
+         call data_reference%copy_data_to(mem_data_reference, rc=status)
+         _VERIFY(status) 
+         ! put calls iSend
+         call this%insert_RequestHandle(id, connection%put(id, mem_data_reference))
+      end associate
+
+      _RETURN(_SUCCESS)
+   end function collective_stage_data
+
+   function stage_nondistributed_data(this, collection_id, file_name, var_name, data_reference, rc) result(request_id)
+      class (FastClientThread), intent(inout) :: this
+      integer, intent(in) :: collection_id
+      character(len=*), intent(in) :: file_name
+      character(len=*), intent(in) :: var_name
+      class (AbstractDataReference), intent(in) :: data_reference
+      integer, optional, intent(out) :: rc
+
+
+      integer :: request_id, status
+
+      class (AbstractMessage), pointer :: handshake_msg
+      class(AbstractSocket),pointer :: connection
+      type (LocalMemReference) :: mem_data_reference
+
+      request_id = this%get_unique_collective_request_id()
+      connection => this%get_connection()
+      call connection%send(CollectiveStageDataMessage( &
+           request_id, &
+           collection_id, &
+           file_name, &
+           var_name, &
+           data_reference))
+
+      handshake_msg => connection%receive()
+      deallocate(handshake_msg)
+      associate (id => request_id)
+         mem_data_reference = LocalMemReference(data_reference%type_kind, data_reference%shape)
+         ! copy data out so the client can move on after done message is send
+         call data_reference%copy_data_to(mem_data_reference, rc=status)
+         _VERIFY(status) 
+         ! put calls iSend
+         call this%insert_RequestHandle(id, connection%put(id, mem_data_reference))
+      end associate
+
+      _RETURN(_SUCCESS)
+   end function stage_nondistributed_data
+
+   ! The data has been copied out and post no wait after isend
+   subroutine post_wait_all(this)
+      use pFIO_AbstractRequestHandleMod
+      class (FastClientThread), target, intent(inout) :: this
+      ! do nothing on purpose
+   end subroutine post_wait_all
+
+end module pFIO_FastClientThreadMod


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a subclass FastClientThread
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When sending data to oserver by isend, the client has to wait before moving on to next work.  The new approach copies the data before isend and does not wait for the isend immediately. Instead it waits for the isend next time when it uses that oserver again
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
