### PR TITLE
Update CHANGELOG and CMakeLists for 2.22.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.22.0] - 2022-06-24
+
+### Fixed
+
 - By pass the check of the missing value of Nan
 - Update CI to work with latest GEOSadas `develop` (Uses a special branch of GEOSadas)
 - Fix bundleio tests
@@ -45,10 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Add `find_package(MPI)` for non-Baselibs builds
    - Add explicit interface dependence of `MPI` for `ESMF` target
    - Add `esmf` alias library for `ESMF` for compatibility
-
-### Removed
-
-### Deprecated
 
 ## [2.21.3] - 2022-06-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.21.3
+  VERSION 2.22.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
This is a trivial PR to prepare `develop` for merge into `main` for a MAPL 2.22.0 release.