### PR TITLE
Prevent History from duplicating output fields whose names end with the component name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,10 @@
 # The MAPL Team owns all the files
 * @GEOS-ESM/mapl-team
 
+# The Python Transition Team will own Python files
+# until the Python 3 transition is completed
+*.py @GEOS-ESM/python-transition-team
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *~
 /ESMA_cmake/
 /ESMA_env/
-/BUILD/
-/build*/
-/install*/
 /.mepo/
+*.py.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add return code to constructor method for MAPL Cap gridded component to allow applications
+  to fail gracefully if an error occurs
+
 ### Changed
 
 - Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
@@ -18,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Have CMake automatically gitignore build and install dirs
+- Properly set return code for MAPL Cap methods
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
+- Change command line interface to --npes_backend_pernode to avoid confusion
+- Remove self-defined-in-file MAPL macros
+
 ### Fixed
+
+- Have CMake automatically gitignore build and install dirs
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New overload for MAPL_ConfigSetAttribute to support array of integers
+- New overload for MAPL_ConfigSetAttribute to support array of reals
+
+- Added ability to "attach" to the pfafstetter grid for land tiles for components running directly on the catchments
 
 - Add return code to constructor method for MAPL Cap gridded component to allow applications
   to fail gracefully if an error occurs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Have CMake automatically gitignore build and install dirs
 - Properly set return code for MAPL Cap methods
+- Prevent History from mistakenly duplicating export fields
+  when field names end with the component's name
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,4 +110,16 @@ install (
    DESTINATION ${INSTALL_DATA_DIR}
    )
 
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+
 ecbuild_install_project (NAME MAPL)

--- a/base/HorizontalFluxRegridder.F90
+++ b/base/HorizontalFluxRegridder.F90
@@ -10,7 +10,6 @@ module mapl_HorizontalFluxRegridder
    use mapl_KeywordEnforcerMod
    use mapl_ErrorHandlingMod
    use mapl_BaseMod
-   use mapl_ErrorHandlingMod
    implicit none
    private
 

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -38,7 +38,7 @@ module MAPL_CapOptionsMod
       ! logging options
       character(:), allocatable :: logging_config
       character(:), allocatable :: oserver_type
-      integer :: npes_output_backend = 0
+      integer :: npes_backend_pernode = 0
    end type MAPL_CapOptions
 
    interface MAPL_CapOptions

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -1,7 +1,6 @@
 #include "MAPL_Generic.h"
 
 
-
 ! This module implements extensions that allow extending an
 ! ESMF_Config object.  Otherwise, ESMF only provides a constructor
 ! that loads the data from a text file.
@@ -17,8 +16,10 @@ module MAPL_ConfigMod
 
    interface MAPL_ConfigSetAttribute
       module procedure :: MAPL_ConfigSetAttribute_real32
+      module procedure :: MAPL_ConfigSetAttribute_reals32
       module procedure :: MAPL_ConfigSetAttribute_real64
       module procedure :: MAPL_ConfigSetAttribute_int32
+      module procedure :: MAPL_ConfigSetAttribute_ints32
       module procedure :: MAPL_ConfigSetAttribute_string
    end interface
 
@@ -595,13 +596,76 @@ contains
       return
    end subroutine MAPL_ConfigSetAttribute_int32
 
+   subroutine MAPL_ConfigSetAttribute_ints32( config, value, label, rc )
+     use, intrinsic :: iso_fortran_env, only: INT32
+! !ARGUMENTS:
+     type(ESMF_Config), intent(inout)             :: config     
+     integer(kind=INT32), intent(in)              :: value(:)
+     character(len=*), intent(in), optional       :: label 
+     integer, intent(out), optional               :: rc   
 ! BOPI -------------------------------------------------------------------
 !
-! !IROUTINE: MAPL_ConfigSetAttribute - Set a 4-byte integer number
+! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
 
 !
 ! !INTERFACE:
       ! Private name; call using MAPL_ConfigSetAttribute()
+
+     integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
+     character(len=LSZ) :: buffer
+     character(len=12) :: tmpStr, newVal
+     integer :: count, i, j
+     integer :: status
+     
+     count = size(value)
+     buffer = '' ! initialize to 
+     do i = 1, count
+        j = len_trim(buffer)
+        write(tmpStr, *) value(i) ! ALT: check if enough space to write
+        newVal = adjustl(tmpStr)
+        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        write(buffer(j+1:), *) trim(newVal)
+     end do
+     call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
+
+     _RETURN(ESMF_SUCCESS)
+   end subroutine MAPL_ConfigSetAttribute_ints32
+
+   subroutine MAPL_ConfigSetAttribute_reals32( config, value, label, rc )
+     use, intrinsic :: iso_fortran_env, only: REAL32
+! !ARGUMENTS:
+     type(ESMF_Config), intent(inout)             :: config     
+     real(kind=REAL32), intent(in)                :: value(:)
+     character(len=*), intent(in), optional       :: label 
+     integer, intent(out), optional               :: rc   
+! BOPI -------------------------------------------------------------------
+!
+! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
+
+!
+! !INTERFACE:
+      ! Private name; call using MAPL_ConfigSetAttribute()
+
+     integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
+     character(len=LSZ) :: buffer
+     character(len=15) :: tmpStr, newVal
+     integer :: count, i, j
+     integer :: status
+
+     count = size(value)
+     buffer = '' ! initialize to 
+     do i = 1, count
+        j = len_trim(buffer)
+        write(tmpStr, *) value(i) ! ALT: check if enough space to write
+        newVal = adjustl(tmpStr)
+        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        write(buffer(j+1:), *) trim(newVal)
+     end do
+     call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
+
+     _RETURN(ESMF_SUCCESS)
+   end subroutine MAPL_ConfigSetAttribute_reals32
+
    subroutine MAPL_ConfigSetAttribute_string(config, value, label, rc)
 ! !ARGUMENTS:
       type(ESMF_Config), intent(inout)             :: config     

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -382,7 +382,7 @@ CONTAINS
 
    type(MAPL_ExtData_state), pointer :: self        ! Legacy state
    type(ESMF_Grid)                   :: GRID        ! Grid
-   type(ESMF_Config)                 :: CF_master          ! Universal Config 
+   type(ESMF_Config)                 :: CF_main          ! Universal Config 
 
    character(len=ESMF_MAXSTR)        :: comp_name
    character(len=ESMF_MAXSTR)        :: Iam
@@ -443,13 +443,13 @@ CONTAINS
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
    Iam = 'Initialize_'
-   call ESMF_GridCompGet( GC, name=comp_name, config=CF_master, __RC__ )
+   call ESMF_GridCompGet( GC, name=comp_name, config=CF_main, __RC__ )
    Iam = trim(comp_name) // '::' // trim(Iam)
 
 !  Extract relevant runtime information
 !  ------------------------------------
