### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *~
+/@ESMA_cmake/
 /ESMA_cmake/
+/ESMA_cmake@/
+/@ESMA_env/
 /ESMA_env/
+/ESMA_env@/
 /.mepo/
 *.py.bak


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.