### PR TITLE
Prepare for 2.15.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Free types and operation created by profiler
-
 ### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.15.0] - 2022-01-04
+
+### Fixed
+
+- Free types and operation created by profiler
 
 ### Changed
 
@@ -20,10 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `changelog-enforcer` to version 3
 - Compress CircleCI artifacts
 - Updated VarRead_2d_r8 interface to match VarRead_2d_r4 interface in NCIO module
-
-### Removed
-
-### Deprecated
 
 ## [2.14.1] - 2021-12-20
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.14.1
+  VERSION 2.15.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
This PR prepares the repo for a 2.15.0 release. 

This release will be useful for the GEOSldas (see https://github.com/GEOS-ESM/GEOSldas/pull/506 by @gmao-rreichle) and for the GEOSctm (see https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/153 by @bena-nasa as well as https://github.com/GEOS-ESM/GEOSctm/pull/42 where the CTM fails to build with latest MAPL/FV3)