### PR TITLE
Use ESMF_Finalize in Cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 ### Changed
+
+- Use `ESMF_Finalize` instead of `MPI_Finalize` in Cap
+
 ### Fixed
 
 ## [2.6.5] - 2021-04-28

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -412,13 +412,13 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
-      integer :: ierror
+      integer :: status
       _UNUSED_DUMMY(unusable)
 
       if (.not. this%mpi_already_initialized) then
          call MAPL_Finalize(comm=this%comm_world)
-         call MPI_Finalize(ierror)
-         _VERIFY(ierror)
+         call ESMF_Finalize(rc=status)
+         _VERIFY(status)
       end if
 
       _RETURN(_SUCCESS)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR moves to use `ESMF_Finalize` instead of `MPI_Finalize`. This comes from the want of the ESMF folks (@rsdunlapiv, @theurich) to use ESMF Profiling. Turns out, that doesn't happen if you don't have 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #817 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Allows the use of the ESMF profiler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested using `ESMF_Finalize` and the model doesn't seem to crash GEOSgcm. 

That said, we should ask our friends at Harvard (@lizziel, et al) and UFS (@rmontuoro or @weiyuan-jiang as a proxy) to try this out in their codes. That is, if they call the Cap? I do not know if they do. If they don't, then this is moot for them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
