### PR TITLE
Fixes #1282. Make History metadata configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made history global metadata configurable. This can be done in two ways
   1. Globally for all collections by setting `COMMENT:`, `CONTACT:`, `CONVENTION:`, `INSTITUTION:`, `REFERENCES:`, and `SOURCE:` at the top of `HISTORY.rc` like `EXPDSC:`
   2. On a per-collection bases by setting `collection.comment:`, `collection.contact:`, `collection.convention:`, `collection.institution:`, `collection.references:`, and `collection.source:`
+  - The default settings for these are to match that of MAPL 2.17.0
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made history global metadata configurable. This can be done in two ways
+  1. Globally for all collections by setting `COMMENT:`, `CONTACT:`, `CONVENTION:`, `INSTITUTION:`, `REFERENCES:`, and `SOURCE:` at the top of `HISTORY.rc` like `EXPDSC:`
+  2. On a per-collection bases by setting `collection.comment:`, `collection.contact:`, `collection.convention:`, `collection.institution:`, `collection.references:`, and `collection.source:`
+
 ### Removed
 
 ### Deprecated

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -142,7 +142,7 @@ module MAPL_HistoryCollectionMod
         integer, intent(inout), optional :: rc
 
         integer :: status
-        character(len=ESMF_MAXSTR), parameter :: Iam = "AddGrid"
+        character(len=*), parameter :: Iam = "AddGrid"
         type(ESMF_Config) :: cfg
         integer :: nx,ny,im_world,jm_world
         character(len=ESMF_MAXSTR) :: tlabel

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -11,7 +11,7 @@ module MAPL_HistoryCollectionMod
   use HistoryTrajectoryMod
   use gFTL_StringStringMap
   implicit none
-  
+
   private
 
   type, public :: FieldSet
@@ -19,13 +19,25 @@ module MAPL_HistoryCollectionMod
      integer :: nfields = 0
   end type FieldSet
 
+  type, public :: HistoryCollectionGlobalAttributes
+     character(len=ESMF_MAXSTR) :: filename
+     character(len=ESMF_MAXSTR) :: descr
+     character(len=ESMF_MAXSTR) :: comment
+     character(len=ESMF_MAXSTR) :: contact
+     character(len=ESMF_MAXSTR) :: convention
+     character(len=ESMF_MAXSTR) :: institution
+     character(len=ESMF_MAXSTR) :: references
+     character(len=ESMF_MAXSTR) :: source
+     contains
+        procedure :: define_collection_attributes
+  end type HistoryCollectionGlobalAttributes
+
   type, public :: HistoryCollection
      character(len=ESMF_MAXSTR)         :: collection
      character(len=ESMF_MAXSTR)         :: filename
      character(len=ESMF_MAXSTR)         :: template
      character(len=ESMF_MAXSTR)         :: format
      character(len=ESMF_MAXSTR)         :: mode
-     character(len=ESMF_MAXSTR)         :: descr
      integer                            :: frequency
      integer                            :: acc_interval
      integer                            :: ref_date
@@ -41,7 +53,7 @@ module MAPL_HistoryCollectionMod
      integer                            :: unit
      type(ESMF_FieldBundle)             :: bundle
      type(MAPL_CFIO)                    :: MCFIO
-     type(MAPL_GriddedIO)                    :: mGriddedIO
+     type(MAPL_GriddedIO)               :: mGriddedIO
      type(VerticalData) :: vdata
      type(TimeData) :: timeInfo
      real   , pointer                   :: levels(:)     => null()
@@ -61,7 +73,7 @@ module MAPL_HistoryCollectionMod
      integer                            :: conservative
      integer                            :: voting
      integer                            :: nbits
-     integer                            :: deflate 
+     integer                            :: deflate
      integer                            :: slices
      integer                            :: Root
      integer                            :: Psize
@@ -81,7 +93,7 @@ module MAPL_HistoryCollectionMod
      type(ESMF_FIELD), pointer          :: r8(:) => null()
      type(ESMF_FIELD), pointer          :: r4(:) => null()
      character(len=ESMF_MAXSTR)         :: output_grid_label
