### PR TITLE
Fixes #951. Adjusted the size for the internal write buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-
+- Fixes #951. Adjusted the size for the internal write, which is compiler dependent. For reals: 15 for Inter, 16 for NAG and Portland group, 18 for gfortran. 
+	
 - Fixed bug when comparing grid equality in the cubed-sphere factory
 - Fixes handling of nested states in MAPL. Removed the requirement to specify horizontal or vertical grid specs for such states. Added a public method to retrieve rootGC
 

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -623,7 +623,7 @@ contains
         j = len_trim(buffer)
         write(tmpStr, *) value(i) ! ALT: check if enough space to write
         newVal = adjustl(tmpStr)
-        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        _ASSERT(j + len_trim(newVal) <= LSZ,'not enough space to write')
         write(buffer(j+1:), *) trim(newVal)
      end do
      call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)
@@ -640,15 +640,25 @@ contains
      integer, intent(out), optional               :: rc   
 ! BOPI -------------------------------------------------------------------
 !
-! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
+! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte real numbers
 
+     ! This uses existing overload of MAPL_ConfogSetAttribute for vector of
+     ! character strings. This limits the number of reals to about 92
+     
 !
 ! !INTERFACE:
       ! Private name; call using MAPL_ConfigSetAttribute()
 
+     ! The next variable, IWSZ, is used for sizing a buffer for internal write
+     ! The value varies between different compilers
+     ! 15 is big enough for Intel
+     ! 16 is good for NAG and Portland Group
+     ! 18 is needed for gfortran
+     ! Hopefully 32 is large enough to fit-all.
+#define IWSZ 32
      integer,   parameter :: LSZ = max (1024,ESMF_MAXPATHLEN)  ! Maximum line size
      character(len=LSZ) :: buffer
-     character(len=15) :: tmpStr, newVal
+     character(len=IWSZ) :: tmpStr, newVal
      integer :: count, i, j
      integer :: status
 
@@ -658,7 +668,7 @@ contains
         j = len_trim(buffer)
         write(tmpStr, *) value(i) ! ALT: check if enough space to write
         newVal = adjustl(tmpStr)
-        _ASSERT(j + len_trim(newVal) < LSZ,'not enough space to write')
+        _ASSERT(j + len_trim(newVal) <= LSZ,'not enough space to write')
         write(buffer(j+1:), *) trim(newVal)
      end do
      call MAPL_ConfigSetAttribute(config, value=buffer, label=label, __RC__)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> This fixes #951 by making the size for internal write big enough for the 3 compilers

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
