### PR TITLE
Add retry to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,13 @@ commands:
             cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
             make -j"$(nproc)" install |& tee /logfiles/make.log
             #MEDIUM# make -j4 install |& tee /logfiles/make.log
+      - run:
+          name: "Retry build and install after failure"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-<< parameters.repo >>
+            make -j"$(nproc)" install |& tee /logfiles/make-retry.log
+            #MEDIUM# make -j4 install |& tee /logfiles/make-retry.log
+          when: on_fail
 
   checkout_mapl_branch:
     description: "Mepo checkout MAPL branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
 - Refactored MAPL_Generic.F90 - lots of changes.
   - consistent indentation (emacs mode)
   - extracted helper procedures in GenericInitialize
+- Added new step to CircleCI to try and re-run build on failure.
 
 ### Removed
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Every so often, the Intel CircleCI build will fail. My current guess is this is due to memory pressure on the `large` VM which has 8 GB of RAM. Since we build with `make -j$(nproc)` this could happen. So what this PR will try and do is add an extra `make -j$(nproc) install` step when the first one fails. This is in the hope that maybe the memory pressure will be less when running the second time (since it might take a different path through the make graph).

Of course, this is impossible to test as the failure is sporadic, but the CI in MAPL is at a much higher frequency than other repos, so this is the best place to start.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Less time needed to re-run CI jobs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
