### PR TITLE
Update to ESMA_cmake 3.5.7, ESMA_env 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Moved Collection ExtData modules into griddedio directory. Removed the Ext prefix for collection modules and subroutines and types
     - Moved BundleRead and BundleWrite modules from base to griddedio
     - Moved Regrid_Util.F90 from base to griddedio  due to griddedio dependency on base. Executable still generated in install/bin
+- Updated `components.yaml`
+    - ESMA_cmake v3.5.7 (Bug fix for NAG, support for mepo styles)
+    - ESMA_env v3.3.1
 
 ### Fixed
-- Fixed #338. Added a workaround for a gfortran bug that handles end-of-file incorrectly (returns IOSTAT=5001).
 
+- Fixed #338. Added a workaround for a gfortran bug that handles end-of-file incorrectly (returns IOSTAT=5001).
 - Fixed ESMF logging errors from MAPL_IO (#1032)
 
 ## [2.8.6] - 2021-09-13

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v3.3.0
+  tag: v3.3.1
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.4
+  tag: v3.5.7
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updates ESMA_cmake to 3.5.7 and ESMA_env 3.3.1. 

The main change is ESMA_cmake. Testing with NAG on Discover for @bena-nasa found that CMake was doing bad things with pthread support (`-pthread` is not a NAG flag). ESMA_cmake 3.5.7 fixes that. 

The ESMA_env update is just to keep up to date. No big change for MAPL.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Let's us use NAG on linux.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built MAPL with it. Should be fine for GEOS as the logic is pretty solid "Only NAG and Linux"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
