### PR TITLE
Fixes #756. The bug was related to putting the split fields in the sa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed spliiting the same field in multiple collections
 - fix out-of-bound access when printing pFIO message
 - Removed program tstqsat.F90 from MAPL.base library.  A followup
   should add cmake logic to create an executable or just delete the

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2775,6 +2775,7 @@ ENDDO PARSER
       character(ESMF_MAXSTR) :: fldName, stateName
       logical :: split
       integer :: k, i
+      logical :: hasField
       
       ! Restrictions:
       ! 1) we do not split 4d vectors
@@ -2863,8 +2864,17 @@ ENDDO PARSER
                   call appendArray(newExpState,idx=list(n)%expState(k),rc=status)
                   _VERIFY(status)
 
-                  call MAPL_StateAdd(expState, field=splitFields(i), rc=status)
+                  ! ALT: this is ONLY a very simple test to make sure that this is not a duplicate
+                  ! this issue might be revisited to assure that possible duplicates have
+                  ! identical content. Otherwise the split fields should be put in its own container
+                  ! perhaps per collection, but this 
+                  hasField = .false. ! initialize just in case
+                  call checkIfStateHasField(expState, fieldName=fldName, hasField=hasField, rc=status)
                   _VERIFY(status)
+                  if (.not. hasField) then
+                     call MAPL_StateAdd(expState, field=splitFields(i), rc=status)
+                     _VERIFY(status)
+                  end if
 
                   item%itemType = ItemTypeScalar
                   item%xname = trim(fldName)
@@ -5170,5 +5180,41 @@ ENDDO PARSER
     _RETURN(ESMF_SUCCESS)
   end subroutine RecordRestart
 
+  subroutine  checkIfStateHasField(state, fieldName, hasField, rc)
+    type(ESMF_State), intent(in) :: state ! export state
+    character(len=*), intent(in) :: fieldName
+    logical, intent(out)         :: hasField
+    integer, intent(out), optional :: rc ! Error code:
+
+    integer :: n, i, status
+    character (len=ESMF_MAXSTR), allocatable  :: itemNameList(:)
+    type(ESMF_StateItem_Flag),   allocatable  :: itemTypeList(:)
+
+    call ESMF_StateGet(state, itemcount=n,  rc=status)
+    _VERIFY(status)
+
+    allocate(itemNameList(n), stat=status)
+    _VERIFY(status)
+    allocate(itemTypeList(n), stat=status)
+    _VERIFY(status)
+    call ESMF_StateGet(state,itemnamelist=itemNamelist,itemtypelist=itemTypeList,rc=status)
+    _VERIFY(STATUS)
+
+    hasField = .false.
+    do I=1,N
+       if(itemTypeList(I)/=ESMF_STATEITEM_FIELD) cycle
+       if(itemNameList(I)==fieldName) then
+          hasField = .true.
+          exit
+       end if
+    end do
+    deallocate(itemNameList, stat=status)
+    _VERIFY(STATUS)
+    deallocate(itemTypeList, stat=status)
+    _VERIFY(status)
+
+    _RETURN(ESMF_SUCCESS)
+  end subroutine checkIfStateHasField
+    
 end module MAPL_HistoryGridCompMod
 


### PR DESCRIPTION
…me export state as the original field. When more than 1 collection is splitting the same field, this resulted in duplicate items in the export state

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->we now check if the split field is already in the export state. If "yes" we do not put it again

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->#756, #673

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
