### PR TITLE
Fixes #642. Remove/comment out cube string variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Do not output `cubed_sphere` and `orientation` variables in native
+  History output as pFIO at present does not handle string variables
+
 ### Fixed
+
+- Bumped cube version to 2.91 in global metadata
 
 ### Removed
 
@@ -28,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed program tstqsat.F90 from MAPL.base library.  A followup
   should add cmake logic to create an executable or just delete the
   file.
-- Bumped cube version to 2.91 in global metadata
 - CMake workaround for macOS + Intel oneAPI FLAP bug (#644)
 
 ## [2.6.3] - 2021-03-09
@@ -50,8 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
 - Change command line interface to --npes_backend_pernode to avoid confusion
 - Remove self-defined-in-file MAPL macros
-- Do not output `cubed_sphere` and `orientation` variables in native
-  History output as pFIO at present does not handle string variables
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
 - Change command line interface to --npes_backend_pernode to avoid confusion
+- Do not output `cubed_sphere` and `orientation` variables in native
+  History output as pFIO at present does not handle string variables
 
 ### Fixed
+
+- Bumped cube version to 2.91 in global metadata
 
 ### Removed
 

--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -843,19 +843,21 @@ contains
       type (Variable) :: v
       integer, parameter :: MAXLEN=80
       character(len=MAXLEN) :: gridspec_file_name
-      character(len=5), allocatable :: cvar(:,:)
+      !!! character(len=5), allocatable :: cvar(:,:)
       integer, allocatable :: ivar(:,:)
       integer, allocatable :: ivar2(:,:,:)
 
       integer :: status
+      integer, parameter :: ncontact = 4
+      integer, parameter :: nf = 6
 
-      ! Grid dimensinos
+      ! Grid dimensions
       call metadata%add_dimension('Xdim', this%im_world, rc=status)
       call metadata%add_dimension('Ydim', this%im_world, rc=status)
       call metadata%add_dimension('XCdim', this%im_world+1, rc=status)
       call metadata%add_dimension('YCdim', this%im_world+1, rc=status)
-      call metadata%add_dimension('nf', 6, rc=status)
-      call metadata%add_dimension('ncontact', 4, rc=status)
+      call metadata%add_dimension('nf', nf, rc=status)
+      call metadata%add_dimension('ncontact', ncontact, rc=status)
       call metadata%add_dimension('orientationStrLen', 5, rc=status)
 
       ! Coordinate variables
@@ -873,98 +875,74 @@ contains
       call v%add_attribute('long_name','cubed-sphere face')
       call v%add_attribute('axis','e')
       call v%add_attribute('grads_dim','e')
-      call v%add_const_value(UnlimitedEntity((/1,2,3,4,5,6/)))
+      call v%add_const_value(UnlimitedEntity([1,2,3,4,5,6]))
       call metadata%add_variable('nf',v)
 
       v = Variable(type=PFIO_INT32, dimensions='ncontact')
       call v%add_attribute('long_name','number of contact points')
-      call v%add_const_value(UnlimitedEntity((/1,2,3,4/)))
+      call v%add_const_value(UnlimitedEntity([1,2,3,4]))
       call metadata%add_variable('ncontact',v)
-
-      v = Variable(type=PFIO_STRING)
-      call  v%add_attribute('grid_mapping_name','gnomonic cubed-sphere')
-      call  v%add_attribute('file_format_version','2.91')
-      call  v%add_attribute('additional_vars','contacts,orientation,anchor')
-      call  v%add_attribute('gridspec_file','gridspec.nc4')
-      call metadata%add_variable('cubed_sphere',v)
 
       ! Other variables
       allocate(ivar(4,6))
-      ivar = reshape( (/5, 3, 2, 6, &
-                     1, 3, 4, 6, &
-                     1, 5, 4, 2, &
-                     3, 5, 6, 2, &
-                     3, 1, 6, 4, &
-                     5, 1, 2, 4 /), (/4,6/))
+      ivar = reshape( [5, 3, 2, 6, &
+                       1, 3, 4, 6, &
+                       1, 5, 4, 2, &
+                       3, 5, 6, 2, &
+                       3, 1, 6, 4, &
+                       5, 1, 2, 4 ], [ncontact,nf])
       v = Variable(type=PFIO_INT32, dimensions='ncontact,nf')
       call v%add_attribute('long_name', 'adjacent face starting from left side going clockwise')
       call v%add_const_value(UnlimitedEntity(ivar))
       call metadata%add_variable('contacts', v)
 
-      allocate(cvar(4,6))
-      !cvar =reshape((/" Y:-X", &
-               !" X:-Y", &
-               !" Y:Y ", &
-               !" X:X ", &
-               !" Y:Y ", &
-               !" X:X ", &
-               !" Y:-X", &
-               !" X:-Y", &
-               !" Y:-X", &
-               !" X:-Y", &
-               !" Y:Y ", &
-               !" X:X ", &
-               !" Y:Y ", &
-               !!" X:X ", &
-               !" Y:-X", &
-               !" X:-Y", &
-               !" Y:-X", &
-               !" X:-Y", &
-               !" Y:Y ", &
-               !" X:X ", &
-               !" Y:Y ", &
-               !" X:X ", &
-               !" Y:-X", &
-               !" X:-Y" /),(/4,6/))
-      v = Variable(type=PFIO_STRING, dimensions='orientationStrLen,ncontact,nf')
-      call v%add_attribute('long_name', 'orientation of boundary')
-      !call v%add_const_value(UnlimitedEntity(cvar))
-      call metadata%add_variable('orientation', v)
+      !!! At present pfio does not seem to work with string variables
+      !!! allocate(cvar(4,6))
+      !!! cvar =reshape([" Y:-X", " X:-Y", " Y:Y ", " X:X ", &
+      !!!                " Y:Y ", " X:X ", " Y:-X", " X:-Y", &
+      !!!                " Y:-X", " X:-Y", " Y:Y ", " X:X ", &
+      !!!                " Y:Y ", " X:X ", " Y:-X", " X:-Y", &
+      !!!                " Y:-X", " X:-Y", " Y:Y ", " X:X ", &
+      !!!                " Y:Y ", " X:X ", " Y:-X", " X:-Y" ], [ncontact,nf])
+      !!! v = Variable(type=PFIO_STRING, dimensions='orientationStrLen,ncontact,nf')
+      !!! call v%add_attribute('long_name', 'orientation of boundary')
+      !!! call v%add_const_value(UnlimitedEntity(cvar))
+      !!! call metadata%add_variable('orientation', v)
 
       im = this%im_world
       allocate(ivar2(4,4,6))
-      ivar2 = reshape(        & 
-                 (/im, im,  1, im, &
-                  1, im,  1,  1, &
-                  1, im,  1,  1, &
-                 im, im,  1, im, &
-                 im,  1, im, im, &
-                  1,  1, im,  1, &
-                  1,  1, im,  1, &
-                 im,  1, im,  im, &
-                 im, im,  1, im, &
-                  1, im,  1,  1, &
-                  1, im,  1,  1, &
-                 im, im,  1, im, &
-                 im,  1, im, im, &
-                  1,  1, im,  1, &
-                  1,  1, im,  1, &
-                 im,  1, im, im, &
-                 im, im,  1, im, &
-                  1, im,  1,  1, &
-                  1, im,  1,  1, &
-                 im, im,  1, im, &
-                 im,  1, im, im, &
-                  1,  1, im,  1, &
-                  1,  1, im,  1, &
-                 im,  1, im, im  /), (/4,4,6/))
+      ivar2 = reshape(            & 
+               [[im, im,  1, im,  &
+                  1, im,  1,  1,  &
+                  1, im,  1,  1,  &
+                 im, im,  1, im], &
+                [im,  1, im, im,  &
+                  1,  1, im,  1,  &
+                  1,  1, im,  1,  &
+                 im,  1, im, im], &
+                [im, im,  1, im,  &
+                  1, im,  1,  1,  &
+                  1, im,  1,  1,  &
+                 im, im,  1, im], &
+                [im,  1, im, im,  &
+                  1,  1, im,  1,  &
+                  1,  1, im,  1,  &
+                 im,  1, im, im], &
+                [im, im,  1, im,  &
+                  1, im,  1,  1,  &
+                  1, im,  1,  1,  &
+                 im, im,  1, im], &
+                [im,  1, im, im,  &
+                  1,  1, im,  1,  &
+                  1,  1, im,  1,  &
+                 im,  1, im, im] ], [ncontact,ncontact,nf])
       v = Variable(type=PFIO_INT32, dimensions='ncontact,ncontact,nf')
       call v%add_attribute('long_name', 'anchor point')
       call v%add_const_value(UnlimitedEntity(ivar2))
       call metadata%add_variable('anchor', v)
 
       call Metadata%add_attribute('grid_mapping_name', 'gnomonic cubed-sphere')
-      call Metadata%add_attribute('file_format_version', '2.90')
+      call Metadata%add_attribute('file_format_version', '2.91')
       call Metadata%add_attribute('additional_vars', 'contacts,orientation,anchor')
       write(gridspec_file_name,'("C",i0,"_gridspec.nc4")') this%im_world
       call Metadata%add_attribute('gridspec_file', trim(gridspec_file_name))


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updates the CubeSphere factory to not output string variables as pFIO does not seem to support them (see https://github.com/GEOS-ESM/MAPL/issues/642#issuecomment-783676553)

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#642 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

With this, you can `nccmp` a native History file and a native History compressed file and it works.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran GEOS, output a cube native file, compressed and it works. Before:
```console
$ ncks -L 1 nativeouttest-gcm-2021Feb22-1day-c24.geosgcm_native.20000415_1800z.nc4 compressed.nc4
$ nccmp -dfsB nativeouttest-gcm-2021Feb22-1day-c24.geosgcm_native.20000415_1800z.nc4 compressed.nc4
DIFFER : VARIABLE : orientation : POSITION : [0,0,0] : VALUES :  <> x
DIFFER : VARIABLE : orientation : POSITION : [0,0,1] : VALUES :  <> W
DIFFER : VARIABLE : orientation : POSITION : [0,0,2] : VALUES :  <> w
DIFFER : VARIABLE : orientation : POSITION : [0,0,3] : VALUES :  <> �
DIFFER : VARIABLE : orientation : POSITION : [0,0,4] : VALUES :  <> �
DIFFER : VARIABLE : orientation : POSITION : [0,1,0] : VALUES :  <> *
DIFFER : VARIABLE : orientation : POSITION : [0,1,3] : VALUES :  <> �
DIFFER : VARIABLE : orientation : POSITION : [0,1,4] : VALUES :  <> �
DIFFER : VARIABLE : orientation : POSITION : [0,2,0] : VALUES :  <> P
DIFFER : VARIABLE : orientation : POSITION : [0,2,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [0,2,2] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [0,3,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [1,0,0] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [1,0,4] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [1,1,3] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [1,2,2] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [1,3,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [2,0,0] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [2,0,4] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [2,1,3] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [2,2,2] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [2,3,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [3,0,0] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [3,0,4] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [3,1,3] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [3,2,2] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [3,3,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [4,0,0] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [4,0,4] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [4,1,3] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [4,2,2] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [5,0,0] : VALUES : 1 <>
DIFFER : VARIABLE : orientation : POSITION : [5,0,1] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,0,3] : VALUES : @ <>
DIFFER : VARIABLE : orientation : POSITION : [5,0,4] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,1,0] : VALUES : 9 <>
DIFFER : VARIABLE : orientation : POSITION : [5,1,1] : VALUES : O <>
DIFFER : VARIABLE : orientation : POSITION : [5,1,2] : VALUES : H <>
DIFFER : VARIABLE : orientation : POSITION : [5,1,3] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,1,4] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,2,0] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [5,2,1] : VALUES : @ <>
DIFFER : VARIABLE : orientation : POSITION : [5,2,2] : VALUES : W <>
DIFFER : VARIABLE : orientation : POSITION : [5,2,3] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,2,4] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,3,0] : VALUES : m <>
DIFFER : VARIABLE : orientation : POSITION : [5,3,1] : VALUES :  <>
DIFFER : VARIABLE : orientation : POSITION : [5,3,2] : VALUES : � <>
DIFFER : VARIABLE : orientation : POSITION : [5,3,3] : VALUES : $ <>
DIFFER : VARIABLE : orientation : POSITION : [5,3,4] : VALUES : @ <>
```
After:
```console
$ ncks -L 1 nativeouttest-gcm-2021Feb22-1day-c24.geosgcm_native.20000415_1800z.nc4 compressed.nc4
$ nccmp -dfsB nativeouttest-gcm-2021Feb22-1day-c24.geosgcm_native.20000415_1800z.nc4 compressed.nc4
Files "nativeouttest-gcm-2021Feb22-1day-c24.geosgcm_native.20000415_1800z.nc4" and "compressed.nc4" are identical.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
