### PR TITLE
Enable GCM run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           develop_repos: "cmake GEOSana_GridComp" # GEOSadas needs some extra branches to work with mainline MAPL
           rebuild_procs: 8
 
-      # Run GCM (note uses bcs executor inside)
+      # Run GCM (1 hour, no ExtData)
       - ci/run_gcm:
           name: run-GCM-on-<< matrix.compiler >>
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
           checkout_fixture: true
           mepodevelop: true
           checkout_mapl_branch: true
-          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra, retained for one day
 
       # Build GEOSldas
       - ci/build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
           checkout_fixture: true
           mepodevelop: true
           checkout_mapl_branch: true
-          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Build GEOSldas
       - ci/build:
@@ -78,15 +78,15 @@ workflows:
           mepodevelop: true
           develop_repos: "cmake GEOSana_GridComp" # GEOSadas needs some extra branches to work with mainline MAPL
           rebuild_procs: 8
-      ##################################################
-      # - ci/run_fv3:                                  #
-      #     name: run-FV3-on-<< matrix.compiler >>     #
-      #     context:                                   #
-      #       - docker-hub-creds                       #
-      #     matrix:                                    #
-      #       parameters:                              #
-      #         compiler: [gfortran, ifort]            #
-      #     requires:                                  #
-      #       - build-GEOSgcm-on-<< matrix.compiler >> #
-      #     repo: GEOSgcm                              #
-      ##################################################
+
+      # Run gcm
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           develop_repos: "cmake GEOSana_GridComp" # GEOSadas needs some extra branches to work with mainline MAPL
           rebuild_procs: 8
 
-      # Run GCM
+      # Run GCM (note uses bcs executor inside)
       - ci/run_gcm:
           name: run-GCM-on-<< matrix.compiler >>
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
           develop_repos: "cmake GEOSana_GridComp" # GEOSadas needs some extra branches to work with mainline MAPL
           rebuild_procs: 8
 
-      # Run gcm
+      # Run GCM
       - ci/run_gcm:
           name: run-GCM-on-<< matrix.compiler >>
           context:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cleaned up a bit of old CMake
 - Updated CircleCI config to use new orb `build` job
+  - Turned on GCM run test
 - Updated `components.yaml` to match GEOSgcm v10.22.1
   - ESMA_env v3.13.0
   - ESMA_cmake v3.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add debug loggers for start/stop during stages in MAPL_Generic
+- Enable GCM run test in CircleCI
 
 ### Changed
 
@@ -57,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cleaned up a bit of old CMake
 - Updated CircleCI config to use new orb `build` job
-  - Turned on GCM run test
 - Updated `components.yaml` to match GEOSgcm v10.22.1
   - ESMA_env v3.13.0
   - ESMA_cmake v3.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add debug loggers for start/stop during stages in MAPL_Generic
 - Handling for double precision input when retrieving single precision attributes
-- Enable GCM run test in CircleCI
+- Enable GCM run test in CircleCI (1-hour, no ExtData)
 
 ### Changed
 


### PR DESCRIPTION
I am using this PR to test running the GCM with a MAPL PR. I'm wanting to know the costs, etc for this. 

Change 1: Need to use the `compiler-bcs` executor for GCM runs. Also, I don't need *all* the `install` directories, just `bin`, `etc` and `lib` → orb v1.2.0

---

Okay. Finally got it to work. In run-credit terms this goes from 1779 → 2134. Now, on top of that are the storage costs. It looks like an Intel run has 678 MiB of storage and a GNU run has 354 MiB. So a total of 1 GiB

---

Next up, I've set the workplace retention setting in CircleCI to be 1 day instead of 15. Not sure this matters. Still, before I re-triggered the CI, we had 3.7 GB "storage-months" of workspace.