### PR TITLE
Fixes #1064. This bug has been in MAPL for a long time (classical "fe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
+- Fixes #1064. This is bug has been in MAPL for a long time. It shows only when the user specifies a non-default duration, and the last step of the duration interval is written to a new, separate file
 ## [2.8.6] - 2021-09-13
 
 ### Added

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -3460,13 +3460,6 @@ ENDDO PARSER
           _VERIFY(STATUS)
        endif
 
-       if( NewSeg .and. list(n)%unit /= 0 .and. list(n)%duration /= 0 ) then
-          if (list(n)%unit > 0 ) then
-             call FREE_FILE( list(n)%unit )
-          end if
-          list(n)%unit = 0
-       endif
-
    end do
 
    if(any(Writing)) call WRITE_PARALLEL("")
@@ -3646,6 +3639,13 @@ ENDDO PARSER
          end if
 
       endif OUTTIME
+
+      if( NewSeg .and. list(n)%unit /= 0 .and. list(n)%duration /= 0 ) then
+         if (list(n)%unit > 0 ) then
+            call FREE_FILE( list(n)%unit )
+         end if
+         list(n)%unit = 0
+       endif
 
    enddo POSTLOOP
 


### PR DESCRIPTION
…nce-post" problem). Once the new segment alarm rings, the new file should be open only after the current time step is written.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail --> Fixes very embarrassing bug: moved the new segment action after the current step is written 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
