### PR TITLE
Fixes #1636. Add History regrid_method attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add option to build source tarfile when building MAPL standalone. By default this is `OFF`, but can be enabled with
   `-DINSTALL_SOURCE_TARFILE=ON`
+- Added `regrid_method` metadata to History output
 
 ### Changed
 

--- a/base/RegridMethods.F90
+++ b/base/RegridMethods.F90
@@ -19,6 +19,7 @@ module mapl_RegridMethods
    public :: UNSPECIFIED_REGRID_METHOD
    public :: TILING_METHODS
    public :: get_regrid_method
+   public :: translate_regrid_method
 
    enum, bind(c)
       enumerator :: REGRID_METHOD_IDENTITY
@@ -59,7 +60,7 @@ module mapl_RegridMethods
       case ("VOTE")
          int_regrid_method = REGRID_METHOD_VOTE
       case ("FRACTION")
-         int_regrid_method = REGRID_METHOD_FRACTION   
+         int_regrid_method = REGRID_METHOD_FRACTION
       case ("CONSERVE_2ND")
          int_regrid_method = REGRID_METHOD_CONSERVE_2ND
       case ("PATCH")
@@ -70,9 +71,44 @@ module mapl_RegridMethods
          int_regrid_method = REGRID_METHOD_CONSERVE_MONOTONIC
       case ("BILINEAR_MONOTONIC")
          int_regrid_method = REGRID_METHOD_BILINEAR_MONOTONIC
+      case ("NEAREST_STOD")
+         int_regrid_method = REGRID_METHOD_NEAREST_STOD
       case default
          int_regrid_method = UNSPECIFIED_REGRID_METHOD
       end select
    end function
 
+   function translate_regrid_method(int_regrid_method) result(string_regrid_method)
+      integer, intent(in) :: int_regrid_method
+      character(len=:), allocatable, intent(out) :: string_regrid_method
+
+      select case (int_regrid_method)
+      case (REGRID_METHOD_IDENTITY)
+         string_regrid_method = "identity"
+      case (REGRID_METHOD_BILINEAR)
+         string_regrid_method = "bilinear"
+      case (REGRID_METHOD_BILINEAR_ROTATE)
+         string_regrid_method = "bilinear_rotate"
+      case (REGRID_METHOD_CONSERVE)
+         string_regrid_method = "conserve"
+      case (REGRID_METHOD_VOTE)
+         string_regrid_method = "vote"
+      case (REGRID_METHOD_FRACTION)
+         string_regrid_method = "fraction"
+      case (REGRID_METHOD_CONSERVE_2ND)
+         string_regrid_method = "conserve_2nd"
+      case (REGRID_METHOD_PATCH)
+         string_regrid_method = "patch"
+      case (REGRID_METHOD_CONSERVE_HFLUX)
+         string_regrid_method = "conserve_hflux"
+      case (REGRID_METHOD_CONSERVE_MONOTONIC)
+         string_regrid_method = "conserve_monotonic"
+      case (REGRID_METHOD_BILINEAR_MONOTONIC)
+         string_regrid_method = "bilinear_monotonic"
+      case (REGRID_METHOD_NEAREST_STOD)
+         string_regrid_method = "nearest_stod"
+      case default
+         string_regrid_method = "unspecified_regrid_method"
+      end select
+   end function
 end module mapl_RegridMethods

--- a/base/RegridMethods.F90
+++ b/base/RegridMethods.F90
@@ -80,7 +80,7 @@ module mapl_RegridMethods
 
    function translate_regrid_method(int_regrid_method) result(string_regrid_method)
       integer, intent(in) :: int_regrid_method
-      character(len=:), allocatable, intent(out) :: string_regrid_method
+      character(len=:), allocatable :: string_regrid_method
 
       select case (int_regrid_method)
       case (REGRID_METHOD_IDENTITY)

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -26,7 +26,7 @@ module MAPL_GriddedIOMod
   use, intrinsic :: iso_fortran_env, only: REAL64
   use ieee_arithmetic, only: isnan => ieee_is_nan
   implicit none
-  
+
   private
 
   type, public :: MAPL_GriddedIO
@@ -92,7 +92,7 @@ module MAPL_GriddedIOMod
         type(GriddedIOitemVector), intent(in), optional :: items
         integer, intent(out), optional :: rc
 
-        if (present(metadata)) GriddedIO%metadata=metadata 
+        if (present(metadata)) GriddedIO%metadata=metadata
         if (present(input_bundle)) GriddedIO%input_bundle=input_bundle
         if (present(output_bundle)) GriddedIO%output_bundle=output_bundle
         if (present(regrid_method)) GriddedIO%regrid_method=regrid_method