-     type(GriddedIOItemVector)            :: items
+     type(GriddedIOItemVector)          :: items
      character(len=ESMF_MAXSTR)         :: currentFile
      character(len=ESMF_MAXPATHLEN)     :: trackFile
      logical                            :: splitField
@@ -89,16 +101,16 @@ module MAPL_HistoryCollectionMod
      logical                            :: timeseries_output = .false.
      logical                            :: recycle_track = .false.
      type(HistoryTrajectory)            :: trajectory
-     character(len=ESMF_MAXSTR)         :: positive 
+     character(len=ESMF_MAXSTR)         :: positive
+     type(HistoryCollectionGlobalAttributes) :: global_atts
      contains
         procedure :: AddGrid
-        procedure :: define_collection_attributes
   end type HistoryCollection
 
   contains
 
      function define_collection_attributes(this,rc) result(global_attributes)
-        class(HistoryCollection), intent(inout) :: this
+        class(HistoryCollectionGlobalAttributes), intent(inout) :: this
         integer, optional, intent(out) :: rc
 
         type(StringStringMap) :: global_attributes
@@ -106,18 +118,18 @@ module MAPL_HistoryCollectionMod
 
         call global_attributes%insert("Title",trim(this%descr))
         call global_attributes%insert("History","File written by MAPL_PFIO")
-        call global_attributes%insert("Source","unknown")
-        call global_attributes%insert("Contact","http://gmao.gsfc.nasa.gov")
-        call global_attributes%insert("Convention","CF")
-        call global_attributes%insert("Institution","NASA Global Modeling and Assimilation Office")
-        call global_attributes%insert("References","see MAPL documentation")
+        call global_attributes%insert("Source",trim(this%source))
+        call global_attributes%insert("Contact",trim(this%contact))
+        call global_attributes%insert("Convention",trim(this%convention))
+        call global_attributes%insert("Institution",trim(this%institution))
+        call global_attributes%insert("References",trim(this%references))
         call global_attributes%insert("Filename",trim(this%filename))
-        call global_attributes%insert("Comment","NetCDF-4")
+        call global_attributes%insert("Comment",trim(this%comment))
 
         _RETURN(_SUCCESS)
      end function define_collection_attributes
 
-     subroutine AddGrid(this,output_grids,resolution,rc) 
+     subroutine AddGrid(this,output_grids,resolution,rc)
         use MAPL_GridManagerMod
         use MAPL_AbstractGridFactoryMod
         use MAPL_ConfigMod
@@ -130,7 +142,7 @@ module MAPL_HistoryCollectionMod
         integer, intent(inout), optional :: rc
 
         integer :: status
-        character(len=ESMF_MAXSTR), parameter :: Iam = "AddGrid" 
+        character(len=ESMF_MAXSTR), parameter :: Iam = "AddGrid"
         type(ESMF_Config) :: cfg
         integer :: nx,ny,im_world,jm_world
         character(len=ESMF_MAXSTR) :: tlabel
