### PR TITLE
Fix to multi day run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to flip native level output in History relative to input
 - Added `MAPL_AllocNodeArray_6DR8` and `MAPL_DeAllocNodeArray_6DR8` to Shmem
 - Refactors Constants into its own library and consolidated mathematical/physical constants used throughout code to use those from library
+- Added single precision Degrees to Radian Conversion
 
 ### Changed
 - Simplified implementation of MAPL_FieldCopyAttributes

--- a/base/Base/Base_implementation.F90
+++ b/base/Base/Base_implementation.F90
@@ -2206,10 +2206,10 @@ contains
 
     !  Compute the coordinates (the corner/center is for backward compatibility)
     !  -------------------------------------------------------------------------
-    deltaX      = MAPL_DEGREES_TO_RADIANS * DelLon_
-    deltaY      = MAPL_DEGREES_TO_RADIANS * DelLat_
-    minCoord(1) = MAPL_DEGREES_TO_RADIANS * BegLon_ - deltaX/2
-    minCoord(2) = MAPL_DEGREES_TO_RADIANS * BegLat_ - deltaY/2 
+    deltaX      = MAPL_DEGREES_TO_RADIANS_R8 * DelLon_
+    deltaY      = MAPL_DEGREES_TO_RADIANS_R8 * DelLat_
+    minCoord(1) = MAPL_DEGREES_TO_RADIANS_R8 * BegLon_ - deltaX/2
+    minCoord(2) = MAPL_DEGREES_TO_RADIANS_R8 * BegLat_ - deltaY/2 
 
     allocate(cornerX(IM_World_+1),cornerY(JM_World_+1), stat=STATUS)
     _VERIFY(STATUS)
@@ -2242,14 +2242,14 @@ contains
     LastOut(2)=90. 
 
     block
-      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS
+      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
       real(kind=REAL64), allocatable :: lons(:)
       real(kind=REAL64), allocatable :: lats(:)
 
       lons = MAPL_Range(FirstOut(1), LastOut(1), im_world_, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8)
       lats = MAPL_Range(FirstOut(2), LastOut(2), JM_WORLD, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8)
 
       call MAPL_GRID_INTERIOR(grid, i1, in, j1, jn)
 
@@ -2394,8 +2394,8 @@ contains
        call ESMF_GridGet(grid,coordSys=coordSys,rc=status)
        _VERIFY(status)
        if (coordSys==ESMF_COORDSYS_SPH_DEG) then
-          gridCornerLons=gridCornerLons*MAPL_DEGREES_TO_RADIANS
-          gridCornerLats=gridCornerLats*MAPL_DEGREES_TO_RADIANS
+          gridCornerLons=gridCornerLons*MAPL_DEGREES_TO_RADIANS_R8
+          gridCornerLats=gridCornerLats*MAPL_DEGREES_TO_RADIANS_R8
        else if (coordSys==ESMF_COORDSYS_CART) then
           _FAIL('Unsupported coordinate system:  ESMF_COORDSYS_CART')
        end if
@@ -3064,8 +3064,8 @@ contains
        allocate(center_lons(im,jm),center_lats(im,jm))
 
        if (coordSys==ESMF_COORDSYS_SPH_DEG) then
-          center_lons=lons*MAPL_DEGREES_TO_RADIANS
-          center_lats=lats*MAPL_DEGREES_TO_RADIANS
+          center_lons=lons*MAPL_DEGREES_TO_RADIANS_R8
+          center_lats=lats*MAPL_DEGREES_TO_RADIANS_R8
        else if (coordSys==ESMF_COORDSYS_SPH_RAD) then
           center_lons=lons
           center_lats=lats

--- a/base/MAPL_CFIO.F90
+++ b/base/MAPL_CFIO.F90
@@ -1000,8 +1000,8 @@ contains
              mcfio%xyoffset = xyoffset
           else
              mcfio%xyoffset = 0
-             lons1d = MAPL_Range(-180.,180.-(360./IMO), IMO, conversion_factor=MAPL_DEGREES_TO_RADIANS)
-             lats1d = MAPL_Range(-90., +90., JMO, conversion_factor=MAPL_DEGREES_TO_RADIANS)
+             lons1d = MAPL_Range(-180.,180.-(360./IMO), IMO, conversion_factor=MAPL_DEGREES_TO_RADIANS_R8)
+             lats1d = MAPL_Range(-90., +90., JMO, conversion_factor=MAPL_DEGREES_TO_RADIANS_R8)
           endif
 
        endif
