### PR TITLE
Fixes an issue with vector names in get levs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Added npes for pfio_MAPL_demo.F90 when --npes_model is not specified in command line
+- Fixed bug in ExtData when doing vector pairs
 
 ## [2.8.2] - 2021-07-29
 

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -2096,7 +2096,7 @@ CONTAINS
         type(ESMF_Time)            :: fTime
         type(ESMF_Field)           :: field
         real, allocatable          :: levFile(:) 
-        character(len=ESMF_MAXSTR) :: buff,levunits,tlevunits
+        character(len=ESMF_MAXSTR) :: buff,levunits,tlevunits,temp_name
         logical                    :: found,lFound,intOK
         integer                    :: maxOffset
         character(len=:), allocatable :: levname
@@ -2104,12 +2104,19 @@ CONTAINS
         type(FileMetadataUtils), pointer :: metadata
         type(Variable), pointer :: var
         type(ESMF_TimeInterval)    :: zero
+        integer :: vect_semi
 
         positive=>null()
 
         call ESMF_TimeIntervalSet(zero,__RC__)
 
-        call ESMF_StateGet(state,trim(item%name),field,__RC__)
+        vect_semi=index(item%name,";")
+        if (vect_semi/=0) then
+           temp_name=item%name(:vect_semi-1)
+        else
+           temp_name=item%name
+        end if
+        call ESMF_StateGet(state,trim(temp_name),field,__RC__)
         call ESMF_FieldGet(field,rank=rank,__RC__)
         if (rank==2) then
            item%lm=0


### PR DESCRIPTION
Test the latest version of MAPL with the CTM revealed a bug in the "GetLevs" routine in ExtData when an entry in the ExtData.rc file represents a vector pair. I was using the name in the PrimaryData structure to retrieve information from the file metadata. THis was introduced recently in ExtData. However, if the item is vector pair the name would look something like this U;V, so I need to check if there is a ; and if so only use one of the variables.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
