### PR TITLE
fixes #1294

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Files read by GriddedIOMod now respect the file defined _FillValue rather than assuming it is MAPL_UNDEF
+
 ### Added
 
 ### Changed

--- a/base/FileMetadataUtilities.F90
+++ b/base/FileMetadataUtilities.F90
@@ -21,6 +21,11 @@ module MAPL_FileMetadataUtilsMod
       procedure :: get_level_name
       procedure :: is_var_present
       procedure :: get_file_name
+      procedure :: var_get_missing_value
+      procedure :: var_has_missing_value
+      procedure :: var_has_attr
+      procedure :: get_var_attr_real32
+      procedure :: get_var_attr_string
    end type FileMetadataUtils
 
    interface FileMetadataUtils
@@ -46,6 +51,110 @@ module MAPL_FileMetadataUtilsMod
       this%filename = fName
    end subroutine create
 
+   function var_get_missing_value(this,var_name,rc) result(missing_value)
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      integer, optional, intent(out) :: rc
+
+      real(REAL32) :: missing_value
+      integer :: status
+      type(Variable), pointer :: var
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      ! check _FillValue, we could do more, not sure what to do here like also check for missing_value ...
+      if (this%var_has_attr(var_name,"_FillValue")) then
+         missing_value = this%get_var_attr_real32(var_name,"_FillValue",_RC)
+      end if
+
+      _RETURN(_SUCCESS)
+   end function var_get_missing_value
+
+   logical function var_has_missing_value(this,var_name,rc)
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      integer, optional, intent(out) :: rc
+     
+      integer :: status
+      type(Variable), pointer :: var
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      var_has_missing_value = var%is_attribute_present("_FillValue")
+
+      _RETURN(_SUCCESS)
+   end function var_has_missing_value
+
+   logical function var_has_attr(this,var_name,attr_name,rc)
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+     
+      integer :: status
+      type(Variable), pointer :: var
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      var_has_attr = var%is_attribute_present(attr_name)
+      _RETURN(_SUCCESS)
+   end function var_has_attr
+
+   function get_var_attr_real32(this,var_name,attr_name,rc) result(attr_real32)
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+
+      real(REAL32) :: attr_real32
+      real(REAL32) :: tmp(1)
+      integer :: status
+      type(Attribute), pointer :: attr
+      type(Variable), pointer :: var
+      class(*), pointer :: attr_val(:)
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      attr => var%get_attribute(attr_name,_RC)
+      _ASSERT(associated(attr),"no attribute named "//attr_name//" in "//var_name//" in file")
+      attr_val => attr%get_values()
+      select type(attr_val)
+      type is(real(kind=REAL32))
+         tmp = attr_val
+         attr_real32 = tmp(1)
+      class default
+         _ASSERT(.false.,'unsupport subclass for units')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function get_var_attr_real32
+
+   function get_var_attr_string(this,var_name,attr_name,rc) result(attr_string)
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+
+      character(len=:), allocatable :: attr_string
+      integer :: status
+      type(Attribute), pointer :: attr
+      type(Variable), pointer :: var
+      class(*), pointer :: attr_val
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      attr => var%get_attribute(attr_name,_RC)
+      _ASSERT(associated(attr),"no attribute named "//attr_name//" in "//var_name//" in file")
+      attr_val => attr%get_value()
+      select type(attr_val)
+      type is(character(*))
+         attr_string = attr_val
+      class default
+         _ASSERT(.false.,'unsupport subclass for units')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function get_var_attr_string
 
    subroutine get_time_info(this,startTime,startyear,startmonth,startday,starthour,startmin,startsec,units,timeVector,rc)
       class (FileMetadataUtils), intent(inout) :: this

--- a/base/FileMetadataUtilities.F90
+++ b/base/FileMetadataUtilities.F90
@@ -133,7 +133,7 @@ module MAPL_FileMetadataUtilsMod
    end function get_var_attr_real32
 
    function get_var_attr_real64(this,var_name,attr_name,rc) result(attr_real64)
-      real(REAL32) :: attr_real64
+      real(REAL64) :: attr_real64
       class(FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: var_name
       character(len=*), intent(in) :: attr_name

--- a/base/FileMetadataUtilities.F90
+++ b/base/FileMetadataUtilities.F90
@@ -25,6 +25,9 @@ module MAPL_FileMetadataUtilsMod
       procedure :: var_has_missing_value
       procedure :: var_has_attr
       procedure :: get_var_attr_real32
+      procedure :: get_var_attr_real64
+      procedure :: get_var_attr_int32
+      procedure :: get_var_attr_int64
       procedure :: get_var_attr_string
    end type FileMetadataUtils
 
@@ -52,11 +55,11 @@ module MAPL_FileMetadataUtilsMod
    end subroutine create
 
    function var_get_missing_value(this,var_name,rc) result(missing_value)
+      real(REAL32) :: missing_value
       class(FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: var_name
       integer, optional, intent(out) :: rc
 
-      real(REAL32) :: missing_value
       integer :: status
       type(Variable), pointer :: var
 
@@ -101,12 +104,12 @@ module MAPL_FileMetadataUtilsMod
    end function var_has_attr
 
    function get_var_attr_real32(this,var_name,attr_name,rc) result(attr_real32)
+      real(REAL32) :: attr_real32
       class(FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: var_name
       character(len=*), intent(in) :: attr_name
       integer, optional, intent(out) :: rc
 
-      real(REAL32) :: attr_real32
       real(REAL32) :: tmp(1)
       integer :: status
       type(Attribute), pointer :: attr
@@ -129,13 +132,100 @@ module MAPL_FileMetadataUtilsMod
       _RETURN(_SUCCESS)
    end function get_var_attr_real32
 
-   function get_var_attr_string(this,var_name,attr_name,rc) result(attr_string)
+   function get_var_attr_real64(this,var_name,attr_name,rc) result(attr_real64)
+      real(REAL32) :: attr_real64
       class(FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: var_name
       character(len=*), intent(in) :: attr_name
       integer, optional, intent(out) :: rc
 
+      real(REAL64) :: tmp(1)
+      integer :: status
+      type(Attribute), pointer :: attr
+      type(Variable), pointer :: var
+      class(*), pointer :: attr_val(:)
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      attr => var%get_attribute(attr_name,_RC)
+      _ASSERT(associated(attr),"no attribute named "//attr_name//" in "//var_name//" in file")
+      attr_val => attr%get_values()
+      select type(attr_val)
+      type is(real(kind=REAL64))
+         tmp = attr_val
+         attr_real64 = tmp(1)
+      class default
+         _ASSERT(.false.,'unsupport subclass for units')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function get_var_attr_real64
+
+   function get_var_attr_int32(this,var_name,attr_name,rc) result(attr_int32)
+      integer(INT32) :: attr_int32
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+
+      integer(INT32) :: tmp(1)
+      integer :: status
+      type(Attribute), pointer :: attr
+      type(Variable), pointer :: var
+      class(*), pointer :: attr_val(:)
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      attr => var%get_attribute(attr_name,_RC)
+      _ASSERT(associated(attr),"no attribute named "//attr_name//" in "//var_name//" in file")
+      attr_val => attr%get_values()
+      select type(attr_val)
+      type is(integer(kind=INT32))
+         tmp = attr_val
+         attr_int32 = tmp(1)
+      class default
+         _ASSERT(.false.,'unsupport subclass for units')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function get_var_attr_int32
+
+   function get_var_attr_int64(this,var_name,attr_name,rc) result(attr_int64)
+      integer(INT64) :: attr_int64
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+
+      integer(INT64) :: tmp(1)
+      integer :: status
+      type(Attribute), pointer :: attr
+      type(Variable), pointer :: var
+      class(*), pointer :: attr_val(:)
+
+      var => this%get_variable(var_name,_RC)
+      _ASSERT(associated(var),"no variable named "//var_name//" in file")
+      attr => var%get_attribute(attr_name,_RC)
+      _ASSERT(associated(attr),"no attribute named "//attr_name//" in "//var_name//" in file")
+      attr_val => attr%get_values()
+      select type(attr_val)
+      type is(integer(kind=INT64))
+         tmp = attr_val
+         attr_int64 = tmp(1)
+      class default
+         _ASSERT(.false.,'unsupport subclass for units')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function get_var_attr_int64
+
+   function get_var_attr_string(this,var_name,attr_name,rc) result(attr_string)
       character(len=:), allocatable :: attr_string
+      class(FileMetadataUtils), intent(inout) :: this
+      character(len=*), intent(in) :: var_name
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+
       integer :: status
       type(Attribute), pointer :: attr
       type(Variable), pointer :: var

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -53,8 +53,6 @@ module MAPL_ESMFFieldBundleRead
          type (StringVector), pointer :: dimensions
          type (StringVectorIterator) :: dim_iter
          integer :: lev_size, grid_size(3)
-         type(Attribute), pointer :: attr
-         class(*), pointer :: attr_val
          character(len=:), allocatable :: units,long_name
 
          collection => DataCollections%at(metadata_id)
@@ -123,24 +121,10 @@ module MAPL_ESMFFieldBundleRead
                _VERIFY(status)
                call ESMF_AttributeSet(field,name='VLOCATION',value=location,rc=status)
                _VERIFY(status)
-               attr => this_variable%get_attribute('units')
-               attr_val=>attr%get_value()
-               select type(attr_val)
-               type is (character(*))
-                  units=attr_val
-               class default
-                  _ASSERT(.false.,'unsupport subclass for units')
-               end select
+               units = metadata%get_var_attr_string(var_name,'units',_RC)
+               long_name = metadata%get_var_attr_string(var_name,'long_name',_RC)
                call ESMF_AttributeSet(field,name='UNITS',value=units,rc=status)
                _VERIFY(status)
-               attr => this_variable%get_attribute('long_name')
-               attr_val=>attr%get_value()
-               select type(attr_val)
-               type is (character(*))
-                  long_name=attr_val
-               class default
-                  _ASSERT(.false.,'unsupport subclass for units')
-               end select
                call ESMF_AttributeSet(field,name='LONG_NAME',value=long_name,rc=status)
                _VERIFY(status)
                call MAPL_FieldBundleAdd(bundle,field,rc=status)

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -28,6 +28,8 @@ module MAPL_GriddedIOMod
   
   private
 
+  character(len=20), parameter :: fill_value_label = "GriddedIO_Fill_Value"
+
   type, public :: MAPL_GriddedIO
      type(FileMetaData) :: metadata
      integer :: write_collection_id
@@ -66,6 +68,7 @@ module MAPL_GriddedIOMod
         procedure :: alphabatize_variables
         procedure :: request_data_from_file
         procedure :: process_data_from_file
+        procedure :: swap_undef_value
   end type MAPL_GriddedIO
 
   interface MAPL_GriddedIO
@@ -930,6 +933,7 @@ module MAPL_GriddedIOMod
      logical :: hasDE
      class(AbstractGridFactory), pointer :: factory
      type(fileMetadataUtils), pointer :: metadata
+     real(REAL32) :: missing_value
 
      collection => Datacollections%at(this%metadata_collection_id)
      metadata => collection%find(filename, __RC__)
@@ -962,6 +966,10 @@ module MAPL_GriddedIOMod
         _VERIFY(status)
         call ESMF_FieldGet(output_field,rank=rank,rc=status)
         _VERIFY(status)
+        missing_value = MAPL_UNDEF
+        if (metadata%var_has_missing_value(trim(names(i)))) then
+           missing_value = metadata%var_get_missing_value(trim(names(i)),_RC)
+        end if
         if (rank==2) then
            input_fields(i) = ESMF_FieldCreate(filegrid,typekind=ESMF_TYPEKIND_R4,gridToFieldMap=[1,2],name=trim(names(i)),rc=status)
            _VERIFY(status)
@@ -999,6 +1007,9 @@ module MAPL_GriddedIOMod
              this%read_collection_id, fileName, trim(names(i)), &
              & ref, start=localStart, global_start=globalStart, global_count=globalCount)
         deallocate(localStart,globalStart,globalCount)
+        if (missing_value /= MAPL_UNDEF) then
+           call ESMF_AttributeSet(input_fields(i),name=fill_value_label,value=missing_value,_RC)
+        end if
      enddo
      deallocate(gridLocalStart,gridGlobalStart,gridGlobalCount)
      this%input_bundle = ESMF_FieldBundleCreate(fieldList=input_fields,rc=status)
@@ -1028,9 +1039,12 @@ module MAPL_GriddedIOMod
      do while(iter /= this%items%end())
         item => iter%get()
         if (item%itemType == ItemTypeScalar) then
+           call this%swap_undef_value(trim(item%xname),_RC)
            call this%regridScalar(trim(item%xname),rc=status)
            _VERIFY(status)
         else if (item%itemType == ItemTypeVector) then
+           call this%swap_undef_value(trim(item%xname),_RC)
+           call this%swap_undef_value(trim(item%yname),_RC)
            call this%regridVector(trim(item%xname),trim(item%yname),rc=status)
            _VERIFY(status)
         end if
@@ -1048,5 +1062,53 @@ module MAPL_GriddedIOMod
      _RETURN(_SUCCESS)
 
   end subroutine process_data_from_file
+
+  subroutine swap_undef_value(this,fname,rc)
+     class (MAPL_GriddedIO), intent(inout) :: this
+     character(len=*), intent(in) :: fname
+     integer, optional, intent(out) :: rc
+
+     integer :: status
+
+     type(ESMF_Field) :: field
+     integer :: fieldRank
+     real, pointer :: ptr3d(:,:,:)
+     real, pointer :: ptr2d(:,:)
+     type(ESMF_Grid) :: gridIn
+     logical :: hasDE_in,has_custom_fill_val
+     real(REAL32) :: fill_value
+
+     call ESMF_FieldBundleGet(this%input_bundle,fname,field=field,_RC)
+     call ESMF_AttributeGet(field,name=fill_value_label,isPresent=has_custom_fill_val,_RC)
+
+     if (has_custom_fill_val) then
+
+        call ESMF_AttributeGet(field,name=fill_value_label,value=fill_value,_RC)
+        call ESMF_FieldGet(field,rank=fieldRank,_RC)
+        _VERIFY(status)
+        call ESMF_FieldBundleGet(this%input_bundle,grid=gridIn,_RC)
+        hasDE_in = MAPL_GridHasDE(gridIn,_RC)
+
+        if (fieldRank==2) then
+           if (hasDE_in) then
+              call MAPL_FieldGetPointer(field,ptr2d,_RC)
+           else
+              allocate(ptr2d(0,0))
+           end if
+           where(ptr2d==fill_value) ptr2d=MAPL_UNDEF
+        else if (fieldRank==3) then
+           if (hasDE_in) then
+              call ESMF_FieldGet(field,farrayPtr=ptr3d,_RC)
+           else
+               allocate(ptr3d(0,0,0))
+           end if
+           where(ptr3d==fill_value) ptr3d=MAPL_UNDEF
+        else
+           _ASSERT(.false.,'rank not supported')
+        end if
+     end if
+     _RETURN(_SUCCESS)
+
+  end subroutine swap_undef_value
 
 end module MAPL_GriddedIOMod


### PR DESCRIPTION
This fixes #1294 
When a file is read in GriddedIO (used by ExtData and my standalone bundle read routine used by Regrid_Util.x) it checks what the value of _FillValue is.
If this differs from MAPL_UNDEF, the _FillValue from the file is replace with MAPL_UNDEF after it is read but before anything else is done with the data.
Note that for now I'm only looking for _FillValue, we may want to expand this, for example what is the file also has missing_value, what is that differs from the _FillValue who wins?
I replied to the issue asking this but no one said anything. In any case this is zero-diff for GEOS and I took an existing file, changed the _FillVlaue with NCO, then confirmed if I regridded the original file and the new file with the different fill value with Regrid_Util.x I got the same answer so seems to be working to me..
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
