### PR TITLE
Prepare CHANGELOG and version for MAPL 2.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 ### Added
+### Changed
+### Fixed
+
+## [2.8.0] - 2021-07-12
+
+### Added
 
 - Unit tests can now use the `_RC` macro for checking results from
   calls to ESMF.  The file must first CPP define either `I_AM_PFUNIT`
   or `I_AM_FUNIT` (serial) and then `#include "MAPL_ErrLog.h"`.
 
 ### Changed
-	
+
 - Activated ESMF logging for unit tests.
 - Fixed problem in unit testing framework that results in
   "harmless" warnings/errors in the ESMF log.
@@ -167,7 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add with_io_profiler option
 
 ### Changed
-	
+
 - Changed the interface to TimeData to have an optional "funits" argument (defaults to "minutes")
 - Changed time units to "days" for monthly collections
 - Simplified the logic for timestamping offsets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.7.3
+  VERSION 2.8.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # mepo can now clone subrepos in three styles


### PR DESCRIPTION
After discussing with @tclune, the change to requiring the latest GFE libraries (i.e, CMake change to `GFTL::gftl`), means the next MAPL should be 2.8.0 

And since the @bena-nasa grid fix has to go to @sdrabenh at some point, this means we need a release to give him. The MAPL 2.8.0 sort of also implies the non-zero-diff ness, though that's not why we change the minor number.