-   call extract_ ( GC, self, CF_master, __RC__)
-   self%CF = CF_master
+   call extract_ ( GC, self, CF_main, __RC__)
+   self%CF = CF_main
 
 !  Get the GC pFlogger
 !  -------------------
@@ -468,10 +468,10 @@ CONTAINS
     _VERIFY(STATUS)
 
     ! set ExtData on by default, let user turn it off if they want
-    call ESMF_ConfigGetAttribute(CF_master,self%active, Label='USE_EXTDATA:',default=.true.,rc=status)
+    call ESMF_ConfigGetAttribute(CF_main,self%active, Label='USE_EXTDATA:',default=.true.,rc=status)
 
     ! set extdata to ignore case on variable names in files
-    call ESMF_ConfigGetAttribute(CF_master,caseSensitiveVarNames, Label='CASE_SENSITIVE_VARIABLE_NAMES:',default=.false.,rc=status)
+    call ESMF_ConfigGetAttribute(CF_main,caseSensitiveVarNames, Label='CASE_SENSITIVE_VARIABLE_NAMES:',default=.false.,rc=status)
     self%ignoreCase = .not. caseSensitiveVarNames
 
     ! no need to run ExtData if there are no imports to fill
@@ -508,14 +508,14 @@ CONTAINS
 !                         Parse ExtData Resource File
 !                         ---------------------------
 
-   call ESMF_ConfigGetAttribute(CF_Master,value=EXTDATA_CF,Label="CF_EXTDATA:",rc=status)
+   call ESMF_ConfigGetAttribute(CF_main,value=EXTDATA_CF,Label="CF_EXTDATA:",rc=status)
    _VERIFY(STATUS)
-   call ESMF_ConfigGetAttribute(CF_Master,value=self%allowExtrap,Label="Ext_AllowExtrap:", default=.false., rc=status)
+   call ESMF_ConfigGetAttribute(CF_main,value=self%allowExtrap,Label="Ext_AllowExtrap:", default=.false., rc=status)
    _VERIFY(STATUS)
-   call ESMF_ConfigGetAttribute(CF_Master,value=self%blocksize,label="BlockSize:",default=1,rc=status)
-   call ESMF_ConfigGetAttribute(CF_Master,value=self%prefetch,label="Prefetch:",default=.true.,rc=status)
+   call ESMF_ConfigGetAttribute(CF_main,value=self%blocksize,label="BlockSize:",default=1,rc=status)
+   call ESMF_ConfigGetAttribute(CF_main,value=self%prefetch,label="Prefetch:",default=.true.,rc=status)
 
-   call ESMF_ConfigGetAttribute(CF_Master,value=self%distributed_trans,Label="CONSERVATIVE_DISTRIBUTED_TRANS:",default=.false., rc=status)
+   call ESMF_ConfigGetAttribute(CF_main,value=self%distributed_trans,Label="CONSERVATIVE_DISTRIBUTED_TRANS:",default=.false., rc=status)
    _VERIFY(STATUS)
 
    CFtemp = ESMF_ConfigCreate (rc=STATUS )
@@ -1058,7 +1058,7 @@ CONTAINS
          item%modelGridFields%v1_finterp1 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
          item%modelGridFields%v1_finterp2 = MAPL_FieldCreate(field,item%var,doCopy=.true.,__RC__)
          if (item%do_fill .or. item%do_vertInterp) then
-            call createFileLevBracket(item,cf_master,__RC__)
+            call createFileLevBracket(item,cf_main,__RC__)
          end if
 
       else if (item%vartype == MAPL_BundleItem) then
@@ -1106,7 +1106,7 @@ CONTAINS
          item%modelGridFields%v2_finterp1 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
          item%modelGridFields%v2_finterp2 = MAPL_FieldCreate(field, item%fcomp2,doCopy=.true.,__RC__)
          if (item%do_fill .or. item%do_vertInterp) then
-            call createFileLevBracket(item,cf_master,__RC__)
+            call createFileLevBracket(item,cf_main,__RC__)
          end if
 
       end if

--- a/base/MAPL_FlapCapOptions.F90
+++ b/base/MAPL_FlapCapOptions.F90
@@ -180,7 +180,7 @@ contains
            error=status)
       _VERIFY(status)
 