@@ -5883,8 +5883,8 @@ CONTAINS
     allocate(lons_radians(size(lons)))
     allocate(lats_radians(size(lats)))
     
-    lons_radians = MAPL_DEGREES_TO_RADIANS * lons
-    lats_radians = MAPL_DEGREES_TO_RADIANS * lats
+    lons_radians = MAPL_DEGREES_TO_RADIANS_R8 * lons
+    lats_radians = MAPL_DEGREES_TO_RADIANS_R8 * lats
     
     lon_array = ESMF_LocalArrayCreate(lons_radians, rc=status)
     _VERIFY(status)

--- a/base/MAPL_LatLonGridFactory.F90
+++ b/base/MAPL_LatLonGridFactory.F90
@@ -355,7 +355,7 @@ contains
 
    ! in radians
    function compute_lon_centers(this, dateline, unusable, rc) result(lon_centers)
-      use MAPL_Constants, only:MAPL_DEGREES_TO_RADIANS
+      use MAPL_Constants, only:MAPL_DEGREES_TO_RADIANS_R8
       use MAPL_BaseMod
       real(kind=REAL64), allocatable :: lon_centers(:)
       class (LatLonGridFactory), intent(in) :: this
@@ -395,14 +395,14 @@ contains
       end if
 
       lon_centers = MAPL_Range(min_coord, max_coord, this%im_world, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS, rc=status)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
    end function compute_lon_centers
 
    function compute_lon_corners(this, dateline, unusable, rc) result(lon_corners)
-      use MAPL_Constants, only:MAPL_DEGREES_TO_RADIANS
+      use MAPL_Constants, only:MAPL_DEGREES_TO_RADIANS_R8
       use MAPL_BaseMod
       real(kind=REAL64), allocatable :: lon_corners(:)
       class (LatLonGridFactory), intent(in) :: this
@@ -442,7 +442,7 @@ contains
       end if
 
       lon_corners = MAPL_Range(min_coord, max_coord, this%im_world+1, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS, rc=status)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
@@ -482,7 +482,7 @@ contains
 
 
    function compute_lat_centers(this, pole, unusable, rc) result(lat_centers)
-      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS
+      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
       use MAPL_BaseMod
       real(kind=REAL64), allocatable :: lat_centers(:)
       class (LatLonGridFactory), intent(in) :: this
@@ -518,14 +518,14 @@ contains
       end if
 
       lat_centers = MAPL_Range(min_coord, max_coord, this%jm_world, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS, rc=status)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8, rc=status)
 
       _RETURN(_SUCCESS)
 
    end function compute_lat_centers
 
    function compute_lat_corners(this, pole, unusable, rc) result(lat_corners)
-      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS
+      use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
       use MAPL_BaseMod
       real(kind=REAL64), allocatable :: lat_corners(:)
       class (LatLonGridFactory), intent(in) :: this
@@ -563,10 +563,10 @@ contains
       end if
 
       lat_corners = MAPL_Range(min_coord, max_coord, this%jm_world+1, &
-           & conversion_factor=MAPL_DEGREES_TO_RADIANS, rc=status)
+           & conversion_factor=MAPL_DEGREES_TO_RADIANS_R8, rc=status)
       if (pole == 'PC') then
-         lat_corners(1)=-90.d0*MAPL_DEGREES_TO_RADIANS
-         lat_corners(this%jm_world+1)=90.d0*MAPL_DEGREES_TO_RADIANS
+         lat_corners(1)=-90.d0*MAPL_DEGREES_TO_RADIANS_R8
+         lat_corners(this%jm_world+1)=90.d0*MAPL_DEGREES_TO_RADIANS_R8
       end if
 
       _RETURN(_SUCCESS)
@@ -864,10 +864,10 @@ contains
 
          if (use_file_coords) then
             this%is_regular = .false.
