### PR TITLE
Improve missing file error handling for untemplated filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `components.yaml`. These changes are to support using Spack to build MAPL
   - ESMA_cmake v3.10.0 (add `FindESMF.cmake` from NOAA-EMC)
   - ecbuild geos/v1.2.0 (updat `FindNetCDF.cmake` to that from NOAA-EMC)
+- File not found error handling in ExtData improved for non-templated filenames
 
 ## [2.17.2] - 2022-02-16
 

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -1889,6 +1889,7 @@ CONTAINS
         character(len=ESMF_MAXSTR) :: creffTime, ctInt
        
         integer :: status
+        logical :: found
  
         creffTime = ''
         ctInt     = ''
@@ -1933,6 +1934,10 @@ CONTAINS
            else
               ! couldn't find any tokens so all the data must be on one file
               call ESMF_TimeIntervalSet(item%frequency,__RC__)
+
+              ! check if non-token file exists
+              inquire(file=trim(item%file),EXIST=found)
+              _ASSERT(found,'File ' // trim(item%file) // ' not found')
            end if
         else
            ! Reference time should look like:


### PR DESCRIPTION
## Description
This update adds an additional case for handling files not found in ExtData. If a file is not found and its filename does not include the template token `%` then an error will be thrown without additional testing.

## Related Issue
https://github.com/geoschem/GCHP/issues/176

## Motivation and Context
This update solves the following problem reported by Sebastian Eastham (@sdeastham):
> Usually, if ExtData comes across a file which it needs but cannot find it fails with an intuitive error message. However, it appears that there is an edge case which still produces a confusing error. The TransportTracers simulation requires the file EDGAR_v42_SF6_IPCC_2.generic.01x01.nc, which contains data for several years (full path: HcoDir/SF6/v2019-01/EDGAR_v42_SF6_IPCC_2.generic.01x01.nc). If the file is missing, ExtData gets very confused because it follows the logic branch for an entry covering multiple years, and which crucially assumes that there will be at least one file per year. This results in it trying to fill out the file template with successively earlier years, and testing to see if a file is present. For reasons which are not 100% clear to me, this results in a failure in ESMF rather than specifically in MAPL, and hence the confusing error. 

## How Has This Been Tested?
Not tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
