### PR TITLE
Fixes to make 2.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2.8.5] - 2021-09-03
+
+### Fixed
+
+- Added missing recursive declaration to MAPL_GenericWrapper
+
 ## [2.8.4] - 2021-08-27
 
 ### Added
 
 - Added `esma_cpack` include for tarring ability
-- Added missing recursive declaration to MAPL_GenericWrapper
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.4
+  VERSION 2.8.5
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # mepo can now clone subrepos in three styles


### PR DESCRIPTION
The last hotfix (#1013) put the changelog entry under 2.8.4. This is incorrect as this would mean 2.8.4 had this fix. This PR updates the Changelog and CMakeLists.txt to make a 2.8.5 release. 