### PR TITLE
#914 specify level orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 ### Added
+
+- Add option to flip native level output in History relative to input
+
 ### Changed
 ### Fixed
 

--- a/base/MAPL_VerticalMethods.F90
+++ b/base/MAPL_VerticalMethods.F90
@@ -16,16 +16,19 @@ module MAPL_VerticalDataMod
   public :: VERTICAL_METHOD_NONE
   public :: VERTICAL_METHOD_SELECT
   public :: VERTICAL_METHOD_ETA2LEV
+  public :: VERTICAL_METHOD_FLIP
   enum, bind(c)
      enumerator :: VERTICAL_METHOD_NONE = -1
      enumerator :: VERTICAL_METHOD_SELECT
      enumerator :: VERTICAL_METHOD_ETA2LEV
+     enumerator :: VERTICAL_METHOD_FLIP
   end enum
 
   type, public :: verticalData
      character(len=:), allocatable :: vunit
      character(len=:), allocatable :: func
      character(len=:), allocatable :: vvar
+     character(len=:), allocatable :: positive
      real :: vscale
      real :: pow=0.0
      real, allocatable :: levs(:)
@@ -46,6 +49,7 @@ module MAPL_VerticalDataMod
         procedure :: skip_var
         procedure :: correct_topo
         procedure :: setup_eta_to_pressure
+        procedure :: flip_levels
   end type verticalData
 
   interface verticalData
@@ -54,16 +58,29 @@ module MAPL_VerticalDataMod
 
   contains
   
-     function newVerticalData(levels,vcoord,vscale,vunit,rc) result(vdata)
+     function newVerticalData(levels,vcoord,vscale,vunit,positive,rc) result(vdata)
         type(VerticalData) :: vData
         real, pointer, intent(in), optional :: levels(:)
         real, intent(in), optional :: vscale
         character(len=*), optional, intent(in) :: vcoord
         character(len=*), optional, intent(in) :: vunit
+        character(len=*), optional, intent(in) :: positive
         integer, optional, intent(Out) :: rc
