### PR TITLE
Added MAPL_VerifyExplain and _VERIFY_EXPLAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New MAPL_VerifyExplain function and _VERIFY_EXPLAIN macro to allow for error messages in failed verifies
 - Added `esma_cpack` include for tarring ability
 
 ### Changed

--- a/include/MAPL_ErrLog.h
+++ b/include/MAPL_ErrLog.h
@@ -32,6 +32,9 @@
 #  ifdef _VERIFY
 #    undef _VERIFY
 #  endif
+#  ifdef _VERIFY_EXPLAIN
+#    undef _VERIFY_EXPLAIN
+#  endif
 #  ifdef _ASSERT
 #    undef _ASSERT
 #  endif
@@ -89,6 +92,7 @@
 #       define _RETURN(A)     call MAPL_Return(A,_FILE_,__LINE__ __rc(rc)); __return
 #       define _VERIFY(A)     if(MAPL_Verify(A,_FILE_,__LINE__ __rc(rc))) __return
 #    endif
+#    define _VERIFY_EXPLAIN(A,HINT) if(MAPL_VerifyExplain(A,HINT,_FILE_,__LINE__ __rc(rc))) __return
 #    define _RC_(rc,status) rc=status);_VERIFY(status
 #    define _RC _RC_(rc,status)
 

--- a/shared/MAPL_ErrorHandling.F90
+++ b/shared/MAPL_ErrorHandling.F90
@@ -6,6 +6,7 @@ module MAPL_ErrorHandlingMod
 
    public :: MAPL_Assert
    public :: MAPL_Verify
+   public :: MAPL_VerifyExplain
    public :: MAPL_Return
    public :: MAPL_RTRN
    public :: MAPL_Vrfy
@@ -126,6 +127,27 @@ contains
       
    end function MAPL_Verify
 
+   logical function MAPL_VerifyExplain(status, explain, filename, line, rc) result(fail)
+      integer, intent(in) :: status
+      character(*), intent(in) :: filename
+      character(*), intent(in) :: explain
+      integer, intent(in) :: line
+      integer, optional, intent(out) :: rc ! Not present in MAIN
+
+      logical :: condition
+      character(:), allocatable :: message
+      character(16) :: status_string
+
+      condition = (status == 0)
+      fail = .not. condition
+
+      if (fail) then
+         message = trim(explain)
+         call MAPL_throw_exception(filename, line, message=message)
+         if (present(rc)) rc = status
+      end if
+      
+   end function MAPL_VerifyExplain
 
    subroutine MAPL_Return(status, filename, line, rc) 
       integer, intent(in) :: status


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I'm trying to improve error handling/reporting in GCHP. Right now, quite a few common pitfalls are reported as "unknown error". The file and line numbers are reported but it would be helpful if we could provide useful error messages especially around the places where there are common pitfalls. 

This is a trivial PR that adds a `MAPL_VerifyExplain` function and an associated `_VERIFY_EXPLAIN` macro. This PR does not affect `_VERIFY` or `MAPL_Verify`.  

In summary, where a `_VERIFY(STATUS)` would return error like this

```
pe=00014 FAIL at line=00574    Chem_GridCompMod.F90                     <status=-1>
```

the `_VERIFY_EXPLAIN(STATUS ,'<msg>')` macro can be used for error messages like this

```
pe=00014 FAIL at line=00574    Chem_GridCompMod.F90                     <Getting GCHPchem_INTERNAL_RESTART_FILE from GCHP.rc>
```

## How Has This Been Tested?
- Tested with GCHP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
