### PR TITLE
allow user to specify decomposition for history, useful for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow user to specify decomposition used by grids in History output, useful for testing
 - Add %S as seconds token to grads style StringTemplate
 - Add new bundle IO routines for non performance critical IO to eventually depreciate MAPL_CFIO and MAPL_cfio
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -361,7 +361,7 @@ contains
     integer                                   :: c
     logical                                   :: isFileName
     logical                                   :: fileExists
-    logical                                   :: isPresent
+    logical                                   :: isPresent,hasNX,hasNY
     real                                      :: lvl
 
     integer                                   :: mntly
@@ -619,15 +619,21 @@ contains
              key => iter%key()
              call ESMF_ConfigGetAttribute(config, value=grid_type, label=trim(key)//".GRID_TYPE:",rc=status)
              _VERIFY(status)
-             if (trim(grid_type)=='Cubed-Sphere') then
-                call MAPL_MakeDecomposition(nx,ny,reduceFactor=6,rc=status)
-                _VERIFY(status)
-             else
-                call MAPL_MakeDecomposition(nx,ny,rc=status)
-                _VERIFY(status)
+             call  ESMF_ConfigFindLabel(config,trim(key)//".NX:",isPresent=hasNX,rc=status)
+             _VERIFY(status)
+             call  ESMF_ConfigFindLabel(config,trim(key)//".NY:",isPresent=hasNY,rc=status)
+             _VERIFY(status)
+             if ((.not.hasNX) .and. (.not.hasNY)) then
+                if (trim(grid_type)=='Cubed-Sphere') then
+                   call MAPL_MakeDecomposition(nx,ny,reduceFactor=6,rc=status)
+                   _VERIFY(status)
+                else
+                   call MAPL_MakeDecomposition(nx,ny,rc=status)
+                   _VERIFY(status)
+                end if
+                call MAPL_ConfigSetAttribute(config, value=nx,label=trim(key)//".NX:",rc=status)
+                call MAPL_ConfigSetAttribute(config, value=ny,label=trim(key)//".NY:",rc=status)
              end if
-             call MAPL_ConfigSetAttribute(config, value=nx,label=trim(key)//".NX:",rc=status)
-             call MAPL_ConfigSetAttribute(config, value=ny,label=trim(key)//".NY:",rc=status)
              output_grid = grid_manager%make_grid(config, prefix=key//'.', rc=status)
              _VERIFY(status)
              call IntState%output_grids%set(key, output_grid)


### PR DESCRIPTION
Just a trivial PR to let the user specify the decomposition to use for the grids created by history rather than let the MAPL pick one. This is just useful for testing like when trying to debug issues like this:
https://github.com/GEOS-ESM/MAPL/issues/698 
and lets me make my own testing a little tighter and run on few cores.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
