### PR TITLE
Feature/atrayano/#660 config set attribute ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New overload for MAPL_ConfigSetAttribute to support array of integers
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New overload for MAPL_ConfigSetAttribute to support array of integers
+- New overload for MAPL_ConfigSetAttribute to support array of reals
 
 ### Changed
 

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -1,7 +1,6 @@
 #include "MAPL_Generic.h"
 
 
-
 ! This module implements extensions that allow extending an
 ! ESMF_Config object.  Otherwise, ESMF only provides a constructor
 ! that loads the data from a text file.
@@ -19,6 +18,7 @@ module MAPL_ConfigMod
       module procedure :: MAPL_ConfigSetAttribute_real32
       module procedure :: MAPL_ConfigSetAttribute_real64
       module procedure :: MAPL_ConfigSetAttribute_int32
+      module procedure :: MAPL_ConfigSetAttribute_ints32
       module procedure :: MAPL_ConfigSetAttribute_string
    end interface
 
@@ -595,13 +595,41 @@ contains
       return
    end subroutine MAPL_ConfigSetAttribute_int32
 
+   subroutine MAPL_ConfigSetAttribute_ints32( config, value, label, rc )
+         use, intrinsic :: iso_fortran_env, only: INT32
+! !ARGUMENTS:
+      type(ESMF_Config), intent(inout)             :: config     
+      integer(kind=INT32), intent(in)            :: value(:)
+      character(len=*), intent(in), optional       :: label 
+      integer, intent(out), optional               :: rc   
 ! BOPI -------------------------------------------------------------------
 !
-! !IROUTINE: MAPL_ConfigSetAttribute - Set a 4-byte integer number
+! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
 
 !
 ! !INTERFACE:
       ! Private name; call using MAPL_ConfigSetAttribute()
+
+       integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
+       character(len=LSZ) :: buffer
+       character(len=12) :: tmpStr, newVal
+       integer :: count, i, j
+       integer :: status
+
+       count = size(value)
+       buffer = '' ! initialize to 
+       do i = 1, count
+          j = len_trim(buffer)
+          write(tmpStr, *) value(i) ! ALT: check if enough space to write
+          newVal = adjustl(tmpStr)
+          _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+          write(buffer(j+1:), *) trim(newVal)
+       end do
+       call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
+
+       _RETURN(ESMF_SUCCESS)
+    end subroutine MAPL_ConfigSetAttribute_ints32
+
    subroutine MAPL_ConfigSetAttribute_string(config, value, label, rc)
 ! !ARGUMENTS:
       type(ESMF_Config), intent(inout)             :: config     

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -16,6 +16,7 @@ module MAPL_ConfigMod
 
    interface MAPL_ConfigSetAttribute
       module procedure :: MAPL_ConfigSetAttribute_real32
+      module procedure :: MAPL_ConfigSetAttribute_reals32
       module procedure :: MAPL_ConfigSetAttribute_real64
       module procedure :: MAPL_ConfigSetAttribute_int32
       module procedure :: MAPL_ConfigSetAttribute_ints32
@@ -596,12 +597,12 @@ contains
    end subroutine MAPL_ConfigSetAttribute_int32
 
    subroutine MAPL_ConfigSetAttribute_ints32( config, value, label, rc )
-         use, intrinsic :: iso_fortran_env, only: INT32
+     use, intrinsic :: iso_fortran_env, only: INT32
 ! !ARGUMENTS:
-      type(ESMF_Config), intent(inout)             :: config     
-      integer(kind=INT32), intent(in)            :: value(:)
-      character(len=*), intent(in), optional       :: label 
-      integer, intent(out), optional               :: rc   
+     type(ESMF_Config), intent(inout)             :: config     
+     integer(kind=INT32), intent(in)              :: value(:)
+     character(len=*), intent(in), optional       :: label 
+     integer, intent(out), optional               :: rc   
 ! BOPI -------------------------------------------------------------------
 !
 ! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
@@ -610,25 +611,60 @@ contains
 ! !INTERFACE:
       ! Private name; call using MAPL_ConfigSetAttribute()
 
-       integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
-       character(len=LSZ) :: buffer
-       character(len=12) :: tmpStr, newVal
-       integer :: count, i, j
-       integer :: status
+     integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
+     character(len=LSZ) :: buffer
+     character(len=12) :: tmpStr, newVal
+     integer :: count, i, j
+     integer :: status
+     
+     count = size(value)
+     buffer = '' ! initialize to 
+     do i = 1, count
+        j = len_trim(buffer)
+        write(tmpStr, *) value(i) ! ALT: check if enough space to write
+        newVal = adjustl(tmpStr)
+        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        write(buffer(j+1:), *) trim(newVal)
+     end do
+     call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
 
-       count = size(value)
-       buffer = '' ! initialize to 
-       do i = 1, count
-          j = len_trim(buffer)
-          write(tmpStr, *) value(i) ! ALT: check if enough space to write
-          newVal = adjustl(tmpStr)
-          _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
-          write(buffer(j+1:), *) trim(newVal)
-       end do
-       call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
+     _RETURN(ESMF_SUCCESS)
+   end subroutine MAPL_ConfigSetAttribute_ints32
 
-       _RETURN(ESMF_SUCCESS)
-    end subroutine MAPL_ConfigSetAttribute_ints32
+   subroutine MAPL_ConfigSetAttribute_reals32( config, value, label, rc )
+     use, intrinsic :: iso_fortran_env, only: REAL32
+! !ARGUMENTS:
+     type(ESMF_Config), intent(inout)             :: config     
+     real(kind=REAL32), intent(in)                :: value(:)
+     character(len=*), intent(in), optional       :: label 
+     integer, intent(out), optional               :: rc   
+! BOPI -------------------------------------------------------------------
+!
+! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
+
+!
+! !INTERFACE:
+      ! Private name; call using MAPL_ConfigSetAttribute()
+
+     integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
+     character(len=LSZ) :: buffer
+     character(len=12) :: tmpStr, newVal
+     integer :: count, i, j
+     integer :: status
+
+     count = size(value)
+     buffer = '' ! initialize to 
+     do i = 1, count
+        j = len_trim(buffer)
+        write(tmpStr, *) value(i) ! ALT: check if enough space to write
+        newVal = adjustl(tmpStr)
+        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        write(buffer(j+1:), *) trim(newVal)
+     end do
+     call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
+
+     _RETURN(ESMF_SUCCESS)
+   end subroutine MAPL_ConfigSetAttribute_reals32
 
    subroutine MAPL_ConfigSetAttribute_string(config, value, label, rc)
 ! !ARGUMENTS:

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -648,7 +648,7 @@ contains
 
      integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
      character(len=LSZ) :: buffer
-     character(len=12) :: tmpStr, newVal
+     character(len=15) :: tmpStr, newVal
      integer :: count, i, j
      integer :: status
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #660. This PR adds 2 new overloads to MAPL_ConfigSetAttribute for arrays of integers and reals. It piggybacks off existing MAPL_ConfigSetAttribute for strings
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->#660

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The GOCART2G developers had requested adding new "vector" overloads for MAPL_ConfigSetAttribute

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Elliot has tested the new features from this PR
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