-      call options%add(switch='--npes_output_backend', &
+      call options%add(switch='--npes_backend_pernode', &
            help='# MPI processes used by the backend output', &
            required=.false., &
            def='0', &
@@ -262,7 +262,7 @@ contains
       ! ouput server type options
       call this%cli_options%get(val=buffer, switch='--oserver_type', error=status); _VERIFY(status)
       this%oserver_type = trim(buffer)
-      call this%cli_options%get(val=this%npes_output_backend, switch='--npes_output_backend', error=status); _VERIFY(status)
+      call this%cli_options%get(val=this%npes_backend_pernode, switch='--npes_backend_pernode', error=status); _VERIFY(status)
 
     end subroutine parse_command_line_arguments
 

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -118,7 +118,6 @@ module MAPL_GenericMod
   use MAPL_ConstantsMod
   use MAPL_SunMod
   use MaplGeneric
-  use MAPL_VarSpecMod
   use MAPL_GenericCplCompMod
   use MAPL_LocStreamMod
   use MAPL_ConfigMod

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -8086,8 +8086,13 @@ module MAPL_IOMod
              x0=1.0d0
              x1=dble(arrdes%JM_WORLD)
           else
-             x0=-90.0d0
-             x1=90.0d0
+             if (arrdes%jm_world==1) then
+                x0=0.0
+                x1=0.0
+             else
+                x0=-90.0d0
+                x1=90.0d0
+             end if
           endif
           lat = MAPL_Range(x0,x1,arrdes%JM_WORLD)
           

--- a/base/MAPL_LocStreamMod.F90
+++ b/base/MAPL_LocStreamMod.F90
@@ -105,6 +105,7 @@ type MAPL_LocStreamType
    type(MAPL_Tiling),        pointer  :: Tiling(:)              =>null() ! Grid associated tilings
    real, pointer              :: D(:,:,:)=>null() ! Bilinear weights
    logical                            :: IsTileAreaValid
+   integer                            :: pfafstetter_catchments
 end type MAPL_LocStreamType
 
 type MAPL_LocStreamXformType
@@ -178,12 +179,11 @@ contains
 !===================================================================
 
 
-  subroutine MAPL_LocStreamGet(LocStream, NT_LOCAL, TILETYPE, TILEKIND, &
+  subroutine MAPL_LocStreamGet(LocStream, NT_LOCAL, nt_global, TILETYPE, TILEKIND, &
                                TILELONS, TILELATS, TILEAREA, &
-!                              TILEI, TILEJ, TILEGRID, &
                                TILEGRID, &
                                GRIDIM, GRIDJM, GRIDNAMES, &
-                               ATTACHEDGRID, LOCAL_ID, RC)
+                               ATTACHEDGRID, LOCAL_ID, local_i, local_j,RC)
     type(MAPL_LocStream),                 intent(IN   ) :: LocStream
     integer, optional,                    intent(  OUT) :: NT_LOCAL
     integer, optional,                    pointer       :: TILETYPE(:)
@@ -196,35 +196,28 @@ contains
     integer, optional,                    pointer       :: GRIDIM(:)
     integer, optional,                    pointer       :: GRIDJM(:)
     integer, optional,                    pointer       :: LOCAL_ID(:)
+    integer, optional,                    intent(out)   :: nt_global
     character(len=*), optional, pointer                 :: GRIDNAMES(:)
     type(ESMF_Grid), optional,            intent(  OUT) :: TILEGRID
     type(ESMF_Grid), optional,            intent(  OUT) :: ATTACHEDGRID
+    integer, optional,  pointer,          intent(  OUT) :: local_i(:)
+    integer, optional,  pointer,          intent(  OUT) :: local_j(:)
     integer, optional,                    intent(  OUT) :: RC
     
 ! Local variables
 
 
-#ifdef __GFORTRAN__
-    integer                    :: i
-    integer, pointer           :: tmp_iptr(:) => null()
-    real,    pointer           :: tmp_rptr(:) => null()
-    character(len=MAPL_TileNameLength), pointer       :: tmp_strptr(:) => null()
-#endif
-
     if (present(NT_LOCAL)) then
        NT_LOCAL = locstream%Ptr%NT_LOCAL
     end if
 
+    if (present(nt_global)) then
+       nt_global = locstream%ptr%nt_global
+    end if
+
+
     if (present(tiletype)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_iptr(lbound(locstream%Ptr%Local_GeoLocation,1):ubound(locstream%Ptr%Local_GeoLocation,1)))
-       do i = lbound(locstream%Ptr%Local_GeoLocation,1), ubound(locstream%Ptr%Local_GeoLocation,1)
-         tmp_iptr(i) = locstream%Ptr%Local_GeoLocation(i)%t
-       enddo
-       tiletype => tmp_iptr
-#else
        tiletype => locstream%Ptr%Local_GeoLocation(:)%t
-#endif
     end if
 
     if (present(tilekind)) then
@@ -234,67 +227,27 @@ contains
     end if
 
     if (present(tilelons)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_rptr(lbound(locstream%Ptr%Local_GeoLocation,1):ubound(locstream%Ptr%Local_GeoLocation,1)))
-       do i = lbound(locstream%Ptr%Local_GeoLocation,1), ubound(locstream%Ptr%Local_GeoLocation,1)
-         tmp_rptr(i) = locstream%Ptr%Local_GeoLocation(i)%x
-       enddo
-       tilelons => tmp_rptr
-#else
        tilelons => locstream%Ptr%Local_GeoLocation(:)%x
-#endif
     end if
 
     if (present(tilelats)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_rptr(lbound(locstream%Ptr%Local_GeoLocation,1):ubound(locstream%Ptr%Local_GeoLocation,1)))
-       do i = lbound(locstream%Ptr%Local_GeoLocation,1), ubound(locstream%Ptr%Local_GeoLocation,1)
-         tmp_rptr(i) = locstream%Ptr%Local_GeoLocation(i)%y
-       enddo
-       tilelats => tmp_rptr
-#else
        tilelats => locstream%Ptr%Local_GeoLocation(:)%y
-#endif
     end if
 
     if (present(tilearea)) then
        if (locstream%Ptr%IsTileAreaValid) then
-#ifdef __GFORTRAN__
-          allocate(tmp_rptr(lbound(locstream%Ptr%Local_GeoLocation,1):ubound(locstream%Ptr%Local_GeoLocation,1)))
-          do i = lbound(locstream%Ptr%Local_GeoLocation,1), ubound(locstream%Ptr%Local_GeoLocation,1)
-            tmp_rptr(i) = locstream%Ptr%Local_GeoLocation(i)%a
-          enddo
-          tilearea => tmp_rptr
-#else
           tilearea => locstream%Ptr%Local_GeoLocation(:)%a
-#endif
        else
           tilearea => null()
        end if
     end if
 
     if (present(gridim)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_iptr(lbound(locstream%Ptr%tiling,1):ubound(locstream%Ptr%tiling,1)))
-       do i = lbound(locstream%Ptr%tiling,1), ubound(locstream%Ptr%tiling,1)
-         tmp_iptr(i) = locstream%Ptr%tiling(i)%im
-       enddo
-       gridim => tmp_iptr
-#else
        gridim => locstream%Ptr%tiling(:)%im
-#endif
     end if
 
     if (present(gridjm)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_iptr(lbound(locstream%Ptr%tiling,1):ubound(locstream%Ptr%tiling,1)))
-       do i = lbound(locstream%Ptr%tiling,1), ubound(locstream%Ptr%tiling,1)
-         tmp_iptr(i) = locstream%Ptr%tiling(i)%jm
-       enddo
-       gridjm => tmp_iptr
-#else
        gridjm => locstream%Ptr%tiling(:)%jm
-#endif
     end if
 
     if (present(local_id)) then
@@ -302,31 +255,23 @@ contains
     end if
 
     if (present(gridnames)) then
-#ifdef __GFORTRAN__
-       allocate(tmp_strptr(lbound(locstream%Ptr%tiling,1):ubound(locstream%Ptr%tiling,1)))
-       do i = lbound(locstream%Ptr%tiling,1), ubound(locstream%Ptr%tiling,1)
-         tmp_strptr(i) = locstream%Ptr%tiling(i)%name
-       enddo
-       gridnames => tmp_strptr
-#else
        gridnames => locstream%Ptr%tiling(:)%name
-#endif
     end if
 
     if (present(attachedgrid)) then
        attachedgrid = locstream%Ptr%grid
     end if
 
-!!$    if (present(tilei)) then
-!!$       tilei => locstream%Ptr%TILING(locstream%ptr%CURRENT_TILING)%Global_IndexLocation(:)%i
-!!$    end if
-!!$
-!!$    if (present(tilej)) then
-!!$       tilej => locstream%Ptr%TILING(locstream%ptr%CURRENT_TILING)%Global_IndexLocation(:)%j
-!!$    end if
-
     if (present(tilegrid)) then
        tilegrid = locstream%Ptr%TILEGRID
+    end if
+
+    if (present(local_i)) then
+       local_i => locstream%Ptr%LOCAL_INDEXLOCATION(:)%i
+    end if
+
+    if (present(local_j)) then
+       local_j => locstream%Ptr%LOCAL_INDEXLOCATION(:)%j
     end if
 
     _RETURN(ESMF_SUCCESS)
@@ -340,7 +285,7 @@ contains
 ! !IIROUTINE: MAPL_LocStreamCreateFromFile --- Create from file
 
   ! !INTERFACE:
-  subroutine MAPL_LocStreamCreateFromFile(LocStream, LAYOUT, FILENAME, NAME, MASK, GRID, NewGridNames, RC)
+  subroutine MAPL_LocStreamCreateFromFile(LocStream, LAYOUT, FILENAME, NAME, MASK, GRID, NewGridNames, use_pfaf, RC)
 
     !ARGUMENTS:
     type(MAPL_LocStream),                 intent(  OUT) :: LocStream
@@ -350,6 +295,7 @@ contains
     integer,                    optional, intent(IN   ) :: MASK(:)
     type(ESMF_Grid), optional,            intent(INout) :: GRID
     logical,                    optional, intent(IN   ) :: NewGridNames
+    logical,                    optional, intent(In   ) :: use_pfaf
     integer,                    optional, intent(  OUT) :: RC  
 
 ! !DESCRIPTION: Creates a location stream from a file. This does
@@ -384,6 +330,7 @@ contains
     type(MAPL_Tiling       ), pointer :: TILING
     type (ESMF_VM)                            :: vm
     logical                           :: NewGridNames_
+    integer                           :: hdr(2)
 
 #ifdef NEW_INTERP_CODE
     integer           :: isc, iec, jsc, jec
@@ -392,6 +339,7 @@ contains
     real, pointer     :: lons(:,:), lats(:,:)
     real, allocatable :: hlons(:,:), hlats(:,:)
 #endif
+    logical :: use_pfaf_
 
 ! Begin
 !------
@@ -399,6 +347,11 @@ contains
     NewGridNames_ = .false.
     if (present(NewGridNames)) then
        NewGridNames_ = NewGridNames
+    end if
+    if (present(use_pfaf)) then
+       use_pfaf_=use_pfaf
+    else
+       use_pfaf_=.false.
     end if
 
 ! Allocate the Location Stream
@@ -449,8 +402,15 @@ contains
 ! Total number of tiles in exchange grid
 !---------------------------------------
 
-       call READ_PARALLEL(layout, NT, UNIT=UNIT, rc=status)
-       _VERIFY(STATUS)
+       if (use_pfaf_) then
+          call READ_PARALLEL(layout, hdr, UNIT=UNIT, rc=status)
+          _VERIFY(STATUS)
+          nt=hdr(1)
+          stream%pfafstetter_catchments=hdr(2)
+       else
+          call READ_PARALLEL(layout, nt, UNIT=UNIT, rc=status)
+          _VERIFY(STATUS)
+       end if 
 
 ! Number of grids that can be attached
 !-------------------------------------
@@ -478,6 +438,11 @@ contains
           call READ_PARALLEL(layout, STREAM%TILING(N)%JM, unit=UNIT, rc=status)
           _VERIFY(STATUS)
        enddo
+       if (use_pfaf_) then
+          STREAM%TILING(2)%IM = stream%pfafstetter_catchments
+          STREAM%TILING(2)%JM = 1
+          STREAM%TILING(2)%name = "CATCHMENT_GRID"
+       end if
 
 
 ! Read location stream file into AVR
@@ -504,6 +469,10 @@ contains
              AVR(:,NumGlobalVars+2+NumLocalVars*(N-1)) = AVR(:,NumGlobalVars+2+NumLocalVars*(N-1))+1
          endif
        enddo
+
+       !if (use_pfaf_) then
+          !AVR(:,NumGlobalVars+2+NumLocalVars) = 1
+       !end if
 
        call FREE_FILE(UNIT)
 
@@ -553,7 +522,13 @@ contains
                    if(MSK(I)) then
                       K = K + 1
                       II = nint(AVR(I,NumGlobalVars+1+NumLocalVars*(N-1)))
-                      JJ = nint(AVR(I,NumGlobalVars+2+NumLocalVars*(N-1)))
+                      if (use_pfaf_ .and. (n==2)) then
+                         !JJ = nint(AVR(I,NumGlobalVars+2+NumLocalVars*(N-1)))
+                         JJ = 1
+                      else
+                         JJ = nint(AVR(I,NumGlobalVars+2+NumLocalVars*(N-1)))
+                         !JJ=1
+                      end if
                       ISMINE(K) = I1<=II .and. IN>=II .and. &
                                   J1<=JJ .and. JN>=JJ
                    endif
@@ -635,8 +610,14 @@ contains
 
 ! Total number of tiles in exchange grid
 !---------------------------------------
-       if ( MAPL_am_I_root() ) read(UNIT) NT
-       call MAPL_CommsBcast(vm, DATA=NT, N=1, ROOT=0, RC=status)
+       if (use_pfaf_) then
+          if ( MAPL_am_I_root() ) read(UNIT) NT,stream%pfafstetter_catchments
+          call MAPL_CommsBcast(vm, DATA=NT, N=1, ROOT=0, RC=status)
+          call MAPL_CommsBcast(vm, DATA=stream%pfafstetter_catchments, N=1, ROOT=0, RC=status)
+       else
+          if ( MAPL_am_I_root() ) read(UNIT) NT
+          call MAPL_CommsBcast(vm, DATA=NT, N=1, ROOT=0, RC=status)
+       end if
 
 ! Number of grids that can be attached
 !-------------------------------------
@@ -666,6 +647,11 @@ contains
           call MAPL_CommsBcast(vm, DATA=STREAM%TILING(N)%IM, N=1, ROOT=0, RC=status)
           call MAPL_CommsBcast(vm, DATA=STREAM%TILING(N)%JM, N=1, ROOT=0, RC=status)
        enddo
+       if (use_pfaf_) then
+          STREAM%TILING(2)%IM = stream%pfafstetter_catchments
+          STREAM%TILING(2)%JM = 1
+          STREAM%TILING(2)%name = "CATCHMENT_GRID"
+       end if
 
 ! Read location stream file into AVR
 !---------------------------------------
@@ -740,6 +726,7 @@ contains
              call MAPL_SyncSharedMemory(RC=STATUS); _VERIFY(STATUS)
              if ( MAPL_am_I_root() ) read(UNIT) AVR
              call MAPL_BcastShared(vm, DATA=AVR, N=NT, ROOT=0, RootOnly=.false., RC=status)
+             !if (use_pfaf_) avr(:,1)=1
              K = 0
              do I=1, NT
                 if(MSK(I)) then
@@ -804,6 +791,7 @@ contains
              call MAPL_BcastShared(vm, DATA=AVR, N=NT, ROOT=0, RootOnly=.false., RC=status)
              K = 0
              L = 0
+             !if (use_pfaf_) avr(:,1)=1
              do I=1, NT
                 if(MSK(I)) then
                    K = K + 1
@@ -976,7 +964,7 @@ contains
     endif
 
 
-    if(present(Grid)) then ! A grid was attached
+    if(present(Grid) .and. (.not.use_pfaf_)) then ! A grid was attached
        deallocate(ISMINE)
 
        DoCoeffs = .true.
@@ -988,7 +976,7 @@ contains
 
        DX = 360./float(tiling%IM)
 
-       I  = index(TILING%NAME,'-',.true.)
+       I  = index(TILING%NAME,'-',.true.) !bmaa got rid
        _ASSERT(I>0,'needs informative message')
        I  = I+1
 
@@ -1528,7 +1516,7 @@ contains
     
     IM_WORLD = DIMS(1)
     JM_WORLD = DIMS(2)
-    
+   
     _ASSERT(IM_WORLD==TILING%IM,'needs informative message')
     _ASSERT(JM_WORLD==TILING%JM,'needs informative message')
     
@@ -2821,6 +2809,7 @@ integer function GRIDINDEX(STREAM,GRID,RC)
         exit
      end if
   end do
+  if (trim(name)=="CATCHMENT_GRID") GridIndex=2
 
   _ASSERT(GridIndex/=0,'needs informative message')
 

--- a/base/MAPL_Mod.F90
+++ b/base/MAPL_Mod.F90
@@ -2,17 +2,14 @@
 
 module MAPL_Mod
 
-  use MAPL_ExceptionHandling
   use ESMFL_Mod         !  Stopgap
   use MAPL_ExceptionHandling
   use MAPL_BaseMod
-  use MAPL_BaseMod, only: MAPL_GRID_INTERIOR
 ! For temporary backward compatibility after moving/renaming:
   use MAPL_BaseMod, only: ESMF_GRID_INTERIOR => MAPL_GRID_INTERIOR
   use MAPL_IOMod
   use MAPL_CFIOMod
   use MAPL_CommsMod
-  use MAPL_LocStreamMod
   use MAPL_GenericMod
   use MAPL_VarSpecMod
   use MAPL_ConstantsMod

--- a/base/MAPL_Mod.F90
+++ b/base/MAPL_Mod.F90
@@ -5,6 +5,7 @@ module MAPL_Mod
   use ESMFL_Mod         !  Stopgap
   use MAPL_ExceptionHandling
   use MAPL_BaseMod
+  use MAPL_BaseMod, only: MAPL_GRID_INTERIOR
 ! For temporary backward compatibility after moving/renaming:
   use MAPL_BaseMod, only: ESMF_GRID_INTERIOR => MAPL_GRID_INTERIOR
   use MAPL_IOMod

--- a/base/ServerManager.F90
+++ b/base/ServerManager.F90
@@ -37,7 +37,7 @@ contains
    end subroutine get_splitcomm
 
    subroutine initialize(this, comm, unusable, application_size, nodes_input_server, nodes_output_server,&
-                         npes_input_server,npes_output_server, oserver_type, npes_output_backend, isolate_nodes, &
+                         npes_input_server,npes_output_server, oserver_type, npes_backend_pernode, isolate_nodes, &
                          fast_oclient, rc)
       class (ServerManager), intent(inout) :: this
       integer, intent(in) :: comm
@@ -46,7 +46,7 @@ contains
       integer, optional, intent(in) :: nodes_input_server(:),nodes_output_server(:)
       integer, optional, intent(in) :: npes_input_server(:),npes_output_server(:)
       character(*), optional, intent(in) :: oserver_type
-      integer, optional, intent(in) :: npes_output_backend
+      integer, optional, intent(in) :: npes_backend_pernode
       logical, optional, intent(in) :: isolate_nodes
       logical, optional, intent(in) :: fast_oclient
       
@@ -98,7 +98,7 @@ contains
       if (present(oserver_type)) oserver_type_ = oserver_type 
       
       npes_out_backend = 0
-      if (present(npes_output_backend)) npes_out_backend = npes_output_backend
+      if (present(npes_backend_pernode)) npes_out_backend = npes_backend_pernode
 
       isolated_ = .true.
       if (present(isolate_nodes)) isolated_ = isolate_nodes

--- a/generic/MaplGeneric.F90
+++ b/generic/MaplGeneric.F90
@@ -2,7 +2,6 @@ module MaplGeneric
    use mapl_AbstractComponent
    use mapl_MaplComponent
    use mapl_ComponentSpecification
-   use mapl_VariableSpecification
    use mapl_StateSpecification
    use mapl_VarSpecVector
    use mapl_VarSpecMod

--- a/generic/MaplGeneric.F90
+++ b/generic/MaplGeneric.F90
@@ -2,6 +2,7 @@ module MaplGeneric
    use mapl_AbstractComponent
    use mapl_MaplComponent
    use mapl_ComponentSpecification
+   use mapl_VariableSpecification
    use mapl_StateSpecification
    use mapl_VarSpecVector
    use mapl_VarSpecMod

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -186,7 +186,7 @@ contains
          npes_input_server=this%cap_options%npes_input_server, &
          npes_output_server=this%cap_options%npes_output_server, &
          oserver_type=this%cap_options%oserver_type, &
-         npes_output_backend=this%cap_options%npes_output_backend, &
+         npes_backend_pernode=this%cap_options%npes_backend_pernode, &
          isolate_nodes = this%cap_options%isolate_nodes, &
          fast_oclient  = this%cap_options%fast_oclient, &
          rc=status)

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -191,6 +191,7 @@ contains
          fast_oclient  = this%cap_options%fast_oclient, &
          rc=status)
      _VERIFY(status)
