### PR TITLE
Only check cubed-sphere restarts for consistency with component grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+- Only check the restart grid compared to component if component grid is Cubed-Sphere. Other factories not yet supported.
+
 ## [2.8.1] - 2021-07-28
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Removed
+### Added
+### Changed
+### Fixed
+
+## [2.8.2] - 2021-07-29
+
 ### Removed
 
 - Removed unneeded `.gitrepo` files
 
-### Added
-### Changed
 ### Fixed
 
 - Only check the restart grid compared to component if component grid is Cubed-Sphere. Other factories not yet supported.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.1
+  VERSION 2.8.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # mepo can now clone subrepos in three styles

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -5905,6 +5905,8 @@ end function MAPL_AddChildFromDSO
              call ESMF_AttributeGet(MPL%GRID%ESMFGRID,'GridType',value=grid_type,rc=status)
              _VERIFY(status)
           end if
+          !note this only works for geos cubed-sphere restarts currently because of 
+          !possible insufficent metadata in the other restarts to support the other grid factories
           if (trim(grid_type) == 'Cubed-Sphere') then
              app_factory => get_factory(MPL%GRID%ESMFGRID)
              allocate(file_factory,source=grid_manager%make_factory(trim(filename)))

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -5905,7 +5905,7 @@ end function MAPL_AddChildFromDSO
              call ESMF_AttributeGet(MPL%GRID%ESMFGRID,'GridType',value=grid_type,rc=status)
              _VERIFY(status)
           end if
-          if (trim(grid_type) /= 'Tripolar' .and. trim(grid_type) /= 'llc' .and. trim(grid_type) /= 'External') then
+          if (trim(grid_type) == 'Cubed-Sphere') then
              app_factory => get_factory(MPL%GRID%ESMFGRID)
              allocate(file_factory,source=grid_manager%make_factory(trim(filename)))
              _ASSERT(file_factory%physical_params_are_equal(app_factory),"Factories not equal")


### PR DESCRIPTION
Well, most unfortunately it appears are restarts are so unlike our history output the only safe one I can check by making a factory to see that it matches the grid comp grid when reading the file is the cubed-sphere. When the LDAS was run with develop that now has the checking of the file grid against the component grid it failed. The LDAS apparently made a lat-lon grid and then when the initialization tried to make a grid from the restart file it failed. It went to the lat-lon factory but the particular restart had no lat/lon variables so the factory threw an error.

So we already discovered that this was not safe with the tripolar grid but apparently not even for a lat-lon grid as if you hit a restart like this it would fail.

So until we refactor MAPL_IO and modify the restart format we can really only do this for the cubed-sphere.
I have modified the check accordingly. This is too bad but at least the organization requesting this feature only uses the cubed-sphere.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