@@ -172,10 +172,10 @@ module MAPL_GriddedIOMod
         order = this%metadata%get_order(rc=status)
         _VERIFY(status)
         metadataVarsSize = order%size()
-         
+
         do while (iter /= this%items%end())
            item => iter%get()
-           if (item%itemType == ItemTypeScalar) then 
+           if (item%itemType == ItemTypeScalar) then
               call this%CreateVariable(item%xname,rc=status)
               _VERIFY(status)
            else if (item%itemType == ItemTypeVector) then
@@ -186,7 +186,7 @@ module MAPL_GriddedIOMod
            end if
            call iter%next()
         enddo
-        
+
         if (this%itemOrderAlphabetical) then
            call this%alphabatize_variables(metadataVarsSize,rc=status)
            _VERIFY(status)
@@ -195,9 +195,9 @@ module MAPL_GriddedIOMod
         if (present(global_attributes)) then
            s_iter = global_attributes%begin()
            do while(s_iter /= global_attributes%end())
-              attr_name => s_iter%key()       
+              attr_name => s_iter%key()
               attr_val => s_iter%value()
-              call this%metadata%add_attribute(attr_name,attr_val,_RC) 
+              call this%metadata%add_attribute(attr_name,attr_val,_RC)
               call s_iter%next()
            enddo
         end if
@@ -303,7 +303,7 @@ module MAPL_GriddedIOMod
         class (MAPL_GriddedIO), intent(inout) :: this
         character(len=*), intent(in) :: itemName
         integer, optional, intent(out) :: rc
- 
+
         integer :: status
 
         type(ESMF_Field) :: field,newField
@@ -345,7 +345,7 @@ module MAPL_GriddedIOMod
            vdims=grid_dims//",time"
         else if (fieldRank==3) then
            vdims=grid_dims//",lev,time"
-        else 
+        else
            _FAIL( 'Unsupported field rank')
         end if
         v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel)
@@ -360,6 +360,7 @@ module MAPL_GriddedIOMod
         call v%add_attribute('add_offset',0.0)
         call v%add_attribute('_FillValue',MAPL_UNDEF)
         call v%add_attribute('valid_range',(/-MAPL_UNDEF,MAPL_UNDEF/))
+        call v%add_attribute('regrid_method', translate_regrid_method(this%regrid_method))
         call factory%append_variable_metadata(v)
         call this%metadata%add_variable(trim(varName),v,rc=status)
         _VERIFY(status)
@@ -379,11 +380,11 @@ module MAPL_GriddedIOMod
 
      end subroutine CreateVariable
 
-     subroutine modifyTime(this, oClients, rc) 
+     subroutine modifyTime(this, oClients, rc)
         class(MAPL_GriddedIO), intent(inout) :: this
         type (ClientManager), optional, intent(inout) :: oClients
         integer, optional, intent(out) :: rc
- 
+
         type(Variable) :: v
         type(StringVariableMap) :: var_map
         integer :: status
@@ -401,11 +402,11 @@ module MAPL_GriddedIOMod
 
      end subroutine modifyTime
 
-     subroutine modifyTimeIncrement(this, frequency, rc) 
+     subroutine modifyTimeIncrement(this, frequency, rc)
         class(MAPL_GriddedIO), intent(inout) :: this
         integer, intent(in) :: frequency
         integer, optional, intent(out) :: rc
- 
+
         integer :: status
 
         call this%timeInfo%setFrequency(frequency, rc=status)
@@ -432,7 +433,7 @@ module MAPL_GriddedIOMod
         this%times = this%timeInfo%compute_time_vector(this%metadata,rc=status)
         _VERIFY(status)
         ref = ArrayReference(this%times)
-        call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref) 
+        call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref)
 
         tindex = size(this%times)
         if (tindex==1) then
@@ -578,7 +579,7 @@ module MAPL_GriddedIOMod
               call MAPL_FieldGetPointer(OutField,outptr3d,rc=status)
               _VERIFY(status)
            else
-              allocate(outptr3d(0,0,0)) 
+              allocate(outptr3d(0,0,0))
            end if
            if (gridIn==gridOut) then
               outPtr3d=Ptr3d
@@ -776,10 +777,10 @@ module MAPL_GriddedIOMod
      integer, allocatable :: localStart(:),globalStart(:),globalCount(:)
      logical :: hasll
      class(Variable), pointer :: var_lat,var_lon
- 
+
      var_lon => this%metadata%get_variable('lons')
      var_lat => this%metadata%get_variable('lats')
