### PR TITLE
Fixes #1059 - cmake install dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored MAPL_IO by separating it into a Binary (BinIO.F90) and NetCDF (NCIO.F90) modules. Shared subroutines and
   types have been moved to FileIOShared.F90. MAPL_IO becomes a package module to hold these aforementioned three modules.
 
+- Changed location of installed MAPL cmake macros to facilitate UFS.   The new location is more conventional.  Also added ecbuild logic to add
+  new location to module path.  I.e., now it's done in a better way, and maybe even the "right"(TM) way.
+
+
 ### Fixed
 
 - Fixed #338. Added a workaround for a gfortran bug that handles end-of-file incorrectly (returns IOSTAT=5001).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ install (
 
 install (
    DIRECTORY cmake
-   DESTINATION ${INSTALL_DATA_DIR}
+      DESTINATION ${INSTALL_CMAKE_DIR}
    )
 
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/


### PR DESCRIPTION
- Changed location of installed MAPL cmake macros to facilitate UFS.
  The new location is more conventional.  Also added ecbuild logic to
  add new location to module path.  I.e., now it's done in a better
  way, and maybe even the "right"(TM) way.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed CMake logic for installing cmake macros for upstream projects.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Simplifies use of MAPL by _external_ projects.  No impact on GEOS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
Only affects upstream projects, so cannot be tested inside GEOS.  Have tested with a toy cmake project.

