### PR TITLE
Fixes to allow MAPL to build with any mepo style (and advance CMake Minimum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set required CMake Version to 3.17
+- Update `components.yaml`
+  - ESMA_cmake v3.4.2 (to match GEOSgcm)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 ### Changed
+
+- Set required CMake Version to 3.17
+
 ### Fixed
+
+- Allow MAPL to build if subrepos are cloned with any mepo style
+  (prefix, postfix, naked)
 
 ## [2.7.0] - 2021-05-25
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required (VERSION 3.17)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
@@ -7,10 +7,19 @@ project (
   VERSION 2.7.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
-if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake)
-  list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake")
-  include (esma)
-endif ()
+# mepo can now clone subrepos in three styles
+set (ESMA_CMAKE_DIRS
+  ESMA_cmake
+  @ESMA_cmake
+  ESMA_cmake@
+  )
+
+foreach (dir IN LISTS ESMA_CMAKE_DIRS)
+  if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
+    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+    include (esma)
+  endif ()
+endforeach ()
 
 # build as standalone project
 if (NOT COMMAND esma)
@@ -22,19 +31,17 @@ if (NOT COMMAND esma)
   if (SKIP_MEPO)
     message (FATAL_ERROR "ESMA not found")
   else ()
-     set (MEPO_INIT_COMMAND mepo init)
-     execute_process (
-        COMMAND ${MEPO_INIT_COMMAND}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        )
-
-     set (MEPO_CLONE_COMMAND mepo clone)
-     execute_process (
-        COMMAND ${MEPO_CLONE_COMMAND}
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        )
-    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/ESMA_cmake")
-    include (esma)
+    set (MEPO_CLONE_COMMAND mepo clone)
+    execute_process (
+      COMMAND ${MEPO_CLONE_COMMAND}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      )
+    foreach (dir IN LISTS ESMA_CMAKE_DIRS)
+      if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
+        list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+        include (esma)
+      endif ()
+    endforeach ()
     option (SKIP_MEPO "Set to skip mepo steps" ON)
   endif ()
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.0
+  tag: v3.4.2
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR allows MAPL to build with any mepo style (prefix, postfix, naked).

Also, this might be controversial, so I'll let @tclune weigh in, but I sort of deliberately used a CMake 3.17 style foreach() loop so I could advance the `cmake_minimum_required` from CMake 3.13 to 3.17. I know at some point I had a "I want to use CMake X but it's only in CMake 3.x and I think that was 17...though I can't remember what the version was. More than 13.) I'd love to go straight to 3.20, but baby steps.

I know we have CMake 3.19 at NCCS, NAS, and GMAO Desktop and the macs using brew are at 3.20 at least. 

And I looked on Orion and I see CMake 3.18.1 is available there (as is CMake 3.17.3). I also asked @bena-nasa how he's built MAPL on there before and he is using CMake 3.18.1. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #865 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Lets MAPL build with all three mepo styles.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I was able to run `cmake` on MAPL using all three styles. And on discover I could build and run MAPL in postfix and all is well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
