### PR TITLE
Remove need for HDF5 Fortran bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Move to ESMA_cmake v3.3.6
+- Remove requirement for HDF5 Fortran bindings in MAPL
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (NOT Baselibs_FOUND)
   add_definitions(-DNETCDF_NEED_NF_MPIIO)
   add_definitions(-DHAS_NETCDF3)
 
-  find_package(HDF5 REQUIRED Fortran)
+  find_package(HDF5 REQUIRED)
   if(HDF5_IS_PARALLEL)
      add_definitions(-DH5_HAVE_PARALLEL)
   endif()


### PR DESCRIPTION
## Description
HDF5 builds by default without Fortran bindings, and these do not seem to be used anywhere in MAPL. As such it should be sufficient to require only the HDF5 package, not also the HDF5 Fortran bindings. This will improve accessibility for non-Baselibs users.

## Motivation and Context
When building MAPL for GCHP, the `find_package(HDF5 REQUIRED Fortran)` line was causing issues, because some clusters which have prebuilt NetCDF libraries did not build the HDF5 Fortran bindings. Since the Fortran bindings do not seem to be necessary for MAPL, this requirement can be removed, enabling the users to proceed. 

## How Has This Been Tested?
Built GCHP 13.0 (including MAPL) after removing the ` Fortran` requirement.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
