### PR TITLE
Update CHANGELOG and CMakeLists for 2.23.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.23.0] - 2022-07-06
+
+### Added
+
 - Check return codes for YAML files when parsing in ExtData2G
 
 ### Changed
 
 - Updated the ESMA_env version to v4.2.0 (Baselibs 7.5.0 → GFE v1.4.0)
-  - With this update, MAPL now requires these versions of GFE libraries
+  - With this update, MAPL now **requires** these versions of GFE libraries
     - yaFyaml v1.0.4 (if building with ExtData2G support)
     - pFlogger v1.9.1 (if building with pFlogger support)
 - Update the CI for Baselibs 7.5.0, BCs version 10.22.3
-
-### Removed
-
-### Deprecated
 
 ## [2.22.0] - 2022-06-24
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.22.0
+  VERSION 2.23.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
Updates to `CHANGELOG.md` and `CMakeLists.txt` to prepare for a 2.23.0 release of MAPL