### PR TITLE
Prevent History from duplicating output fields whose names end with their component name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Have CMake automatically gitignore build and install dirs
+- Prevent History from mistakenly duplicating export fields
+  when field names end with their component's name
 
 ### Removed
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -4736,11 +4736,18 @@ ENDDO PARSER
   iRealFields = 0
   allocate(isBundle(nfield))
   do m=1,nfield
-    if (scan(trim(fields(1,m)),'()^*/+-.')/=0) then
+    VarName = fields(1,m)
+    i = len_trim(fields(1,m))
+    j = len_trim(fields(2,m))
+    idx = i-j
+    if (idx > 0) then
+       if (fields(1,m)(idx+1:i) == fields(2,m)(1:j)) VarName = fields(1,m)(1:idx)
+    end if
+    if (scan(trim(VarName),'()^*/+-.')/=0) then
        rewrite(m)= .TRUE.
        tmpfields(m)= trim(fields(1,m))
     else
-       if (index(fields(1,m),'%') == 0) then
+       if (index(VarName,'%') == 0) then
           iRealFields = iRealFields + 1
           rewrite(m)= .FALSE.
           isBundle(m) = .FALSE.


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fields included in History collections may accidentally be duplicated when their name end with their corresponding component name, if such a name includes non-alphabetical characters used to identify expressions in `MAPL_SetExpression()`. For example, this happens when running two instances of GOCART's carbonaceous aerosol (CA) component: one for black carbon, named `CA.bc`, and the other for organic carbon, named `CA.oc`. Exported fields from each component are differentiated by adding to the component's name to their original name (_e.g._ `CAphilicCA.bc`).

This PR introduces changes to explicitly take into account this case, preventing History from duplicating such fields and generating the error: `existing item CAphilicCA.bc not replacable`

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR reintroduces changes submitted with PR #729 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR addresses an issue potentially preventing History from writing exported fields whose names end with their component's name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested on Orion using a UFS-GOCART test case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)