### PR TITLE
Prepare for 2.9.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+### Added
+
+### Changed
+
 ### Removed
+
+## [2.9.0] - 2021-10-19
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.10
+  VERSION 2.9.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release
@@ -99,7 +99,7 @@ endif ()
 
 if (BUILD_WITH_PFLOGGER)
   add_definitions(-DBUILD_WITH_PFLOGGER)
-else ()  
+else ()
   add_subdirectory (pflogger_stub)
 endif ()
 


### PR DESCRIPTION
This is to prepare `develop` → `main` for a 2.9.0 release.