### PR TITLE
Handmerge main to develop 2021-Oct-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MAPL finds yaFyaml in CMake through `PFLOGGER::pflogger`, so if you build the stub, specifically add it as a dependency
 - Fix annoying misspelling of FLAP
 
+## [2.8.10] - 2021-10-15
+
+### Fixed
+
+- Fixed a missing copy of the output after ESMF_FieldHalo (see #1090)
+
 ## [2.8.9] - 2021-10-15
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.9
+  VERSION 2.8.10
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -906,6 +906,7 @@ contains
       ptr = array
       call ESMF_FieldHalo(field,this%rh,rc=status)
       _VERIFY(status)
+      array = ptr
       call ESMF_FieldDestroy(field,rc=status)
       _VERIFY(status)
       


### PR DESCRIPTION
This is to get the Halo fix (#1091) into `develop` as the automerge failed due to a conflict.