### PR TITLE
Feature/bmauer/protect against 2 d flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (prefix, postfix, naked)
 - Add missing variable declaration preventing MAPL from building
   if H5_HAVE_PARALLEL is defined
+- Protect against trying to flip 2D variable in ExtData if there are mixed 2D/3D in file
 
 ## [2.7.0] - 2021-05-25
 

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -1038,7 +1038,7 @@ CONTAINS
       ! get clim year if this is cyclic
       call GetClimYear(item,__RC__)
       ! get levels, other information
-      call GetLevs(item,time,self%allowExtrap,__RC__)
+      call GetLevs(item,time,self%ExtDataState,self%allowExtrap,__RC__)
       call ESMF_VMBarrier(vm)
       ! register collections
       item%iclient_collection_id=i_clients%add_ext_collection(trim(item%file))
@@ -2077,10 +2077,11 @@ CONTAINS
 
      end subroutine GetClimYear
 
-     subroutine GetLevs(item, time, allowExtrap, rc)
+     subroutine GetLevs(item, time, state, allowExtrap, rc)
 
         type(PrimaryExport)      , intent(inout) :: item
         type(ESMF_Time)          , intent(inout) :: time
+        type(ESMF_State)         , intent(in   ) :: state
         logical                  , intent(in   ) :: allowExtrap
         integer, optional        , intent(out  ) :: rc
 
@@ -2088,8 +2089,9 @@ CONTAINS
 
         integer(ESMF_KIND_I4)      :: iyr,imm,idd,ihr,imn,iss,i,n,refYear
         character(len=ESMF_MAXPATHLEN) :: file
-        integer                    :: nymd, nhms
+        integer                    :: nymd, nhms, rank
         type(ESMF_Time)            :: fTime
+        type(ESMF_Field)           :: field
         real, allocatable          :: levFile(:) 
         character(len=ESMF_MAXSTR) :: buff,levunits,tlevunits
         logical                    :: found,lFound,intOK
@@ -2104,8 +2106,15 @@ CONTAINS
 
         call ESMF_TimeIntervalSet(zero,__RC__)
 
-        if (item%frequency == zero) then
+        call ESMF_StateGet(state,trim(item%name),field,__RC__)
+        call ESMF_FieldGet(field,rank=rank,__RC__)
+        if (rank==2) then
+           item%lm=0
+           _RETURN(_SUCCESS)
+        end if
 
+        if (item%frequency == zero) then
+           
            file = item%file
            Inquire(file=trim(file),EXIST=found)
 
@@ -3410,6 +3419,9 @@ CONTAINS
      integer :: id_ps
      type(ESMF_Field) :: field, newfield,psF
 
+     if (item%lm==0) then
+        _RETURN(_SUCCESS)
+     end if
      if (item%do_VertInterp) then
         if (trim(item%importVDir)/=trim(item%fileVDir)) then
            call MAPL_ExtDataFlipVertical(item,filec,rc=status)
@@ -4420,7 +4432,7 @@ CONTAINS
       type(ESMF_Field) :: Field,field1,field2
       real, pointer    :: ptr(:,:,:)
       real, allocatable :: ptemp(:,:,:)
-      integer :: ls, le, rank
+      integer :: ls, le
 
       if (item%isVector) then
 
@@ -4432,23 +4444,20 @@ CONTAINS
             call MAPL_ExtDataGetBracket(item,filec,field=Field2,vcomp=2,__RC__)
          end if
 
-         call ESMF_FieldGet(field1,rank=rank,__RC__)
-         if (rank==3) then
-            call ESMF_FieldGet(Field1,0,farrayPtr=ptr,rc=status)
-            _VERIFY(STATUS)
-            allocate(ptemp,source=ptr,stat=status)
-            _VERIFY(status)
-            ls = lbound(ptr,3)
-            le = ubound(ptr,3)
-            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+         call ESMF_FieldGet(Field1,0,farrayPtr=ptr,rc=status)
+         _VERIFY(STATUS)
+         allocate(ptemp,source=ptr,stat=status)
+         _VERIFY(status)
+         ls = lbound(ptr,3)
+         le = ubound(ptr,3)
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
-            call ESMF_FieldGet(Field2,0,farrayPtr=ptr,rc=status)
-            _VERIFY(STATUS)
-            ptemp=ptr
-            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+         call ESMF_FieldGet(Field2,0,farrayPtr=ptr,rc=status)
+         _VERIFY(STATUS)
+         ptemp=ptr
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
-            deallocate(ptemp)
-         end if
+         deallocate(ptemp)
 
       else
 
