### PR TITLE
Set return code for MAPL Cap and CapGridComp methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add return code to constructor method for MAPL Cap gridded component to allow applications
+  to fail gracefully if an error occurs
+
 ### Changed
 
 ### Fixed
+
+- Properly set return code for MAPL Cap methods
 
 ### Removed
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -191,6 +191,7 @@ contains
          fast_oclient  = this%cap_options%fast_oclient, &
          rc=status)
      _VERIFY(status)
+     _RETURN(_SUCCESS)
 
    end subroutine initialize_io_clients_servers
      
@@ -212,6 +213,8 @@ contains
          call o_Clients%terminate()
       end select
                   
+     _RETURN(_SUCCESS)
+
    end subroutine run_member
 
 
@@ -300,6 +303,7 @@ contains
      integer, intent(out) :: rc
      integer :: status
      call this%cap_gc%step(rc = status); _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine step_model
   
    subroutine rewind_model(this, time, rc)
@@ -308,6 +312,7 @@ contains
      integer, intent(out) :: rc
      integer :: status
      call this%cap_gc%rewind_clock(time,rc = status); _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine rewind_model 
 
    integer function create_member_subcommunicator(this, comm, unusable, rc) result(subcommunicator)

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -236,7 +236,8 @@ contains
       call ESMF_Initialize (vm=vm, logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, rc=status)
       _VERIFY(status)
 
-      call this%initialize_cap_gc()
+      call this%initialize_cap_gc(rc=status)
+      _VERIFY(status)
 
       call this%cap_gc%set_services(rc = status)
       _VERIFY(status)
@@ -290,11 +291,19 @@ contains
 
    end subroutine run_model
    
-   subroutine initialize_cap_gc(this)
+   subroutine initialize_cap_gc(this, unusable, rc)
      class(MAPL_Cap), intent(inout) :: this
+     class (KeywordEnforcer), optional, intent(in) :: unusable
+     integer, optional, intent(out) :: rc
+
+     integer :: status
+
+     _UNUSED_DUMMY(unusable)
 
      call MAPL_CapGridCompCreate(this%cap_gc, this%set_services, this%get_cap_rc_file(), &
-           this%name, this%get_egress_file())     
+           this%name, this%get_egress_file(), rc=status)
+     _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine initialize_cap_gc
    
 

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -91,19 +91,23 @@ module MAPL_CapGridCompMod
 contains
 
   
-   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file)
+   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file, unusable, rc)
       use mapl_StubComponent
     type(MAPL_CapGridComp), intent(out), target :: cap
     procedure() :: root_set_services
     character(*), intent(in) :: cap_rc, name
     character(len=*), optional, intent(in) :: final_file
+    class(KeywordEnforcer), optional, intent(in) :: unusable
+    integer, optional, intent(out) :: rc
 
     type(MAPL_CapGridComp_Wrapper) :: cap_wrapper
     type(MAPL_MetaComp), pointer :: meta => null()
-    integer :: status, rc
+    integer :: status
     character(*), parameter :: cap_name = "CAP"
     type(StubComponent) :: stub_component
     
+    _UNUSED_DUMMY(unusable)
+
     cap%cap_rc_file = cap_rc
     cap%root_set_services => root_set_services
     if (present(final_file)) then
@@ -129,6 +133,8 @@ contains
     cap_wrapper%ptr => cap
     call ESMF_UserCompSetInternalState(cap%gc, internal_cap_name, cap_wrapper, status)
     _VERIFY(status)
+
+    _RETURN(_SUCCESS)
 
   end subroutine MAPL_CapGridCompCreate
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->
This PR introduces changes to fix the return code value for MAPL Cap methods and adds a return code argument to the Cap gridded component constructor method.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The included changes set the return code of some MAPL Cap methods to the correct value upon exit, and add a return code to the MAPL Cap gridded component constructor API to allow applications to handle gracefully potential errors.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR includes changes addressing existing shortfalls in a few MAPL Cap methods, which did not properly set their return code upon exit.

Additional changes add a return code to the Cap gridded component's constructor API, which is required to ensure the UFS-GOCART application can return gracefully in the case an error occurs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR was tested on Orion. MAPL was built as standalone library and used to build and run UFS-GOCART.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
