### PR TITLE
Add automatic PR actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
@@ -1,0 +1,10 @@
+## :memo:  Automatic PR: `develop` → `release/MAPL-v3`
+
+### Description
+
+<!-- Write your description here -->
+
+## :file_folder:  Modified files
+<!-- Diff files - START -->
+<!-- Diff files - END -->
+

--- a/.github/PULL_REQUEST_TEMPLATE/gitflow_main_develop.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gitflow_main_develop.md
@@ -1,0 +1,10 @@
+## :memo:  Automatic PR: Gitflow: `main` → `develop`
+
+### Description
+
+<!-- Write your description here -->
+
+## :file_folder:  Modified files
+<!-- Diff files - START -->
+<!-- Diff files - END -->
+

--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -1,0 +1,30 @@
+name: Push to Develop
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run the action
+        uses: devops-infra/action-pull-request@v0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: develop
+          target_branch: release/MAPL-v3
+          label: automatic,MAPL3
+          template: .github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+          get_diff: true
+          assignee: ${{ github.actor }}
+          old_string: "<!-- Write your description here -->"
+          new_string: ${{ github.event.commits[0].message }}
+          title: Auto PR - develop → MAPL-v3 - ${{ github.event.commits[0].message }}
+

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -1,0 +1,30 @@
+name: Push to main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run the action
+        uses: devops-infra/action-pull-request@v0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: main
+          target_branch: develop
+          label: automatic
+          template: .github/PULL_REQUEST_TEMPLATE/gitflow_main_develop.md
+          get_diff: true
+          assignee: ${{ github.actor }}
+          old_string: "<!-- Write your description here -->"
+          new_string: ${{ github.event.commits[0].message }}
+          title: Auto GitFlow - main → develop
+


### PR DESCRIPTION
This should add two automatic PR actions to MAPL.

1. A push into `main` will trigger a PR to `develop`
2. A push into `develop` will trigger a PR into `release/MAPL-v3`

ETA: **NOTE**: This *should* work. It did in a toy repo. It might take a few times to get it to work...