### PR TITLE
Update ESMA_cmake and ESMA_env, other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Moved BundleRead and BundleWrite modules from base to griddedio
     - Moved Regrid_Util.F90 from base to griddedio  due to griddedio dependency on base. Executable still generated in install/bin
 - Updated `components.yaml`
-    - ESMA_cmake v3.5.7 (Bug fix for NAG, support for mepo styles)
-    - ESMA_env v3.3.1
+    - ESMA_cmake v3.6.1 (Bug fix for NAG, support for mepo styles, `Release` flags are now vectorized)
+    - ESMA_env v3.4.0 (Support for Cascade Lake, moves to Intel 2021.2)
 - Refactored MAPL_IO by separating it into a Binary (BinIO.F90) and NetCDF (NCIO.F90) modules. Shared subroutines and
   types have been moved to FileIOShared.F90. MAPL_IO becomes a package module to hold these aforementioned three modules.
 
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed #338. Added a workaround for a gfortran bug that handles end-of-file incorrectly (returns IOSTAT=5001).
 - Fixed ESMF logging errors from MAPL_IO (#1032)
+- Make `BUILD_WITH_PFLOGGER` a CMake `option()`
+- MAPL finds yaFyaml in CMake through `PFLOGGER::pflogger`, so if you build the stub, specifically add it as a dependency
+- Fix annoying misspelling of FLAP
 
 ## [2.8.6] - 2021-09-13
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ endif ()
 
 ecbuild_declare_project()
 
+option(BUILD_WITH_PFLOGGER "Build MAPL with pFlogger library support" ON)
+
 if (NOT Baselibs_FOUND)
   find_package(NetCDF REQUIRED Fortran)
   add_definitions(-DHAS_NETCDF4)
@@ -86,8 +88,6 @@ if (NOT Baselibs_FOUND)
   endif()
 
   find_package(ESMF MODULE REQUIRED)
-
-  find_package(YAFYAML REQUIRED)
 
   find_package(GFTL REQUIRED)
   find_package(GFTL_SHARED REQUIRED)

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -34,7 +34,7 @@ if (APPLE AND CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_Fortran_COMPILER
       "MAPL developers have found an issue with Intel oneAPI on macOS\n"
       "where GEOSgcm.x would not work. Debugging found the issue was\n"
       "that command_argument_count() would return -1 which should *NEVER*\n"
-      "happen per Fortran Standard and then this broke FlAP.\n"
+      "happen per Fortran Standard and then this broke FLAP.\n"
       "A workaround was found that if the ${this} library was compiled\n"
       "as TYPE STATIC, the model would work. So we are setting ${this} as\n"
       "a TYPE STATIC library. Note: This might interfere with coupled model.")

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v3.3.1
+  tag: v3.4.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.7
+  tag: v3.6.1
   develop: develop
 
 ecbuild:

--- a/pflogger_stub/CMakeLists.txt
+++ b/pflogger_stub/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
   pflogger_stub.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared YAFYAML::yafyaml TYPE ${MAPL_LIBRARY_TYPE})
 add_library(PFLOGGER::pflogger ALIAS ${this})
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR is mainly to update the ESMA_cmake and ESMA_env versions for MAPL. v3.6.0 of ESMA_cmake broke `make tests` but v3.6.1 fixes it. ESMA_env v3.4.0 moves GEOS to use Intel 2021.2 by default.

This also has a few other bugfixes:

1. @bena-nasa discovered that if you don't use Baselibs/real pFlogger, then the pflogger_stub needs to provide yaFyaml. We were depending on it from `PFLOGGER::pflogger` transitiveness.
2. Made `BUILD_WITH_PFLOGGER` a real CMake `option()` for clarity
3. Fixed a dumb misspelling that annoyed me.

It might be good for @weiyuan-jiang or @rmontuoro to make sure I didn't break any UFS stuff. I can't remember if it was UFS or Harvard that wanted the pflogger stub...

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Keeps MAPL up-to-date with GEOSgcm

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I did run MAPL with it. I'll make sure to do a test with full GEOS soon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
