### PR TITLE
Handmerge main to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue #486. Empty state restarts will now be ignored (with warning) for writing (the code also protects reading, but the existing code already had a different protection)
 - Added default `CMAKE_BUILD_TYPE` for MAPL standalone. Defaults to `Release` build if not set on command line
 
+## [2.8.5] - 2021-09-03
+
+### Fixed
+
+- Added missing recursive declaration to MAPL_GenericWrapper
+
 ## [2.8.4] - 2021-08-27
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.4
+  VERSION 2.8.5
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/base/MAPL_Generic.F90
+++ b/base/MAPL_Generic.F90
@@ -1705,7 +1705,7 @@ end subroutine MAPL_GenericInitialize
 !=============================================================================
 !=============================================================================
 
-subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
+recursive subroutine MAPL_GenericWrapper ( GC, IMPORT, EXPORT, CLOCK, RC)
 
   !ARGUMENTS:
   type(ESMF_GridComp)  :: GC     ! Gridded component 


### PR DESCRIPTION
Because of...some reason, auto PRs from `main` to `develop` are fubar'd (see #1016). So we do this by hand.