### PR TITLE
Hotfix 1530: Initialize lperp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.21.2] - 2022-05-27
+
+### Fixed
+
+- Initialize `cap%lperp` in `MAPL_CapGridComp.F90` (see Issue #1530)
+
 ## [2.21.1] - 2022-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [2.21.2] - 2022-05-27
+## [2.21.2] - 2022-05-31
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.21.1
+  VERSION 2.21.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -33,7 +33,7 @@ module MAPL_CapGridCompMod
   use MAPL_ExternalGCStorage
 
   use iso_fortran_env
-  
+
   implicit none
   private
 
@@ -53,7 +53,8 @@ module MAPL_CapGridCompMod
      procedure(), pointer, nopass  :: root_set_services => null()
      character(len=:), allocatable :: final_file, name, cap_rc_file
      integer :: nsteps, heartbeat_dt, perpetual_year, perpetual_month, perpetual_day
-     logical :: amiroot, lperp, started_loop_timer
+     logical :: amiroot, started_loop_timer
+     logical :: lperp = .false.
      integer :: extdata_id, history_id, root_id, printspec
      type(ESMF_Clock) :: clock, clock_hist
      type(ESMF_Config) :: cf_ext, cf_root, cf_hist, config
@@ -105,7 +106,7 @@ module MAPL_CapGridCompMod
 
 contains
 
-  
+
    subroutine MAPL_CapGridCompCreate(cap, root_set_services, cap_rc, name, final_file, unusable, n_run_phases, rc)
       use mapl_StubComponent
     type(MAPL_CapGridComp), intent(out), target :: cap
@@ -118,10 +119,10 @@ contains
 
     type(MAPL_CapGridComp_Wrapper) :: cap_wrapper
     type(MAPL_MetaComp), pointer :: meta => null()
-    integer :: status 
+    integer :: status
     character(*), parameter :: cap_name = "CAP"
     type(StubComponent) :: stub_component
-    
+
     _UNUSED_DUMMY(unusable)
 
     cap%cap_rc_file = cap_rc
@@ -275,7 +276,7 @@ contains
         cap%nsteps = 1
         cap%compute_throughput = .false.
     else
-    !  Create Clock. This is a private routine that sets the start and 
+    !  Create Clock. This is a private routine that sets the start and
     !   end times and the time interval of the clock from the configuration.
     !   The start time is temporarily set to 1 interval before the time in the
     !   configuration. Once the Alarms are set in intialize, the clock will
@@ -369,33 +370,33 @@ contains
        endif
     endif
 
-    !  Get configurable info to create HIST 
+    !  Get configurable info to create HIST
     !  and the ROOT of the computational hierarchy
     !---------------------------------------------
 
     !BOR
 
     ! !RESOURCE_ITEM: string :: Name of ROOT's config file
-    call MAPL_GetResource(MAPLOBJ, ROOT_CF, "ROOT_CF:", default = "ROOT.rc", rc = status) 
+    call MAPL_GetResource(MAPLOBJ, ROOT_CF, "ROOT_CF:", default = "ROOT.rc", rc = status)
     _VERIFY(status)
 
     ! !RESOURCE_ITEM: string :: Name to assign to the ROOT component
-    call MAPL_GetResource(MAPLOBJ, ROOT_NAME, "ROOT_NAME:", default = "ROOT", rc = status) 
+    call MAPL_GetResource(MAPLOBJ, ROOT_NAME, "ROOT_NAME:", default = "ROOT", rc = status)
     _VERIFY(status)
 
-    ! !RESOURCE_ITEM: string :: Name of HISTORY's config file 
-    call MAPL_GetResource(MAPLOBJ, HIST_CF, "HIST_CF:", default = "HIST.rc", rc = status) 
+    ! !RESOURCE_ITEM: string :: Name of HISTORY's config file
+    call MAPL_GetResource(MAPLOBJ, HIST_CF, "HIST_CF:", default = "HIST.rc", rc = status)
     _VERIFY(status)
 
     ! !RESOURCE_ITEM: string :: Name of ExtData's config file
     call MAPL_GetResource(MAPLOBJ, EXTDATA_CF, "EXTDATA_CF:", default = 'ExtData.rc', rc = status)
     _VERIFY(status)
 
-    ! !RESOURCE_ITEM: string :: Control Timers 
+    ! !RESOURCE_ITEM: string :: Control Timers
     call MAPL_GetResource(MAPLOBJ, enableTimers, "MAPL_ENABLE_TIMERS:", default = 'NO', rc = status)
     _VERIFY(status)
 
-    ! !RESOURCE_ITEM: string :: Control Memory Diagnostic Utility 
+    ! !RESOURCE_ITEM: string :: Control Memory Diagnostic Utility
     call MAPL_GetResource(MAPLOBJ, enableMemUtils, "MAPL_ENABLE_MEMUTILS:", default='NO', rc = status)
     _VERIFY(status)
     call MAPL_GetResource(MAPLOBJ, MemUtilsMode, "MAPL_MEMUTILS_MODE:", default = MAPL_MemUtilsModeBase, rc = status)
@@ -414,7 +415,7 @@ contains
        _VERIFY(STATUS)
 
        timerModeStr = ESMF_UtilStringUpperCase(timerModeStr, rc=STATUS)
-       _VERIFY(STATUS) 
+       _VERIFY(STATUS)
 
     end if
     cap%started_loop_timer=.false.
@@ -534,11 +535,11 @@ contains
     root_set_services => cap%root_set_services
 
     call t_p%start('SetService')
-    cap%root_id = MAPL_AddChild(MAPLOBJ, name = root_name, SS = root_set_services, rc = status)  
+    cap%root_id = MAPL_AddChild(MAPLOBJ, name = root_name, SS = root_set_services, rc = status)
     _VERIFY(status)
     root_gc => maplobj%get_child_gridcomp(cap%root_id)
-    call MAPL_GetObjectFromGC(root_gc, root_obj, rc=status) 
-    _ASSERT(cap%n_run_phases <= SIZE(root_obj%phase_run),"n_run_phases in cap_gc should not exceed n_run_phases in root") 
+    call MAPL_GetObjectFromGC(root_gc, root_obj, rc=status)
+    _ASSERT(cap%n_run_phases <= SIZE(root_obj%phase_run),"n_run_phases in cap_gc should not exceed n_run_phases in root")
 
     !  Create History child
     !----------------------
@@ -546,7 +547,7 @@ contains
     call MAPL_Set(MAPLOBJ, CF=CAP%CF_HIST, RC=STATUS)
     _VERIFY(STATUS)
 
-    cap%history_id = MAPL_AddChild( MAPLOBJ, name = 'HIST', SS = HIST_SetServices, rc = status)  
+    cap%history_id = MAPL_AddChild( MAPLOBJ, name = 'HIST', SS = HIST_SetServices, rc = status)
     _VERIFY(status)
 
 
@@ -572,7 +573,7 @@ contains
     _VERIFY(STATUS)
 
     if (use_extdata2g) then
-#if defined(BUILD_WITH_EXTDATA2G) 
+#if defined(BUILD_WITH_EXTDATA2G)
        cap%extdata_id = MAPL_AddChild (MAPLOBJ, name = 'EXTDATA', SS = ExtData2G_SetServices, _RC)
 #else
        call lgr%error('ExtData2G requested but not built')
@@ -647,7 +648,7 @@ contains
           _VERIFY(STATUS)
           ExtData_internal_state => wrap%ptr
           ExtData_internal_state%gc = CAP%GCS(cap%extdata_id)
-          ExtData_internal_state%expState = CAP%CHILD_EXPORTS(cap%extdata_id) 
+          ExtData_internal_state%expState = CAP%CHILD_EXPORTS(cap%extdata_id)
        end if
        call t_p%stop('Initialize')
     end if
@@ -656,7 +657,7 @@ contains
     _RETURN(ESMF_SUCCESS)
   end subroutine initialize_gc
 
-  
+
   subroutine initialize_history(cap, rc)
     class(MAPL_CapGridComp), intent(inout) :: cap
     integer, optional, intent(out) :: rc
@@ -775,18 +776,18 @@ contains
     !------------------------
 
     call ESMF_GridCompInitialize (cap%gcs(cap%extdata_id), importState = cap%child_imports(cap%extdata_id), &
-         exportState = cap%child_exports(cap%extdata_id), & 
+         exportState = cap%child_exports(cap%extdata_id), &
          clock = cap%clock, userRc = status)
     _VERIFY(status)
 
     _RETURN(ESMF_SUCCESS)
 
   end subroutine initialize_extdata
-  
-  
+
+
   subroutine run_gc(gc, import, export, clock, rc)
     !ARGUMENTS:
-    type(ESMF_GridComp) :: GC     ! Gridded component 
+    type(ESMF_GridComp) :: GC     ! Gridded component
     type(ESMF_State) :: import ! Import state
     type(ESMF_State) :: export ! Export state
     type(ESMF_Clock) :: clock  ! The clock
@@ -830,7 +831,7 @@ contains
     _UNUSED_DUMMY(import_state)
     _UNUSED_DUMMY(export_state)
     _UNUSED_DUMMY(clock)
-    
+
     cap => get_CapGridComp_from_gc(gc)
     call MAPL_GetObjectFromGC(gc, maplobj, rc=status)
     _VERIFY(status)
@@ -924,7 +925,7 @@ contains
   subroutine initialize(this, rc)
     class(MAPL_CapGridComp), intent(inout) :: this
     integer, optional, intent(out) :: rc
-    
+
     integer :: status
 
     call ESMF_GridCompInitialize(this%gc, userRC=status)
@@ -954,9 +955,9 @@ contains
   subroutine finalize(this, rc)
     class(MAPL_CapGridComp), intent(inout) :: this
     integer, optional, intent(out) :: rc
-    
-    integer :: status    
-    
+
+    integer :: status
+
     call ESMF_GridCompFinalize(this%gc, rc = status)
     _VERIFY(status)
     _RETURN(ESMF_SUCCESS)
@@ -975,7 +976,7 @@ contains
 
   end function get_model_duration
 
-  
+
   function get_am_i_root(this, rc) result (amiroot)
     class (MAPL_CapGridComp) :: this
     integer, optional, intent(out) :: rc
@@ -1042,8 +1043,8 @@ contains
     cap => cap_wrapper%ptr
   end function get_CapGridComp_from_gc
 
-  
-  
+
+
   function get_vec_from_config(config, key) result(vec)
     type(ESMF_Config), intent(inout) :: config
     character(len=*), intent(in) :: key
@@ -1051,13 +1052,13 @@ contains
     integer :: status, rc
     character(len=ESMF_MAXSTR) :: cap_import
     type(StringVector) :: vec
-    
+
     call ESMF_ConfigFindLabel(config, key//":", isPresent = present, rc = status)
     _VERIFY(status)
 
     cap_import = ""
     if (present) then
-       
+
        do while(trim(cap_import) /= "::")
           call ESMF_ConfigNextLine(config, rc = status)
           _VERIFY(status)
@@ -1066,10 +1067,10 @@ contains
           if (trim(cap_import) /= "::") call vec%push_back(trim(cap_import))
        end do
     end if
-       
+
   end function get_vec_from_config
 
-  
+
   logical function vector_contains_str(vector, string)
     type(StringVector), intent(in) :: vector
     character(len=*), intent(in) :: string
@@ -1091,12 +1092,12 @@ contains
 
   end function vector_contains_str
 
-  
+
   subroutine run_MAPL_GridComp(gc, phase, rc)
     type (ESMF_Gridcomp) :: gc
     integer, optional, intent(in)  :: phase
     integer, optional, intent(out) :: rc
-    
+
     integer :: n, status, phase_
     logical :: done
 
@@ -1247,19 +1248,19 @@ contains
            _VERIFY(status)
            end_run_timer = MPI_WTime(status)
         end if
- 
+
         call ESMF_ClockAdvance(this%clock, rc = status)
         _VERIFY(STATUS)
         call ESMF_ClockAdvance(this%clock_hist, rc = status)
         _VERIFY(STATUS)
-    
+
         ! Update Perpetual Clock
         ! ----------------------
         if (this%lperp) then
            call Perpetual_Clock(this, status)
            _VERIFY(status)
         end if
-    
+
         call ESMF_GridCompRun(this%gcs(this%history_id), importstate=this%child_imports(this%history_id), &
              exportstate = this%child_exports(this%history_id), &
              clock = this%clock_hist, userrc = status)
@@ -1290,7 +1291,7 @@ contains
         integer                 :: AGCM_YY, AGCM_MM, AGCM_DD, AGCM_H, AGCM_M, AGCM_S
         integer                 :: HRS_R, MIN_R, SEC_R
 
- 
+
         call ESMF_ClockGet(this%clock, CurrTime = currTime, rc = status)
         _VERIFY(status)
         call ESMF_TimeGet(CurrTime, YY = AGCM_YY, &
@@ -1334,7 +1335,7 @@ contains
                 f5.1,'% : ',f5.1,'% Mem Comm:Used')
 
         _RETURN(_SUCCESS)
-        
+
      end subroutine
 
   end subroutine step
@@ -1374,7 +1375,7 @@ contains
     integer, intent(out) :: rc
     integer :: status
 
-    integer :: i 
+    integer :: i
     call MAPL_GenericStateRestore(this%gcs(this%root_id),this%child_imports(this%root_id), &
              this%child_exports(this%root_id),this%clock,rc=status)
     _VERIFY(status)
@@ -1501,7 +1502,7 @@ contains
 
     call MAPL_DestroyStateSave(this%gcs(this%root_id),rc=status)
     _VERIFY(status)
-   
+
      if (allocated(this%alarm_list)) deallocate(this%alarm_list)
      if (allocated(this%AlarmRingTime)) deallocate(this%alarmRingTime)
      if (allocated(this%ringingState)) deallocate(this%ringingState)
@@ -1522,7 +1523,7 @@ contains
     if (current_time >  time) then
        call ESMF_ClockSet(this%clock,direction=ESMF_DIRECTION_REVERSE,rc=status)
        _VERIFY(status)
-       do 
+       do
           call ESMF_ClockAdvance(this%clock,rc=status)
           _VERIFY(status)
           call ESMF_ClockGet(this%clock,currTime=ct,rc=status)
@@ -1532,13 +1533,13 @@ contains
        call ESMF_ClockSet(this%clock,direction=ESMF_DIRECTION_FORWARD,rc=status)
        _VERIFY(status)
     end if
-      
+
     call ESMF_ClockGet(this%clock_hist,currTime=current_time,rc=status)
     _VERIFY(status)
     if (current_time >  time) then
        call ESMF_ClockSet(this%clock_hist,direction=ESMF_DIRECTION_REVERSE,rc=status)
        _VERIFY(status)
-       do 
+       do
           call ESMF_ClockAdvance(this%clock_hist,rc=status)
           _VERIFY(status)
           call ESMF_ClockGet(this%clock_hist,currTime=ct,rc=status)
@@ -1548,15 +1549,15 @@ contains
        call ESMF_ClockSet(this%clock_hist,direction=ESMF_DIRECTION_FORWARD,rc=status)
        _VERIFY(status)
     end if
-      
-       
+
+
     _RETURN(_SUCCESS)
   end subroutine rewind_clock
 
 
   ! !IROUTINE: MAPL_ClockInit -- Sets the clock
 
-  ! !INTERFACE: 
+  ! !INTERFACE:
 
   subroutine MAPL_ClockInit ( MAPLOBJ, Clock, nsteps, rc)
 
@@ -1569,10 +1570,10 @@ contains
 
     !  !DESCRIPTION:
 
-    !   This is a private routine that sets the start and 
+    !   This is a private routine that sets the start and
     !   end times and the time interval of the application clock from the configuration.
     !   This time interal is the ``heartbeat'' of the application.
-    !   The Calendar is set to Gregorian by default. 
+    !   The Calendar is set to Gregorian by default.
     !   The start time is temporarily set to 1 interval before the time in the
     !   configuration. Once the Alarms are set in intialize, the clock will
     !   be advanced to guarantee it and its alarms are in the same state as they
@@ -1781,7 +1782,7 @@ contains
          M = END_M , &
          S = END_S , &
          calendar=cal,  rc = STATUS  )
-    _VERIFY(STATUS)  
+    _VERIFY(STATUS)
 
     ! Read CAP Restart File for Current Time
     ! --------------------------------------
@@ -1823,7 +1824,7 @@ contains
          S = CUR_S , &
          calendar=cal,  rc = STATUS  )
     _VERIFY(STATUS)