-     
+
      hasll = associated(var_lon) .and. associated(var_lat)
      if (hasll) then
         factory => get_factory(this%output_grid,rc=status)
@@ -809,7 +810,7 @@ module MAPL_GriddedIOMod
 
      var_lon => this%metadata%get_variable('corner_lons')
      var_lat => this%metadata%get_variable('corner_lats')
-     
+
      hasll = associated(var_lon) .and. associated(var_lat)
      if (hasll) then
         factory => get_factory(this%output_grid,rc=status)
@@ -838,8 +839,8 @@ module MAPL_GriddedIOMod
      _RETURN(_SUCCESS)
 
   end subroutine stage2DLatLon
-  
-  subroutine stageData(this, field, fileName, tIndex, oClients, rc) 
+
+  subroutine stageData(this, field, fileName, tIndex, oClients, rc)
      class (MAPL_GriddedIO), intent(inout) :: this
      type(ESMF_Field), intent(inout) :: field
      character(len=*), intent(in) :: fileName
@@ -912,7 +913,7 @@ module MAPL_GriddedIOMod
      class (MAPL_GriddedIO), intent(inout) :: this
      integer, intent(in) :: nFixedVars
      integer, optional, intent(out) :: rc
-      
+
      type(StringVector) :: order
      type(StringVector) :: newOrder
      character(len=:), pointer :: v1
@@ -930,7 +931,7 @@ module MAPL_GriddedIOMod
         v1 => order%at(i)
         if ( i > nFixedVars) temp(i)=trim(v1)
      enddo
- 
+
      swapped = .true.
      do while(swapped)
         swapped = .false.
@@ -957,7 +958,7 @@ module MAPL_GriddedIOMod
      deallocate(temp)
 
      _RETURN(_SUCCESS)
- 
+
   end subroutine alphabatize_variables
 
   subroutine request_data_from_file(this,filename,timeindex,rc)
@@ -1045,7 +1046,7 @@ module MAPL_GriddedIOMod
            ref=factory%generate_file_reference3D(ptr3d,metadata=this%current_file_metadata%filemetadata)
            allocate(localStart,source=[gridLocalStart,1,timeIndex])
            allocate(globalStart,source=[gridGlobalStart,1,timeIndex])
-           allocate(globalCount,source=[gridGlobalCount,lm,1]) 
+           allocate(globalCount,source=[gridGlobalCount,lm,1])
         end if
         call i_Clients%collective_prefetch_data( &
              this%read_collection_id, fileName, trim(names(i)), &
@@ -1063,7 +1064,7 @@ module MAPL_GriddedIOMod
      class(mapl_GriddedIO), intent(inout) :: this
      integer, intent(out), optional :: rc
 
-     integer :: status     
+     integer :: status
      integer :: i,numVars
      character(len=ESMF_MAXSTR), allocatable :: names(:)
      type(ESMF_Field) :: field
@@ -1124,7 +1125,7 @@ module MAPL_GriddedIOMod
      endif
 
      fill_value = this%current_file_metadata%var_get_missing_value(fname,_RC)
-     
+
      call ESMF_FieldBundleGet(this%input_bundle,fname,field=field,_RC)
      call ESMF_FieldBundleGet(this%input_bundle,grid=gridIn,_RC)
      call ESMF_FieldGet(field,rank=fieldRank,_RC)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds a new variable metadata to history corresponding to the regrid method used. Testing shows it to be zero-diff and all seems to work.

Also, this fixes a bug where in NEAREST_STOD was not supported by mistake.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1636 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We could eventually have different regridding methods per variable. Now we at least have per-collection. By adding some extra metadata, we can at least tell how each variable was regridded:

```
        float BCDP001(time, lat, lon) ;
                BCDP001:_FillValue = 1.e+15f ;
                BCDP001:add_offset = 0.f ;
                BCDP001:fmissing_value = 1.e+15f ;
                BCDP001:long_name = "Carbonaceous Aerosol Dry Deposition (Bin %d)" ;
                BCDP001:missing_value = 1.e+15f ;
                BCDP001:regrid_method = "conserve_2nd" ;
                BCDP001:scale_factor = 1.f ;
                BCDP001:standard_name = "Carbonaceous Aerosol Dry Deposition (Bin %d)" ;
                BCDP001:units = "kg m-2 s-1" ;
                BCDP001:valid_range = -1.e+15f, 1.e+15f ;
                BCDP001:vmax = 1.e+15f ;
                BCDP001:vmin = -1.e+15f ;
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran GEOS and it built and ran and was zero-diff

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
