### PR TITLE
Build as shared/static according to BUILD_SHARED_LIBS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 - Regrid_Util.x now checks if file exsts and captures the units and long_name of the input for the output file
+- Build libraries either as shared (default) or static based on BUILD_SHARED_LIBS flag
 ### Changed
 
 - Set required CMake Version to 3.17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ project (
   VERSION 2.7.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
+# build as shared libraries by default
+option (BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 # mepo can now clone subrepos in three styles
 set (ESMA_CMAKE_DIRS
   ESMA_cmake

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -6,7 +6,6 @@ esma_add_library (${this}
   DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
                $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
-  TYPE SHARED
   )
 
 target_include_directories (${this} PUBLIC

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -38,8 +38,6 @@ if (APPLE AND CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_Fortran_COMPILER
       "A workaround was found that if the ${this} library was compiled\n"
       "as TYPE STATIC, the model would work. So we are setting ${this} as\n"
       "a TYPE STATIC library. Note: This might interfere with coupled model.")
-else ()
-   set (LIBRARY_TYPE SHARED)
 endif ()
 
 esma_add_library (${lib}

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -62,13 +62,13 @@ esma_add_library(
   ${this} SRCS ${srcs}
   DEPENDENCIES MAPL.generic MAPL.shared MAPL.profiler MAPL.pfio MAPL_cfio_r4 PFLOGGER::pflogger GFTL_SHARED::gftl-shared
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-  TYPE SHARED)
+  )
 else ()
 esma_add_library(
   ${this} SRCS ${srcs}
   DEPENDENCIES MAPL.generic MAPL.shared MAPL.profiler MAPL.pfio MAPL_cfio_r4 pflogger gftl-shared
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-  TYPE SHARED)
+  )
 endif ()
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -36,9 +36,9 @@ find_package(GFTL REQUIRED)
 find_package(GFTL_SHARED REQUIRED)
 
 if (ESMA_USE_GFE_NAMESPACE)
-  esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL.shared PFLOGGER::pflogger GFTL_SHARED::gftl-shared GFTL::gftl TYPE SHARED)
+  esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL.shared PFLOGGER::pflogger GFTL_SHARED::gftl-shared GFTL::gftl)
 else ()
-  esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL.shared pflogger gftl-shared gftl TYPE SHARED)
+  esma_add_library(${this} SRCS ${srcs} DEPENDENCIES MAPL.shared pflogger gftl-shared gftl)
 endif ()
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/gridcomps/CMakeLists.txt
+++ b/gridcomps/CMakeLists.txt
@@ -2,7 +2,6 @@ esma_set_this(OVERRIDE MAPL.gridcomps)
 esma_add_library (${this}
      SRCS MAPL_GridComps.F90
      DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.cap
-     TYPE SHARED
      )
 
 target_include_directories (${this} PUBLIC

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
      MAPL_NUOPCWrapperMod.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler MAPL.history TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler MAPL.history)
 if (ESMA_USE_GFE_NAMESPACE)
    target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
                                  PRIVATE MPI::MPI_Fortran $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>)

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
      MAPL_HistoryGridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.profiler)
 if (ESMA_USE_GFE_NAMESPACE)
    target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
                                  PRIVATE MPI::MPI_Fortran)

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -89,7 +89,7 @@ set (srcs
   StringVectorUtil.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran)
 if (ESMA_USE_GFE_NAMESPACE)
   target_link_libraries (${this} PUBLIC GFTL_SHARED::gftl-shared
     PRIVATE MPI::MPI_Fortran)

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -55,9 +55,9 @@ set (srcs
   )
 
 if (ESMA_USE_GFE_NAMESPACE)
-  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl MAPL.shared MPI::MPI_Fortran TYPE SHARED)
+  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl MAPL.shared MPI::MPI_Fortran)
 else ()
-  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared gftl MAPL.shared MPI::MPI_Fortran TYPE SHARED)
+  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared gftl MAPL.shared MPI::MPI_Fortran)
 endif ()
 target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
 

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -30,9 +30,9 @@ set (srcs
     )
 
 if (ESMA_USE_GFE_NAMESPACE)
-  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared MPI::MPI_Fortran PFLOGGER::pflogger TYPE SHARED)
+  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared MPI::MPI_Fortran PFLOGGER::pflogger)
 else ()
-  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared MPI::MPI_Fortran pflogger TYPE SHARED)
+  esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared MPI::MPI_Fortran pflogger)
 endif ()
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
This PR allows MAPL to be built as a set of shared (default) or static libraries based on the value of BUILD_SHARED_LIBS
## Description
<!--- Describe your changes in detail -->
The included changes remove hardcoded settings aimed at building MAPL as shared libraries and allow users to choose between shared and static builds based on the CMake `BUILD_SHARED_LIBS` flag.

The previous build behavior is retained by setting `BUILD_SHARED_LIBS` to `ON` by default.
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR addresses issue #866.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes allow building MAPL as static, which is required for the UFS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR was tested on NOAA RDHPCS platforms Hera and Orion by means of the UFS FV3-GOCART application.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