+     _RETURN(_SUCCESS)
 
    end subroutine initialize_io_clients_servers
      
@@ -212,6 +213,8 @@ contains
          call o_Clients%terminate()
       end select
                   
+     _RETURN(_SUCCESS)
+
    end subroutine run_member
 
 
@@ -233,7 +236,8 @@ contains
       call ESMF_Initialize (vm=vm, logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, rc=status)
       _VERIFY(status)
 
-      call this%initialize_cap_gc()
+      call this%initialize_cap_gc(rc=status)
+      _VERIFY(status)
 
       call this%cap_gc%set_services(rc = status)
       _VERIFY(status)
@@ -287,11 +291,19 @@ contains
 
    end subroutine run_model
    
-   subroutine initialize_cap_gc(this)
+   subroutine initialize_cap_gc(this, unusable, rc)
      class(MAPL_Cap), intent(inout) :: this
+     class (KeywordEnforcer), optional, intent(in) :: unusable
+     integer, optional, intent(out) :: rc
+
+     integer :: status
+
+     _UNUSED_DUMMY(unusable)
 
      call MAPL_CapGridCompCreate(this%cap_gc, this%set_services, this%get_cap_rc_file(), &
-           this%name, this%get_egress_file())     
+           this%name, this%get_egress_file(), rc=status)
+     _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine initialize_cap_gc
    
 
@@ -300,6 +312,7 @@ contains
      integer, intent(out) :: rc
      integer :: status
      call this%cap_gc%step(rc = status); _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine step_model
   
    subroutine rewind_model(this, time, rc)