@@ -4458,17 +4467,14 @@ CONTAINS
             call MAPL_ExtDataGetBracket(item,filec,field=Field,__RC__)
          end if
 
-         call ESMF_FieldGet(field,rank=rank,__RC__)
-         if (rank==3) then
-            call ESMF_FieldGet(Field,0,farrayPtr=ptr,rc=status)
-            _VERIFY(STATUS)
-            allocate(ptemp,source=ptr,stat=status)
-            _VERIFY(status)
-            ls = lbound(ptr,3)
-            le = ubound(ptr,3)
-            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
-            deallocate(ptemp)
-         end if
+         call ESMF_FieldGet(Field,0,farrayPtr=ptr,rc=status)
+         _VERIFY(STATUS)
+         allocate(ptemp,source=ptr,stat=status)
+         _VERIFY(status)
+         ls = lbound(ptr,3)
+         le = ubound(ptr,3)
+         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+         deallocate(ptemp)
       end if
 
       _RETURN(ESMF_SUCCESS)

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -4420,7 +4420,7 @@ CONTAINS
       type(ESMF_Field) :: Field,field1,field2
       real, pointer    :: ptr(:,:,:)
       real, allocatable :: ptemp(:,:,:)
-      integer :: ls, le
+      integer :: ls, le, rank
 
       if (item%isVector) then
 
@@ -4432,20 +4432,23 @@ CONTAINS
             call MAPL_ExtDataGetBracket(item,filec,field=Field2,vcomp=2,__RC__)
          end if
 
-         call ESMF_FieldGet(Field1,0,farrayPtr=ptr,rc=status)
-         _VERIFY(STATUS)
-         allocate(ptemp,source=ptr,stat=status)
-         _VERIFY(status)
-         ls = lbound(ptr,3)
-         le = ubound(ptr,3)
-         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+         call ESMF_FieldGet(field1,rank=rank,__RC__)
+         if (rank==3) then
+            call ESMF_FieldGet(Field1,0,farrayPtr=ptr,rc=status)
+            _VERIFY(STATUS)
+            allocate(ptemp,source=ptr,stat=status)
+            _VERIFY(status)
+            ls = lbound(ptr,3)
+            le = ubound(ptr,3)
+            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
-         call ESMF_FieldGet(Field2,0,farrayPtr=ptr,rc=status)
-         _VERIFY(STATUS)
-         ptemp=ptr
-         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+            call ESMF_FieldGet(Field2,0,farrayPtr=ptr,rc=status)
+            _VERIFY(STATUS)
+            ptemp=ptr
+            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
 
-         deallocate(ptemp)
+            deallocate(ptemp)
+         end if
 
       else
 
@@ -4455,14 +4458,17 @@ CONTAINS
             call MAPL_ExtDataGetBracket(item,filec,field=Field,__RC__)
          end if
 
-         call ESMF_FieldGet(Field,0,farrayPtr=ptr,rc=status)
-         _VERIFY(STATUS)
-         allocate(ptemp,source=ptr,stat=status)
-         _VERIFY(status)
-         ls = lbound(ptr,3)
-         le = ubound(ptr,3)
-         ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
-         deallocate(ptemp)
+         call ESMF_FieldGet(field,rank=rank,__RC__)
+         if (rank==3) then
+            call ESMF_FieldGet(Field,0,farrayPtr=ptr,rc=status)
+            _VERIFY(STATUS)
+            allocate(ptemp,source=ptr,stat=status)
+            _VERIFY(status)
+            ls = lbound(ptr,3)
+            le = ubound(ptr,3)
+            ptr(:,:,le:ls:-1) = ptemp(:,:,ls:le:+1)
+            deallocate(ptemp)
+         end if
       end if
 
       _RETURN(ESMF_SUCCESS)


### PR DESCRIPTION
A user found a corner case that was not protected against. The issue arises when you have a file with 2D and 3D variables and according to the vertical metadata for the level variable it decides you need to flip it.
It was trying to do this to 2D variables and failing as the flip routine assumes the fields are 3D. 
I just now early on detect if the field has a 3rd dimension and if not bypass any vertical handling at all.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
