### PR TITLE
normal return for no data bit shaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- return 0 when there is no data for bit shave
+
 ### Added
 
 - Add the i and j index as variables to use to generate synthetic data in ExtDataDriver.x

--- a/pfio/pFIO_ShaveMantissa.c
+++ b/pfio/pFIO_ShaveMantissa.c
@@ -117,9 +117,13 @@ int pFIO_ShaveMantissa32 ( float32 a[], float32 ain[], int32 len, int xbits, int
     uint32  i;
   } aa;
 
+  if ( len == 0 ) {
+    // if there is no data, do nothing
+    return 0;
+  }
   /* sanity checks */
 
-  if ( len < 1 || xbits < 1 ) {
+  if ( len < 0 || xbits < 1 ) {
     fprintf(stderr,
 	    "ShaveMantissa32: Bad length of mask bits: len= %d, xbits= %d\n", 
 	    len, xbits );


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
When a processor has no data, the bit shave should not return error. 
## Description
<!--- Describe your changes in detail -->
return 0 when there is no data

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