@@ -308,6 +321,7 @@ contains
      integer, intent(out) :: rc
      integer :: status
      call this%cap_gc%rewind_clock(time,rc = status); _VERIFY(status)
+     _RETURN(_SUCCESS)
    end subroutine rewind_model 
 
    integer function create_member_subcommunicator(this, comm, unusable, rc) result(subcommunicator)

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -91,19 +91,23 @@ module MAPL_CapGridCompMod
 contains
 
   
-   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file)
+   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file, unusable, rc)
       use mapl_StubComponent
     type(MAPL_CapGridComp), intent(out), target :: cap
     procedure() :: root_set_services
     character(*), intent(in) :: cap_rc, name
     character(len=*), optional, intent(in) :: final_file
+    class(KeywordEnforcer), optional, intent(in) :: unusable
+    integer, optional, intent(out) :: rc
 
     type(MAPL_CapGridComp_Wrapper) :: cap_wrapper
     type(MAPL_MetaComp), pointer :: meta => null()
-    integer :: status, rc
+    integer :: status
     character(*), parameter :: cap_name = "CAP"
     type(StubComponent) :: stub_component
     
+    _UNUSED_DUMMY(unusable)
+
     cap%cap_rc_file = cap_rc
     cap%root_set_services => root_set_services
     if (present(final_file)) then