-            this%lon_centers = MAPL_DEGREES_TO_RADIANS * this%lon_centers
-            this%lat_centers = MAPL_DEGREES_TO_RADIANS * this%lat_centers
-            this%lon_corners = MAPL_DEGREES_TO_RADIANS * this%lon_corners
-            this%lat_corners = MAPL_DEGREES_TO_RADIANS * this%lat_corners
+            this%lon_centers = MAPL_DEGREES_TO_RADIANS_R8 * this%lon_centers
+            this%lat_centers = MAPL_DEGREES_TO_RADIANS_R8 * this%lat_centers
+            this%lon_corners = MAPL_DEGREES_TO_RADIANS_R8 * this%lon_corners
+            this%lat_corners = MAPL_DEGREES_TO_RADIANS_R8 * this%lat_corners
          else
             compute_lons=.false.
             compute_lats=.false.
@@ -887,10 +887,10 @@ contains
                this%lat_corners = this%compute_lat_corners(this%pole, rc=status)
                _VERIFY(status)
             else
-               this%lon_centers = MAPL_DEGREES_TO_RADIANS * this%lon_centers
-               this%lat_centers = MAPL_DEGREES_TO_RADIANS * this%lat_centers
-               this%lon_corners = MAPL_DEGREES_TO_RADIANS * this%lon_corners
-               this%lat_corners = MAPL_DEGREES_TO_RADIANS * this%lat_corners
+               this%lon_centers = MAPL_DEGREES_TO_RADIANS_R8 * this%lon_centers
+               this%lat_centers = MAPL_DEGREES_TO_RADIANS_R8 * this%lat_centers
+               this%lon_corners = MAPL_DEGREES_TO_RADIANS_R8 * this%lon_corners
+               this%lat_corners = MAPL_DEGREES_TO_RADIANS_R8 * this%lat_corners
             end if
          end if
 

--- a/base/MAPL_NominalOrbitsMod.F90
+++ b/base/MAPL_NominalOrbitsMod.F90
@@ -875,7 +875,7 @@ REAL(dp) FUNCTION deg2rad(angle)
        IMPLICIT NONE
 
        REAL(dp), INTENT(IN) :: angle
-       deg2rad = MAPL_DEGREES_TO_RADIANS * angle
+       deg2rad = MAPL_DEGREES_TO_RADIANS_R8 * angle
 END FUNCTION deg2rad
 
 REAL(dp) FUNCTION rad2deg(rad)

--- a/base/MAPL_OrbGridCompMod.F90
+++ b/base/MAPL_OrbGridCompMod.F90
@@ -1069,7 +1069,7 @@ CONTAINS
             endif
 
             ! interpolate along great circle unless endpoints of interpolation have same lon
-            associate(d2r => MAPL_DEGREES_TO_RADIANS, r2d => MAPL_RADIANS_TO_DEGREES)
+            associate(d2r => MAPL_DEGREES_TO_RADIANS_R8, r2d => MAPL_RADIANS_TO_DEGREES)
              eplatl1 = slats(1,n-1) 
              eplatr1 = slats(3,n-1) 
              eplatl2 = slats(1,n) 
@@ -1226,7 +1226,7 @@ CONTAINS
             endif
 
             ! interpolate along great circle unless endpoints of interpolation have same lon
-            associate(d2r => MAPL_DEGREES_TO_RADIANS, r2d => MAPL_RADIANS_TO_DEGREES)
+            associate(d2r => MAPL_DEGREES_TO_RADIANS_R8, r2d => MAPL_RADIANS_TO_DEGREES)
              eplatl1 = slats(1,n-1) 
              eplatr1 = slats(3,n-1) 
              eplatl2 = slats(1,n) 

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -976,7 +976,7 @@ contains
       real(kind=REAL64), intent(in) :: x
       real(kind=REAL64) :: s
 
-      s = sin(x * MAPL_DEGREES_TO_RADIANS)
+      s = sin(x * MAPL_DEGREES_TO_RADIANS_R8)
       
    end function sind
 
@@ -984,7 +984,7 @@ contains
       real(kind=REAL64), intent(in) :: x
       real(kind=REAL64) :: c
 
-      c = cos(x * MAPL_DEGREES_TO_RADIANS)
+      c = cos(x * MAPL_DEGREES_TO_RADIANS_R8)
       
    end function cosd
 

--- a/base/tests/Test_LatLon_Corners.pf
+++ b/base/tests/Test_LatLon_Corners.pf
@@ -7,7 +7,7 @@ module Test_LatLon_Corners
    use MAPL_LatLonGridFactoryMod
    use MAPL_Constants, only: MAPL_PI_R8
    use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES
