### PR TITLE
set logical values through Flap without specifying true or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Regrid_Util.x now checks if file exsts and captures the units and long_name of the input for the output file
 ### Changed
-
+- set logical values in flap commmand line without true or false values
 - Set required CMake Version to 3.17
 - Update `components.yaml`
   - ESMA_cmake v3.4.2 (to match GEOSgcm)

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -98,7 +98,7 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
       character(80) :: buffer
-      logical :: one_node_output, no_isolated_nodes, use_sub_comm
+      logical :: one_node_output, compress_nodes, use_sub_comm
 
       integer, allocatable :: nodes_output_server(:)
 
@@ -118,8 +118,8 @@ contains
       endif
 
       call flapCLI%cli_options%get(val=cap_options%npes_model, switch='--npes_model', error=status); _VERIFY(status)
-      call flapCLI%cli_options%get(val=no_isolated_nodes, switch='--no_isolated_nodes', error=status); _VERIFY(status)
-      cap_options%isolate_nodes = .not. no_isolated_nodes
+      call flapCLI%cli_options%get(val=compress_nodes, switch='--compress_nodes', error=status); _VERIFY(status)
+      cap_options%isolate_nodes = .not. compress_nodes
       call flapCLI%cli_options%get(val=cap_options%fast_oclient, switch='--fast_oclient', error=status); _VERIFY(status)
       call flapCLI%cli_options%get(val=cap_options%with_io_profiler, switch='--with_io_profiler', error=status); _VERIFY(status)
       call flapCLI%cli_options%get(val=cap_options%with_esmf_moab, switch='--with_esmf_moab', error=status); _VERIFY(status)

--- a/base/MAPL_CapOptions.F90
+++ b/base/MAPL_CapOptions.F90
@@ -96,13 +96,15 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
       character(80) :: buffer
-      logical :: one_node_output
+      logical :: one_node_output, no_isolated_nodes, use_sub_comm
+
       integer, allocatable :: nodes_output_server(:)
 
       call flapCLI%cli_options%get(val=buffer, switch='--egress_file', error=status); _VERIFY(status)
       cap_options%egress_file = trim(buffer)
 
-      call flapCLI%cli_options%get(val=cap_options%use_comm_world, switch='--use_comm_world', error=status); _VERIFY(status)
+      call flapCLI%cli_options%get(val=use_sub_comm, switch='--use_sub_comm', error=status); _VERIFY(status)
+      cap_options%use_comm_world = .not. use_sub_comm
 
       if ( .not. cap_options%use_comm_world) then
          call flapCLI%cli_options%get(val=buffer, switch='--comm_model', error=status); _VERIFY(status)
@@ -114,7 +116,8 @@ contains
       endif
 
       call flapCLI%cli_options%get(val=cap_options%npes_model, switch='--npes_model', error=status); _VERIFY(status)
-      call flapCLI%cli_options%get(val=cap_options%isolate_nodes, switch='--isolate_nodes', error=status); _VERIFY(status)
+      call flapCLI%cli_options%get(val=no_isolated_nodes, switch='--no_isolated_nodes', error=status); _VERIFY(status)
+      cap_options%isolate_nodes = .not. no_isolated_nodes
       call flapCLI%cli_options%get(val=cap_options%fast_oclient, switch='--fast_oclient', error=status); _VERIFY(status)
       call flapCLI%cli_options%get(val=cap_options%with_io_profiler, switch='--with_io_profiler', error=status); _VERIFY(status)
       call flapCLI%cli_options%get_varying(val=cap_options%npes_input_server, switch='--npes_input_server', error=status); _VERIFY(status)

--- a/base/MAPL_FlapCLI.F90
+++ b/base/MAPL_FlapCLI.F90
@@ -185,8 +185,8 @@ contains
            error=status)
       _VERIFY(status)
 
-      call options%add(switch='--no_isolated_nodes', &
-           help='Padding extra processes in the last nodes with idle', &
+      call options%add(switch='--compress_nodes', &
+           help='MPI processes continue on the nodes even MPI communicator is divided', &
            required=.false., &
            def='.false.', &
            act='store_true', &

--- a/base/MAPL_FlapCLI.F90
+++ b/base/MAPL_FlapCLI.F90
@@ -97,11 +97,11 @@ contains
            error=status)
       _VERIFY(status)
 
-      call options%add(switch='--use_comm_world', &
+      call options%add(switch='--use_sub_comm', &
            help='# The model by default is using MPI_COMM_WORLD : .true. or .false.', &
            required=.false., &
-           act='store',      &
-           def='.true.',     &
+           def='.false.',     &
+           act='store_true',      &
            error=status)
       _VERIFY(status)
 
@@ -185,11 +185,11 @@ contains
            error=status)
       _VERIFY(status)
 
-      call options%add(switch='--isolate_nodes', &
+      call options%add(switch='--no_isolated_nodes', &
            help='Padding extra processes in the last nodes with idle', &
            required=.false., &
-           def='.true.', &
-           act='store', &
+           def='.false.', &
+           act='store_true', &
            error=status)
       _VERIFY(status)
 
@@ -197,7 +197,7 @@ contains
            help='Copying data before isend. Client would wait until it is re-used', &
            required=.false., &
            def='.false.', &
-           act='store', &
+           act='store_true', &
            error=status)
       _VERIFY(status)
 
@@ -205,14 +205,14 @@ contains
            help='Specify if each output server has only one nodes', &
            required=.false., &
            def='.false.', &
-           act='store', &
+           act='store_true', &
            error=status)
 
       call options%add(switch='--with_io_profiler', &
            help='Turning on io_profler', &
            required=.false., &
            def='.false.', &
-           act='store', &
+           act='store_true', &
            error=status)
       _VERIFY(status)
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
Now it can get the logical values without specifying true or false.
For example, --with_io_profiler  would give a true value. To avoid confusion, we change the command_line from --use_comm_world to --use_sub_comm and --isolate_nodes to --no_isolated_nodes .

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
