### PR TITLE
Ensure grid coordinates are always provided in radians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+- Ensure grid coordinates are always provided in radians
+
 ## [2.7.2] - 2021-06-23
 
 ### Fixed

--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -379,7 +379,7 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
   else if (crdSys == ESMF_COORDSYS_SPH_RAD) then
      conv2rad = 1._ESMF_KIND_R8
   else
-     _RETURN(ESMF_FAILURE)
+     _FAIL('Unsupported coordinate system:  ESMF_COORDSYS_CART')
   end if
 
   if (tk == ESMF_TYPEKIND_R4) then

--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -317,11 +317,13 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
 
 !	local variables
   integer                   :: rank
+  type(ESMF_CoordSys_Flag)  :: crdSys
   type(ESMF_TypeKind_Flag)  :: tk
   integer                   :: counts(ESMF_MAXDIM)
   integer                   :: crdOrder
   real(ESMF_KIND_R4), pointer :: r4d2(:,:)
   real(ESMF_KIND_R8), pointer :: r8d2(:,:)
+  real(ESMF_KIND_R8)        :: conv2rad
   integer                   :: STATUS
   integer                   :: i
   integer                   :: j
@@ -331,7 +333,7 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
 
   _UNUSED_DUMMY(Units)
 
-  call ESMF_GridGet(grid, coordTypeKind=tk, &
+  call ESMF_GridGet(grid, coordSys=crdSys, coordTypeKind=tk, &
           dimCount=rank, coordDimCount=coordDimCount, rc=status)
   _VERIFY(STATUS) 
 
@@ -372,6 +374,14 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
      _RETURN(ESMF_SUCCESS)
   end if
 
+  if (crdSys == ESMF_COORDSYS_SPH_DEG) then
+     conv2rad = MAPL_PI_R8 / 180._ESMF_KIND_R8
+  else if (crdSys == ESMF_COORDSYS_SPH_RAD) then
+     conv2rad = 1._ESMF_KIND_R8
+  else
+     _RETURN(ESMF_FAILURE)
+  end if
+
   if (tk == ESMF_TYPEKIND_R4) then
      if (coordDimCount(crdOrder)==2) then
         call ESMF_GridGetCoord(grid, localDE=0, coordDim=crdOrder, &
@@ -381,7 +391,7 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
         _VERIFY(STATUS) 
         allocate(coord(counts(1), counts(2)), STAT=status)
         _VERIFY(STATUS)
-        coord = R4D2
+        coord = conv2rad * R4D2
      else
         _RETURN(ESMF_FAILURE)
      endif
@@ -394,7 +404,7 @@ subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)
         _VERIFY(STATUS) 
         allocate(coord(counts(1), counts(2)), STAT=status)
         _VERIFY(STATUS)
-        coord = R8D2
+        coord = conv2rad * R8D2
      else
         _RETURN(ESMF_FAILURE)
      endif

--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -301,7 +301,7 @@ contains
 
 !BOP
 
-! !IROUTINE: ESMFL_GridCoordGet - retrieves the coordinates of a particular axis 
+! !IROUTINE: ESMFL_GridCoordGet - retrieves the coordinates of a particular axis in radians
 
 ! !INTERFACE:
 subroutine ESMFL_GridCoordGet(GRID, coord, name, Location, Units, rc)


### PR DESCRIPTION
based on the grid's coordinate system flag.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds changes ensuring that grid coordinates are always provided in units of radians regardless of the ESMF Grid object used.

Grid coordinates are assumed to be in radians throughout MAPL and GOCART. This assumption may no longer hold if an ESMF Grid object is provided externally to MAPL (as done in the UFS). This PR implements automatic unit conversion to radians for grid coordinates based on the coordinate system used to create the ESMF Grid object.

Note that `ESMFL_GridCoordGet()` will return with a generic `ESMF_FAILURE` error code if the coordinate system flag is neither `ESMF_COORDSYS_SPH_DEG`, nor `ESMF_COORDSYS_SPH_RAD`.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes issue #899 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested on the NOAA RDHPCS platform Hera within the UFS weather model.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
