### PR TITLE
Fix bug setting target stretched grid lat/lon from restart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix setting stretched grid target latitude and longitude from restart file metadata
+
 ### Added
 
 - Add option to build source tarfile when building MAPL standalone. By default this is `OFF`, but can be enabled with

--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -338,7 +338,7 @@ contains
          attr_val => attr%get_values()
          select type(q=>attr_val)
          type is (real(kind=REAL32))
-            this%target_lon = q(1)
+            this%target_lat = q(1)
          class default
             _FAIL('unsupport subclass for stretch params')
          end select
@@ -346,7 +346,7 @@ contains
          attr_val => attr%get_values()
          select type(q=>attr_val)
          type is (real(kind=REAL32))
-            this%target_lat = q(1)
+            this%target_lon = q(1)
          class default
             _FAIL('unsupport subclass for stretch params')
          end select


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Stretched grid target latitude and longitude are incorrectly assigned when setting them from restart file metadata. Target lat is set to lon, and lon is set to lat. This bug only impacts running with stretched grid using target latitude and longitude from restart file metadata.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/geoschem/GCHP/issues/246

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix uses the correct restart file metadata to set stretched grid target latitude and longitude.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in GCHP 14.0.0 using MAPL 2.18.3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
