### PR TITLE
fixes #928

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+- Fixed bug with tripolar grids and restarts to not check the file grid matches the application grid if application grid is tripolar 
+
 ## [2.8.0] - 2021-07-12
 
 ### Added

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -5657,6 +5657,7 @@ end function MAPL_AddChildFromDSO
     logical                               :: is_tile
     class(AbstractGridFactory), pointer :: app_factory
     class (AbstractGridFactory), allocatable :: file_factory
+    character(len=ESMF_MAXSTR) :: grid_type
 
     _UNUSED_DUMMY(CLOCK)
 
@@ -5898,9 +5899,17 @@ end function MAPL_AddChildFromDSO
           call ArrDescrSetNCPar(arrdes,MPL,tile=.TRUE.,num_readers=mpl%grid%num_readers,RC=STATUS)
           _VERIFY(STATUS)
        else
-          app_factory => get_factory(MPL%GRID%ESMFGRID)
-          allocate(file_factory,source=grid_manager%make_factory(trim(filename)))
-          _ASSERT(file_factory%physical_params_are_equal(app_factory),"Factories not equal")
+          call ESMF_AttributeGet(MPL%GRID%ESMFGRID,'GridType',isPresent=isPresent,rc=status)
+          _VERIFY(status)
+          if (isPresent) then
+             call ESMF_AttributeGet(MPL%GRID%ESMFGRID,'GridType',value=grid_type,rc=status)
+             _VERIFY(status)
+          end if
+          if (trim(grid_type) /= 'Tripolar' .and. trim(grid_type) /= 'llc' .and. trim(grid_type) /= 'External') then
+             app_factory => get_factory(MPL%GRID%ESMFGRID)
+             allocate(file_factory,source=grid_manager%make_factory(trim(filename)))
+             _ASSERT(file_factory%physical_params_are_equal(app_factory),"Factories not equal")
+          end if
           call ArrDescrSetNCPar(arrdes,MPL,num_readers=mpl%grid%num_readers,RC=STATUS)
           _VERIFY(STATUS)
        end if PNC4_TILE


### PR DESCRIPTION
Fixes issue #928, unfortunately the restarts when using a tripolar grid do not have any metadata to indicate this so the strategy of checking if the file grid on the restart matches the component grid just can not work for tripolar grids at this point until refactoring of MAPL_IO occurs. Therefore just don't do the check if the component grid is tripolar. 
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
