### PR TITLE
Fixes #809. Added explicit initialization after allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed possibly uninitialized values when handling members of Segment_T derived type. Helps on the Rome nodes.
 - Fixed print diagnostics for monthly collections (proper reporting of frequency, duration, eliminated acc_interval)
 - Fixed another bug related to the incorrect time increment for monthly averaged collections
 - Fixed few memory leaks (average and stampOffset arrays were allocated twice)

--- a/shared/MAPL_ShmemMod.F90
+++ b/shared/MAPL_ShmemMod.F90
@@ -55,7 +55,7 @@
 
     type Segment_T
        integer (c_int) :: shmid=-1
-       type    (c_ptr) :: addr
+       type    (c_ptr) :: addr=C_NULL_PTR
     end type Segment_T
 
     type(Segment_T), pointer :: Segs(:) => NULL()
@@ -198,6 +198,8 @@
 
       allocate(Segs(CHUNK),stat=STATUS)
       _ASSERT(STATUS==0,'needs informative message')
+      Segs(:)%shmid = -1
+      Segs(:)%addr=C_NULL_PTR
 
       MAPL_ShmInitialized=.true.
 
@@ -1083,6 +1085,7 @@
 
       pos=1
       do while(pos<=size(Segs))
+         if(Segs(pos)%shmid == -1) cycle
          if(c_associated(Segs(pos)%addr,Caddr)) exit
          pos = pos + 1
       end do
@@ -1118,6 +1121,7 @@
 !!! Free the position in the segment list
 
       Segs(pos)%shmid=-1
+      Segs(pos)%addr=C_NULL_PTR
 
       _RETURN(SHM_SUCCESS)
     end subroutine ReleaseSharedMemory
@@ -1148,6 +1152,8 @@
          if(pos==size(Segs)) then ! Expand the segment list
             allocate(SegsNew(size(Segs)+CHUNK),stat=STATUS)
             _ASSERT(STATUS==0,'needs informative message')
+            SegsNew(:)%shmid = -1
+            SegsNew(:)%addr=C_NULL_PTR
 
             SegsNew(1:size(Segs)) = Segs
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Initialize the members of Segment_T after allocation

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#809

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
