### PR TITLE
Handmerge develop into MAPL3 2022-May-18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,3 +99,4 @@ workflows:
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
+          baselibs_version: *baselibs_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+# Anchor to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.0.0
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2.1
 
+baselibs_version: &baselibs_version v7.0.0
+
 orbs:
   ci: geos-esm/circleci-tools@1
 
@@ -15,7 +17,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: v7.0.0
+          baselibs_version: *baselibs_version
           repo: MAPL
           mepodevelop: false
           run_unit_tests: true
@@ -29,7 +31,7 @@ workflows:
           matrix:
             parameters:
               compiler: [ifort]
-          baselibs_version: v7.0.0
+          baselibs_version: *baselibs_version
           repo: MAPL
           mepodevelop: false
           extra_cmake_options: "-DBUILD_WITH_FLAP=OFF -DBUILD_WITH_PFLOGGER=OFF -DBUILD_SHARED_MAPL=OFF"
@@ -44,7 +46,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: v7.0.0
+          baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true
@@ -60,7 +62,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: v7.0.0
+          baselibs_version: *baselibs_version
           repo: GEOSldas
           mepodevelop: false
           checkout_fixture: true
@@ -77,7 +79,7 @@ workflows:
             parameters:
               compiler: [ifort]
           resource_class: xlarge
-          baselibs_version: v7.0.0
+          baselibs_version: *baselibs_version
           repo: GEOSadas
           checkout_fixture: true
           fixture_branch: release/MAPL-v3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
           mepodevelop: true
           checkout_mapl3_release_branch: true
           checkout_mapl_branch: true
-          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra, retained for one day
 
       # Build GEOSldas
       - ci/build:
@@ -85,15 +85,15 @@ workflows:
           checkout_mapl_branch: true
           mepodevelop: false
           rebuild_procs: 8
-      ##################################################
-      # - ci/run_fv3:                                  #
-      #     name: run-FV3-on-<< matrix.compiler >>     #
-      #     context:                                   #
-      #       - docker-hub-creds                       #
-      #     matrix:                                    #
-      #       parameters:                              #
-      #         compiler: [gfortran, ifort]            #
-      #     requires:                                  #
-      #       - build-GEOSgcm-on-<< matrix.compiler >> #
-      #     repo: GEOSgcm                              #
-      ##################################################
+
+      # Run GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add debug loggers for start/stop during stages in MAPL_Generic
 - Handling for double precision input when retrieving single precision attributes
+- Enable GCM run test in CircleCI (1-hour, no ExtData)
 
 ### Changed
 


### PR DESCRIPTION
Handmerge in `develop` into `release/MAPL-v3`. This is done to test to make sure the GCM run test works with MAPL 3 as well.