### PR TITLE
Add "latest version" Zenodo badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![GEOS-ESM](https://circleci.com/gh/GEOS-ESM/MAPL.svg?style=svg)](https://app.circleci.com/pipelines/github/GEOS-ESM/MAPL)
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3903434.svg)](https://doi.org/10.5281/zenodo.3903434)
+[![DOI](https://zenodo.org/badge/195083467.svg)](https://zenodo.org/badge/latestdoi/195083467)
 
 MAPL is a foundation layer of the GEOS architecture, whose original purpose is to supplement the Earth System Modeling Framework (ESMF).   MAPL fills in missing capabilities of ESMF, provides higher-level interfaces for common boiler-plate logic, and enforces various componentization conventions across ESMF gridded components within GEOS.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [![GEOS-ESM](https://circleci.com/gh/GEOS-ESM/MAPL.svg?style=svg)](https://app.circleci.com/pipelines/github/GEOS-ESM/MAPL)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3903434.svg)](https://doi.org/10.5281/zenodo.3903434)
+
 MAPL is a foundation layer of the GEOS architecture, whose original purpose is to supplement the Earth System Modeling Framework (ESMF).   MAPL fills in missing capabilities of ESMF, provides higher-level interfaces for common boiler-plate logic, and enforces various componentization conventions across ESMF gridded components within GEOS.
 
 MAPL has 10 primary subdirectories for Fortran source code.


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds an "latest-version" Zenodo badge to the README. I'll skip enforcing changelog as I'm sure this warrants a change...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

At the moment, Zenodo badges have to be added to releases by hand. Fine, doesn't happen too often.

~But it would be nice to have a badge pointing to the "latest" version of the Zenodo entry. Per [this GitHub post](https://github.com/zenodo/zenodo/issues/1582) there is a nice DOI that always points to the latest version. Thus, we can add one here!~

Turns out there's a better way to do this: the [latest version badge](https://github.com/zenodo/zenodo/issues/276#issuecomment-879740695)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
