### PR TITLE
Fix bug in latlon factory for use_file_coords logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix format for writing out large number
 - Fixed CMAKE_Fortran_MODULE_DIRECTORY for some directories
 - Update handling of file coordinates when creating grids from file. Now if identified as a standard grid compute coordinates. Option to allow this to be overrided and use file coordinates. Fixed issue if two files are identified as a standard grid but has very slightly different coordinates causing one or the other to be used depending on which file is used first.
+- Fixed bug with corner case in the new logic to compute lons if matching one of our standard grids
 
 ## [2.7.3] - 2021-06-24
 

--- a/base/MAPL_LatLonGridFactory.F90
+++ b/base/MAPL_LatLonGridFactory.F90
@@ -681,7 +681,7 @@ contains
       
       integer :: i_min, i_max
       real(kind=REAL64) :: d_lat, d_lat_temp, extrap_lat
-      logical :: is_valid, use_file_coords
+      logical :: is_valid, use_file_coords, compute_lons, compute_lats
       
       _UNUSED_DUMMY(unusable)
 
@@ -872,17 +872,28 @@ contains
             this%lon_corners = MAPL_DEGREES_TO_RADIANS * this%lon_corners
             this%lat_corners = MAPL_DEGREES_TO_RADIANS * this%lat_corners
          else
+            compute_lons=.false.
+            compute_lats=.false.
             if (regLon .and. (this%dateline.ne.'XY')) then 
+               compute_lons=.true.
+            end if
+            if (regLat .and. (this%pole.ne.'XY')) then 
+               compute_lats=.true.
+            end if
+            if (compute_lons .and. compute_lats) then
                this%lon_centers = this%compute_lon_centers(this%dateline, rc=status)
                _VERIFY(status)
                this%lon_corners = this%compute_lon_corners(this%dateline, rc=status)
                _VERIFY(status)
-            end if
-            if (regLat .and. (this%pole.ne.'XY')) then 
                this%lat_centers = this%compute_lat_centers(this%pole, rc=status)
                _VERIFY(status)
                this%lat_corners = this%compute_lat_corners(this%pole, rc=status)
                _VERIFY(status)
+            else
+               this%lon_centers = MAPL_DEGREES_TO_RADIANS * this%lon_centers
+               this%lat_centers = MAPL_DEGREES_TO_RADIANS * this%lat_centers
+               this%lon_corners = MAPL_DEGREES_TO_RADIANS * this%lon_corners
+               this%lat_corners = MAPL_DEGREES_TO_RADIANS * this%lat_corners
             end if
          end if
 


### PR DESCRIPTION
Thanks to Matt's nightly testing I found a corner case I had not protected against yesterday with my PR that was to address this issue #887 
If you weren't using the file coordinates by force it tested independently the lons and the lats if they were regular and one of our standard PC/PE/DC/PE and if they indepently matched they were computed.

But I did not consider the case where it only detected one of the two dimensions as regular. In that case it was computing one but using the file for the other. And that a side effect was that the file coordinate was not being converted to degrees.

So I have modified the logic to say both dimensions must be regular to use the computed  coordinates. If one is not the grid is not regular and we use the the file coordinates, and I make sure they are converted to degrees.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
