### PR TITLE
Add automatic label to changelog enforcer

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v2
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'Skip Changelog,0 diff trivial'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic'
         missingUpdateErrorMessage: >
             No update to CHANGELOG.md found! Please add a changelog
             entry to it describing your change.  Please note that the


### PR DESCRIPTION
I swear I will get the auto PRs to MAPL3 working seamlessly. For this we try adding the "automatic" label to skip the changelog enforcer...