### PR TITLE
Update Changelog Enforcer, add error message

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -9,7 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.6.1
+    - uses: dangoslen/changelog-enforcer@v2
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabels: 'Skip Changelog,0 diff trivial'
+        missingUpdateErrorMessage: >
+            No update to CHANGELOG.md found! Please add a changelog
+            entry to it describing your change.  Please note that the
+            keepachangelog (https://keepachangelog.com) format is
+            used. If your change is very trivial not applicable for a
+            changelog entry, add a 'Skip Changelog' label to the pull
+            request to skip the changelog enforcer.
+


### PR DESCRIPTION
This is an update to the changelog enforcer that now apparently allows a more exciting error message. This is to test that!