@@ -155,7 +167,7 @@ module MAPL_HistoryCollectionMod
         _VERIFY(status)
         call MAPL_ConfigSetAttribute(cfg,value=ny, label=trim(tlabel)//".NY:",rc=status)
         _VERIFY(status)
-       
+
         if (resolution(2)==resolution(1)*6) then
           call MAPL_ConfigSetAttribute(cfg,value="Cubed-Sphere", label=trim(tlabel)//".GRID_TYPE:",rc=status)
           _VERIFY(status)
@@ -177,20 +189,20 @@ module MAPL_HistoryCollectionMod
         end if
         output_grid = grid_manager%make_grid(cfg,prefix=trim(tlabel)//'.',rc=status)
         _VERIFY(status)
-        
+
         factory => grid_manager%get_factory(output_grid,rc=status)
         _VERIFY(status)
         this%output_grid_label = factory%generate_grid_name()
         lgrid => output_grids%at(trim(this%output_grid_label))
-        if (.not.associated(lgrid)) call output_grids%insert(this%output_grid_label,output_grid) 
+        if (.not.associated(lgrid)) call output_grids%insert(this%output_grid_label,output_grid)
 
      end subroutine AddGrid
-  
+
 end module MAPL_HistoryCollectionMod
 
 module MAPL_HistoryCollectionVectorMod
   use MAPL_HistoryCollectionMod
-  
+
 #define _type type (HistoryCollection)
 #define _vector HistoryCollectionVector
 #define _iterator HistoryCollectionVectorIterator
@@ -200,7 +212,7 @@ module MAPL_HistoryCollectionVectorMod
 #undef _iterator
 #undef _vector
 #undef _type
-  
+
 end module MAPL_HistoryCollectionVectorMod
 
 module MAPL_StringFieldSetMapMod
@@ -218,5 +230,5 @@ module MAPL_StringFieldSetMapMod
 #undef _map
 #undef _value
 #undef _key
-  
+
 end module MAPL_StringFieldSetMapMod

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -505,22 +505,16 @@ contains
     _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%institution, &
                                    label ='INSTITUTION:', default='NASA Global Modeling and Assimilation Office', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%references, &
                                    label ='REFERENCES:', default='see MAPL documentation', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%contact, &
                                    label ='CONTACT:', default='http://gmao.gsfc.nasa.gov', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%comment, &
                                    label ='COMMENT:', default='NetCDF-4', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%convention, &
                                    label ='CONVENTION:', default='CF', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%source, &
                                    label ='SOURCE:', default='unknown', _RC)
-    _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%CoresPerNode, &
                                    label ='CoresPerNode:', default=min(npes,8), rc=status )
     _VERIFY(STATUS)

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -799,27 +799,21 @@ contains
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%comment, &
                                       default=INTSTATE%global_atts%comment, &
                                       label=trim(string) // 'comment:' ,_RC)
-       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%contact, &
                                       default=INTSTATE%global_atts%contact, &
                                       label=trim(string) // 'contact:' ,_RC)
-       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%convention, &
                                       default=INTSTATE%global_atts%convention, &
                                       label=trim(string) // 'convention:' ,_RC)
-       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%institution, &
                                       default=INTSTATE%global_atts%institution, &
                                       label=trim(string) // 'institution:' ,_RC)
-       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%references, &
                                       default=INTSTATE%global_atts%references, &
                                       label=trim(string) // 'references:' ,_RC)
-       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%source, &
                                       default=INTSTATE%global_atts%source, &
                                       label=trim(string) // 'source:' ,_RC)
-       _VERIFY(STATUS)
 
        call ESMF_ConfigGetAttribute ( cfg, mntly, default=0, &
                                       label=trim(string) // 'monthly:',rc=status )

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -28,7 +28,7 @@ module MAPL_HistoryGridCompMod
   use MAPL_ConfigMod
   use, intrinsic :: iso_fortran_env, only: INT64
   use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
-  use MAPL_HistoryCollectionMod, only: HistoryCollection, FieldSet
+  use MAPL_HistoryCollectionMod, only: HistoryCollection, FieldSet, HistoryCollectionGlobalAttributes
   use MAPL_HistoryCollectionVectorMod, only: HistoryCollectionVector
   use MAPL_StringFieldSetMapMod, only: StringFieldSetMap
   use MAPL_StringFieldSetMapMod, only: StringFieldSetMapIterator
@@ -105,12 +105,7 @@ module MAPL_HistoryGridCompMod
      character(len=ESMF_MAXSTR)          :: expsrc
      character(len=ESMF_MAXSTR)          :: expid
      character(len=ESMF_MAXSTR)          :: expdsc
-     character(len=ESMF_MAXSTR)          :: comment
-     character(len=ESMF_MAXSTR)          :: contact
-     character(len=ESMF_MAXSTR)          :: convention
-     character(len=ESMF_MAXSTR)          :: institution
-     character(len=ESMF_MAXSTR)          :: references
-     character(len=ESMF_MAXSTR)          :: source
+     type(HistoryCollectionGlobalAttributes) :: global_atts
      integer                             :: CoresPerNode, mype, npes
      integer                             :: AvoidRootNodeThreshold
      integer                             :: blocksize
@@ -508,23 +503,23 @@ contains
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%expdsc, &
                                    label ='EXPDSC:', default='', rc=status )
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%institution, &
-                                   label ='INSTITUTION:', default='NASA Global Modeling and Assimilation Office', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%institution, &
+                                   label ='INSTITUTION:', default='NASA Global Modeling and Assimilation Office', _RC)
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%references, &
-                                   label ='REFERENCES:', default='see MAPL documentation', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%references, &
+                                   label ='REFERENCES:', default='see MAPL documentation', _RC)
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%contact, &
-                                   label ='CONTACT:', default='http://gmao.gsfc.nasa.gov', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%contact, &
+                                   label ='CONTACT:', default='http://gmao.gsfc.nasa.gov', _RC)
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%comment, &
-                                   label ='COMMENT:', default='NetCDF-4', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%comment, &
+                                   label ='COMMENT:', default='NetCDF-4', _RC)
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%convention, &
-                                   label ='CONVENTION:', default='CF', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%convention, &
+                                   label ='CONVENTION:', default='CF', _RC)
     _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%source, &
