### PR TITLE
New generic set_services is now in place with the legacy interface being

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed failures to fully trap errors in
+  . History GC
+  . MemUtils
+  . `register_generic_entry_points`
 - Fixed issue in `CMakePresets.json` where Ninja presets were broken
 - Fixed io profiler report format
 - Fixed issue on macOS where enabling memutils caused crash
+
 
 ### Added
 
@@ -23,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Major refactoring of GenericSetServices
+  Work is not completed, but a new layer is introduced with the intent that the user SetServices is called
+  from with in the new layer as opposed to the previous mechanism that obligated user SetServices to call
+  generic.   That call is now deprecated.   Significant cleanup remains.
+- Improved diagnostic message for profiler imbalances at end of run.
+  Now gives the name of the timer that has not been stopped when
+  finalizing a profiler.
 - A small performance improvement. cycle => exit in MAPL_Generic.F90
 - Made history global metadata configurable. This can be done in two ways
   1. Globally for all collections by setting `COMMENT:`, `CONTACT:`, `CONVENTION:`, `INSTITUTION:`, `REFERENCES:`, and `SOURCE:` at the top of `HISTORY.rc` like `EXPDSC:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed failures to fully trap errors in
-  . History GC
-  . MemUtils
-  . `register_generic_entry_points`
+  - History GC
+  - MemUtils
+  - `register_generic_entry_points`
 - Fixed issue in `CMakePresets.json` where Ninja presets were broken
 - Fixed io profiler report format
 - Fixed issue on macOS where enabling memutils caused crash

--- a/base/ApplicationSupport.F90
+++ b/base/ApplicationSupport.F90
@@ -61,8 +61,7 @@ module MAPL_ApplicationSupport
       else
          comm_world=MPI_COMM_WORLD
       end if
-      call stop_global_time_profiler(rc=status)
-      _VERIFY(status)
+      call stop_global_time_profiler(_RC)
       call report_global_profiler(comm=comm_world)
       call finalize_profiler()
       call finalize_pflogger()

--- a/base/MAPL_MemUtils.F90
+++ b/base/MAPL_MemUtils.F90
@@ -395,7 +395,7 @@ module MAPL_MemUtilsMod
 #if defined(__sgi) || defined(__aix) || defined(__SX)
     m = memuse()*1e-3
 #else
-    call mem_dump(mhwm, mrss, memused, swapused, commitlimit, committed_as)
+    call mem_dump(mhwm, mrss, memused, swapused, commitlimit, committed_as, _RC)
 #endif
     call MPI_Comm_Size(comm_,npes,status)
     if (MAPL_MemUtilsMode == MAPL_MemUtilsModeFull) then

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -42,6 +42,7 @@ set (srcs
 
   GenericCplComp.F90
 
+  SetServicesWrapper.F90
   MaplGeneric.F90
 
   MAPL_Generic.F90

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -126,6 +126,7 @@ module MAPL_GenericMod
    use MAPL_ExceptionHandling
    use MAPL_KeywordEnforcerMod
    use MAPL_StringTemplate
+   use MAPL_SetServicesWrapper
    use mpi
    use netcdf
    use pFlogger, only: logging, Logger
@@ -143,6 +144,7 @@ module MAPL_GenericMod
    private
 
    public MAPL_GenericSetServices
+   public new_generic_setservices
    public MAPL_GenericInitialize
    public MAPL_GenericRunChildren
    public MAPL_GenericFinalize
@@ -391,13 +393,14 @@ module MAPL_GenericMod
    !BOP
    !BOC
    type, extends(MaplGenericComponent) ::  MAPL_MetaComp
-      private
+!      private
       ! Move to Base ?
       character(len=ESMF_MAXSTR)               :: COMPNAME
       type (ESMF_Config             )          :: CF
       character(:), allocatable :: full_name ! Period separated list of ancestor names
       real                                     :: HEARTBEAT
 
+      class(AbstractSetServicesWrapper), allocatable, public :: user_setservices_wrapper
       ! Move to decorator?
       type (DistributedProfiler), public :: t_profiler
 
@@ -548,202 +551,17 @@ contains
       ! Create the generic state, intializing its configuration and grid.
       !----------------------------------------------------------
       call MAPL_InternalStateRetrieve( GC, meta, __RC__)
-
-      call meta%t_profiler%start('generic',__RC__)
-
-      call register_generic_entry_points(gc, __RC__)
+!!$
+!!$      call meta%t_profiler%start('generic',__RC__)
+!!$
+!!$      call register_generic_entry_points(gc, __RC__)
       call MAPL_GetRootGC(GC, meta%rootGC, __RC__)
-      call setup_children(meta, __RC__)
 
-      call meta%t_profiler%stop('generic',__RC__)
-
+!!$      call meta%t_profiler%stop('generic',__RC__)
+!!$
       _RETURN(ESMF_SUCCESS)
 
    contains
-
-      subroutine register_generic_entry_points(gc, rc)
-         type(ESMF_GridComp), intent(inout) :: gc
-         integer, optional, intent(out) :: rc
-
-         integer :: status
-
-         if (.not. associated(meta%phase_init)) then
-            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_INITIALIZE, MAPL_GenericInitialize,  __RC__)
-         endif
-
-         if (.not. associated(meta%phase_run)) then
-            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_RUN, MAPL_GenericRunChildren,  __RC__)
-         endif
-
-
-         if (.not. associated(meta%phase_final)) then
-            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_FINALIZE, MAPL_GenericFinalize,  __RC__)
-         endif
-
-         !ALT check record!!!
-         if (.not. associated(meta%phase_record)) then
-            call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_WRITERESTART, MAPL_GenericRecord, __RC__)
-         end if
-         _ASSERT(size(meta%phase_record)==1,'needs informative message')  !ALT: currently we support only 1 record
-
-         if (.not.associated(meta%phase_coldstart)) then
-            !ALT: this part is not supported yet
-            !      call MAPL_GridCompSetEntryPoint(GC, ESMF_METHOD_READRESTART, &
-            !                                      MAPL_Coldstart, __RC__)
-         endif
-      end subroutine register_generic_entry_points
-
-#define LOWEST_(c) m=0; do while (m /= c) ;\
-      m = c; c=label(c);\
-   enddo
-
-      ! Complex algorithm - difficult to explain
-      recursive subroutine setup_children(meta, rc)
-         type (MAPL_MetaComp), target, intent(inout) :: meta
-         integer, optional, intent(out) :: rc
-
-         integer :: nc
-         integer :: i
-         integer :: ts
-         integer :: lbl, k, m
-         type (VarConn), pointer :: connect
-         type(StateSpecification) :: specs
-         type (MAPL_VarSpec), pointer :: im_specs(:)
-         type (MAPL_VarSpec), pointer :: ex_specs(:)
-         type (MAPL_VarSpecPtr), pointer :: ImSpecPtr(:)
-         type (MAPL_VarSpecPtr), pointer :: ExSpecPtr(:)
-         type(ESMF_Field), pointer :: field
-         type(ESMF_FieldBundle), pointer :: bundle
-         type(ESMF_State), pointer :: state
-         integer :: fLBL, tLBL
-         integer :: good_label, bad_label
-         integer, pointer :: label(:)
-
-         NC = meta%get_num_children()
-         CHILDREN: if(nc > 0) then
-
-            do I=1,NC
-               call MAPL_GenericStateClockAdd(GC, name=trim(meta%GCNameList(I)), __RC__)
-            end do
-
-
-            ! The child should've been already created by MAPL_AddChild
-            ! and set his services should've been called.
-            ! -------------------------------------
-
-            ! Create internal couplers and composite
-            ! component's Im/Ex specs.
-            !---------------------------------------
-
-            call MAPL_WireComponent(GC, __RC__)
-
-            ! Relax connectivity for non-existing imports
-            if (NC > 0) then
-
-               CONNECT => meta%connectList%CONNECT
-
-               allocate (ImSpecPtr(NC), ExSpecPtr(NC), __STAT__)
-
-               DO I = 1, NC
-                  gridcomp => meta%get_child_gridcomp(i)
-                  call MAPL_GridCompGetVarSpecs(gridcomp, &
-                       IMPORT=IM_SPECS, EXPORT=EX_SPECS, __RC__)
-                  ImSpecPtr(I)%Spec => IM_SPECS
-                  ExSpecPtr(I)%Spec => EX_SPECS
-               END DO
-
-               call connect%checkReq(ImSpecPtr, ExSpecPtr, __RC__)
-
-               deallocate (ImSpecPtr, ExSpecPtr)
-
-            end if
-
-            ! If I am root call Label from here; everybody else
-            !  will be called recursively from Label
-            !--------------------------------------------------
-            ROOT: if (.not. associated(meta%parentGC)) then
-
-               call MAPL_GenericConnCheck(GC, __RC__)
-
-               ! Collect all IMPORT and EXPORT specs in the entire tree in one list
-               !-------------------------------------------------------------------
-               call MAPL_GenericSpecEnum(GC, SPECS, __RC__)
-
-               ! Label each spec by its place on the list--sort of.
-               !--------------------------------------------------
-
-               TS = SPECS%var_specs%size()
-               allocate(LABEL(TS), __STAT__)
-
-               do I = 1, TS
-                  LABEL(I)=I
-               end do
-
-               ! For each spec...
-               !-----------------
-
-               do I = 1, TS
-
-                  !  Get the LABEL attribute on the spec
-                  !-------------------------------------
-                  call MAPL_VarSpecGet(SPECS%old_var_specs(I), LABEL=LBL, __RC__)
-                  _ASSERT(LBL > 0, "GenericSetServices :: Expected LBL > 0.")
-
-                  ! Do something to sort labels???
-                  !-------------------------------
-                  LOWEST_(LBL)
-
-                  good_label = min(lbl, i)
-                  bad_label = max(lbl, i)
-                  label(bad_label) = good_label
-
-
-               end do
-
-               if (associated(meta%LINK)) then
-                  do I = 1, size(meta%LINK)
-                     fLBL = MAPL_LabelGet(meta%LINK(I)%ptr%FROM, __RC__)
-                     tLBL = MAPL_LabelGet(meta%LINK(I)%ptr%TO,   __RC__)
-                     LOWEST_(fLBL)
-                     LOWEST_(tLBL)
-
-                     if (fLBL < tLBL) then
-                        good_label = fLBL
-                        bad_label  = tLBL
-                     else
-                        good_label = tLBL
-                        bad_label  = fLBL
-                     end if
-                     label(bad_label) = good_label
-                  end do
-               end if
-
-               K=0
-               do I = 1, TS
-                  LBL = LABEL(I)
-                  LOWEST_(LBL)
-
-                  if (LBL == I) then
-                     K = K+1
-                  else
-                     call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), FIELDPTR = FIELD, __RC__)
-                     call MAPL_VarSpecSet(SPECS%old_var_specs(I), FIELDPTR = FIELD, __RC__)
-                     call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), BUNDLEPTR = BUNDLE, __RC__  )
-                     call MAPL_VarSpecSet(SPECS%old_var_specs(I), BUNDLEPTR = BUNDLE, __RC__  )
-                     call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), STATEPTR = STATE, __RC__  )
-                     call MAPL_VarSpecSet(SPECS%old_var_specs(I), STATEPTR = STATE, __RC__  )
-                  end if
-
-                  call MAPL_VarSpecSet(SPECS%old_var_specs(I), LABEL=LBL, __RC__)
-               end do
-
-               deallocate(LABEL, __STAT__)
-
-            end if ROOT
-
-         end if CHILDREN  !  Setup children
-      end subroutine setup_children
-#undef LOWEST_
 
    end subroutine MAPL_GenericSetServices
 
@@ -4549,8 +4367,9 @@ contains
       call child_meta%t_profiler%start('SetService',__RC__)
 
 !!$     gridcomp => META%GET_CHILD_GRIDCOMP(I)
-      call ESMF_GridCompSetServices ( child_meta%gridcomp, SS, userRC=userRC, __RC__ )
-      _VERIFY(userRC)
+      child_meta%user_setservices_wrapper = ProcSetServicesWrapper(SS)
+!!$      call ESMF_GridCompSetServices ( child_meta%gridcomp, SS, userRC=userRC, __RC__ )
+!!$      _VERIFY(userRC)
 
       call child_meta%t_profiler%stop('SetService',__RC__)
       call child_meta%t_profiler%stop(__RC__)
@@ -4801,10 +4620,11 @@ contains
       end if
 
       shared_object_library_to_load = adjust_dso_name(sharedObj)
-      call ESMF_GridCompSetServices ( child_meta%gridcomp, userRoutine, &
-           sharedObj=shared_object_library_to_load,userRC=userRC,__RC__)
-      _VERIFY(userRC)
+!!$      call ESMF_GridCompSetServices ( child_meta%gridcomp, userRoutine, &
+!!$           sharedObj=shared_object_library_to_load,userRC=userRC,__RC__)
+!!$      _VERIFY(userRC)
 
+      child_meta%user_setservices_wrapper = DSO_SetServicesWrapper(sharedObj, userRoutine)
       call child_meta%t_profiler%stop('SetService',__RC__)
       call child_meta%t_profiler%stop(__RC__)
       call t_p%stop(trim(name),__RC__)
@@ -11299,5 +11119,220 @@ contains
       end if
       _RETURN(ESMF_SUCCESS)
    end subroutine warn_empty
+
+   ! Interface mandated by ESMF
+   recursive subroutine new_generic_setservices(gc, rc)
+      type(ESMF_GridComp), intent(inout) :: gc
+      integer, intent(out) :: rc
+
+      type(MAPL_MetaComp), pointer :: meta
+      integer :: status
+
+      call MAPL_InternalStateGet (gc, meta, _RC)
+      call meta%t_profiler%start(_RC)
+
+      call meta%user_setservices_wrapper%run(gc, _RC)
+      ! TODO: Fix this is a terrible kludge.
+      if (meta%compname /= 'CAP') then
+         call register_generic_entry_points(gc, _RC)
+      end if
+      call run_children_generic_setservices(meta,_RC)
+
+      ! TODO: Fix this is a terrible kludge.
+      if (meta%compname /= 'CAP') then
+         call process_connections(meta,_RC) ! needs better name
+      end if
+
+      call meta%t_profiler%stop(_RC)
+
+      _RETURN(_SUCCESS)
+   contains
+
+#define LOWEST_(c) m=0; do while (m /= c) ; m = c; c=label(c); enddo
+
+      recursive subroutine run_children_generic_setservices(meta, rc)
+         type(MAPL_MetaComp), pointer :: meta
+         integer, intent(out) :: rc
+
+         integer :: status, i
+         type(ESMF_GridComp), pointer :: child_gc
+
+         do i = 1, meta%get_num_children()
+            child_gc => meta%get_child_gridcomp(i)
+            call new_generic_setservices(child_gc, _RC)
+         end do
+
+         _RETURN(_SUCCESS)
+      end subroutine run_children_generic_setservices
+
+      recursive subroutine process_connections(meta, rc)
+         type(MAPL_MetaComp), pointer :: meta
+         integer, intent(out) :: rc
+
+         integer :: status
+         integer :: i, m, k
+         integer :: ts
+         integer :: fLBL, tLBL, lbl
+         integer :: good_label, bad_label
+         integer, pointer :: label(:)
+         type(StateSpecification) :: specs
+         type(ESMF_Field), pointer :: field
+         type(ESMF_FieldBundle), pointer :: bundle
+         type(ESMF_State), pointer :: state
+         type (MAPL_VarSpec), pointer :: im_specs(:)
+         type (MAPL_VarSpec), pointer :: ex_specs(:)
+         type (MAPL_VarSpecPtr), pointer :: ImSpecPtr(:)
+         type (MAPL_VarSpecPtr), pointer :: ExSpecPtr(:)
+         type (VarConn), pointer :: connect
+         type(ESMF_GridComp), pointer :: child_gc
+         integer :: nc
+         nc = meta%get_num_children()
+
+         call MAPL_WireComponent(gc, _RC)
+
+         nc = meta%get_num_children()
+
+         ! Relax connectivity for non-existing imports
+         CONNECT => meta%connectList%CONNECT
+
+         allocate (ImSpecPtr(nc), ExSpecPtr(nc), __STAT__)
+
+         do I = 1, nc
+            child_gc => meta%get_child_gridcomp(i)
+            call MAPL_GridCompGetVarSpecs(child_gc, &
+                 import=IM_SPECS, EXPORT=EX_SPECS, __RC__)
+            ImSpecPtr(I)%Spec => IM_SPECS
+            ExSpecPtr(I)%Spec => EX_SPECS
+         end do
+
+         call connect%checkReq(ImSpecPtr, ExSpecPtr, __RC__)
+
+         deallocate (ImSpecPtr, ExSpecPtr)
+
+
+
+
+         ! If I am root call Label from here; everybody else
+         !  will be called recursively from Label
+         !--------------------------------------------------
+         ROOT: if (.not. associated(meta%parentGC)) then
+
+            call MAPL_GenericConnCheck(GC, __RC__)
+
+            ! Collect all IMPORT and EXPORT specs in the entire tree in one list
+            !-------------------------------------------------------------------
+            call MAPL_GenericSpecEnum(GC, SPECS, __RC__)
+
+            ! Label each spec by its place on the list--sort of.
+            !--------------------------------------------------
+
+            TS = SPECS%var_specs%size()
+            allocate(LABEL(TS), __STAT__)
+
+            do I = 1, TS
+               LABEL(I)=I
+            end do
+
+            ! For each spec...
+            !-----------------
+
+            do I = 1, TS
+
+               !  Get the LABEL attribute on the spec
+               !-------------------------------------
+               call MAPL_VarSpecGet(SPECS%old_var_specs(I), LABEL=LBL, __RC__)
+               _ASSERT(LBL > 0, "GenericSetServices :: Expected LBL > 0.")
+
+               ! Do something to sort labels???
+               !-------------------------------
+               LOWEST_(LBL)
+
+               good_label = min(lbl, i)
+               bad_label = max(lbl, i)
+               label(bad_label) = good_label
+
+
+            end do
+
+            if (associated(meta%LINK)) then
+               do I = 1, size(meta%LINK)
+                  fLBL = MAPL_LabelGet(meta%LINK(I)%ptr%FROM, __RC__)
+                  tLBL = MAPL_LabelGet(meta%LINK(I)%ptr%TO,   __RC__)
+                  LOWEST_(fLBL)
+                  LOWEST_(tLBL)
+
+                  if (fLBL < tLBL) then
+                     good_label = fLBL
+                     bad_label  = tLBL
+                  else
+                     good_label = tLBL
+                     bad_label  = fLBL
+                  end if
+                  label(bad_label) = good_label
+               end do
+            end if
+
+            K=0
+            do I = 1, TS
+               LBL = LABEL(I)
+               LOWEST_(LBL)
+
+               if (LBL == I) then
+                  K = K+1
+               else
+                  call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), FIELDPTR = FIELD, __RC__)
+                  call MAPL_VarSpecSet(SPECS%old_var_specs(I), FIELDPTR = FIELD, __RC__)
+                  call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), BUNDLEPTR = BUNDLE, __RC__  )
+                  call MAPL_VarSpecSet(SPECS%old_var_specs(I), BUNDLEPTR = BUNDLE, __RC__  )
+                  call MAPL_VarSpecGet(SPECS%old_var_specs(LBL), STATEPTR = STATE, __RC__  )
+                  call MAPL_VarSpecSet(SPECS%old_var_specs(I), STATEPTR = STATE, __RC__  )
+               end if
+
+               call MAPL_VarSpecSet(SPECS%old_var_specs(I), LABEL=LBL, __RC__)
+            end do
+
+            deallocate(LABEL, __STAT__)
+
+         end if ROOT
+
+         _RETURN(_SUCCESS)
+      end subroutine process_connections
+#undef LOWEST_
+
+
+      subroutine register_generic_entry_points(gc, rc)
+         type(ESMF_GridComp), intent(inout) :: gc
+         integer, optional, intent(out) :: rc
+
+         integer :: status
+
+         if (.not. associated(meta%phase_init)) then
+            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_INITIALIZE, MAPL_GenericInitialize,  __RC__)
+         endif
+
+         if (.not. associated(meta%phase_run)) then
+            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_RUN, MAPL_GenericRunChildren,  __RC__)
+         endif
+
+
+         if (.not. associated(meta%phase_final)) then
+            call MAPL_GridCompSetEntrypoint(GC, ESMF_METHOD_FINALIZE, MAPL_GenericFinalize,  __RC__)
+         endif
+
+         if (.not. associated(meta%phase_record)) then
+            call MAPL_GridCompSetEntryPoint ( GC, ESMF_METHOD_WRITERESTART, MAPL_GenericRecord, __RC__)
+         end if
+         _ASSERT(size(meta%phase_record)==1,'Currently, only 1 record is supported.')
+
+         if (.not.associated(meta%phase_coldstart)) then
+            ! not supported
+         endif
+         _RETURN(_SUCCESS)
+      end subroutine register_generic_entry_points
+
+
+
+   end subroutine new_generic_setservices
+
 
 end module MAPL_GenericMod

--- a/generic/SetServicesWrapper.F90
+++ b/generic/SetServicesWrapper.F90
@@ -1,0 +1,84 @@
+#include "MAPL_ErrLog.h"
+module mapl_SetServicesWrapper
+   use ESMF
+   use MAPL_KeywordEnforcerMod
+   use mapl_ErrorHandlingMod
+   implicit none
+   private
+
+   public :: AbstractSetServicesWrapper
+   public :: DSO_SetServicesWrapper
+   public :: ProcSetServicesWrapper
+
+
+   type, abstract :: AbstractSetServicesWrapper
+   contains
+      procedure(I_Run), deferred :: run
+   end type AbstractSetServicesWrapper
+
+   type, extends(AbstractSetServicesWrapper) :: DSO_SetServicesWrapper
+      character(:), allocatable :: sharedObj
+      character(:), allocatable :: userRoutine
+   contains
+      procedure :: run => run_dso
+   end type DSO_SetServicesWrapper
+
+   type, extends(AbstractSetServicesWrapper) :: ProcSetServicesWrapper
+      procedure(I_SetServices), nopass, pointer :: userRoutine
+   contains
+      procedure :: run => run_proc
+   end type ProcSetServicesWrapper
+
+   abstract interface
+      subroutine I_Run(this, gc, unusable, rc)
+         use ESMF
+         use MAPL_KeywordEnforcerMod
+         import AbstractSetServicesWrapper
+         class(AbstractSetServicesWrapper), intent(in) :: this
+         type(ESMF_GridComp), intent(inout) :: gc
+         class(KeywordEnforcer), optional, intent(in) :: unusable
+         integer, optional, intent(out) :: rc
+      end subroutine I_Run
+
+      subroutine I_SetServices(gc, rc)
+         use ESMF
+         type(ESMF_GridComp) :: gc
+         integer, intent(out) :: rc
+      end subroutine I_SetServices
+
+   end interface
+
+contains
+
+   recursive subroutine run_dso(this, gc, unusable, rc)
+      class(DSO_SetServicesWrapper), intent(in) :: this
+      type(ESMF_GridComp), intent(inout) :: gc
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status, userRC
+      
+      call ESMF_GridCompSetServices(gc, this%userRoutine, sharedObj=this%sharedObj, userRC=userRC, _RC)
+      _VERIFY(userRC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine run_dso
+      
+      
+   recursive subroutine run_proc(this, gc, unusable, rc)
+      class(ProcSetServicesWrapper), intent(in) :: this
+      type(ESMF_GridComp), intent(inout) :: gc
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status, userRC
+
+      call ESMF_GridCompSetServices(gc, this%userRoutine, userRC=userRC, _RC)
+      _VERIFY(userRC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine run_proc
+
+end module mapl_SetServicesWrapper

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -315,7 +315,7 @@ contains
      _UNUSED_DUMMY(unusable)
 
      call MAPL_CapGridCompCreate(this%cap_gc, this%set_services, this%get_cap_rc_file(), &
-           this%name, this%get_egress_file(), n_run_phases=n_run_phases, rc=status)
+           this%name, this%get_egress_file(), this%comm_world, n_run_phases=n_run_phases, rc=status)
      _VERIFY(status)
      _RETURN(_SUCCESS)
    end subroutine initialize_cap_gc

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -145,11 +145,6 @@ contains
     meta%user_setservices_wrapper = ProcSetServicesWrapper(set_services_gc)
     call MAPL_Set(meta, CF=cap%config, __RC__)
 
-    block
-      character(ESMF_MAXSTR) :: root_name
-      call MAPL_GetResource(meta, root_name, "ROOT_NAME:", default = "ROOT", _RC)
-    end block
-
     call MAPL_Set(meta, name=cap_name, component=stub_component, __RC__)
 
     cap_wrapper%ptr => cap

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -103,12 +103,15 @@ module MAPL_CapGridCompMod
 contains
 
   
-   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file, unusable, n_run_phases, rc)
+   subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file, comm_world, unusable, n_run_phases, rc)
+      use MAPL_SetServicesWrapper
       use mapl_StubComponent
+      use mapl_profiler
     type(MAPL_CapGridComp), intent(out), target :: cap
     procedure() :: root_set_services
     character(*), intent(in) :: cap_rc, name
     character(len=*), optional, intent(in) :: final_file
+    integer, intent(in) :: comm_world
     class(KeywordEnforcer), optional, intent(in) :: unusable
     integer, optional, intent(in)  :: n_run_phases
     integer, optional, intent(out) :: rc
@@ -137,7 +140,15 @@ contains
 
     meta => null()
     call MAPL_InternalStateCreate(cap%gc, meta, __RC__)
+
+    meta%t_profiler = DistributedProfiler(trim(cap_name), MpiTimerGauge(), comm=comm_world)
+    meta%user_setservices_wrapper = ProcSetServicesWrapper(set_services_gc)
     call MAPL_Set(meta, CF=cap%config, __RC__)
+
+    block
+      character(ESMF_MAXSTR) :: root_name
+      call MAPL_GetResource(meta, root_name, "ROOT_NAME:", default = "ROOT", _RC)
+    end block
 
     call MAPL_Set(meta, name=cap_name, component=stub_component, __RC__)
 
@@ -375,10 +386,6 @@ contains
     call MAPL_GetResource(MAPLOBJ, ROOT_CF, "ROOT_CF:", default = "ROOT.rc", rc = status) 
     _VERIFY(status)
 
-    ! !RESOURCE_ITEM: string :: Name to assign to the ROOT component
-    call MAPL_GetResource(MAPLOBJ, ROOT_NAME, "ROOT_NAME:", default = "ROOT", rc = status) 
-    _VERIFY(status)
-
     ! !RESOURCE_ITEM: string :: Name of HISTORY's config file 
     call MAPL_GetResource(MAPLOBJ, HIST_CF, "HIST_CF:", default = "HIST.rc", rc = status) 
     _VERIFY(status)
@@ -391,11 +398,6 @@ contains
     call MAPL_GetResource(MAPLOBJ, enableTimers, "MAPL_ENABLE_TIMERS:", default = 'NO', rc = status)
     _VERIFY(status)
 
-    ! !RESOURCE_ITEM: string :: Control Memory Diagnostic Utility 
-    call MAPL_GetResource(MAPLOBJ, enableMemUtils, "MAPL_ENABLE_MEMUTILS:", default='NO', rc = status)
-    _VERIFY(status)
-    call MAPL_GetResource(MAPLOBJ, MemUtilsMode, "MAPL_MEMUTILS_MODE:", default = MAPL_MemUtilsModeBase, rc = status)
-    _VERIFY(status)
     !EOR
     enableTimers = ESMF_UtilStringUpperCase(enableTimers, rc = status)
     _VERIFY(status)
@@ -412,18 +414,8 @@ contains
        _VERIFY(STATUS) 
 
     end if
+
     cap%started_loop_timer=.false.
-
-    enableMemUtils = ESMF_UtilStringUpperCase(enableMemUtils, rc=STATUS)
-    _VERIFY(STATUS)
-
-    if (enableMemUtils /= 'YES') then
-       call MAPL_MemUtilsDisable( rc=STATUS )
-       _VERIFY(STATUS)
-    else
-       call MAPL_MemUtilsInit( mode=MemUtilsMode, rc=STATUS )
-       _VERIFY(STATUS)
-    end if
 
     call MAPL_GetResource( MAPLOBJ, cap%printSpec, label='PRINTSPEC:', default = 0, rc=STATUS )
     _VERIFY(STATUS)
@@ -465,21 +457,6 @@ contains
 
     ! Add EXPID and EXPDSC from HISTORY.rc to AGCM.rc
     !------------------------------------------------
-    cap%cf_hist = ESMF_ConfigCreate(rc=STATUS )
-    _VERIFY(STATUS)
-    call ESMF_ConfigLoadFile(cap%cf_hist, HIST_CF, rc=STATUS )
-    _VERIFY(STATUS)
-
-    call MAPL_ConfigSetAttribute(cap%cf_hist, value=HIST_CF, Label="HIST_CF:", rc=status)
-    _VERIFY(STATUS)
-
-    call ESMF_ConfigGetAttribute(cap%cf_hist, value=EXPID,  Label="EXPID:", default='',  rc=status)
-    _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute(cap%cf_hist, value=EXPDSC, Label="EXPDSC:", default='', rc=status)
-    _VERIFY(STATUS)
-
-    call MAPL_ConfigSetAttribute(cap%cf_hist, value=heartbeat_dt, Label="RUN_DT:", rc=status)
-    _VERIFY(STATUS)
 
     call MAPL_ConfigSetAttribute(cap%cf_root, value=EXPID,  Label="EXPID:",  rc=status)
     _VERIFY(STATUS)
@@ -523,64 +500,64 @@ contains
 
     !  Create Root child
     !-------------------
-    call MAPL_Set(MAPLOBJ, CF=CAP%CF_ROOT, RC=STATUS)
-    _VERIFY(STATUS)
-
+!!$    call MAPL_Set(MAPLOBJ, CF=CAP%CF_ROOT, RC=STATUS)
+!!$    _VERIFY(STATUS)
+!!$
     root_set_services => cap%root_set_services
 
     call t_p%start('SetService')
-    cap%root_id = MAPL_AddChild(MAPLOBJ, name = root_name, SS = root_set_services, rc = status)  
-    _VERIFY(status)
-    root_gc => maplobj%get_child_gridcomp(cap%root_id)
-    call MAPL_GetObjectFromGC(root_gc, root_obj, rc=status) 
-    _ASSERT(cap%n_run_phases <= SIZE(root_obj%phase_run),"n_run_phases in cap_gc should not exceed n_run_phases in root") 
-
-    !  Create History child
-    !----------------------
-
-    call MAPL_Set(MAPLOBJ, CF=CAP%CF_HIST, RC=STATUS)
-    _VERIFY(STATUS)
-
-    cap%history_id = MAPL_AddChild( MAPLOBJ, name = 'HIST', SS = HIST_SetServices, rc = status)  
-    _VERIFY(status)
-
-
-    !  Create ExtData child
-    !----------------------
-    cap%cf_ext = ESMF_ConfigCreate(rc=STATUS )
-    _VERIFY(STATUS)
-    call ESMF_ConfigLoadFile(cap%cf_ext, EXTDATA_CF, rc=STATUS )
-    _VERIFY(STATUS)
-
-    call ESMF_ConfigGetAttribute(cap%cf_ext, value=RUN_DT, Label="RUN_DT:", rc=status)
-    if (STATUS == ESMF_SUCCESS) then
-       if (heartbeat_dt /= run_dt) then
-          call lgr%error('inconsistent values of HEARTBEAT_DT (%g0) and ExtData RUN_DT (%g0)', heartbeat_dt, run_dt)
-          _FAIL('inconsistent values of HEARTBEAT_DT and RUN_DT')
-       end if
-    else
-       call MAPL_ConfigSetAttribute(cap%cf_ext, value=heartbeat_dt, Label="RUN_DT:", rc=status)
-       _VERIFY(STATUS)
-    endif
-
-    call MAPL_Set(MAPLOBJ, CF=CAP%CF_EXT, RC=STATUS)
-    _VERIFY(STATUS)
-
-    cap%extdata_id = MAPL_AddChild (MAPLOBJ, name = 'EXTDATA', SS = ExtData_SetServices, rc = status)
-    _VERIFY(status)
+!!$    cap%root_id = MAPL_AddChild(MAPLOBJ, name = root_name, SS = root_set_services, rc = status)  
+!!$    _VERIFY(status)
+!!$    root_gc => maplobj%get_child_gridcomp(cap%root_id)
+!!$    call MAPL_GetObjectFromGC(root_gc, root_obj, rc=status) 
+!!$    _ASSERT(cap%n_run_phases <= SIZE(root_obj%phase_run),"n_run_phases in cap_gc should not exceed n_run_phases in root") 
+!!$
+!!$    !  Create History child
+!!$    !----------------------
+!!$
+!!$    call MAPL_Set(MAPLOBJ, CF=CAP%CF_HIST, RC=STATUS)
+!!$    _VERIFY(STATUS)
+!!$
+!!$    cap%history_id = MAPL_AddChild( MAPLOBJ, name = 'HIST', SS = HIST_SetServices, rc = status)  
+!!$    _VERIFY(status)
+!!$
+!!$
+!!$    !  Create ExtData child
+!!$    !----------------------
+!!$    cap%cf_ext = ESMF_ConfigCreate(rc=STATUS )
+!!$    _VERIFY(STATUS)
+!!$    call ESMF_ConfigLoadFile(cap%cf_ext, EXTDATA_CF, rc=STATUS )
+!!$    _VERIFY(STATUS)
+!!$
+!!$    call ESMF_ConfigGetAttribute(cap%cf_ext, value=RUN_DT, Label="RUN_DT:", rc=status)
+!!$    if (STATUS == ESMF_SUCCESS) then
+!!$       if (heartbeat_dt /= run_dt) then
+!!$          call lgr%error('inconsistent values of HEARTBEAT_DT (%g0) and ExtData RUN_DT (%g0)', heartbeat_dt, run_dt)
+!!$          _FAIL('inconsistent values of HEARTBEAT_DT and RUN_DT')
+!!$       end if
+!!$    else
+!!$       call MAPL_ConfigSetAttribute(cap%cf_ext, value=heartbeat_dt, Label="RUN_DT:", rc=status)
+!!$       _VERIFY(STATUS)
+!!$    endif
+!!$
+!!$    call MAPL_Set(MAPLOBJ, CF=CAP%CF_EXT, RC=STATUS)
+!!$    _VERIFY(STATUS)
+!!$
+!!$    cap%extdata_id = MAPL_AddChild (MAPLOBJ, name = 'EXTDATA', SS = ExtData_SetServices, rc = status)
+!!$    _VERIFY(status)
     call t_p%stop('SetService')
-
-    ! Add NX and NY from AGCM.rc to ExtData.rc as well as name of ExtData rc file
-    call ESMF_ConfigGetAttribute(cap%cf_root, value = NX, Label="NX:", rc=status)
-    _VERIFY(STATUS)
-    call ESMF_ConfigGetAttribute(cap%cf_root, value = NY, Label="NY:", rc=status)
-    _VERIFY(STATUS)
-    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NX,  Label="NX:",  rc=status)
-    _VERIFY(STATUS)
-    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NY,  Label="NY:",  rc=status)
-    _VERIFY(STATUS)
-    call MAPL_ConfigSetAttribute(cap%cf_ext, value=EXTDATA_CF,  Label="CF_EXTDATA:",  rc=status)
-    _VERIFY(STATUS)
+!!$
+!!$    ! Add NX and NY from AGCM.rc to ExtData.rc as well as name of ExtData rc file
+!!$    call ESMF_ConfigGetAttribute(cap%cf_root, value = NX, Label="NX:", rc=status)
+!!$    _VERIFY(STATUS)
+!!$    call ESMF_ConfigGetAttribute(cap%cf_root, value = NY, Label="NY:", rc=status)
+!!$    _VERIFY(STATUS)
+!!$    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NX,  Label="NX:",  rc=status)
+!!$    _VERIFY(STATUS)
+!!$    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NY,  Label="NY:",  rc=status)
+!!$    _VERIFY(STATUS)
+!!$    call MAPL_ConfigSetAttribute(cap%cf_ext, value=EXTDATA_CF,  Label="CF_EXTDATA:",  rc=status)
+!!$    _VERIFY(STATUS)
 
     !  Query MAPL for the the children's for GCS, IMPORTS, EXPORTS
     !-------------------------------------------------------------
@@ -880,18 +857,139 @@ contains
 
     integer :: status, phase
     type(MAPL_CapGridComp), pointer :: cap
+    type(MAPL_MetaComp), pointer :: meta, root_meta
+    class(BaseProfiler), pointer :: t_p
+
+    type (ESMF_GridComp), pointer :: root_gc
+    character(len=ESMF_MAXSTR)   :: ROOT_NAME
+    procedure(), pointer :: root_set_services
+    class(Logger), pointer :: lgr
+    character(len=ESMF_MAXSTR)   :: HIST_CF, ROOT_CF, EXTDATA_CF
+    integer                      :: RUN_DT
+    integer                      :: heartbeat_dt
+    integer :: NX, NY
+    integer                      :: MemUtilsMode
+    character(len=ESMF_MAXSTR)   :: enableMemUtils
+    character(len=ESMF_MAXSTR)   :: enableTimers
+    type(ESMF_GridComp), pointer :: child_gc
+    type(MAPL_MetaComp), pointer :: child_meta
+    character(len=ESMF_MAXSTR)   :: EXPID
+    character(len=ESMF_MAXSTR)   :: EXPDSC
+    logical                      :: cap_clock_is_present
+    type(ESMF_TimeInterval)      :: Frequency
 
     cap => get_CapGridComp_from_gc(gc)
-    call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, userRoutine = initialize_gc, rc = status)
-    _VERIFY(status)
+    call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, userRoutine = initialize_gc, _RC)
 
     do phase = 1, cap%n_run_phases
-       call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, userRoutine = run_gc, rc = status)
-       _VERIFY(status)
+       call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, userRoutine = run_gc, _RC)
     enddo
 
-    call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_FINALIZE, userRoutine = finalize_gc, rc = status)
-    _VERIFY(status)
+    call ESMF_GridCompSetEntryPoint(gc, ESMF_METHOD_FINALIZE, userRoutine = finalize_gc, _RC)
+
+    call ESMF_GridCompGet(gc, clockIsPresent=cap_clock_is_present, _RC)
+
+    if (cap_clock_is_present) then
+       call ESMF_ClockGet(cap%clock, timeStep=frequency, _RC)
+       call ESMF_TimeIntervalGet(frequency, s=heartbeat_dt, _RC)
+    else
+       call ESMF_ConfigGetAttribute(cap%config, value = heartbeat_dt, Label = "HEARTBEAT_DT:", _RC)
+       call ESMF_TimeIntervalSet(frequency, s = heartbeat_dt, _RC)
+    end if
+
+    cap%heartbeat_dt = heartbeat_dt
+
+    ! Register the children with MAPL
+    !--------------------------------
+
+    !  Create Root child
+    !-------------------
+    call MAPL_InternalStateRetrieve(gc, meta, _RC)
+!!$    call MAPL_Set(meta, CF=CAP%CF_ROOT, _RC)
+    call MAPL_GetLogger(gc, lgr, _RC)
+
+    t_p => get_global_time_profiler()
+    call t_p%start('SetService')
+
+    ! !RESOURCE_ITEM: string :: Name to assign to the ROOT component
+    call MAPL_GetResource(meta, root_name, "ROOT_NAME:", default = "ROOT", _RC)
+    call MAPL_GetResource(meta, ROOT_CF, "ROOT_CF:", default = "ROOT.rc", _RC)
+    root_set_services => cap%root_set_services
+    cap%root_id = MAPL_AddChild(meta, name = root_name, SS=root_set_services, configFile=ROOT_CF, _RC)  
+
+      child_gc => meta%get_child_gridcomp(cap%root_id)
+      call MAPL_InternalStateRetrieve(child_gc, child_meta, _RC)
+      call MAPL_Get(child_meta, cf=cap%cf_root, _RC)
+      ! Add NX and NY from ROOT config to ExtData config
+      call ESMF_ConfigGetAttribute(cap%cf_root, value = NX, Label="NX:", _RC)
+      call ESMF_ConfigGetAttribute(cap%cf_root, value = NY, Label="NY:", _RC)
+      call ESMF_ConfigSetAttribute(cap%cf_root, value = heartbeat_dt, Label="RUN_DT:", _RC)
+
+    !  Create History child
+    !----------------------
+
+    ! !RESOURCE_ITEM: string :: Name of HISTORY's config file 
+    call MAPL_GetResource(meta, HIST_CF, "HIST_CF:", default = "HIST.rc", _RC)
+    cap%history_id = MAPL_AddChild( meta, name='HIST', SS=HIST_SetServices, configFile=HIST_CF, _RC)  
+
+    child_gc => meta%get_child_gridcomp(cap%history_id)
+    call MAPL_InternalStateRetrieve(child_gc, child_meta, _RC)
+    call MAPL_Get(child_meta, cf=cap%cf_hist, _RC)
+    call ESMF_ConfigLoadFile(cap%cf_hist, HIST_CF, _RC)
+
+    call MAPL_ConfigSetAttribute(cap%cf_hist, value=HIST_CF, Label="HIST_CF:", _RC)
+    call ESMF_ConfigGetAttribute(cap%cf_hist, value=EXPID,  Label="EXPID:", default='', _RC)
+    call ESMF_ConfigGetAttribute(cap%cf_hist, value=EXPDSC, Label="EXPDSC:", default='', _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_root, value=EXPID,  Label="EXPID:",  _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_root, value=EXPDSC, Label="EXPDSC:", _RC)
+
+    call MAPL_ConfigSetAttribute(cap%cf_hist, value=heartbeat_dt, Label="RUN_DT:", _RC)
+
+    call ESMF_ConfigGetAttribute(cap%cf_root, value = NX, Label="NX:", _RC)
+    call ESMF_ConfigGetAttribute(cap%cf_root, value = NY, Label="NY:", _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_hist, value = NX, Label="NX:",  _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_hist, value = NY, Label="NY:",  _RC)
+
+    !  Create ExtData child
+    !----------------------
+    cap%cf_ext = ESMF_ConfigCreate(_RC)
+    call MAPL_GetResource(meta, EXTDATA_CF, "EXTDATA_CF:", default = "ExtData.rc", _RC)
+    call ESMF_ConfigLoadFile(cap%cf_ext, EXTDATA_CF, _RC)
+
+
+    cap%extdata_id = MAPL_AddChild (meta, name='EXTDATA', SS=ExtData_SetServices, configFile=EXTDATA_CF, _RC)
+    child_gc => meta%get_child_gridcomp(cap%extdata_id)
+    call MAPL_InternalStateRetrieve(child_gc, child_meta, _RC)
+    call MAPL_Get(child_meta, cf=cap%cf_ext, _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NX,  Label="NX:",  _RC)
+    call MAPL_ConfigSetAttribute(cap%cf_ext, value=NY,  Label="NY:",  _RC)
+
+    call ESMF_ConfigGetAttribute(cap%cf_ext, value=RUN_DT, Label="RUN_DT:", rc=status)
+    if (status == ESMF_SUCCESS) then
+       if (heartbeat_dt /= run_dt) then
+          call lgr%error('inconsistent values of heartbeat_dt (%g0) and ExtData RUN_DT (%g0)', heartbeat_dt, run_dt)
+          _FAIL('inconsistent values of heartbeat_dt and RUN_DT')
+       end if
+    else
+       call MAPL_ConfigSetAttribute(cap%cf_ext, value=heartbeat_dt, Label="RUN_DT:", _RC)
+    endif
+    call MAPL_ConfigSetAttribute(cap%cf_ext, value=EXTDATA_CF,  Label="CF_EXTDATA:",  _RC)
+
+      
+    call t_p%stop('SetService')
+
+
+    ! !RESOURCE_ITEM: string :: Control Memory Diagnostic Utility 
+    call MAPL_GetResource(meta, enableMemUtils, "MAPL_ENABLE_MEMUTILS:", default='NO', _RC)
+    call MAPL_GetResource(meta, MemUtilsMode, "MAPL_MEMUTILS_MODE:", default = MAPL_MemUtilsModeBase, _RC)
+    enableMemUtils = ESMF_UtilStringUpperCase(enableMemUtils, _RC)
+
+    if (enableMemUtils /= 'YES') then
+       call MAPL_MemUtilsDisable(_RC)
+    else
+       call MAPL_MemUtilsInit( mode=MemUtilsMode, _RC)
+    end if
+
     _RETURN(ESMF_SUCCESS)
 
   end subroutine set_services_gc
@@ -902,8 +1000,9 @@ contains
     integer, optional, intent(out) :: rc
     integer :: status
 
-    call ESMF_GridCompSetServices(this%gc, set_services_gc, rc = status)
-    _VERIFY(status)
+    call new_generic_setservices(this%gc, _RC)
+!!$    call ESMF_GridCompSetServices(this%gc, set_services_gc, rc = status)
+!!$    _VERIFY(status)
     _RETURN(ESMF_SUCCESS)
   end subroutine set_services
 
@@ -1115,8 +1214,7 @@ contains
 
           call cap%increment_step_counter()
 
-          call MAPL_MemUtilsWrite(cap%vm, 'MAPL_Cap:TimeLoop', rc = status)
-          _VERIFY(status)
+          call MAPL_MemUtilsWrite(cap%vm, 'MAPL_Cap:TimeLoop', _RC)
 
           if (.not.cap%lperp) then
              done = ESMF_ClockIsStopTime(cap%clock_hist, rc = status)

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -923,7 +923,6 @@ contains
        if (old_fields_style) then
           field_set_name = trim(string) // 'fields'
           allocate(field_set)
-          print*,__FILE__,__LINE__,'looking for ', trim(field_set_name)
           call parse_fields(cfg, trim(field_set_name), field_set, list(n)%items, _RC)
        end if
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -923,7 +923,8 @@ contains
        if (old_fields_style) then
           field_set_name = trim(string) // 'fields'
           allocate(field_set)
-          call parse_fields(cfg, trim(field_set_name), field_set, list(n)%items, rc=status)
+          print*,__FILE__,__LINE__,'looking for ', trim(field_set_name)
+          call parse_fields(cfg, trim(field_set_name), field_set, list(n)%items, _RC)
        end if
 
        list(n)%field_set => field_set

--- a/profiler/BaseProfiler.F90
+++ b/profiler/BaseProfiler.F90
@@ -179,7 +179,11 @@ contains
       class(AbstractMeterNode), pointer :: node
 
       if (this%stack%size()/= 1) this%status = INCORRECTLY_NESTED_METERS
-      _ASSERT_RC(this%stack%size()== 1,"Stack not empty when timer stopped.",INCORRECTLY_NESTED_METERS)
+      if (this%stack%size() /= 1) then
+         node_ptr => this%stack%back()
+         node => node_ptr%ptr
+         _ASSERT_RC(this%stack%size()== 1,"Stack not empty when timer stopped.  Active timer: " // node%get_name(),INCORRECTLY_NESTED_METERS)
+      end if
 
       node_ptr => this%stack%back()
       node => node_ptr%ptr


### PR DESCRIPTION
just a deprecated stub.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented a new generic setservices that is designed to wrap user setservices.  This is as opposed to the legacy generic setservices that is called from within user setservices.  That legacy procedure is now an empty (deprecated) subroutine.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Small step to supporting NUOPC.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with C12 on laptop with ifort.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
