### PR TITLE
Update VarRead 2D_R8 interface to match VarRead 2D_R4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `changelog-enforcer` to version 3
 - Compress CircleCI artifacts
+- Updated VarRead_2d_r8 interface to match VarRead_2d_r4 interface in NCIO module
 
 ### Removed
 

--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -2516,13 +2516,14 @@ module NCIOMod
 
 !---------------------------
 
-  subroutine MAPL_VarReadNCpar_R8_2d(formatter, name, A, ARRDES, lev, RC)
+  subroutine MAPL_VarReadNCpar_R8_2d(formatter, name, A, ARRDES, lev, offset2, RC)
   
     type(Netcdf4_Fileformatter)           , intent(IN   ) :: formatter
     character(len=*)            , intent(IN   ) :: name
     real(kind=ESMF_KIND_R8)     , intent(INOUT) :: A(:,:)
     type(ArrDescr),    optional , intent(INOUT) :: ARRDES
     integer,           optional , intent(IN   ) :: lev
+    integer,           optional , intent(IN   ) :: offset2
     integer,           optional , intent(  OUT) :: RC
 
 ! Local variables
@@ -2590,6 +2591,7 @@ module NCIOMod
           start(3) = 1
           if (present(lev)) start(3)=lev
           start(4) = 1
+          if (present(offset2)) start(4) = offset2
           cnt(1) = IM_WORLD
           cnt(2) = jsize
           cnt(3) = 1
@@ -2647,6 +2649,7 @@ module NCIOMod
        start(3) = 1
        if (present(lev) ) start(3) = lev
        start(4) = 1
+       if (present(offset2)) start(4) = offset2
        cnt(1) = size(a,1)
        cnt(2) = size(a,2)
        cnt(3) = 1


### PR DESCRIPTION
When the CTM was updated to use the latest version of the GEOSgcm libraries the build failed as that builds fv3 with interp_restart.x because it was calling into VarREAD_2D_R8 in NCIO due to some changes in that code (the GEOSgcm fixture uses the R4 version).
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
