### PR TITLE
Remove Pandas dependency from automatic code generator

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -3,7 +3,6 @@ import argparse
 import sys
 import os
 import csv
-import pandas as pd
 
 
 ###############################################################
@@ -183,6 +182,13 @@ def read_specs(specs_filename):
             elif not prev_row_blank:
                 return
 
+    def dataframe(reader, columns):
+        """ Read a reader iterator and return a list of dictionaries, each including column name and value. """
+        df = []
+        for row in reader:
+            df.append(dict(zip(columns, row)))
+        return df
+
     column_aliases = {
         'NAME'       : 'short_name',
         'LONG NAME'  : 'long_name',
@@ -217,7 +223,7 @@ def read_specs(specs_filename):
                         columns.append(column_aliases[c])
                     else:
                         columns.append(c)
-                specs[category] = pd.DataFrame(gen, columns=columns)
+                specs[category] = dataframe(gen, columns)
             except StopIteration:
                 break
 
@@ -310,7 +316,7 @@ else:
 
 # Generate code from specs (processed above with pandas)
 for category in ("IMPORT","EXPORT","INTERNAL"):
-    for item in specs[category].to_dict("records"):
+    for item in specs[category]:
         spec = MAPL_DataSpec(category.lower(), item)
         if f_specs[category]:
             f_specs[category].write(spec.emit_specs())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
+- Removed Pandas dependency
+
 ### Added
 
 - Add option to flip native level output in History relative to input


### PR DESCRIPTION
## Description
This is a draft PR attempting to remove the automatic code generator's dependency on Pandas.

## Motivation and Context
Minimize the number of dependencies for the UFS weather model. Only standard (vanilla) Python 3 installations are supported on some NOAA platforms. 

## How Has This Been Tested?
This PR has been tested on NOAA Hera/Intel platform with Intel Python 3.6.8.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
