### PR TITLE
Feature/bmauer/#887 consistent fgrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix format for writing out large number
 - Fixed CMAKE_Fortran_MODULE_DIRECTORY for some directories
+- Update handling of file coordinates when creating grids from file. Now if identified as a standard grid compute coordinates. Option to allow this to be overrided and use file coordinates. Fixed issue if two files are identified as a standard grid but has very slightly different coordinates causing one or the other to be used depending on which file is used first.
 
 ## [2.7.3] - 2021-06-24
 

--- a/base/MAPL_AbstractGridFactory.F90
+++ b/base/MAPL_AbstractGridFactory.F90
@@ -111,13 +111,14 @@ module MAPL_AbstractGridFactoryMod
       end subroutine initialize_from_config_with_prefix
 
 
-      subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+      subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates,rc)
         use MAPL_KeywordEnforcerMod
         use pFIO
         import AbstractGridFactory
         class (AbstractGridFactory), intent(inout)  :: this
         type (FileMetadata), target, intent(in) :: file_metadata
         class (KeywordEnforcer), optional, intent(in) :: unusable
+        logical, optional, intent(in) :: force_file_coordinates
         integer, optional, intent(out) :: rc
       end subroutine initialize_from_file_metadata
 

--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -289,13 +289,14 @@ contains
       _RETURN(_SUCCESS)
    end function create_basic_grid
    
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       use MAPL_KeywordEnforcerMod
       use MAPL_BaseMod, only: MAPL_DecomposeDim
 
       class (CubedSphereGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam= MOD_NAME // 'initialize_from_file_metadata()'

--- a/base/MAPL_ExtDataCollection.F90
+++ b/base/MAPL_ExtDataCollection.F90
@@ -15,6 +15,7 @@ module MAPL_ExtDataCollectionMod
 
   type :: MAPLExtDataCollection
     character(len=:), allocatable :: template
+    logical :: use_file_coords
     type (FileMetadataUtilsVector) :: metadatas
     type (StringIntegerMap) :: file_ids
     type(ESMF_Grid), allocatable :: src_grid
@@ -32,11 +33,17 @@ module MAPL_ExtDataCollectionMod
 contains
 
 
-  function new_MAPLExtDataCollection(template) result(collection)
+  function new_MAPLExtDataCollection(template,use_file_coords) result(collection)
     type (MAPLExtDataCollection) :: collection
     character(len=*), intent(in) :: template
+    logical, optional, intent(in) :: use_file_coords
 
     collection%template = template 
+    if (present(use_file_coords)) then
+       collection%use_file_coords=use_file_coords
+    else
+       collection%use_file_coords=.false.
+    end if
 
   end function new_MAPLExtDataCollection
 
@@ -97,7 +104,7 @@ contains
        deallocate(metadata)
        metadata => this%metadatas%back()
        if (.not. allocated(this%src_grid)) then
-          allocate(factory, source=grid_manager%make_factory(trim(file_name)))
+          allocate(factory, source=grid_manager%make_factory(trim(file_name),force_file_coordinates=this%use_file_coords))
           this%src_grid = grid_manager%make_grid(factory)
        end if
        ! size() returns 64-bit integer;  cast to 32 bit for this usage.

--- a/base/MAPL_ExtDataCollectionManager.F90
+++ b/base/MAPL_ExtDataCollectionManager.F90
@@ -11,8 +11,9 @@ public MAPL_ExtDataAddCollection
 
 contains
 
-  function MAPL_ExtDataAddCollection(template) result(id)
+  function MAPL_ExtDataAddCollection(template,use_file_coords) result(id)
      character(len=*), intent(in) :: template
+     logical, optional, intent(in) :: use_file_coords
       integer :: n
       logical :: found
       type (MAPLCollectionVectorIterator) :: iter
@@ -36,7 +37,7 @@ contains
       end do
 
       if (.not. found) then
-         c = MAPLExtDataCollection(template)
+         c = MAPLExtDataCollection(template,use_file_coords=use_file_coords)
          call ExtDatacollections%push_back(c)
       end if
 

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -201,6 +201,7 @@
      integer              :: blocksize
      logical              :: prefetch
      logical              :: distributed_trans
+     logical              :: use_file_coords
   end type MAPL_ExtData_State
 
 ! Hook for the ESMF
@@ -517,6 +518,8 @@ CONTAINS
 
    call ESMF_ConfigGetAttribute(CF_main,value=self%distributed_trans,Label="CONSERVATIVE_DISTRIBUTED_TRANS:",default=.false., rc=status)
    _VERIFY(STATUS)
+   call ESMF_ConfigGetAttribute(CF_main,value=self%use_file_coords,Label="Use_File_Coords:",default=.false., rc=status)
+   _VERIFY(status)
 
    CFtemp = ESMF_ConfigCreate (rc=STATUS )
    _VERIFY(STATUS)
@@ -947,7 +950,7 @@ CONTAINS
 
       call lgr%debug('ExtData Initialize_(): PrimaryLoop: ')
 
-      item%pfioCollection_id = MAPL_ExtDataAddCollection(item%file)
+      item%pfioCollection_id = MAPL_ExtDataAddCollection(item%file,use_file_coords=self%use_file_coords)
 
       ! parse refresh template to see if we have a time shift during constant updating
       k = index(item%refresh_template,';')

--- a/base/MAPL_ExternalGridFactory.F90
+++ b/base/MAPL_ExternalGridFactory.F90
@@ -119,10 +119,11 @@ contains
       end select
    end function equals
 
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       class(ExternalGridFactory),       intent(inout) :: this
       type(FileMetadata),     target,   intent(in   ) :: file_metadata
       class(KeywordEnforcer), optional, intent(in   ) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer,                optional, intent(  out) :: rc
 
       character(len=*), parameter :: Iam = MOD_NAME // 'initialize_from_file_metadata'

--- a/base/MAPL_GridManager.F90
+++ b/base/MAPL_GridManager.F90
@@ -399,12 +399,13 @@ contains
    ! TODO: need to check on whether all factory constructors should be
    ! included in the factories component for grid_manager.
 
-   function make_factory_from_file(this, file_name, unused, rc) result(factory)
+   function make_factory_from_file(this, file_name, unused, force_file_coordinates, rc) result(factory)
       use pFIO
       class (AbstractGridFactory), allocatable :: factory
       class (GridManager), intent(inout) :: this
       character(*), intent(in) :: file_name
       class (KeywordEnforcer), optional, intent(in) :: unused
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
       
       type (FileMetadata) :: file_metadata
@@ -502,7 +503,7 @@ contains
 
      end if
 
-     call factory%initialize(file_metadata, rc=status)
+     call factory%initialize(file_metadata, force_file_coordinates=force_file_coordinates, rc=status)
      _VERIFY(status)
      call file_formatter%close(rc=status)
 

--- a/base/MAPL_LlcGridFactory.F90
+++ b/base/MAPL_LlcGridFactory.F90
@@ -276,12 +276,13 @@ contains
 
    end subroutine add_horz_coordinates
 
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       use MAPL_KeywordEnforcerMod
 
       class (LlcGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam= MOD_NAME // 'initialize_from_file_metadata()'

--- a/base/MAPL_OldCubedSphereGridFactory.F90
+++ b/base/MAPL_OldCubedSphereGridFactory.F90
@@ -287,13 +287,14 @@ contains
       _RETURN(_SUCCESS)
    end function create_basic_grid
    
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       use MAPL_KeywordEnforcerMod
       use MAPL_BaseMod, only: MAPL_DecomposeDim
 
       class (OldCubedSphereGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam= MOD_NAME // 'initialize_from_file_metadata()'

--- a/base/MAPL_TripolarGridFactory.F90
+++ b/base/MAPL_TripolarGridFactory.F90
@@ -332,11 +332,12 @@ contains
 
    end subroutine add_horz_coordinates
 
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       use MAPL_KeywordEnforcerMod
       class (TripolarGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
 
       character(len=*), parameter :: Iam= MOD_NAME // 'initialize_from_file_metadata()'

--- a/base/tests/MockGridFactory.F90
+++ b/base/tests/MockGridFactory.F90
@@ -154,11 +154,12 @@ contains
       _UNUSED_DUMMY(this)
    end function generate_grid_name
 
-   subroutine initialize_from_file_metadata(this, file_metadata, unusable, rc)
+   subroutine initialize_from_file_metadata(this, file_metadata, unusable, force_file_coordinates, rc)
       use MAPL_KeywordEnforcerMod
       class (MockGridFactory), intent(inout)  :: this
       type (FileMetadata), target, intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in) :: force_file_coordinates
       integer, optional, intent(out) :: rc
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(file_metadata)


### PR DESCRIPTION
Fixes issue #887 
Note this is a non-zero diff change.
This now forces consistent behavior when using the coordinates from a file. We hit a non-zero diff as described in the issue #887. The problem was that we had two files with every so slightly different coordinates that were identified as a standard geos grid, but use the file coordinates. If the grids are defined as standard we say they are regular and PC/PE/DC/PE and in this case the equals operator in gridfactory was not checking the coordinates.

This forces consistent behavior. Now if the grid is identified as a standard grid (i.e. is evenly space and PC/DC/PE/DE up to a numerical tolerance) we use the computed coordinates from the routines in the factory. This way each grid has consistent coordinates. This can be overwritten to use the coordinates from the file. In this case we say the grid is not regular which forces a different chain in the "equals" operator in the grid factory and if the two grids are not regular will compare the coordinates themselves.
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
