### PR TITLE
add seconds to string template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add %S as seconds token to grads style StringTemplate
 - Add new bundle IO routines for non performance critical IO to eventually depreciate MAPL_CFIO and MAPL_cfio
 
 ### Changed

--- a/base/StringTemplate.F90
+++ b/base/StringTemplate.F90
@@ -11,7 +11,7 @@ private
 public fill_grads_template
 public StrTemplate
 
-character(len=2), parameter :: valid_tokens(13) = ["y4","y2","m1","m2","mc","Mc","MC","d1","d2","h1","h2","h3","n2"]
+character(len=2), parameter :: valid_tokens(14) = ["y4","y2","m1","m2","mc","Mc","MC","d1","d2","h1","h2","h3","n2","S2"]
 character(len=3),parameter :: mon_lc(12) = [&
    'jan','feb','mar','apr','may','jun',   &
    'jul','aug','sep','oct','nov','dec']
@@ -127,7 +127,7 @@ contains
                   if (.not.preserve_) then
                      _ASSERT(present(nymd) .or. present(nhms) .or. present(time),'Using token with no time')
                   end if
-                  sbuf = evaluate_token(c1//c2,year,month,day,hour,minute,preserve_)
+                  sbuf = evaluate_token(c1//c2,year,month,day,hour,minute,second,preserve_)
                   kstp = len_trim(sbuf)
                   m=k+kstp-1
                   output_string(k:m)=sbuf
@@ -159,9 +159,9 @@ contains
       enddo
    end function check_token
 
-   function evaluate_token(token,year,month,day,hour,minute,preserve) result(buffer)
+   function evaluate_token(token,year,month,day,hour,minute,second,preserve) result(buffer)
       character(len=2), intent(in) :: token
-      integer, intent(in) :: year,month,day,hour,minute
+      integer, intent(in) :: year,month,day,hour,minute,second
       logical, intent(in) :: preserve
       character(len=4) :: buffer
       character(len=1) :: c1,c2
@@ -227,6 +227,12 @@ contains
       case("n")
          if (.not.skip_token(minute,preserve)) then
             write(buffer,'(i2.2)')minute
+         else
+            buffer="%"//token
+         end if
+      case("S")
+         if (.not.skip_token(second,preserve)) then
+            write(buffer,'(i2.2)')second
          else
             buffer="%"//token
          end if


### PR DESCRIPTION
Add %S (note capital!, lower case was already used) to allow seconds in the string template function used by History etc, note allows one to output to a unique file every timestep when the timestep is not a whole minute.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
