### PR TITLE
Add Python Transition Team Codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,10 @@
 # The MAPL Team owns all the files
 * @GEOS-ESM/mapl-team
 
+# The Python Transition Team will own Python files
+# until the Python 3 transition is completed
+*.py @GEOS-ESM/python-transition-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /build*/
 /install*/
 /.mepo/
+*.py.bak


### PR DESCRIPTION
As we prepare for the Python 3 Transition, add @GEOS-ESM/python-transition-team to the `CODEOWNERS` file.