### PR TITLE
Fix for BaseProfiler to match v2.6.4

### DIFF
--- a/profiler/BaseProfiler.F90
+++ b/profiler/BaseProfiler.F90
@@ -112,13 +112,15 @@ contains
       class(AbstractMeterNode), pointer :: node
       class(AbstractMeter), allocatable :: m
 
-      if (this%stack%empty()) this%status = INCORRECTLY_NESTED_METERS
-      _ASSERT_RC(.not. this%stack%empty(),"Timer <"//name// "> should not start when empty.",INCORRECTLY_NESTED_METERS)
-
-      node => this%stack%back()
-      if (.not. node%has_child(name)) then
-         m = this%make_meter()
-         call node%add_child(name, m) !this%make_meter())
+      if (this%stack%empty()) then
+         this%status = INCORRECTLY_NESTED_METERS
+         _ASSERT_RC(.not. this%stack%empty(),"Timer <"//name// "> should not start when empty.",INCORRECTLY_NESTED_METERS)
+      else
+         node => this%stack%back()
+         if (.not. node%has_child(name)) then
+            m = this%make_meter()
+            call node%add_child(name, m) !this%make_meter())
+         end if
       end if
 
       node => node%get_child(name)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I believe I found an issue between BaseProfiler in v2.6.4 and in develop.

First in v2.6.4:
```fortran
      if (this%stack%empty()) then
         block
           use MPI
           integer :: rank, ierror
           call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
           if (rank == 0) then
             _ASSERT(.false., "Timer "//name//' should not start when empty: ')
           end if
         end block
         return
      else
         node => this%stack%back()
         if (.not. node%has_child(name)) then
           m = this%make_meter()
           call node%add_child(name, m) !this%make_meter())
         end if
      endif
```
now in `develop`:
```fortran
      if (this%stack%empty()) this%status = INCORRECTLY_NESTED_METERS
      _ASSERT_RC(.not. this%stack%empty(),"Timer <"//name// "> should not start when empty.",INCORRECTLY_NESTED_METERS)


      node => this%stack%back()
      if (.not. node%has_child(name)) then
         m = this%make_meter()
         call node%add_child(name, m) !this%make_meter())
      end if
```
The if-block got collapsed. Note, this doesn't seem to fix #762, but I saw it during my code walkthrough.


## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I think it's a bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
