### PR TITLE
Fixes #644. Allow for Intel oneAPI on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CMake workaround for macOS + Intel oneAPI FLAP bug (#644)
+
 ### Removed
 
 ## [2.6.3] - 2021-03-09

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -27,10 +27,25 @@ set (EOS )
 
 set (lib MAPL_cfio_${precision})
 
+if (APPLE AND CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 20.2.1)
+   set (LIBRARY_TYPE STATIC)
+   ecbuild_warn (
+      "Found Intel oneAPI on macOS.\n"
+      "MAPL developers have found an issue with Intel oneAPI on macOS\n"
+      "where GEOSgcm.x would not work. Debugging found the issue was\n"
+      "that command_argument_count() would return -1 which should *NEVER*\n"
+      "happen per Fortran Standard and then this broke FlAP.\n"
+      "A workaround was found that if the ${this} library was compiled\n"
+      "as TYPE STATIC, the model would work. So we are setting ${this} as\n"
+      "a TYPE STATIC library. Note: This might interfere with coupled model.")
+else ()
+   set (LIBRARY_TYPE SHARED)
+endif ()
+
 esma_add_library (${lib}
   SRCS ${srcs}
   DEPENDENCIES esmf NetCDF::NetCDF_Fortran
-  TYPE SHARED
+  TYPE ${LIBRARY_TYPE}
   )
 
 if (precision MATCHES "r8")

--- a/MAPL_cfio/examples/testr.f90
+++ b/MAPL_cfio/examples/testr.f90
@@ -20,16 +20,15 @@
 
     integer :: fid
     integer :: argc
-    integer, external :: iargc
     logical :: passed = .true.
 
     character(len=256) :: inFile
 
-    argc = iargc()
+    argc = command_argument_count()
     if ( argc < 1 ) then 
        inFile = "GEOS5.ana.hdf"
     else
-       call GetArg ( 1, inFile )
+       call get_command_argument ( 1, inFile )
     end if
 
 ! Create a CFIO object

--- a/MAPL_cfio/examples/testr_gd.f90
+++ b/MAPL_cfio/examples/testr_gd.f90
@@ -20,16 +20,15 @@
 
     integer :: fid
     integer :: argc
-    integer, external :: iargc
     logical :: passed = .true.
 
     character(len=256) :: inFile
 
-    argc = iargc()
+    argc = command_argument_count()
     if ( argc < 1 ) then 
        inFile = "GEOS5.ana.hdf"
     else
-       call GetArg ( 1, inFile )
+       call get_command_argument ( 1, inFile )
     end if
 
 ! Create a CFIO object

--- a/MAPL_cfio/examples/testr_gd_wr.f90
+++ b/MAPL_cfio/examples/testr_gd_wr.f90
@@ -39,17 +39,16 @@
 
     integer :: fid
     integer :: argc
-    integer, external :: iargc
     logical :: passed = .true.
     logical :: new_file
 
     character(len=256) :: inFile
 
-    argc = iargc()
+    argc = command_argument_count()
     if ( argc < 1 ) then 
        inFile = "GEOS5.ana.hdf"
     else
-       call GetArg ( 1, inFile )
+       call get_command_argument ( 1, inFile )
     end if
 
 ! Create a CFIO object

--- a/MAPL_cfio/examples/testr_st.f90
+++ b/MAPL_cfio/examples/testr_st.f90
@@ -20,17 +20,16 @@
     real, pointer :: ts(:,:)  
 
     integer :: argc
-    integer, external :: iargc
     logical :: passed = .true.
 
     integer :: fid
     character(len=256) :: inFile
     
-    argc = iargc()
+    argc = command_argument_count()
     if ( argc < 1 ) then
        inFile = "GEOS5.ana.hdf"
     else
-       call GetArg ( 1, inFile )
+       call get_command_argument ( 1, inFile )
     end if
 
 ! Create a CFIO object


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR provides a *workaround* for using Intel oneAPI Fortran on macOS. For some reason, on my macOS laptop, if `GEOSgcm.x` was built with oneAPI, FLAP would fail to function. Working with @tclune, it was eventually seen that if both `libfms_r8.dylib` and `libMAPL_cfio_r4.dylib` were linked to `GEOSgcm.x`, then `command_argument_count()` would return -1...which is not allowed by the Fortran Standard.

The workaround found was to compile `MAPL_cfio` as `TYPE STATIC`. This might interfere with use of, say, MOM6, but no one has, at yet, even *tried* to run coupled GEOS on a Mac laptop. But, this workaround *does* let GEOSgcm.x run.

This PR also just fixes some MAPL_cfio code that annoyed me because it used `iargc` and `getarg`. Fortran has moved on, and so should we. (Note these codes aren't even compiled so it's a no-op.)

## Related Issue

Closes #644

<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Allows MAPL and GEOS developers to use the free Intel oneAPI Fortran compiler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I was able to run GEOS. Also, you can do `./GEOSgcm.x --help` and it works!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
