### PR TITLE
Add Skip Changelog to Auto PRs to MAPL3 branch

### DIFF
--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -20,7 +20,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: develop
           target_branch: release/MAPL-v3
-          label: automatic,MAPL3
+          label: automatic,MAPL3,Skip Changelog
           template: .github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
           get_diff: true
           assignee: ${{ github.actor }}


### PR DESCRIPTION
Update to the Auto PR to MAPL 3 action. This now adds "Skip Changelog" label automatically as well. Since this is more of a "gitflow" sort of action, we just want the code. The Changelog matters less.