### PR TITLE
Add CLI switch to enable MOAB in ESMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 ### Added
+
 - Regrid_Util.x now checks if file exsts and captures the units and long_name of the input for the output file
+- Add `--with_esmf_moab` to enable MOAB Mesh in ESMF
+
 ### Changed
 
 - Set required CMake Version to 3.17

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -34,6 +34,8 @@ module MAPL_CapOptionsMod
       logical              :: fast_oclient  = .false.
       ! whether or not turn on the io profiler
       logical              :: with_io_profiler = .false.
+      ! whether or not to use MOAB in ESMF
+      logical              :: with_esmf_moab = .false.
       ! server groups
       integer :: n_iserver_group = 1
       integer :: n_oserver_group = 1
@@ -117,6 +119,7 @@ contains
       call flapCLI%cli_options%get(val=cap_options%isolate_nodes, switch='--isolate_nodes', error=status); _VERIFY(status)
       call flapCLI%cli_options%get(val=cap_options%fast_oclient, switch='--fast_oclient', error=status); _VERIFY(status)
       call flapCLI%cli_options%get(val=cap_options%with_io_profiler, switch='--with_io_profiler', error=status); _VERIFY(status)
+      call flapCLI%cli_options%get(val=cap_options%with_esmf_moab, switch='--with_esmf_moab', error=status); _VERIFY(status)
       call flapCLI%cli_options%get_varying(val=cap_options%npes_input_server, switch='--npes_input_server', error=status); _VERIFY(status)
       call flapCLI%cli_options%get_varying(val=cap_options%npes_output_server, switch='--npes_output_server', error=status); _VERIFY(status)
       call flapCLI%cli_options%get_varying(val=cap_options%nodes_input_server, switch='--nodes_input_server', error=status); _VERIFY(status)

--- a/base/MAPL_FlapCLI.F90
+++ b/base/MAPL_FlapCLI.F90
@@ -216,6 +216,14 @@ contains
            error=status)
       _VERIFY(status)
 
+      call options%add(switch='--with_esmf_moab', &
+           help='Enables use of MOAB library for ESMF meshes', &
+           required=.false., &
+           def='.false.', &
+           act='store_true', &
+           error=status)
+      _VERIFY(status)
+
       _RETURN(_SUCCESS)
 
    end subroutine add_command_line_options

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -242,6 +242,15 @@ contains
       call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, rc=status)
       _VERIFY(status)
 
+      ! Note per ESMF this is a temporary routine as eventually MOAB will
+      ! be the only mesh generator. But until then, this allows us to
+      ! test it
+      call ESMF_MeshSetMOAB(this%cap_options%with_esmf_moab, rc=status)
+      _VERIFY(status)
+
+      lgr => logging%get_logger('MAPL')
+      call lgr%info("Running with MOAB library for ESMF Mesh: %l1", this%cap_options%with_esmf_moab)
+
       call this%initialize_cap_gc(rc=status)
       _VERIFY(status)
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a new CLI switch `--with_esmf_moab` to enable the MOAB mesh in ESMF.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #869 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

ESMF is moving to MOAB eventually. This switch will let us test MOAB within MAPL and GEOS to help the ESMF folks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran GEOS with and without the switch. It runs in both cases and, surprisingly(?) is zero-diff on or off (at C24).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
