### PR TITLE
Fixes #678. This fixes incorrect referrences to R4 variables when rea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixes for allowing forked PRs to pass CI
+- Fixes incorrect referrencing of R4 variables when reading R8 tile vars in base/MAPL_IO.F90
 
 ### Removed
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -1135,7 +1135,7 @@ module MAPL_IOMod
           _VERIFY(STATUS)
           if (associated(vr8_1d)) then
              if (DIMS == MAPL_DimsTileOnly .or. DIMS == MAPL_DimsTileTile) then
-                call MAPL_VarRead(formatter, name, var_1d, layout=layout, arrdes=arrdes, mask=mask, rc=status)
+                call MAPL_VarRead(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, mask=mask, rc=status)
                 _VERIFY(STATUS)
              else if (DIMS == MAPL_DimsVertOnly .or. DIMS==MAPL_DimsNone) then
                 call MAPL_VarRead(formatter, name, vr8_1d, layout=layout, arrdes=arrdes, rc=status)
@@ -1174,7 +1174,7 @@ module MAPL_IOMod
                    call MAPL_VarRead(formatter, name, vr8_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, rc=status)
                 end do
              else if (DIMS == MAPL_DimsTileTile) then
-                do j=1,size(var_2d,2)
+                do j=1,size(vr8_2d,2)
                    call MAPL_VarRead(formatter, name, vr8_2d(:,J), layout=layout, arrdes=arrdes, mask=mask, offset1=j, rc=status)
                    _VERIFY(STATUS)
                 enddo


### PR DESCRIPTION
…ding R8 tile variables. Currently GEOS does not exercise this section of code

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