+        
+
+        if (present(positive)) then
+           _ASSERT(trim(positive)=='up'.or.trim(positive)=='down',trim(positive)//" not allowed for positive argument")
+           vdata%positive=trim(positive)
+        else
+           vdata%positive='down'
+        end if         
 
         if (.not.present(levels)) then
-           vdata%regrid_type = VERTICAL_METHOD_NONE
+           if (trim(vdata%positive)=='down') then
+              vdata%regrid_type = VERTICAL_METHOD_NONE
+           else
+              vdata%regrid_type = VERTICAL_METHOD_FLIP
+           end if
            _RETURN(ESMF_SUCCESS)
         end if
 
@@ -212,9 +229,26 @@ module MAPL_VerticalDataMod
           call vertinterp(ptrout(:,:,k),ptrin,this%interp_levels(k),this%ple3d,this%pl3d,rc=status)
           _VERIFY(status)
        end do
-        
+       _RETURN(_SUCCESS)
 
      end subroutine regrid_eta_to_pressure
+
+     subroutine flip_levels(this,ptrin,ptrout,rc)
+        class(verticaldata), intent(inout) :: this
+        real, intent(inout) :: ptrin(:,:,:)
+        real, intent(inout) :: ptrout(:,:,:)
+        integer, optional, intent(out) :: rc
+
+        integer :: km
+
+        _ASSERT(all(shape(ptrin)==shape(ptrout)),"array must match shape to flip")
+        
+        km = size(ptrin,3)
+        
+        ptrout(:,:,1:km)=ptrin(:,:,km:1:-1)
+        _RETURN(_SUCCESS)
+
+     end subroutine flip_levels
 
      subroutine correct_topo(this,field,rc) 
         class(verticalData), intent(inout) :: this
@@ -414,7 +448,7 @@ module MAPL_VerticalDataMod
 
         if (haveVert) then
            this%lm=lm
-           if (this%regrid_type == VERTICAL_METHOD_NONE) then
+           if (this%regrid_type == VERTICAL_METHOD_NONE .or. this%regrid_type == VERTICAL_METHOD_FLIP) then
               if (.not.allocated(this%levs)) then
                  allocate(this%levs(lm))
                  do i=1,lm
@@ -433,16 +467,18 @@ module MAPL_VerticalDataMod
                  call v%add_attribute('coordinate','N/A')
                  call v%add_const_value(UnlimitedEntity(this%levs))
                  call metadata%add_variable('lev',v,rc=status)
+                 _VERIFY(status)
               else 
                  call metadata%add_dimension('lev', lm, rc=status)
                  v = Variable(type=PFIO_REAL64, dimensions='lev')
                  call v%add_attribute('long_name','vertical level')
                  call v%add_attribute('units','layer')
-                 call v%add_attribute('positive','down')
+                 call v%add_attribute('positive',trim(this%positive))
                  call v%add_attribute('coordinate','eta')
                  call v%add_attribute('standard_name','model_layer')
                  call v%add_const_value(UnlimitedEntity(this%levs))
                  call metadata%add_variable('lev',v,rc=status)
+                 _VERIFY(status)
               end if
 
            else if (this%regrid_type == VERTICAL_METHOD_ETA2LEV) then
@@ -459,6 +495,7 @@ module MAPL_VerticalDataMod
               call v%add_attribute('standard_name',trim(this%vvar)//"_level")
               call v%add_const_value(UnlimitedEntity(this%levs))
               call metadata%add_variable('lev',v,rc=status)
+              _VERIFY(status)
 
            else if (this%regrid_type == VERTICAL_METHOD_SELECT) then
               call metadata%add_dimension('lev', lm, rc=status)
@@ -470,6 +507,7 @@ module MAPL_VerticalDataMod
               call v%add_attribute('standard_name','model_layer')
               call v%add_const_value(UnlimitedEntity(this%levs))
               call metadata%add_variable('lev',v,rc=status)
+              _VERIFY(status)
            end if
         end if
         _RETURN(_SUCCESS)

--- a/base/MAPL_newCFIO.F90
+++ b/base/MAPL_newCFIO.F90
@@ -295,7 +295,8 @@ module MAPL_newCFIOMod
         call v%add_attribute('_FillValue',MAPL_UNDEF)
         call v%add_attribute('valid_range',(/-MAPL_UNDEF,MAPL_UNDEF/))
         call factory%append_variable_metadata(v)
-        call this%metadata%add_variable(trim(varName),v)
+        call this%metadata%add_variable(trim(varName),v,rc=status)
+        _VERIFY(status)
         ! finally make a new field if neccessary
         if (this%doVertRegrid .and. (fieldRank ==3) ) then
            newField = MAPL_FieldCreate(field,this%output_grid,lm=this%vData%lm,rc=status)
@@ -460,6 +461,9 @@ module MAPL_newCFIOMod
               else if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
                  call this%vdata%regrid_eta_to_pressure(ptr3d,ptr3d_inter,rc=status)
                  _VERIFY(status)
+              else if (this%vdata%regrid_type==VERTICAL_METHOD_FLIP) then
+                 call this%vdata%flip_levels(ptr3d,ptr3d_inter,rc=status)
+                 _VERIFY(status)
               end if
               ptr3d => ptr3d_inter
            end if
@@ -574,6 +578,9 @@ module MAPL_newCFIOMod
               else if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
                  call this%vdata%regrid_eta_to_pressure(xptr3d,xptr3d_inter,rc=status)
                  _VERIFY(status)
+              else if (this%vdata%regrid_type==VERTICAL_METHOD_FLIP) then
+                 call this%vdata%flip_levels(xptr3d,xptr3d_inter,rc=status)
+                 _VERIFY(status)
               end if
               xptr3d => xptr3d_inter
            end if
@@ -595,6 +602,9 @@ module MAPL_newCFIOMod
                  _VERIFY(status)
               else if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
                  call this%vdata%regrid_eta_to_pressure(yptr3d,yptr3d_inter,rc=status)
+                 _VERIFY(status)
+              else if (this%vdata%regrid_type==VERTICAL_METHOD_FLIP) then
+                 call this%vdata%flip_levels(yptr3d,yptr3d_inter,rc=status)
                  _VERIFY(status)
               end if
               yptr3d => yptr3d_inter

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -88,6 +88,7 @@ module MAPL_HistoryCollectionMod
      logical                            :: timeseries_output = .false.
      logical                            :: recycle_track = .false.
      type(HistoryTrajectory)            :: trajectory
+     character(len=ESMF_MAXSTR)         :: positive 
      contains
         procedure :: AddGrid
   end type HistoryCollection

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -891,6 +891,18 @@ contains
 
        list(n)%field_set => field_set
 
+! Decide on orientation of output
+! -------------------------------
+
+          call ESMF_ConfigFindLabel(cfg,trim(string)//'positive:',isPresent=isPresent,rc=status)
+          if (isPresent) then
+             call ESMF_ConfigGetAttribute(cfg,value=list(n)%positive,rc=status)
+             _VERIFY(status)
+             _ASSERT(list(n)%positive=='down'.or.list(n)%positive=='up',"positive value for collection must be down or up")
+          else
+             list(n)%positive = 'down'
+          end if
+
 ! Get an optional list of output levels
 ! -------------------------------------
 
@@ -2410,7 +2422,7 @@ ENDDO PARSER
              list(n)%vdata = VerticalData(levels=list(n)%levels,rc=status)
              _VERIFY(status)
           else
-             list(n)%vdata = VerticalData(rc=status)
+             list(n)%vdata = VerticalData(positive=list(n)%positive,rc=status)
              _VERIFY(status)
           end if
           call list(n)%mNewCFIO%set_param(deflation=list(n)%deflate,rc=status)


### PR DESCRIPTION
This addresses #914
The GCHP users requested the ability to flip the native output relative to the input. It was agreed that for now we will assume History always gets fields "down" in that level 1 is the top of the atmosphere. This is true in GEOS and in GCHP they adjust the inputs to History so the is the case. However, they were requesting that it would be nice if you could get output from History that conforms to the GCHP convention that level 1 is the surface so it would be less confusing for users. 
This PR adds a 'positive' option to the history collection. By default it is 'down' and the only other allowed option is 'up'. If you specify any "levels" either to select model levels to regrid to pressure, height etc ... this is ignored, so only used if you are specifying full native level output. We assume all 3D fields coming to history will be 'down' as in GEOS and so by default nothing is done. If you specify 'up' the positive attribute in the output is now 'up' and the levels will be flipped relative to what came into History.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
