### PR TITLE
Propagate errors in SetServices upwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug in MAPL_AddChildFromMeta so that an error in the SetServices of a gridded component is propagated upwards correctly
+
 ## [2.8.4] - 2021-08-27
 
 ### Added

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -4542,6 +4542,7 @@ end subroutine MAPL_DateStampGet
     !EOPI
 
   integer                                     :: STATUS
+  integer                                     :: SS_STATUS
 
   integer                                     :: I
   type(MAPL_MetaComp), pointer                :: CHILD_META, tmp_meta
@@ -4673,7 +4674,9 @@ end subroutine MAPL_DateStampGet
   call CHILD_META%t_profiler%start(__RC__)
   call CHILD_META%t_profiler%start('SetService',__RC__)
   gridcomp => META%GET_CHILD_GRIDCOMP(I)
-  call ESMF_GridCompSetServices ( gridcomp, SS, RC=status )
+  call ESMF_GridCompSetServices ( gridcomp, SS, userRC=SS_STATUS, RC=status )
+  _VERIFY(STATUS)
+  _VERIFY(SS_STATUS)
   call CHILD_META%t_profiler%stop('SetService',__RC__)
   call CHILD_META%t_profiler%stop(__RC__)
   call t_p%stop(trim(NAME),__RC__)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I don't think errors in the GEOS-Chem gridded component's SetServices are getting caught properly. A failed `_VERIFY` in SetServices doesn't stop the simulation. 

Is there supposed to be a `_VERIFY(STATUS)` and `_VERIFY(SS_STATUS)`, where `SS_STATUS` is the userRC from ESMF_GridCompSetServices, in MAPL_AddChildFromMeta? 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/geoschem/GCHP/issues/101
- https://github.com/geoschem/GCHP/issues/134 (related b/c it was hard to identify because error in SetServices wasn't getting gettting propagated up)
- https://github.com/geoschem/GCHP/issues/136 (A GCHP user opened this  issue yesterday. It looks like HEMCO SetServices failed, but the error wasn't caught which has lead to confusion. See their gchp.log.201901_met.txt log file. ) 