-   
+
 
     ! initialize final stop time
     ! --------------------------
@@ -1982,7 +1983,7 @@ contains
          (PERPETUAL_DAY   == -999) ) then
        AGCM_YY  = PERPETUAL_YEAR
        AGCM_MM  = PERPETUAL_MONTH
-       if( HIST_MM /= PERPETUAL_MONTH ) then 
+       if( HIST_MM /= PERPETUAL_MONTH ) then
           HIST_MM  = PERPETUAL_MONTH
           if( PERPETUAL_MONTH /= 12) HIST_YY  = HIST_YY + 1
           call ESMF_AlarmRingerOn( PERPETUAL, rc=status )
@@ -1998,7 +1999,7 @@ contains
          (PERPETUAL_MONTH /= -999)  .and. &
          (PERPETUAL_DAY   == -999) ) then
        AGCM_MM  = PERPETUAL_MONTH
-       if( HIST_MM /= PERPETUAL_MONTH ) then 
+       if( HIST_MM /= PERPETUAL_MONTH ) then
           HIST_MM  = PERPETUAL_MONTH
           if( PERPETUAL_MONTH /= 12) HIST_YY  = HIST_YY + 1
           AGCM_YY  = HIST_YY
@@ -2013,7 +2014,7 @@ contains
        AGCM_YY  = PERPETUAL_YEAR
        AGCM_MM  = PERPETUAL_MONTH
        AGCM_DD  = PERPETUAL_DAY
-       if( HIST_MM /= PERPETUAL_MONTH ) then 
+       if( HIST_MM /= PERPETUAL_MONTH ) then
           HIST_MM  = PERPETUAL_MONTH
           if( PERPETUAL_MONTH /= 12) HIST_YY  = HIST_YY + 1
           call ESMF_AlarmRingerOn( PERPETUAL, rc=status )
@@ -2055,7 +2056,7 @@ contains
     ! ErrLog vars
     integer                                :: status
 
-    ! Local Vars    
+    ! Local Vars
     type(ESMF_Time)                        :: targetTime
     type(ESMF_Time)                        :: cTime
     type(ESMF_TimeInterval)                :: zero


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Initialize `cap%lperp` to `.false.` in the data type declaration. Our UFS friends found a bug in MAPL when you run in a way where you pass the clock into Cap. This is not how GEOS runs, but it is how UFS runs. In our case, `cap%lperp` is always set to something, but for UFS it's uninitialized.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1530 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes a bug found by UFS with GCC 11.3

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] GEOSgcm.x run
- [ ] UFS GOCART run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
