### PR TITLE
Handmerge develop into MAPL3 - 2022-May-16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,7 @@ workflows:
           fixture_branch: release/MAPL-v3
           checkout_mapl3_release_branch: true
           checkout_mapl_branch: true
-          mepodevelop: true
-          develop_repos: "cmake GEOSana_GridComp" # GEOSadas needs some extra branches to work with mainline MAPL
+          mepodevelop: false
           rebuild_procs: 8
       ##################################################
       # - ci/run_fv3:                                  #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update CI to work with latest GEOSadas `develop` (Uses a special branch of GEOSadas)
+
 ### Added
 
 ### Changed


### PR DESCRIPTION
This is a handmerge of `develop` into `release/MAPL-v3` to make sure the CI works.