## Motivation and Context
I'm working on improving the error reporting in GCHP. Errors related to the config files often result in hard crashes and the error messages can be hard to decipher. I believe this is because `MAPL_AddChildFromMeta` isn't verifying the `userRC` (`STATUS` from the grid comp's SetServices).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran a GCHP simulation with an intentional error in the root config (GCHP.rc) file. The intentional error was what happened in https://github.com/geoschem/GCHP/issues/134. 

<details>
<summary>Log without this PR</summary>

```
 Starting pFIO input server on Clients
 Starting pFIO output server on Clients
          SHMEM: INFO: NumCores per Node = 6
          SHMEM: INFO: NumNodes in use   = 1
          SHMEM: INFO: Total PEs         = 6
          SHMEM: INFO: NumNodes in use  = 1
 Integer*4 Resource Parameter: HEARTBEAT_DT:600
 NOT using buffer I/O for file: cap_restart
 Character Resource Parameter: ROOT_CF:GCHP.rc
 Character Resource Parameter: ROOT_NAME:GCHP
 Character Resource Parameter: HIST_CF:HISTORY.rc
 Character Resource Parameter: MAPL_ENABLE_TIMERS:YES
 Character Resource Parameter: MAPL_ENABLE_MEMUTILS:YES
 Continuing after adding AtmosChemSetServices:           0           2
 Continuing after adding AtmosChemSetServices:           0           2
 Character Resource Parameter: DYCORE:OFF
 Continuing after adding AtmosChemSetServices:           0           2
 Continuing after adding AtmosChemSetServices:           0           2
 Continuing after adding AtmosChemSetServices:           0           2
 Continuing after adding AtmosChemSetServices:           0           2
pe=00005 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00000 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00001 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00002 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00003 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00004 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
NOTE from PE     0: MPP_DOMAINS_SET_STACK_SIZE: stack size set to    32768.
&MPP_IO_NML
 HEADER_BUFFER_VAL=16384      ,
 GLOBAL_FIELD_ON_ROOT_PE=T,
 IO_CLOCKS_ON=F,
 SHUFFLE=0          ,
 DEFLATE_LEVEL=-1         ,
 CF_COMPLIANCE=F,
 /
NOTE from PE     0: MPP_IO_SET_STACK_SIZE: stack size set to     131072.
NOTE from PE     0: MPP_DOMAINS_SET_STACK_SIZE: stack size set to 20000000.
 Integer*4 Resource Parameter: NX:1
 Integer*4 Resource Parameter: NY:6
 Integer*4 Resource Parameter: IM:24
 Integer*4 Resource Parameter: JM:144
 Integer*4 Resource Parameter: RUN_DT:600
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
 For k_split (remapping)=           1
n_split is set to 02 for resolution-dt=0025x0025x6-  600.000
Using n_zfilter : 000
Using n_sponge : 001
Using non_ortho :       T
 Starting PEs :            6
 Starting Threads :            1
 Cubic: cubed-sphere domain decomposition
whalo =    3, ehalo =    3, shalo =    3, nhalo =    3
  X-AXIS =   24
  Y-AXIS =   24
 Cubic: cubed-sphere domain decomposition
whalo =    1, ehalo =    1, shalo =    1, nhalo =    1
  X-AXIS =   24
  Y-AXIS =   24
NOTE from PE     0: tracer_manager_init : No tracers are available to be registered.
NOTE from PE     0: tracer_manager_init : No tracers are available to be registered.
NOTE from PE     0: tracer_manager_init : No tracers are available to be registered.
NOTE from PE     0: tracer_manager_init : No tracers are available to be registered.
NOTE from PE     0: tracer_manager_init : No tracers are available to be registered.
 ncnst=           0  num_prog=           0  pnats=           0  dnats=           0  num_family=           0
 
 Grid distance at face edge (km)=   326768.43532825337     
 Corner interpolation coefficient=   1.4728933761817289     
 Corner interpolation coefficient=   1.4728933761817309     
 Corner interpolation coefficient=   1.4728933761817260     
 Corner interpolation coefficient=   1.4728933761817327     
 Corner interpolation coefficient=   1.4728933761817156     
RADIUS (m): 0.63710000000000E+07
PI: 0.31415926535898E+01
MAX    AREA (m*m): 0.21280966055028E+12          MIN AREA (m*m): 0.95959708752603E+11
GLOBAL AREA (m*m): 0.51006447190982E+15 IDEAL GLOBAL AREA (m*m): 0.51006447190979E+15
 
  Cubed-Sphere Grid Stats :           25 x          25 x           6
      Grid Length               : min: 326768.44 max: 461715.98 avg: 386515.92 min/max:      0.71
      Deviation from Orthogonal : min:      0.00 max:     28.13 avg:      8.60
      Aspect Ratio              : min:      1.00 max:      1.08 avg:      1.03
 
 Grid_init          72           1   100.00000000000000     
 Hybrid Sigma-P: minimum allowable surface pressure (hpa)=   14.888888888889058     
 Corner interpolation coefficient=   1.4728933761817253     
 da_max/da_min=   2.2176980663721220     
 da_max_c/da_min_c=   2.2606506684909289     
  
 Divergence damping Coefficients
 For small dt=   300.00000000000000     
 External mode del-2 (m**2/s)=   6284027.9018087257     
 Internal mode del-2 SMAG dimensionless coeff=   0.0000000000000000     
 Internal mode del-2 background diff=   0.0000000000000000     
 Internal mode del-4 background diff=  0.16000000000000000     
 Vorticity del-4 (m**4/s)=   0.0000000000000000     
 tracer del-2 diff=   0.0000000000000000     
 Vorticity del-4 (m**4/s)=   0.0000000000000000     
 beta=   0.0000000000000000     
  

Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

Backtrace for this error:
pe=00002 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00002 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00002 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00002 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00002 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00002 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00002 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00002 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00002 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00002 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00003 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00003 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00003 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00003 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00003 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00003 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00003 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00003 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00003 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00003 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer INITIALIZE needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer GenInitTot needs to be set first
 ERROR: Timer --GenInitMine needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer INITIALIZE needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer GenInitTot needs to be set first
 ERROR: Timer --GenInitMine needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer INITIALIZE needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer GenInitTot needs to be set first
 ERROR: Timer --GenInitMine needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer INITIALIZE needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer GenInitTot needs to be set first
 ERROR: Timer --GenInitMine needs to be set first
                                                       Mem/Swap Used (MB) at GCHPctmEnvMAPL_GenericInitialize=  5.941E+04  2.000E+00
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer INITIALIZE needs to be set first
 ERROR: Timer TOTAL needs to be set first
 ERROR: Timer GenInitTot needs to be set first
 ERROR: Timer --GenInitMine needs to be set first
pe=00005 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00005 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00005 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00005 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00005 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00005 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00005 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00005 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00005 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00005 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00000 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00000 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00000 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00000 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00000 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00000 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00000 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00000 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00000 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00000 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00001 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00001 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00001 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00001 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00001 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00001 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00001 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00001 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
pe=00001 FAIL at line=00096    MAPL_Profiler.F90                        <unknown error>
pe=00001 FAIL at line=05217    MAPL_Generic.F90                         <status=-1>
#0  0x7f2c727c0dfd in ???
#1  0x7f2c727c0013 in ???
#2  0x7f2c71fba3af in ???
#3  0x7f2c720eec20 in ???
#4  0x7f2c729d7f5a in ???
#5  0x131e3d2 in __mapl_profmod_MOD_mapl_profclockon
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/base/MAPL_Profiler.F90:88
#6  0x138777c in __mapl_genericmod_MOD_mapl_genericstateclockon
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/base/MAPL_Generic.F90:5216
#7  0x42b1ad in initialize_
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/GCHP_GridComp/GEOSChem_GridComp/geos-chem/Interfaces/GCHP/Chem_GridCompMod.F90:1598
#8  0x1fc3a85 in ???
#9  0x1fc3d29 in ???
#10  0x1d2cdd5 in ???
#11  0x1fe1a40 in ???
#12  0x1fc275b in ???
#13  0x1b845ca in ???
#14  0x1f815a5 in ???
#15  0x1397568 in mapl_genericwrapper
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/base/MAPL_Generic.F90:1838
#16  0x1fc3a85 in ???
#17  0x1fc3d29 in ???
#18  0x1d2cdd5 in ???
#19  0x1fe1a40 in ???
#20  0x1fc275b in ???
#21  0x1b845ca in ???
#22  0x1f815a5 in ???
#23  0x139e9f4 in __mapl_genericmod_MOD_mapl_genericinitialize
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/base/MAPL_Generic.F90:1505
#24  0x41f257 in initialize
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/GCHP_GridComp/GCHP_GridCompMod.F90:332
#25  0x1fc3a85 in ???
#26  0x1fc3d29 in ???
#27  0x1d2cdd5 in ???
#28  0x1fe1a40 in ???
#29  0x1fc275b in ???
#30  0x1b845ca in ???
#31  0x1f815a5 in ???
#32  0x1397568 in mapl_genericwrapper
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/base/MAPL_Generic.F90:1838
#33  0x1fc3a85 in ???
#34  0x1fc3d29 in ???
#35  0x1d2cdd5 in ???
#36  0x1fe1a40 in ???
#37  0x1fc275b in ???
#38  0x1b845ca in ???
#39  0x1f815a5 in ???
#40  0xd9a07d in initialize_gc
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_CapGridComp.F90:614
#41  0x1fc3a85 in ???
#42  0x1fc3d29 in ???
#43  0x1d2cdd5 in ???
#44  0x1fe1a40 in ???
#45  0x1fc275b in ???
#46  0x1b845ca in ???
#47  0x1f815a5 in ???
#48  0xd9631a in __mapl_capgridcompmod_MOD_initialize
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_CapGridComp.F90:907
#49  0xd90536 in __mapl_capmod_MOD_run_model
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_Cap.F90:244
#50  0xd8fe55 in __mapl_capmod_MOD_run_member
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_Cap.F90:211
#51  0xd9007e in __mapl_capmod_MOD_run_ensemble
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_Cap.F90:154
#52  0xd90161 in __mapl_capmod_MOD_run
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/MAPL/gridcomps/Cap/MAPL_Cap.F90:129
#53  0x41dafb in gchpctm_main
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/GCHPctm.F90:30
#54  0x41c248 in main
	at /scratch1/fs1/rvmartin/bs6/liam.bindle/temp/2021-08-26/GCHP/src/GCHPctm.F90:15
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 4 with PID 0 on node compute1-exec-4 exited on signal 11 (Segmentation fault).
```

</details>

<details>
<summary>Log after this PR</summary>

```
 Starting pFIO input server on Clients
 Starting pFIO output server on Clients
          SHMEM: INFO: NumCores per Node = 6
          SHMEM: INFO: NumNodes in use   = 1
          SHMEM: INFO: Total PEs         = 6
          SHMEM: INFO: NumNodes in use  = 1
 Integer*4 Resource Parameter: HEARTBEAT_DT:600
 NOT using buffer I/O for file: cap_restart
 Character Resource Parameter: ROOT_CF:GCHP.rc
 Character Resource Parameter: ROOT_NAME:GCHP
 Character Resource Parameter: HIST_CF:HISTORY.rc
 Character Resource Parameter: MAPL_ENABLE_TIMERS:YES
 Character Resource Parameter: MAPL_ENABLE_MEMUTILS:YES
pe=00003 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00003 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00003 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00003 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00003 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00003 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00003 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00001 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00001 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00001 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00005 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00005 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00005 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00005 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00003 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00003 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00003 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00003 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00003 FAIL at line=00030    GCHPctm.F90                              <status=8>
pe=00000 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00000 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00000 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00000 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00000 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00005 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00005 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00005 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00005 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00005 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00005 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00005 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00005 FAIL at line=00030    GCHPctm.F90                              <status=8>
pe=00002 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00002 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00002 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00002 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00002 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00002 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00004 FAIL at line=00574    Chem_GridCompMod.F90                     <status=8>
pe=00004 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00004 FAIL at line=04714    MAPL_Generic.F90                         <status=8>
pe=00004 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00001 FAIL at line=00158    GCHP_GridCompMod.F90                     <status=8>
pe=00001 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00001 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00001 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00001 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00001 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00001 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00001 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00001 FAIL at line=00030    GCHPctm.F90                              <status=8>
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 1 in communicator MPI_COMM_WORLD
with errorcode 0.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
pe=00000 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00000 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00000 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00000 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00000 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00000 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00000 FAIL at line=00030    GCHPctm.F90                              <status=8>
pe=00002 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00002 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00002 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00002 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00002 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00004 FAIL at line=04678    MAPL_Generic.F90                         <status=8>
pe=00004 FAIL at line=00535    MAPL_CapGridComp.F90                     <status=8>
pe=00004 FAIL at line=00908    MAPL_CapGridComp.F90                     <status=8>
pe=00004 FAIL at line=00245    MAPL_Cap.F90                             <status=8>
pe=00004 FAIL at line=00211    MAPL_Cap.F90                             <status=8>
pe=00004 FAIL at line=00154    MAPL_Cap.F90                             <status=8>
pe=00004 FAIL at line=00129    MAPL_Cap.F90                             <status=8>
pe=00004 FAIL at line=00030    GCHPctm.F90                              <status=8>
pe=00002 FAIL at line=00030    GCHPctm.F90                              <status=8>
[compute1-exec-4.ris.wustl.edu:09224] PMIX ERROR: UNREACHABLE in file server/pmix_server.c at line 1741
[compute1-exec-4.ris.wustl.edu:09224] PMIX ERROR: UNREACHABLE in file server/pmix_server.c at line 1741
[compute1-exec-4.ris.wustl.edu:09224] PMIX ERROR: UNREACHABLE in file server/pmix_server.c at line 1741
[compute1-exec-4.ris.wustl.edu:09224] PMIX ERROR: UNREACHABLE in file server/pmix_server.c at line 1741
[compute1-exec-4.ris.wustl.edu:09224] PMIX ERROR: UNREACHABLE in file server/pmix_server.c at line 1741
[compute1-exec-4.ris.wustl.edu:09224] 5 more processes have sent help message help-mpi-api.txt / mpi-abort
[compute1-exec-4.ris.wustl.edu:09224] Set MCA parameter "orte_base_help_aggregate" to 0 to see all help / error messages
```

</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
