### PR TITLE
Added log entries for stage start/finish in MAPL.GENERIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added log entries for stage start/finish in MAPL.GENERIC
+
 ### Changed
 
 ### Fixed

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -1743,6 +1743,9 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
   character(len=12), target :: timers_run(2) = &
        [character(len=12):: 'GenRunTot','--GenRunMine'] 
   character(len=12) :: sbrtn
+  character(len=ESMF_MAXSTR) :: stage_description
+  logical                    :: stage_is_one_time
+  class(Logger), pointer :: lgr => null()
 
 
 !=============================================================================
@@ -1761,6 +1764,8 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
   _VERIFY(STATUS)
   Iam = trim(COMP_NAME) // trim(Iam)
 
+  lgr => logging%get_logger('MAPL.GENERIC')
+
   call ESMF_VmGetCurrent(VM)
 ! Retrieve the pointer to the internal state. It comes in a wrapper.
 ! ------------------------------------------------------------------
@@ -1774,6 +1779,7 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
 
   t_p => get_global_time_profiler()
 
+  stage_is_one_time = .true.
   MethodBlock: if (method == ESMF_METHOD_RUN) then
      func_ptr => ESMF_GridCompRun
      timers => timers_run
@@ -1782,6 +1788,7 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
         write(char_phase,'(i1)')phase
         sbrtn = 'Run'//char_phase
      end if
+     stage_is_one_time = .false.
   else if (method == ESMF_METHOD_INITIALIZE) then
      func_ptr => ESMF_GridCompInitialize
 !ALT: enable this when fully implemented (for now NULLIFY)
@@ -1806,7 +1813,9 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
 !     timers => timers_writereastart
      NULLIFY(timers)
      sbrtn = 'WriteRestart'
+     stage_is_one_time = .false.
   endif MethodBlock
+  stage_description = ''''//trim(sbrtn)//''' stage of the gridded component '''//trim(COMP_NAME)//''''
 
 ! TIMERS on
   call t_p%start(trim(state%compname),__RC__)
@@ -1831,13 +1840,22 @@ subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
   end IF
 #endif
 
-
+  if (stage_is_one_time) then
+    call lgr%info('Started the  %a', trim(stage_description))
+  else 
+    call lgr%debug('Started the  %a', trim(stage_description))
+  end if
   call func_ptr (GC, &
        importState=IMPORT, &
        exportState=EXPORT, &
        clock=CLOCK, PHASE=PHASE_, &
        userRC=userRC, RC=STATUS )
   _ASSERT(userRC==ESMF_SUCCESS .and. STATUS==ESMF_SUCCESS,'needs informative message')
+  if (stage_is_one_time) then
+    call lgr%info('Finished the %a', trim(stage_description))
+  else 
+    call lgr%debug('Finished the %a', trim(stage_description))
+  end if
 
   ! TIMERS off
   if (associated(timers)) then
@@ -4548,6 +4566,7 @@ end subroutine MAPL_DateStampGet
   class(AbstractFrameworkComponent), pointer :: tmp_framework
   character(len=ESMF_MAXSTR), allocatable     :: TMPNL(:)
   character(len=ESMF_MAXSTR)                  :: FNAME, PNAME
+  character(len=ESMF_MAXSTR)                  :: stage_description
   type(ESMF_GridComp)                         :: pGC
   type(ESMF_Context_Flag)                     :: contextFlag
   class(BaseProfiler), pointer                :: t_p
@@ -4669,11 +4688,17 @@ end subroutine MAPL_DateStampGet
 
   t_p => get_global_time_profiler()
 
+  stage_description = '''SetServices'' stage of the gridded component '''//trim(FNAME)//''''
+
   call t_p%start(trim(NAME),__RC__)
   call CHILD_META%t_profiler%start(__RC__)
   call CHILD_META%t_profiler%start('SetService',__RC__)
   gridcomp => META%GET_CHILD_GRIDCOMP(I)
-  call ESMF_GridCompSetServices ( gridcomp, SS, RC=status )
+  call lgr%info("Started the  %a", trim(stage_description))
+  call ESMF_GridCompSetServices ( gridcomp, SS, userRC=SS_STATUS, RC=status )
+  _VERIFY(STATUS)
+  _VERIFY(SS_STATUS)
+  call lgr%info("Finished the %a", trim(stage_description))
   call CHILD_META%t_profiler%stop('SetService',__RC__)
   call CHILD_META%t_profiler%stop(__RC__)
   call t_p%stop(trim(NAME),__RC__)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds logging of the start/finish of gridcomp stages. For example

```
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'GCHP'
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'GCHPctmEnv'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'GCHPctmEnv'
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'GCHPchem'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'GCHPchem'
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'DYNAMICS'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'DYNAMICS'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'GCHP'
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'HIST'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'HIST'
0000: MAPL.GENERIC: INFO: Started the  'SetServices' stage of the gridded component 'EXTDATA'
0000: MAPL.GENERIC: INFO: Finished the 'SetServices' stage of the gridded component 'EXTDATA'
0000: MAPL.GENERIC: INFO: Started the  'Initialize' stage of the gridded component 'GCHP'
...
```

Note that one-time stages like SetServices, Initialize, and Finalize are going to MAPL.GENERIC info, and many-time stages like Run and WriteRestartFile go to debug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

I'm working on making it easier to troubleshoot errors in GCHP. Logging the start/end of each stage helps keep track of what is going on. If the model crashes for some reason, the log will show what stage of what component it happened in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested it with GCHP.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
