### PR TITLE
Prepare CHANGELOG and version for MAPL 2.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add stretch parameters to restarts and check the file grid compared to MAPL grid
-  when reading restarts
+### Removed
+### Added
+### Changed
+### Fixed
+
+## [2.8.1] - 2021-07-28
 
 ### Removed
 
@@ -16,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add stretch parameters to restarts and check the file grid compared to MAPL grid
+  when reading restarts
 - Add `CMakePresets.json` file
   - Note: requires CMake 3.21.0 to use
   - Per CMake advice, add `CMakeUserPresets.json` to `.gitignore`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.0
+  VERSION 2.8.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # mepo can now clone subrepos in three styles


### PR DESCRIPTION
This PR prepares for a MAPL 2.8.1 release. The main impetus for this release is to fix an error seen by the LDAS found by @biljanaorescanin (see #930).