### PR TITLE
Remove unguarded FLAP dependencies preventing MAPL from building with BUILD_WITH_FLAP=NO

### DIFF
--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -4,7 +4,7 @@ esma_set_this()
 esma_add_library (${this}
   SRCS MAPL.F90
   DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps
-               esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran FLAP::FLAP
+               esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE SHARED
   )
 

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -5,12 +5,9 @@ esma_add_library (${this}
   SRCS MAPL.F90
   DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
+               $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
   TYPE SHARED
   )
-
-if (BUILD_WITH_FLAP)
-   target_link_libraries(${this} PRIVATE FLAP::FLAP)
-endif ()
 
 target_include_directories (${this} PUBLIC
           $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -8,5 +8,9 @@ esma_add_library (${this}
   TYPE SHARED
   )
 
+if (BUILD_WITH_FLAP)
+   target_link_libraries(${this} PRIVATE FLAP::FLAP)
+endif ()
+
 target_include_directories (${this} PUBLIC
           $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -8,7 +8,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler MAPL.history TYPE SHARED)
 target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran FLAP::FLAP)
+                               PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -8,13 +8,11 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler MAPL.history TYPE SHARED)
 target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran)
+                               PRIVATE MPI::MPI_Fortran $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>)
+
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-if (BUILD_WITH_FLAP)
-   target_link_libraries(${this} PRIVATE FLAP::FLAP)
 endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries (${this} PUBLIC gftl gftl-shared esmf NetCDF::NetCDF_Fortr
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
+if (BUILD_WITH_FLAP)
+   target_link_libraries(${this} PRIVATE FLAP::FLAP)
+endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These changes remove unguarded FLAP dependencies in the build systems added by commit be2fa9bc.
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#780 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes address an issue preventing MAPL from building if `BUILD_WITH_FLAP=NO`.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested on NOAA RDHPCS platforms.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
`CHANGELOG.md` not updated since changes are trivial.