### PR TITLE
Closes #1032. Fix logging error with FLIPPED AttributeGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed ESMF logging errors from MAPL_IO (#1032)
+
 ## [2.8.6] - 2021-09-13
 
 ### Added

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -8521,7 +8521,7 @@ module MAPL_IOMod
             call ESMF_FieldDestroy(field,noGarbage=.true.,rc=status)
             _VERIFY(status)
          end if
-      end if
+       end if
        
     enddo
 

--- a/base/MAPL_IO.F90
+++ b/base/MAPL_IO.F90
@@ -8514,11 +8514,14 @@ module MAPL_IOMod
        call MAPL_FieldWriteNCPar(formatter, fieldName, field, arrdes, HomePE=mask, oClients=oClients, rc=status)
        _VERIFY(STATUS)
 
-       call ESMF_AttributeGet(field,"FLIPPED",fieldName,rc=status)
-       if (status == _SUCCESS) then
-          call ESMF_FieldDestroy(field,noGarbage=.true.,rc=status)
-          _VERIFY(status)
-       end if
+       call ESMF_AttributeGet(field,name="FLIPPED",isPresent=isPresent,rc=status)
+       if (isPresent) then
+         call ESMF_AttributeGet(field,name="FLIPPED",value=fieldName,rc=status)
+         if (status == _SUCCESS) then
+            call ESMF_FieldDestroy(field,noGarbage=.true.,rc=status)
+            _VERIFY(status)
+         end if
+      end if
        
     enddo
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This uses `isPresent` to avoid the ESMF logging errors seen in #1032 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1032 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

It keeps GEOS free of any ESMF logging errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build and ran GEOS with this fix. Zero diff and no ESMF logfiles to be seen!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
