### PR TITLE
Fixes #907 ESMF warnings in log.

### DIFF
--- a/pfunit/MAPL_Initialize.F90
+++ b/pfunit/MAPL_Initialize.F90
@@ -5,7 +5,7 @@ contains
       use MAPL_ThrowMod, only: MAPL_set_throw_method
       use MAPL_pFUnit_ThrowMod
    
-      call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_NONE)
+      call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_MULTI)
       call MAPL_set_throw_method(throw)
 
    end subroutine Initialize


### PR DESCRIPTION
Despite the documentation, one does need to pass an importState,
exportState, and clock to the ESMF GridComp run methods.  Previously,
ESMF_TestCase tests would present numerous warnigs when logging was
turned on.  Logging was not on, which is why this was not noticed for
so long.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
