### PR TITLE
Print NetCDF error message if pFIO_NetCDF4_FileFormatterMod::open() fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added error message to pFIO_NetCDF4_FileFormatterMod if nf90_open() fails. 
 - Add option to flip native level output in History relative to input
 - Added `MAPL_AllocNodeArray_6DR8` and `MAPL_DeAllocNodeArray_6DR8` to Shmem
 - Refactors Constants into its own library and consolidated mathematical/physical constants used throughout code to use those from library


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hi all, this is a trivial update to print `nf90_strerror(status)` if `nf90_open()` in  pFIO_NetCDF4_FileFormatterMod::open() fails. 

## Motivation and Context
Currently there is not error handling if `nf90_open()` fails in pFIO_NetCDF4_FileFormatterMod::open(). As a result, a file missing read permissions will cause an error message that looks like this:
```
pe=00213 FAIL at line=00245    NetCDF4_FileFormatter.F90                <status=13>
pe=00213 FAIL at line=00090    MAPL_ExtDataCollection.F90               <status=13>
pe=00213 FAIL at line=00232    FileMetadata.F90                         <can not find time>
pe=00213 FAIL at line=00083    FileMetadataUtilities.F90                <status=1>
pe=00213 FAIL at line=02777    MAPL_ExtDataGridCompMod.F90              <status=1>
pe=00213 FAIL at line=01512    MAPL_ExtDataGridCompMod.F90              <status=1>
```
and the offending file isn't printed.

Now an error message like this is written to stderr
```
nf90_open: returned error code (13) opening ./MetDir/2016/12/MERRA2.20161214.A3dyn.05x0625.nc4 [Permission denied]
```
follow by the normal stack traces following the failed `_VERIFY(status)`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
