### PR TITLE
Update CHANGELOG and CMakeLists for 2.24.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.24.0] - 2022-08-08
+
+### Fixed
+
 - Fix error trapping in bundleio test
 
 ### Added
@@ -24,10 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced depreciated __RC__ macro with _RC and remove unsed code  in ExtData2G
 - Moved to `checkout@v3` action due to git safe directory issue
 - Added tutorials to CI
-
-### Removed
-
-### Deprecated
 
 ## [2.23.1] - 2022-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tutorials
 - Check for duplicate entries in the History.rc file
-- Check that a user provided chunking in the History.rc is compatible with the output grid
-- If a user request CFIOasync in the History.rc print warning and set to CFIO
+- Check that a user-provided chunking in the History.rc is compatible with the output grid
+- If a user requests CFIOasync in the History.rc, print warning and set to CFIO
 - Added option allow writing to pre-existing files with History
 
 ### Changed
 
-- Replaced depreciated __RC__ macro with _RC and remove unsed code  in ExtData2G
+- Replaced deprecated __RC__ macro with _RC and remove unused code in ExtData2G
 - Moved to `checkout@v3` action due to git safe directory issue
 - Added tutorials to CI
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.23.1
+  VERSION 2.24.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
This PR is to prepare `develop` for a 2.24.0 release.