### PR TITLE
Minor update to Regrid_Util.x and FieldBundleRead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 ### Added
+- Regrid_Util.x now checks if file exsts and captures the units and long_name of the input for the output file
 ### Changed
 ### Fixed
 

--- a/base/FieldBundleRead.F90
+++ b/base/FieldBundleRead.F90
@@ -53,6 +53,9 @@ module MAPL_ESMFFieldBundleRead
          type (StringVector), pointer :: dimensions
          type (StringVectorIterator) :: dim_iter
          integer :: lev_size, grid_size(3)
+         type(Attribute), pointer :: attr
+         class(*), pointer :: attr_val
+         character(len=:), allocatable :: units,long_name
 
          collection => ExtDataCollections%at(metadata_id)
          metadata => collection%find(trim(file_name))
@@ -78,6 +81,7 @@ module MAPL_ESMFFieldBundleRead
             var_has_levels = .false.
             var_name => var_iter%key()
             this_variable => var_iter%value()
+            
             if (has_vertical_level) then
                dimensions => this_variable%get_dimensions()
                dim_iter = dimensions%begin()
@@ -119,9 +123,25 @@ module MAPL_ESMFFieldBundleRead
                _VERIFY(status)
                call ESMF_AttributeSet(field,name='VLOCATION',value=location,rc=status)
                _VERIFY(status)
-               call ESMF_AttributeSet(field,name='UNITS',value='NA',rc=status)
+               attr => this_variable%get_attribute('units')
+               attr_val=>attr%get_value()
+               select type(attr_val)
+               type is (character(*))
+                  units=attr_val
+               class default
+                  _ASSERT(.false.,'unsupport subclass for units')
+               end select
+               call ESMF_AttributeSet(field,name='UNITS',value=units,rc=status)
                _VERIFY(status)
-               call ESMF_AttributeSet(field,name='LONG_NAME',value='NA',rc=status)
+               attr => this_variable%get_attribute('long_name')
+               attr_val=>attr%get_value()
+               select type(attr_val)
+               type is (character(*))
+                  long_name=attr_val
+               class default
+                  _ASSERT(.false.,'unsupport subclass for units')
+               end select
+               call ESMF_AttributeSet(field,name='LONG_NAME',value=long_name,rc=status)
                _VERIFY(status)
                call MAPL_FieldBundleAdd(bundle,field,rc=status)
                _VERIFY(status)                  

--- a/base/Regrid_Util.F90
+++ b/base/Regrid_Util.F90
@@ -71,7 +71,7 @@ CONTAINS
    type(ESMF_TimeInterval) :: timeInterval
    type(ESMF_Clock) :: clock
 
-   logical :: fileCreated
+   logical :: fileCreated,file_exists
 
    character(len=ESMF_MAXSTR) :: RegridMth
 
@@ -201,6 +201,9 @@ CONTAINS
     if (trim(regridMth) == 'conservative2') then
        regridMethod = REGRID_METHOD_CONSERVE_2ND
     end if
+
+    inquire(file=trim(outputfile),exist=file_exists)
+    _ASSERT(.not.file_exists,"output file already exists: exiting!")
 
     call MAPL_GetNodeInfo (comm=MPI_COMM_WORLD, rc=status)
     _VERIFY(STATUS)


### PR DESCRIPTION
Very minor update, when using Regrid_Util.x I noticed that the output files did not have the units and long_name of the input, fixed that. Also make sure Regrid_Util.x can't clobber an existing file if the requested output file already exists.
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
