### PR TITLE
Bugfix/wjiang/fix array out of bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix array out of bound when prinnting io message
+
 ### Removed
 
 ## [2.6.3] - 2021-03-09

--- a/base/ServerManager.F90
+++ b/base/ServerManager.F90
@@ -179,9 +179,9 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
            call this%directory_service%connect_to_client(s_name, this%i_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. nodes_in(i) /=0 ) then
+           if (rank == 0 .and. nodes_in(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO input server on ",nodes_in(i)," nodes"
-           else if (rank==0 .and. npes_in(i) /=0 ) then
+           else if (rank==0 .and. npes_in(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO input server on ",npes_in(i)," pes"
            end if
         endif
@@ -223,9 +223,9 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%o_server), this%o_server)
            call this%directory_service%connect_to_client(s_name, this%o_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
-           if (rank == 0 .and. nodes_out(i) /=0 ) then
+           if (rank == 0 .and. nodes_out(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO output server on ",nodes_out(i)," nodes"
-           else if (rank==0 .and. npes_out(i) /=0 ) then
+           else if (rank==0 .and. npes_out(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO output server on ",npes_out(i)," pes"
            end if
         endif


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
fix out of bound access of nodes_out(in) or npes_out(in) 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
