### PR TITLE
Fixes for building MAPL without Baselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [2.6.1] - 2021-02-16
+
+### Changed
+
+- Move to ESMA_cmake v3.3.6
+
+### Fixed
+
+- Fixes build of MAPL on non-Baselibs machines
+
 ## [2.6.0] - 2021-02-12
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.6.0
+  VERSION 2.6.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.5
+  tag: v3.3.6
   develop: develop
 
 ecbuild:

--- a/generic/AbstractComponent.F90
+++ b/generic/AbstractComponent.F90
@@ -1,5 +1,5 @@
 module mapl_AbstractComponent
-   implicit none(external)
+   implicit none
    private
 
    public :: AbstractComponent

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -37,8 +37,7 @@ find_package(GFTL_SHARED REQUIRED)
 esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL.shared pflogger gftl-shared gftl)
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF})
-target_link_libraries (${this} PUBLIC ${ESMF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+target_link_libraries (${this} PUBLIC esmf NetCDF::NetCDF_Fortran)
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -7,13 +7,12 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler MAPL.history TYPE SHARED)
-target_link_libraries (${this} PUBLIC gftl gftl-shared ${ESMF_LIBRARIES}
+target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF}
-          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -13,6 +13,6 @@ target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortr
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_include_directories (${this} $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -7,13 +7,12 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler TYPE SHARED)
-target_link_libraries (${this} PUBLIC gftl gftl-shared ${ESMF_LIBRARIES}
+target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_include_directories (${this} PUBLIC ${INC_ESMF} ${INC_NETCDF}
-          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+target_include_directories (${this} $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -128,7 +128,7 @@ endif ()
 ecbuild_add_executable (
   TARGET pfio_writer.x
   SOURCES pfio_writer.F90
-  LIBS ${this} ${NETCDF_LIBRARIES}  MPI::MPI_Fortran)
+  LIBS ${this} NetCDF::NetCDF_Fortran MPI::MPI_Fortran)
 set_target_properties (pfio_writer.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 #--------------------

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ ecbuild_add_executable (
   TARGET ${TESTO}
   NOINSTALL
   SOURCES pfio_ctest_io.F90
-  LIBS MAPL.shared MAPL.pfio ${NETCDF_LIBRARIES} MPI::MPI_Fortran
+  LIBS MAPL.shared MAPL.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   DEFINITIONS USE_MPI)
 # CMake has an OpenMP issue with Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
@@ -106,12 +106,12 @@ ecbuild_add_executable (
   NOINSTALL
   SOURCES pfio_performance.F90
   DEFINITIONS USE_MPI
-  LIBS MAPL.pfio ${NETCDF_LIBRARIES} MPI::MPI_Fortran)
+  LIBS MAPL.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran)
 # CMake has an OpenMP issue with Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${TESTPERF} OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${TESTPERF} MAPL.pfio ${NETCDF_LIBRARIES})
+target_link_libraries(${TESTPERF} MAPL.pfio NetCDF::NetCDF_Fortran)
 add_test(NAME pFIO_performance
   COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 12 ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${TESTO} ${TESTO_FLAGS} -s hybrid
   )


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As reported by @rmontuoro, MAPL 2.6.0 doesn't build in a non-Baselibs environment. This PR should fix it (pending testing by @rmontuoro )

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Allows MAPL standalone (and more?) to build at Orion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test builds and runs of MAPL tests. GEOSgcm test upcoming.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
