### PR TITLE
Add option to make time an integer variable if needed for backwards c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Option to force integer time variable in History output via the History.rc file (IntegerTime: .true./.false. default .false.) rather than the default float time variable if allowed by frequency of output
+
 ### Changed
 
 - A small performance improvement. cycle => exit in MAPL_Generic.F90

--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -131,17 +131,17 @@ contains
        time_increment = packed_hms
     case('minutes')
        if (this%integer_time) then
-          ASSERT(mod(this%frequency,60)==0,"Requested output frequency not representable as an integer minute")
+          _ASSERT(mod(this%frequency,60)==0,"Requested output frequency not representable as an integer minute")
        end if
        time_increment = packed_hms
     case('hours')
        if (this%integer_time) then
-          ASSERT(mod(this%frequency,3600)==0,"Requested output frequency not representable as an integer hour")
+          _ASSERT(mod(this%frequency,3600)==0,"Requested output frequency not representable as an integer hour")
        end if
        time_increment = packed_hms
     case('days')
        if (this%integer_time) then
-          ASSERT(mod(this%frequency,86400)==0,"Requested output frequency not representable as an integer day")
+          _ASSERT(mod(this%frequency,86400)==0,"Requested output frequency not representable as an integer day")
        end if
        time_increment = this%frequency/86400
     case default

--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -94,10 +94,9 @@ contains
     character(len=ESMF_MAXSTR) :: startTime,timeUnits
     type(ESMF_Time) :: currTime
     integer :: i1,i2,i3,ipos1,ipos2,isc,imn,ihr
-    logical :: integer_representable
     integer :: begin_date, begin_time, time_increment, packed_hms
 
-    _ASSERT(this%frequency/=TimeData_uninit_int,"TimeData object was not created before use")
+    _ASSERT(this%frequency/=TimeData_uninit_int,"Frequency component was not set before use.")
 
     call ESMF_ClockGet(this%clock,currTime=currTime,rc=status)
     _VERIFY(status)
@@ -129,24 +128,25 @@ contains
     packed_hms=10000*ihr+100*imn+isc 
     select case(trim(this%funits))
     case('seconds')
-       integer_representable = .true.
        time_increment = packed_hms
     case('minutes')
-       integer_representable = mod(this%frequency,60)==0
+       if (this%integer_time) then
+          ASSERT(mod(this%frequency,60)==0,"Requested output frequency not representable as an integer minute")
+       end if
        time_increment = packed_hms
     case('hours')
-       integer_representable = mod(this%frequency,3600) == 0
+       if (this%integer_time) then
+          ASSERT(mod(this%frequency,3600)==0,"Requested output frequency not representable as an integer hour")
+       end if
        time_increment = packed_hms
     case('days')
-       integer_representable = mod(this%frequency,86400) == 0
+       if (this%integer_time) then
+          ASSERT(mod(this%frequency,86400)==0,"Requested output frequency not representable as an integer day")
+       end if
        time_increment = this%frequency/86400
     case default
        _ASSERT(.false., 'Not supported yet')
     end select
-
-    if (this%integer_time) then
-        _ASSERT(integer_representable,"time interval requested not integer representable")
-    end if
 
     call this%tvec%clear()
     this%tcount=0

--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -10,15 +10,16 @@ module MAPL_TimeDataMod
   implicit none
 
   private
-
+  integer, parameter :: TimeData_uninit_int = -1
   type, public :: timeData
      type(ESMF_Clock) :: clock
      integer :: ntime
      integer :: tcount
      type(ESMFTimeVector) :: tvec
-     integer :: frequency
+     integer :: frequency = TimeData_uninit_int 
      type(ESMF_TimeInterval) :: offset
      character(len=:), allocatable :: funits
+     logical :: integer_time
    contains
      procedure :: add_time_to_metadata
      procedure :: define_time_variable
@@ -33,13 +34,14 @@ module MAPL_TimeDataMod
   end interface timeData
 contains
 
-  function new_time_data(clock,ntime,frequency,offset,funits,rc) result(tData)
+  function new_time_data(clock,ntime,frequency,offset,funits,integer_time,rc) result(tData)
     type(timeData) :: tData
     type(ESMF_Clock),intent(inout) :: clock
     integer, intent(in) :: ntime
     integer, intent(in) :: frequency
     type(ESMF_TimeInterval) :: offset
     character(len=*), optional, intent(in) :: funits
+    logical, optional, intent(in) :: integer_time
     integer, optional, intent(Out) :: rc
 
     tdata%clock=clock
@@ -50,6 +52,12 @@ contains
        tdata%funits=funits
     else
        tdata%funits="minutes"
+    end if
+
+    if(present(integer_time)) then
+      tdata%integer_time = integer_time
+    else
+      tdata%integer_time = .false.
     end if
 
     _RETURN(ESMF_SUCCESS)
@@ -85,52 +93,74 @@ contains
     integer :: status
     character(len=ESMF_MAXSTR) :: startTime,timeUnits
     type(ESMF_Time) :: currTime
-    integer :: i1,i2,i3,i123,ipos1,ipos2,isc,imn,ihr,ifreq
+    integer :: i1,i2,i3,ipos1,ipos2,isc,imn,ihr
+    logical :: integer_representable
+    integer :: begin_date, begin_time, time_increment, packed_hms
 