@@ -129,6 +133,8 @@ contains
     cap_wrapper%ptr => cap
     call ESMF_UserCompSetInternalState(cap%gc, internal_cap_name, cap_wrapper, status)
     _VERIFY(status)
+
+    _RETURN(_SUCCESS)
 
   end subroutine MAPL_CapGridCompCreate
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -4736,11 +4736,18 @@ ENDDO PARSER
   iRealFields = 0
   allocate(isBundle(nfield))
   do m=1,nfield
-    if (scan(trim(fields(1,m)),'()^*/+-.')/=0) then
+    VarName = fields(1,m)
+    i = len_trim(fields(1,m))
+    j = len_trim(fields(2,m))
+    idx = i-j
+    if (idx > 0) then
+       if (fields(1,m)(idx+1:i) == fields(2,m)(1:j)) VarName = fields(1,m)(1:idx)
+    end if
+    if (scan(trim(VarName),'()^*/+-.')/=0) then
        rewrite(m)= .TRUE.
        tmpfields(m)= trim(fields(1,m))
     else
-       if (index(fields(1,m),'%') == 0) then
+       if (index(VarName,'%') == 0) then
           iRealFields = iRealFields + 1
           rewrite(m)= .FALSE.
           isBundle(m) = .FALSE.

--- a/pfio/BaseServer.F90
+++ b/pfio/BaseServer.F90
@@ -21,7 +21,6 @@ module pFIO_BaseServerMod
    use pFIO_ShmemReferenceMod
    use pFIO_RDMAReferenceMod
    use pFIO_AbstractDataMessageMod
-   use pFIO_AbstractSocketMod
    use pFIO_MpiSocketMod
    use pFIO_SimpleSocketMod
    use pFIO_MessageVectorMod

--- a/pfio/BaseServer.F90
+++ b/pfio/BaseServer.F90
@@ -57,7 +57,7 @@ contains
      integer, optional, intent(out) :: rc
 
      integer :: i, client_num, status
-     type (ServerThread),pointer :: threadPtr
+     class (ServerThread),pointer :: threadPtr
      class (AbstractDataReference), pointer :: dataRefPtr
 
      client_num = this%threads%size()
@@ -83,7 +83,7 @@ contains
      integer, optional, intent(out) :: rc
 
      integer ::  n
-     type (ServerThread),pointer :: threadPtr
+     class (ServerThread),pointer :: threadPtr
      class (AbstractMessage),pointer :: msg
      type (MessageVectorIterator) :: iter
      type (StringInteger64MapIterator) :: request_iter
@@ -157,7 +157,7 @@ contains
      integer, optional, intent(out) :: rc
 
      integer :: i, client_num, status
-     type (ServerThread),pointer :: threadPtr
+     class (ServerThread),pointer :: threadPtr
 
      client_num = this%threads%size()
 
@@ -260,7 +260,7 @@ contains
       class (AbstractMessage), pointer :: msg
       integer :: collection_counter, collection_total
       character(len=*),parameter :: Iam = 'create_remote_win'