-                                   label ='SOURCE:', default='unknown', rc=status )
+    call ESMF_ConfigGetAttribute ( config, value=INTSTATE%global_atts%source, &
+                                   label ='SOURCE:', default='unknown', _RC)
     _VERIFY(STATUS)
     call ESMF_ConfigGetAttribute ( config, value=INTSTATE%CoresPerNode, &
                                    label ='CoresPerNode:', default=min(npes,8), rc=status )
@@ -802,28 +797,28 @@ contains
                                       label=trim(string) // 'descr:' ,rc=status )
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%comment, &
-                                      default=INTSTATE%comment, &
-                                      label=trim(string) // 'comment:' ,rc=status )
+                                      default=INTSTATE%global_atts%comment, &
+                                      label=trim(string) // 'comment:' ,_RC)
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%contact, &
-                                      default=INTSTATE%contact, &
-                                      label=trim(string) // 'contact:' ,rc=status )
+                                      default=INTSTATE%global_atts%contact, &
+                                      label=trim(string) // 'contact:' ,_RC)
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%convention, &
-                                      default=INTSTATE%convention, &
-                                      label=trim(string) // 'convention:' ,rc=status )
+                                      default=INTSTATE%global_atts%convention, &
+                                      label=trim(string) // 'convention:' ,_RC)
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%institution, &
-                                      default=INTSTATE%institution, &
-                                      label=trim(string) // 'institution:' ,rc=status )
+                                      default=INTSTATE%global_atts%institution, &
+                                      label=trim(string) // 'institution:' ,_RC)
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%references, &
-                                      default=INTSTATE%references, &
-                                      label=trim(string) // 'references:' ,rc=status )
+                                      default=INTSTATE%global_atts%references, &
+                                      label=trim(string) // 'references:' ,_RC)
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, value=list(n)%global_atts%source, &
-                                      default=INTSTATE%source, &
-                                      label=trim(string) // 'source:' ,rc=status )
+                                      default=INTSTATE%global_atts%source, &
+                                      label=trim(string) // 'source:' ,_RC)
        _VERIFY(STATUS)
 
        call ESMF_ConfigGetAttribute ( cfg, mntly, default=0, &


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR makes the history metadata in MAPL more configurable.

This can be done in two ways:

1. Globally for all collections by setting `COMMENT:`, `CONTACT:`, `CONVENTION:`, `INSTITUTION:`, `REFERENCES:`, and `SOURCE:` at the top of `HISTORY.rc` like `EXPDSC:`
2. On a per-collection bases by setting `collection.comment:`, `collection.contact:`, `collection.convention:`, `collection.institution:`, `collection.references:`, and `collection.source:`

By default the values are those in MAPL 2.17.0.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1282 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Current History metadata is hardcoded to say:

```
// global attributes:
		:Comment = "NetCDF-4" ;
		:Contact = "http://gmao.gsfc.nasa.gov" ;
		:Convention = "CF" ;
		:History = "File written by MAPL_PFIO" ;
		:Institution = "NASA Global Modeling and Assimilation Office" ;
		:References = "see MAPL documentation" ;
		:Source = "unknown" ;
```
Some or all of these might not apply in each situation. This allows flexibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the model and it is zero-diff (as it should be!)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
