### PR TITLE
Fixes #511. Use INT64 for SYSTEM_CLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed error handling in profiler/BaseProfiler.F90
 - Fix memory leak when using fast_oserver in write_restart_by_oserver
 - Bumped cube version to 2.91 in global metadata
-
+- Change calls to `system_clock()` to be `INT64` (#511)
 
 ### Removed
 

--- a/base/MAPL_Profiler.F90
+++ b/base/MAPL_Profiler.F90
@@ -21,7 +21,7 @@
 #ifdef _CUDA
   use cudafor
 #endif
-  use, intrinsic :: ISO_FORTRAN_ENV, only: REAL64
+  use, intrinsic :: ISO_FORTRAN_ENV, only: REAL64, INT64
   implicit none
   private
 
@@ -30,7 +30,7 @@
   type, public :: MAPL_Prof
     private
     character(len=ESMF_MAXSTR) :: NAME=""
-    integer        :: START_TIME
+    integer(kind=INT64) :: START_TIME
     real  (kind=REAL64) :: CUMM_TIME   
   end type MAPL_Prof
 
@@ -53,7 +53,7 @@
   integer, public, parameter  :: MAPL_TimerModeMinMax = 3
 
   type(ESMF_VM), save :: VM
-  integer,       save :: COUNT_MAX, COUNT_RATE
+  integer(kind=INT64), save :: COUNT_MAX, COUNT_RATE
   real(kind=REAL64),  save :: CRI
   logical,       save :: FIRSTTIME = .true.
   logical,       save :: DISABLED  = .false.

--- a/base/MAPL_Profiler.F90
+++ b/base/MAPL_Profiler.F90
@@ -119,7 +119,7 @@
 
       character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_ProfClockOff"
 
-      integer :: COUNTS
+      integer(kind=INT64) :: COUNTS
       integer :: I, NN
       integer :: status
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -15,6 +15,7 @@ module MAPL_CapMod
    use MAPL_CapOptionsMod
    use MAPL_ServerManager
    use MAPL_ApplicationSupport
+   use, intrinsic :: iso_fortran_env, only: REAL64, INT64, OUTPUT_UNIT
    implicit none
    private
 
@@ -226,7 +227,7 @@ contains
       integer, optional, intent(out) ::rc
 
       type (ESMF_VM) :: vm
-      integer :: start_tick, stop_tick, tick_rate
+      integer(kind=INT64) :: start_tick, stop_tick, tick_rate
       integer :: status
       class(Logger), pointer :: lgr
       
@@ -267,7 +268,6 @@ contains
       end subroutine stop_timer
 
       subroutine report_throughput(rc)
-         use, intrinsic :: iso_fortran_env, only: REAL64, OUTPUT_UNIT
          integer, optional, intent(out) :: rc
 
          integer :: rank, ierror

--- a/profiler/FortranTimerGauge.F90
+++ b/profiler/FortranTimerGauge.F90
@@ -23,7 +23,7 @@ contains
 
    function new_FortranTimerGauge() result(gauge)
       type (FortranTimerGauge) :: gauge
-      integer(kind=REAL64) :: count_rate
+      integer(kind=INT64) :: count_rate
 
       call system_clock(count_rate=count_rate)
       gauge%denominator = 1._REAL64/count_rate


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Uses `INT64` for `system_clock()` calls in MAPL. This should prevent negative throughputs.

I also changed all the other places I saw `system_clock()` that could be in `libMAPL.a`. Note there are some programs and tests that are still `INT32` but I figure they don't quite need it.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #511 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Can prevent rare negative throughputs, and other timers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