-      type (ServerThread) , pointer :: thread_ptr
+      class (ServerThread) , pointer :: thread_ptr
 
       this%stage_offset = StringInteger64map()
 

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -47,6 +47,7 @@ set (srcs
   CollectiveStageDataMessage.F90
   AddHistCollectionMessage.F90
   ModifyMetadataMessage.F90
+  ForwardDataAndMessage.F90
   ForwardDataMessage.F90
   ProtocolParser.F90
 

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -539,7 +539,7 @@ contains
       integer, optional, intent(in) :: n_hist_split
       integer, optional, intent(out) :: rc
 
-      integer :: i, nsplit, nwriteCutoff, tsize
+      integer :: i, nsplit, tsize
       integer, allocatable :: server_sizes(:), tmp_position(:)
       integer :: pos
 

--- a/pfio/DirectoryService.F90
+++ b/pfio/DirectoryService.F90
@@ -171,7 +171,7 @@ contains
       integer, allocatable :: client_ranks(:)
       integer, allocatable :: server_ranks(:)
       
-      type(ServerThread), pointer :: server_thread_ptr
+      class(ServerThread), pointer :: server_thread_ptr
       class(BaseServer), pointer :: server_ptr
 
       ! First, check ports to see if server is local, in which case

--- a/pfio/DownBit.F90
+++ b/pfio/DownBit.F90
@@ -1,9 +1,3 @@
-#define _SUCCESS      0
-#define _FAILURE     1
-#define _VERIFY(A)   if(  A/=0) then; if(present(rc)) rc=A; PRINT *, Iam, __LINE__; return; endif
-#define _ASSERT(A)   if(.not.(A)) then; if(present(rc)) rc=_FAILURE; PRINT *, Iam, __LINE__; return; endif
-#define _RETURN(A)   if(present(rc)) rc=A; return
-
 module pFIO_DownbitMod
 
    implicit none

--- a/pfio/ForwardDataAndMessage.F90
+++ b/pfio/ForwardDataAndMessage.F90
@@ -1,0 +1,102 @@
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
+
+module pFIO_ForwardDataAndMessageMod
+   use mpi
+   use MAPL_ExceptionHandling
+   use pFIO_AbstractMessageMod
+   use pFIO_UtilitiesMod
+   use pFIO_AbstractDataReferenceMod
+   use pFIO_KeywordEnforcerMod
+   use pFIO_AbstractDataMessageMod
+   use pFIO_FileMetaDataMod
+   use pFIO_MessageVectorMod
+   use pFIO_MessageVectorUtilMod
+
+   implicit none
+   private
+
+   public :: ForwardDataAndMessage
+
+   type :: ForwardDataAndMessage
+      type (MessageVector) :: msg_vec
+      integer, allocatable :: idata(:)
+   contains
+      procedure :: add_data_message
+      procedure :: serialize
+      procedure :: deserialize
+   end type ForwardDataAndMessage
+
+   interface ForwardDataAndMessage
+      module procedure new_ForwardDataAndMessage
+   end interface ForwardDataAndMessage
+
+contains
+
+   function new_ForwardDataAndMessage() result(message)
+      type (ForwardDataAndMessage) :: message
+      message%msg_vec = MessageVector()
+   end function new_ForwardDataAndMessage
+
+   subroutine serialize(this, buffer, rc)
+      class (ForwardDataAndMessage), intent(in) :: this
+      integer, allocatable, intent(inout) :: buffer(:)
+      integer, optional, intent(out) :: rc
+      integer :: i
+      integer, allocatable :: buff_tmp(:)
+
+      if (allocated(buffer)) deallocate(buffer)
+
+      call serialize_message_vector(this%msg_vec, buff_tmp)
+      if ( size(this%idata) > 0 ) then
+         i = size(this%idata)+1
+         buffer =[buff_tmp, i, this%idata]
+      else
+         buffer = buff_tmp
+      endif
+
+      _RETURN(_SUCCESS)
+
+   end subroutine serialize
+
+   subroutine deserialize(this, buffer, rc)
+      class (ForwardDataAndMessage), intent(inout) :: this
+      integer, intent(in) :: buffer(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: n
+      !integer :: k
+      
+      call deserialize_message_vector(buffer,this%msg_vec)
+      n = 1 + buffer(1)
+      !k = 0
+      if (size(buffer) > n) then
+         allocate(this%idata(buffer(n)-1))
+         this%idata(:) = buffer(n+1:)
+         !k = buffer(n)
+      endif
+      !_ASSERT(size(buffer) == buffer(1)+ k,"buffer size does not match")
+      _RETURN(_SUCCESS)
+   end subroutine deserialize
+
+   subroutine add_data_message(this, msg, i_ptr, rc)
+      class (ForwardDataAndMessage), intent(inout) :: this
+      class (AbstractMessage) :: msg
+      integer, intent(in) :: i_ptr(:)
+      integer, optional, intent(out) :: rc
+     
+      call this%msg_vec%push_back(msg)
+      if (size(i_ptr) ==0 ) then
+         _RETURN(_SUCCESS)
+      endif
+      if (.not. allocated(this%idata)) then
+         this%idata = [i_ptr]
+      else
+         this%idata = [this%idata, i_ptr]
+      endif
+
+      _RETURN(_SUCCESS)
+   end subroutine
+
+end module pFIO_ForwardDataAndMessageMod
+

--- a/pfio/LocalMemReference.F90
+++ b/pfio/LocalMemReference.F90
@@ -362,6 +362,7 @@ contains
       n_words = n * word_size(this%type_kind)
       allocate(this%i_ptr(n_words), stat=status)
       _VERIFY(status)
+
 #ifdef __NAG_COMPILER_BUILD
       if (n > 0) then
          this%base_address = c_loc(this%i_ptr)

--- a/pfio/MessageVector.F90
+++ b/pfio/MessageVector.F90
@@ -1,3 +1,6 @@
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
+
 module pFIO_MessageVectorMod
    use pFIO_AbstractMessageMod
 
@@ -11,9 +14,11 @@ module pFIO_MessageVectorMod
 end module pFIO_MessageVectorMod
 
 module pFIO_MessageVectorUtilMod
+   use MAPL_ExceptionHandling
    use pFIO_AbstractMessageMod
    use pFIO_MessageVectorMod
    use pFIO_ProtocolParserMod
+   use pFIO_CollectiveStageDataMessageMod
    implicit none
    private 
 
@@ -37,28 +42,40 @@ contains
         msg=>msgVec%at(i)
         tmp =[tmp, parser%encode(msg)]
      enddo
-     buffer = tmp
+     i = size(tmp)+1
+     if (allocated(buffer)) deallocate(buffer)
+     buffer =[i,tmp]
 
   end subroutine
 
-  subroutine deserialize_message_vector(buffer, msgVec)
+  subroutine deserialize_message_vector(buffer, msgVec, rc)
      type (MessageVector),intent(inout) :: msgVec
      integer, intent(in) :: buffer(:)
+     integer, optional, intent(out) :: rc
+
      class (AbstractMessage),allocatable:: msg
 
      integer :: n, length
      type (ProtocolParser) :: parser
+    ! integer, allocatable :: buffer_test(:)
 
      parser = ProtocolParser()
-     length = size(buffer)
-     n=1
+     length = buffer(1)
+     n=2
      msgVec = MessageVector()
      do while (n < length)
        allocate(msg, source = parser%decode(buffer(n:))) 
        call msgVec%push_back(msg)
-       n= n+ msg%get_length()+1
+       n = n + msg%get_length()+1 
        deallocate(msg)
      enddo
+     _ASSERT(n-1 == length, "wrong length of message vector")
+
+    ! lazy UNIT test! W.J notes: ifor passes, gfortran fails
+    ! call serialize_message_vector(msgVec,buffer_test)
+    ! _ASSERT(all(buffer(1:length) == buffer_test), "serialize-deserialize error")
+    
+     _RETURN(_SUCCESS)
   end subroutine
 
 end module pFIO_MessageVectorUtilMod

--- a/pfio/MpiSocket.F90
+++ b/pfio/MpiSocket.F90
@@ -161,8 +161,10 @@ contains
 
       n_words = product(local_reference%shape) * word_size(local_reference%type_kind)
       call c_f_pointer(local_reference%base_address, data, shape=[n_words])
+      if (n_words ==0) allocate(data(1))
       call MPI_Isend(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
       allocate(handle, source=MpiRequestHandle(local_reference, request))
+      if (n_words ==0) deallocate(data)
       _RETURN(_SUCCESS)
    end function put
 
@@ -184,8 +186,10 @@ contains
 
       n_words = product(local_reference%shape) * word_size(local_reference%type_kind)
       call c_f_pointer(local_reference%base_address, data, shape=[n_words])
+      if (n_words ==0) allocate(data(1))
       call MPI_Irecv(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
       allocate(handle, source=MpiRequestHandle(local_reference, request))
+      if (n_words ==0) deallocate(data)
       _RETURN(_SUCCESS)
    end function get
 

--- a/pfio/MultiCommServer.F90
+++ b/pfio/MultiCommServer.F90
@@ -17,7 +17,6 @@ module pFIO_MultiCommServerMod
    use pFIO_ServerThreadVectorMod
    use pFIO_AbstractSocketMod
    use pFIO_AbstractSocketVectorMod
-   use pFIO_AbstractDataReferenceMod
    use pFIO_AbstractServerMod
    use gFTL_StringInteger64Map
    use pFIO_AbstractMessageMod

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -17,7 +17,6 @@ module pFIO_MultiGroupServerMod
    use pFIO_ServerThreadVectorMod
    use pFIO_AbstractSocketMod
    use pFIO_AbstractSocketVectorMod
-   use pFIO_AbstractDataReferenceMod
    use pFIO_AbstractServerMod
    use gFTL_StringInteger64Map
    use pFIO_AbstractMessageMod

--- a/pfio/MultiLayerServer.F90
+++ b/pfio/MultiLayerServer.F90
@@ -140,7 +140,7 @@ contains
      integer, optional, intent(out) :: rc
 
      integer ::  n
-     type (ServerThread),pointer :: threadPtr
+     class (ServerThread),pointer :: threadPtr
      class (AbstractMessage),pointer :: msg
      type (MessageVectorIterator) :: iter
      type (StringInteger64MapIterator) :: request_iter

--- a/pfio/MultiLayerServer.F90
+++ b/pfio/MultiLayerServer.F90
@@ -17,7 +17,6 @@ module pFIO_MultiLayerServerMod
    use pFIO_ServerThreadVectorMod
    use pFIO_AbstractSocketMod
    use pFIO_AbstractSocketVectorMod
-   use pFIO_AbstractDataReferenceMod
    use pFIO_AbstractServerMod
    use gFTL_StringInteger64Map
    use pFIO_AbstractMessageMod

--- a/pfio/ProtocolParser.F90
+++ b/pfio/ProtocolParser.F90
@@ -1,7 +1,6 @@
 #include "unused_dummy.H"
 module pFIO_ProtocolParserMod
    use pFIO_AbstractMessageMod
-   use pFIO_AbstractMessageMod
    use pFIO_IntegerMessageMapMod
    use pFIO_FileMetadataMod
 

--- a/pfio/ServerThread.F90
+++ b/pfio/ServerThread.F90
@@ -220,18 +220,11 @@ contains
       type (DoneMessage), intent(in) :: message
       integer, optional, intent(out) :: rc
 
-      type (LocalMemReference) :: mem_data_reference
-      class(AbstractDataReference),pointer :: dataRefPtr
       class(AbstractMessage),pointer :: dMessage
-      integer :: data_status, node_rank, innode_rank
-      integer(kind=INT64) :: g_offset, offset,msize_word
-      type(c_ptr) :: offset_address
-      integer,pointer :: i_ptr(:)
       type (MessageVectorIterator) :: iter
       class (AbstractMessage), pointer :: msg
       class(AbstractSocket),pointer :: connection
-      class (AbstractRequestHandle), pointer :: handle
-      integer :: status, cmd
+      integer :: status
 
       ! first time handling the "Done" message, simple return
       this%containing_server%serverthread_done_msgs(this%thread_rank) = .true. 
@@ -781,7 +774,11 @@ contains
 
       integer, allocatable :: start(:),count(:)
 
-      hist_collection=>this%hist_collections%at(message%collection_id)
+      if (this%hist_collections%size() == 1) then
+         hist_collection=>this%hist_collections%at(1)
+      else
+         hist_collection=>this%hist_collections%at(message%collection_id)
+      endif
       formatter =>hist_collection%find(message%file_name)
  
       select type (message)
@@ -955,7 +952,7 @@ contains
       type (CollectiveStageDoneMessage), intent(in) :: message
       integer, optional, intent(out) :: rc
 
-      integer :: status, data_status, cmd
+      integer :: status
 
       _UNUSED_DUMMY(message)
 

--- a/pfio/ServerThreadVector.F90
+++ b/pfio/ServerThreadVector.F90
@@ -1,7 +1,7 @@
 module pFIO_ServerThreadVectorMod
    use pFIO_ServerThreadMod
 
-#define _type type (ServerThread)
+#define _type class (ServerThread)
 #define _pointer
 #define _vector ServerThreadVector
 #define _iterator ServerThreadVectorIterator

--- a/pfio/pFIO.F90
+++ b/pfio/pFIO.F90
@@ -26,8 +26,6 @@ module pFIO
    use pFIO_SimpleSocketMod
    use pFIO_AbstractDataReferenceMod
    use pFIO_ArrayReferenceMod
-   use pFIO_CoordinateVariableMod
-   use pFIO_AttributeMod
    use pFIO_StringAttributeMapMod
    use pFIO_StringVariableMapMod
    use pFIO_DownBitMod

--- a/pfio/pFIO_Utilities.F90
+++ b/pfio/pFIO_Utilities.F90
@@ -501,7 +501,6 @@ contains
       integer(kind=INT64) :: i64
       real (kind=REAL32) :: r32
       real (kind=REAL64) :: r64
-      logical(kind=C_BOOL) :: l
 
       select case(type_kind)
       case (pFIO_INT32)

--- a/shared/MAPL_Range.F90
+++ b/shared/MAPL_Range.F90
@@ -1,9 +1,4 @@
-#define _SUCCESS      0
-#define _FAILURE     1
-#define _VERIFY(A)   if(  A/=0) then; call MAPL_throw_exception(__FILE__,__LINE__); return; endif
-#define _ASSERT(A)   if(.not.A) then; if(present(rc)) rc=_FAILURE; call MAPL_throw_exception(__FILE__,__LINE__); return; endif
-#define _RETURN(A)   if(present(rc)) rc=A; return
-
+#include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
 module MAPL_RangeMod
@@ -39,7 +34,7 @@ contains
      integer :: i
      real(kind=REAL64) :: delta
 
-     _ASSERT(((n /= 1) .or. (x0 == x1)))
+     _ASSERT(((n /= 1) .or. (x0 == x1)),'needs informative message')
      allocate(range(n))
      
      range(1) = x0
@@ -71,7 +66,7 @@ contains
      integer :: i
      real(kind=REAL64) :: delta
 
-     _ASSERT((n /= 1) .or. (x0 == x1))
+     _ASSERT((n /= 1) .or. (x0 == x1),'needs informative message')
      allocate(range(n))
      
      range(1) = x0


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fields included in History collections may accidentally be duplicated when their name end with their corresponding component name, if such a name includes non-alphabetical characters used to identify expressions in `MAPL_SetExpression()`. For example, this happens when running two instances of GOCART's carbonaceous aerosol (CA) component: one for black carbon, named `CA.bc`, and the other for organic carbon, named `CA.oc`. Exported fields from each component are differentiated by adding to the component's name to their original name (_e.g._ `CAphilicCA.bc`).

This PR introduces changes to explicitly take into account this case, preventing History from duplicating such fields and generating the error: `existing item CAphilicCA.bc not replacable`

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR addresses an issue potentially preventing History from writing exported fields whose names end with their component's name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested on Orion using a UFS-GOCART test case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
