### PR TITLE
Bmauer/feature/#731 fixdotinname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Have CMake automatically gitignore build and install dirs
+- Fix issue with History when field names have "." in them
 
 ### Removed
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -4750,6 +4750,7 @@ ENDDO PARSER
           isBundle(m) = .FALSE.
           tmpfields(m)= trim(fields(1,m))
        else 
+          isBundle(m) = .false.
           rewrite(m)= .TRUE.
           tmpfields(m)= trim(fields(1,m))
        end if

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -4731,26 +4731,34 @@ ENDDO PARSER
 ! rather than the actual output field variables (i.e., fields(1,:)).
 ! Also do check that there are no illegal operations
 !-------------------------------------------------------------------
+  allocate ( exptmp (1), stat=status )
+  _VERIFY(STATUS)
+  exptmp(1) = ExpState
   ! check which fields are actual exports or expressions
   nPExtraFields = 0
   iRealFields = 0
   allocate(isBundle(nfield))
   do m=1,nfield
-    if (scan(trim(fields(1,m)),'()^*/+-.')/=0) then
-       rewrite(m)= .TRUE.
-       tmpfields(m)= trim(fields(1,m))
-    else
-       if (index(fields(1,m),'%') == 0) then
+
+    call MAPL_ExportStateGet(exptmp,fields(2,m),state,rc=status)
+    _VERIFY(STATUS)
+    if (index(fields(1,m),'%') == 0) then
+       call ESMF_StateGet(state,fields(1,m),field,rc=status)
+       if (status==_SUCCESS) then
           iRealFields = iRealFields + 1
           rewrite(m)= .FALSE.
           isBundle(m) = .FALSE.
           tmpfields(m)= trim(fields(1,m))
-       else
-          isBundle(m)=.true.
-          rewrite(m)= .FALSE.
+       else 
+          rewrite(m)= .TRUE.
           tmpfields(m)= trim(fields(1,m))
-       endif
+       end if
+    else
+       isBundle(m)=.true.
+       rewrite(m)= .FALSE.
+       tmpfields(m)= trim(fields(1,m))
     endif
+    
   enddo
 
   ! now that we know this allocated a place to store the names of the real fields
@@ -4851,9 +4859,6 @@ ENDDO PARSER
   allocate(TotLoc(totFields),stat=status)
   _VERIFY(STATUS)
 
-  allocate ( exptmp (1), stat=status )
-  _VERIFY(STATUS)
-  exptmp(1) = ExpState
   iRealFields = 0
   do i=1,nfield
     if ( (.not.rewrite(i)) .and. (.not.isBundle(i)) ) then


### PR DESCRIPTION
Fixes #731 
This fixes the issue that Raffaele covered, that having "." in the variable name confused History. The issue is **NOT** the parser. The issue was the logic I have to determine if the variables in the expression are already in the collection and that not being properly detected leading to duplicate fields being placed in a state.
I modified the code so when scanning the fields it first checks if the field string actually is a field in the export state, rather than just assuming if you find one of these characters "+-/*()." it is an expression.
I was able to output fields with "." in the name with this fix.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
