### PR TITLE
Fixes #1295. Clean up ESMC use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed include of `ESMC_ReturnCodes.h`. Changed some `ESMC_RC` codes to `ESMF_RC` codes
+
 ### Removed
 
 ### Deprecated

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -58,13 +58,13 @@ contains
       subroutine MAPL_ConfigSetAttribute_real64( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: REAL64
 ! !ARGUMENTS:
-      type(ESMF_Config), intent(inout)             :: config     
+      type(ESMF_Config), intent(inout)             :: config
       real(kind=REAL64), intent(in)                :: value
-      character(len=*), intent(in), optional       :: label 
-      integer, intent(out), optional               :: rc   
+      character(len=*), intent(in), optional       :: label
+      integer, intent(out), optional               :: rc
 
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  Sets an integer {\tt value} in the {\tt config} object.
 !
 !   The arguments are:
@@ -72,9 +72,9 @@ contains
 !   \item [config]
 !     Already created {\tt ESMF\_Config} object.
 !   \item [value]
-!     Integer value to set. 
+!     Integer value to set.
 !   \item [{[label]}]
-!     Identifying attribute label. 
+!     Identifying attribute label.
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -88,9 +88,9 @@ contains
                                           ! of non-blank/comment lines
                                           ! (because most lines are shorter
                                           ! then LSZ)
- 
+
        integer,   parameter :: NBUF_MAX = MSZ*LSZ ! max size of buffer
-       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;  
+       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;
                                                   ! assumes an average line
                                                   ! size of 16, the code
                                                   ! will do a bound check
@@ -151,7 +151,7 @@ contains
         if ( (j-i) .gt. LSZ) then
            write(logmsg, *) ", attribute label, value & EOL are ", j-i, &
                " characters long, only ", LSZ, " characters allowed per line"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
 
         ! check if enough space left in config buffer
@@ -159,7 +159,7 @@ contains
            write(logmsg, *) ", attribute label & value require ", j-i+1, &
                " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                " characters left in config buffer"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
       endif
 
@@ -184,7 +184,7 @@ contains
             if (j-m+1 .gt. LSZ) then
                write(logmsg, *) ", attribute label, value & EOL are ", j-m+1, &
                   " characters long, only ", LSZ, " characters allowed per line"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ! check if enough space left in config buffer to extend line
@@ -192,7 +192,7 @@ contains
                write(logmsg, *) ", attribute label & value require ", j-m+1, &
                    " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                    " characters left in config buffer"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ninsert = nchar - lenThisLine
@@ -226,7 +226,7 @@ contains
         if ( iret .eq. ESMF_RC_NOT_FOUND ) iret = ESMF_SUCCESS
         rc = iret
       endif
-      
+
       return
    end subroutine MAPL_ConfigSetAttribute_real64
 
@@ -241,13 +241,13 @@ contains
       subroutine MAPL_ConfigSetAttribute_real32( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: REAL32
 ! !ARGUMENTS:
-      type(ESMF_Config), intent(inout)             :: config     
+      type(ESMF_Config), intent(inout)             :: config
       real(kind=REAL32), intent(in)                :: value
-      character(len=*), intent(in), optional       :: label 
-      integer, intent(out), optional               :: rc   
+      character(len=*), intent(in), optional       :: label
+      integer, intent(out), optional               :: rc
 
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  Sets an integer {\tt value} in the {\tt config} object.
 !
 !   The arguments are:
@@ -255,9 +255,9 @@ contains
 !   \item [config]
 !     Already created {\tt ESMF\_Config} object.
 !   \item [value]
-!     Integer value to set. 
+!     Integer value to set.
 !   \item [{[label]}]
-!     Identifying attribute label. 
+!     Identifying attribute label.
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -271,9 +271,9 @@ contains
                                           ! of non-blank/comment lines
                                           ! (because most lines are shorter
                                           ! then LSZ)
- 
+
        integer,   parameter :: NBUF_MAX = MSZ*LSZ ! max size of buffer
-       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;  
+       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;
                                                   ! assumes an average line
                                                   ! size of 16, the code
                                                   ! will do a bound check
@@ -334,7 +334,7 @@ contains
         if ( (j-i) .gt. LSZ) then
            write(logmsg, *) ", attribute label, value & EOL are ", j-i, &
                " characters long, only ", LSZ, " characters allowed per line"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
 
         ! check if enough space left in config buffer
@@ -342,7 +342,7 @@ contains
            write(logmsg, *) ", attribute label & value require ", j-i+1, &
                " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                " characters left in config buffer"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
       endif
 
@@ -367,7 +367,7 @@ contains
             if (j-m+1 .gt. LSZ) then
                write(logmsg, *) ", attribute label, value & EOL are ", j-m+1, &
                   " characters long, only ", LSZ, " characters allowed per line"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ! check if enough space left in config buffer to extend line
@@ -375,7 +375,7 @@ contains
                write(logmsg, *) ", attribute label & value require ", j-m+1, &
                    " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                    " characters left in config buffer"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ninsert = nchar - lenThisLine
@@ -409,7 +409,7 @@ contains
         if ( iret .eq. ESMF_RC_NOT_FOUND ) iret = ESMF_SUCCESS
         rc = iret
       endif
-      
+
       return
    end subroutine MAPL_ConfigSetAttribute_real32
 
@@ -424,13 +424,13 @@ contains
       subroutine MAPL_ConfigSetAttribute_int32( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: INT32
 ! !ARGUMENTS:
-      type(ESMF_Config), intent(inout)             :: config     
+      type(ESMF_Config), intent(inout)             :: config
       integer(kind=INT32), intent(in)            :: value
-      character(len=*), intent(in), optional       :: label 
-      integer, intent(out), optional               :: rc   
+      character(len=*), intent(in), optional       :: label
+      integer, intent(out), optional               :: rc
 
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  Sets an integer {\tt value} in the {\tt config} object.
 !
 !   The arguments are:
@@ -438,9 +438,9 @@ contains
 !   \item [config]
 !     Already created {\tt ESMF\_Config} object.
 !   \item [value]
-!     Integer value to set. 
+!     Integer value to set.
 !   \item [{[label]}]
-!     Identifying attribute label. 
+!     Identifying attribute label.
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -454,9 +454,9 @@ contains
                                           ! of non-blank/comment lines
                                           ! (because most lines are shorter
                                           ! then LSZ)
- 
+
        integer,   parameter :: NBUF_MAX = MSZ*LSZ ! max size of buffer
-       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;  
+       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;
                                                   ! assumes an average line
                                                   ! size of 16, the code
                                                   ! will do a bound check
@@ -517,7 +517,7 @@ contains
         if ( (j-i) .gt. LSZ) then
            write(logmsg, *) ", attribute label, value & EOL are ", j-i, &
                " characters long, only ", LSZ, " characters allowed per line"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
 
         ! check if enough space left in config buffer
@@ -525,7 +525,7 @@ contains
            write(logmsg, *) ", attribute label & value require ", j-i+1, &
                " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                " characters left in config buffer"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
       endif
 
@@ -550,7 +550,7 @@ contains
             if (j-m+1 .gt. LSZ) then
                write(logmsg, *) ", attribute label, value & EOL are ", j-m+1, &
                   " characters long, only ", LSZ, " characters allowed per line"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ! check if enough space left in config buffer to extend line
@@ -558,7 +558,7 @@ contains
                write(logmsg, *) ", attribute label & value require ", j-m+1, &
                    " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                    " characters left in config buffer"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ninsert = nchar - lenThisLine
@@ -592,17 +592,17 @@ contains
         if ( iret .eq. ESMF_RC_NOT_FOUND ) iret = ESMF_SUCCESS
         rc = iret
       endif
-      
+
       return
    end subroutine MAPL_ConfigSetAttribute_int32
 
    subroutine MAPL_ConfigSetAttribute_ints32( config, value, label, rc )
      use, intrinsic :: iso_fortran_env, only: INT32
 ! !ARGUMENTS:
-     type(ESMF_Config), intent(inout)             :: config     
+     type(ESMF_Config), intent(inout)             :: config
      integer(kind=INT32), intent(in)              :: value(:)
-     character(len=*), intent(in), optional       :: label 
-     integer, intent(out), optional               :: rc   
+     character(len=*), intent(in), optional       :: label
+     integer, intent(out), optional               :: rc
 ! BOPI -------------------------------------------------------------------
 !
 ! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte integer numbers
@@ -616,9 +616,9 @@ contains
      character(len=12) :: tmpStr, newVal
      integer :: count, i, j
      integer :: status
-     
+
      count = size(value)
-     buffer = '' ! initialize to 
+     buffer = '' ! initialize to
      do i = 1, count
         j = len_trim(buffer)
         write(tmpStr, *) value(i) ! ALT: check if enough space to write
@@ -634,17 +634,17 @@ contains
    subroutine MAPL_ConfigSetAttribute_reals32( config, value, label, rc )
      use, intrinsic :: iso_fortran_env, only: REAL32
 ! !ARGUMENTS:
-     type(ESMF_Config), intent(inout)             :: config     
+     type(ESMF_Config), intent(inout)             :: config
      real(kind=REAL32), intent(in)                :: value(:)
-     character(len=*), intent(in), optional       :: label 
-     integer, intent(out), optional               :: rc   
+     character(len=*), intent(in), optional       :: label
+     integer, intent(out), optional               :: rc
 ! BOPI -------------------------------------------------------------------
 !
 ! !IROUTINE: MAPL_ConfigSetAttribute - Set an array of 4-byte real numbers
 
      ! This uses existing overload of MAPL_ConfogSetAttribute for vector of
      ! character strings. This limits the number of reals to about 92
-     
+
 !
 ! !INTERFACE:
       ! Private name; call using MAPL_ConfigSetAttribute()
@@ -663,7 +663,7 @@ contains
      integer :: status
 
      count = size(value)
-     buffer = '' ! initialize to 
+     buffer = '' ! initialize to
      do i = 1, count
         j = len_trim(buffer)
         write(tmpStr, *) value(i) ! ALT: check if enough space to write
@@ -678,13 +678,13 @@ contains
 
    subroutine MAPL_ConfigSetAttribute_string(config, value, label, rc)
 ! !ARGUMENTS:
-      type(ESMF_Config), intent(inout)             :: config     
+      type(ESMF_Config), intent(inout)             :: config
       character(len=*), intent(in)                 :: value
-      character(len=*), intent(in), optional       :: label 
-      integer, intent(out), optional               :: rc   
+      character(len=*), intent(in), optional       :: label
+      integer, intent(out), optional               :: rc
 
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  Sets an integer {\tt value} in the {\tt config} object.
 !
 !   The arguments are:
@@ -692,9 +692,9 @@ contains
 !   \item [config]
 !     Already created {\tt ESMF\_Config} object.
 !   \item [value]
-!     Integer value to set. 
+!     Integer value to set.
 !   \item [{[label]}]
-!     Identifying attribute label. 
+!     Identifying attribute label.
 !   \item [{[rc]}]
 !     Return code; equals {\tt ESMF\_SUCCESS} if there are no errors.
 !   \end{description}
@@ -708,9 +708,9 @@ contains
                                           ! of non-blank/comment lines
                                           ! (because most lines are shorter
                                           ! then LSZ)
- 
+
        integer,   parameter :: NBUF_MAX = MSZ*LSZ ! max size of buffer
-       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;  
+       integer,   parameter :: NATT_MAX = NBUF_MAX/64 ! max # attributes;
                                                   ! assumes an average line
                                                   ! size of 16, the code
                                                   ! will do a bound check
@@ -771,7 +771,7 @@ contains
         if ( (j-i) .gt. LSZ) then
            write(logmsg, *) ", attribute label, value & EOL are ", j-i, &
                " characters long, only ", LSZ, " characters allowed per line"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
 
         ! check if enough space left in config buffer
@@ -779,7 +779,7 @@ contains
            write(logmsg, *) ", attribute label & value require ", j-i+1, &
                " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                " characters left in config buffer"
-           _RETURN(ESMC_RC_LONG_STR)
+           _RETURN(ESMF_RC_LONG_STR)
         endif
       endif
 
@@ -803,7 +803,7 @@ contains
             if (j-m+1 .gt. LSZ) then
                write(logmsg, *) ", attribute label, value & EOL are ", j-m+1, &
                   " characters long, only ", LSZ, " characters allowed per line"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ! check if enough space left in config buffer to extend line
@@ -811,7 +811,7 @@ contains
                write(logmsg, *) ", attribute label & value require ", j-m+1, &
                    " characters (including EOL & EOB), only ", NBUF_MAX-i, &
                    " characters left in config buffer"
-               _RETURN(ESMC_RC_LONG_STR)
+               _RETURN(ESMF_RC_LONG_STR)
             endif
 
             ninsert = nchar - lenThisLine
@@ -845,7 +845,7 @@ contains
         if ( iret .eq. ESMF_RC_NOT_FOUND ) iret = ESMF_SUCCESS
         rc = iret
       endif
-      
+
       _RETURN(_SUCCESS)
 
    end subroutine MAPL_ConfigSetAttribute_string

--- a/include/MAPL_Exceptions.h
+++ b/include/MAPL_Exceptions.h
@@ -87,7 +87,7 @@
       __raise(e,d)__   |  raise exception *e* usinf the string *d*
                        |   as a verbose description of the exception.
       -----------------|---------------------------------------------
- 
+
     IMPORTANT: No do-loops allowed inside __try__/__endtry__ blocks.
                Use the named __Try__/__endTry__ construct in such
                cases.
@@ -98,10 +98,10 @@
 
   !BUGS:
 
-    In the curent implementation, the scope of __try_/__endtry__ blocks 
-    cannot contain Fortran do-loops. Use the alternative "named" 
+    In the curent implementation, the scope of __try_/__endtry__ blocks
+    cannot contain Fortran do-loops. Use the alternative "named"
     __Try__/__endTry__ construct in such cases.
-  
+
  !REVISION HISTORY:
 
   05Nov2008  da Silva  Design and initial implementation
@@ -127,12 +127,12 @@
 #define __STAT__       STAT=STATUS); _VERIFY(STATUS
 
 !
-! Try & catch exception functionality; the __rc__ macro is similar 
+! Try & catch exception functionality; the __rc__ macro is similar
 ! to the __RC__ macro above but it does not invole the _VERIFY(STATUS)
 ! macro. Instead, it jumps out of the TRY block.
 !
 
-#define __try__        do 
+#define __try__        do
 #define __endtry__     exit; end do
 #define __except__     exit; end do; do; if(STATUS==ESMF_SUCCESS) exit
 #define __rc__         RC=STATUS); if(STATUS/=0) exit; IGNORE_(STATUS
@@ -140,7 +140,7 @@
 #define __catch__      select case(STATUS)
 #define __endcatch__   end select
 
-#define __Try__(label)     label: do 
+#define __Try__(label)     label: do
 #define __endTry__(label)  exit label; end do
 #define __Rc__(label)      RC=STATUS); if(STATUS/=ESMF_SUCCESS)exit label; IGNORE_(STATUS
 
@@ -148,13 +148,7 @@
 ! Raising exceptions
 !
 
-#define __raise__(exception,description) print '(a,'': '',a)', "exception", description; _RETURN(exception)  
-
-!
-! ESMF Error codes are defined here
-!                     
-
-#include "ESMC_ReturnCodes.h"
+#define __raise__(exception,description) print '(a,'': '',a)', "exception", description; _RETURN(exception)
 
 !
 ! Pre-defined MAPL error codes


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This removes the `#include "ESMC_ReturnCodes.h"` that was in `MAPL_Exceptions.h`. It then turns out you can then replace all the `ESMC_RC_` codes in `MAPL_Config.F90` to `ESMF_RC_` that I suppose are provided via `use ESMF`?

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1295 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Cleans up MAPL a bit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It built and ran GEOS just fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