-   use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS
+   use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
    use MAPL_MinMaxMod
    use ESMF
    implicit none

--- a/base/tests/Test_LatLon_GridFactory.pf
+++ b/base/tests/Test_LatLon_GridFactory.pf
@@ -8,7 +8,7 @@ module Test_LatLon_GridFactory
    use MAPL_LatLonGridFactoryMod
    use MAPL_Constants, only: MAPL_PI_R8
    use MAPL_Constants, only: MAPL_RADIANS_TO_DEGREES
-   use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS
+   use MAPL_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
    use MAPL_MinMaxMod
    use ESMF
    implicit none

--- a/shared/Constants/MathConstants.F90
+++ b/shared/Constants/MathConstants.F90
@@ -12,7 +12,8 @@ module MAPL_MathConstantsMod
 ! !PUBLIC VARIABLES:
    real(kind=REAL64), parameter :: MAPL_PI_R8              = 3.14159265358979323846d0
    real(kind=REAL32), parameter :: MAPL_PI                 = MAPL_PI_R8
-   real(kind=REAL64), parameter :: MAPL_DEGREES_TO_RADIANS = MAPL_PI_R8 / 180.
+   real(kind=REAL64), parameter :: MAPL_DEGREES_TO_RADIANS_R8 = MAPL_PI_R8 / 180.
+   real(kind=REAL32), parameter :: MAPL_DEGREES_TO_RADIANS = MAPL_PI / 180.
    real(kind=REAL64), parameter :: MAPL_RADIANS_TO_DEGREES = 180. / MAPL_PI_R8
 
 !EOP

--- a/shared/Constants/PhysicalConstants.F90
+++ b/shared/Constants/PhysicalConstants.F90
@@ -1,7 +1,7 @@
 module MAPL_PhysicalConstantsMod
 
    use, intrinsic :: iso_fortran_env, only: REAL64, REAL32
-   use MAPL_MathConstantsMod, only: MAPL_PI_R8, MAPL_PI, MAPL_RADIANS_TO_DEGREES, MAPL_DEGREES_TO_RADIANS
+   use MAPL_MathConstantsMod, only: MAPL_PI_R8, MAPL_PI, MAPL_RADIANS_TO_DEGREES, MAPL_DEGREES_TO_RADIANS_R8
    implicit none
 
 !=============================================================================
@@ -32,7 +32,7 @@ module MAPL_PhysicalConstantsMod
    real(kind=REAL64), parameter :: MAPL_EARTH_ECCENTRICITY        = 8.1819190842622d-2                            ! --
    real(kind=REAL64), parameter :: MAPL_EARTH_SEMIMAJOR_AXIS      = 6378137                                       ! m
    real(kind=REAL64), parameter :: MAPL_KM_PER_DEG                    = (1.0/(MAPL_RADIUS/1000.)) * MAPL_RADIANS_TO_DEGREES
-   real(kind=REAL64), parameter :: MAPL_DEG_PER_KM                    = (MAPL_RADIUS/1000.) * MAPL_DEGREES_TO_RADIANS
+   real(kind=REAL64), parameter :: MAPL_DEG_PER_KM                    = (MAPL_RADIUS/1000.) * MAPL_DEGREES_TO_RADIANS_R8
 
 
    ! Physical properties


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the Multi-Day GEOS non-zero diff bug. Bug appeared because `base/MAPL_sun_uc.F90` is the only module in MAPL that uses `MAPL_DEGREES_TO_RADIANS` in single precision. Rather than creating a `MAPL_DEGREES_TO_RADIANS_R4`, I went with changing the double precision instances to `MAPL_DEGREES_TO_RADIANS_R8` as there is precedence for other double precision variables. However, I didn't create a `MAPL_RADIANS_TO_DEGREES_R8` because compilation issues would have appeared since this module `Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSmoist_GridComp/GEOS_MoistGridComp.F90` would still use the old name.

If there are any other recommendations, let me know.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#961 

## Motivation and Context
Fixes bug that appeared from Constants refactoring

## How Has This Been Tested?
I ran the GEOS-5 model past 5 days and 5hours which was the threshold identified where non-zero diffs started appearing and it was finally zero-diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