-    call ESMF_CLockGet(this%clock,currTime=currTime,rc=status)
+    _ASSERT(this%frequency/=TimeData_uninit_int,"TimeData object was not created before use")
+
+    call ESMF_ClockGet(this%clock,currTime=currTime,rc=status)
     _VERIFY(status)
     currTime = currTime - this%offset
     call ESMF_TimeGet(currTime,timeString=StartTime,rc=status)
     _VERIFY(status)
     timeUnits = trim(this%funits)//" since "//startTime( 1: 10)//" "//startTime(12:19)
-    v = Variable(type=PFIO_REAL32,dimensions='time')
-    call v%add_attribute('long_name','time')
-    call v%add_attribute('units',trim(timeUnits))
   
     ipos1=index(startTime,"-")
     ipos2=index(startTime,"-",back=.true.)
     read(startTime(1:ipos1-1),'(i4)')i1
     read(startTime(ipos1+1:ipos2-1),'(i2)')i2
     read(startTime(ipos2+1:10),'(i2)')i3
-    i123=10000*i1+100*i2+i3
-    call v%add_attribute('begin_date',i123)
+    begin_date=10000*i1+100*i2+i3
 
     ipos1=index(startTime,":")
     ipos2=index(startTime,":",back=.true.)
     read(startTime(12:ipos1-1),'(i2)')i1
     read(startTime(ipos1+1:ipos2-1),'(i2)')i2
     read(startTime(ipos2+1:19),'(i2)')i3
-    i123=10000*i1+100*i2+i3
-    call v%add_attribute('begin_time',i123)
+    begin_time=10000*i1+100*i2+i3
 
+    isc=mod(this%frequency,60)
+    i2=this%frequency-isc
+    i2=i2/60
+    imn=mod(i2,60)
+    i2=i2-imn
+    ihr=i2/60
+    packed_hms=10000*ihr+100*imn+isc 
     select case(trim(this%funits))
+    case('seconds')
+       integer_representable = .true.
+       time_increment = packed_hms
     case('minutes')
-       isc=mod(this%frequency,60)
-       i2=this%frequency-isc
-       i2=i2/60
-       imn=mod(i2,60)
-       i2=i2-imn
-       ihr=i2/60
-       ifreq=10000*ihr+100*imn+isc 
+       integer_representable = mod(this%frequency,60)==0
+       time_increment = packed_hms
+    case('hours')
+       integer_representable = mod(this%frequency,3600) == 0
+       time_increment = packed_hms
     case('days')
-       ifreq = this%frequency/86400
+       integer_representable = mod(this%frequency,86400) == 0
+       time_increment = this%frequency/86400
     case default
        _ASSERT(.false., 'Not supported yet')
     end select
-    call v%add_attribute('time_increment',ifreq)
+
+    if (this%integer_time) then
+        _ASSERT(integer_representable,"time interval requested not integer representable")
+    end if
 
     call this%tvec%clear()
     this%tcount=0
+
+    if (this%integer_time) then
+       v = Variable(type=PFIO_INT32,dimensions='time')
+    else
+       v = Variable(type=PFIO_REAL32,dimensions='time')
+    end if
+    call v%add_attribute('long_name','time')
+    call v%add_attribute('units',trim(timeUnits))
+    call v%add_attribute('begin_date',begin_date)
+    call v%add_attribute('begin_time',begin_time)
+    call v%add_attribute('time_increment',time_increment)
     
     _RETURN(ESMF_SUCCESS)
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -113,6 +113,7 @@ module MAPL_HistoryGridCompMod
      integer                             :: PrePost
      integer                             :: version
      logical                             :: fileOrderAlphabetical
+     logical                             :: integer_time
      integer                             :: collectionWriteSplit
      integer                             :: serverSizeSplit
   end type HISTORY_STATE
@@ -539,6 +540,8 @@ contains
     else
        _ASSERT(.false.,'needs informative message')
     end if
+
+    call ESMF_ConfigGetAttribute(config, value=intstate%integer_time,label="IntegerTime:", default=.false.,_RC)
 
     call ESMF_ConfigGetAttribute(config, value=IntState%collectionWriteSplit, &
          label = 'CollectionWriteSplit:', default=0, rc=status)
@@ -2473,9 +2476,9 @@ ENDDO PARSER
                nextMonth = currTime - oneMonth
                dur = nextMonth - currTime
                call ESMF_TimeIntervalGet(dur, s=sec, __RC__)
-             list(n)%timeInfo = TimeData(clock,tm,sec,IntState%stampoffset(n),'days')
+             list(n)%timeInfo = TimeData(clock,tm,sec,IntState%stampoffset(n),funits='days')
           else
-             list(n)%timeInfo = TimeData(clock,tm,MAPL_nsecf(list(n)%frequency),IntState%stampoffset(n))
+             list(n)%timeInfo = TimeData(clock,tm,MAPL_nsecf(list(n)%frequency),IntState%stampoffset(n),integer_time=intstate%integer_time)
           end if
           if (list(n)%timeseries_output) then
              list(n)%trajectory = HistoryTrajectory(trim(list(n)%trackfile),rc=status)


### PR DESCRIPTION
Add a global option to the History.rc to make time an integer variable for backwards compatibility if desired (by default the time variable is a floating point variable as it should be). If this is not possible with the time interval specified throws an error. Also this option is not used in collections specifying monthly output as I'm worried about breaking this feature.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because the the existing GEOS file spec says the time variable is an integer with units of minutes since date/time although this needs to change as GEOSgcm.x runs operationally at a 7.5 minute timestep. Note a similar change was made in the MAPL v2.8.0.1 patch, this gives the option of keeping integer time if somebody really wants that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
