### PR TITLE
ExtDataDriver.x generating spatially varying synthetic data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improvement to ExtDataDriver when generating synthetic data
 - Allow user to specify decomposition used by grids in History output, useful for testing
 - Add %S as seconds token to grads style StringTemplate
 - Add new bundle IO routines for non performance critical IO to eventually depreciate MAPL_CFIO and MAPL_cfio

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -121,6 +121,18 @@ MODULE ExtDataUtRoot_GridCompMod
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
                vlocation = MAPL_VLocationCenter, rc=status)
+         call MAPL_AddInternalSpec(GC,&
+               short_name='lats', &
+               long_name='na' , &
+               units = 'na', &
+               dims = MAPL_DimsHorzOnly, &
+               vlocation = MAPL_VLocationCenter, rc=status)
+         call MAPL_AddInternalSpec(GC,&
+               short_name='lons', &
+               long_name='na' , &
+               units = 'na', &
+               dims = MAPL_DimsHorzOnly, &
+               vlocation = MAPL_VLocationCenter, rc=status)
 
 !   Generic Set Services
 !   --------------------
@@ -291,6 +303,9 @@ MODULE ExtDataUtRoot_GridCompMod
          type(ESMF_State) :: internal
          type(ESMF_Config) :: cf
          type(ESMF_Time) :: currTime
+         real(ESMF_KIND_R8),pointer :: ptrR8(:,:)
+         real, pointer :: ptrR4(:,:)
+         type(ESMF_Grid) :: grid
 
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
@@ -312,6 +327,17 @@ MODULE ExtDataUtRoot_GridCompMod
          call ESMF_UserCompGetInternalState(gc,wrap_name,synthWrap,status)
          _VERIFY(status)
          synth => synthWrap%ptr
+         call ESMF_GridCompGet(GC,grid=grid,__RC__)
+         call MAPL_GetPointer(internal,ptrR4,'lons',__RC__)
+         call ESMF_GridGetCoord (Grid, coordDim=1, localDE=0, &
+                           staggerloc=ESMF_STAGGERLOC_CENTER, &
+                           farrayPtr=ptrR8, rc=status)
+         ptrR4=ptrR8
+         call MAPL_GetPointer(internal,ptrR4,'lats',__RC__)
+         call ESMF_GridGetCoord (Grid, coordDim=2, localDE=0, &
+                           staggerloc=ESMF_STAGGERLOC_CENTER, &
+                           farrayPtr=ptrR8, rc=status) 
+         ptrR4=ptrR8
 
          select case (trim(synth%runMode))
 
@@ -523,7 +549,7 @@ MODULE ExtDataUtRoot_GridCompMod
       real, pointer                       :: Exptr2(:,:) => null()
       integer :: itemcount
       character(len=ESMF_MAXSTR), allocatable :: outNameList(:)
-      type(ESMF_Field) :: expf,farray(1)
+      type(ESMF_Field) :: expf,farray(3)
       type(ESMF_State) :: pstate
       character(len=:), pointer :: fexpr
 
@@ -537,6 +563,10 @@ MODULE ExtDataUtRoot_GridCompMod
       exPtr2=synth%tFunc%evaluateTime(Time,rc=status)
       _VERIFY(status)
       call ESMF_StateGet(inState,'time',farray(1),rc=status)
+      _VERIFY(status)
+      call ESMF_StateGet(inState,'lons',farray(2),rc=status)
+      _VERIFY(status)
+      call ESMF_StateGet(inState,'lats',farray(3),rc=status)
       _VERIFY(status)
       pstate = ESMF_StateCreate(rc=status)
       _VERIFY(status)


### PR DESCRIPTION
Added the ability to use the grid lons and lats in the expression used to fill the exports when generating synthetic data. This allows one to get spatially varying data which may provide more useful tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
