### PR TITLE
Update CHANGELOG and CMakeLists for 2.25.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
 ### Added
 
--Added an overloaded interface for MAPL_BalanceWork to handle both REAL32 and REAl64
-## [Unreleased]
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.25.0] - 2022-09-01
 
 ### Fixed
 
@@ -20,19 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option to build source tarfile when building MAPL standalone. By default this is `OFF`, but can be enabled with
   `-DINSTALL_SOURCE_TARFILE=ON`
 - Added `regrid_method` metadata to History output
+- Added an overloaded interface for MAPL_BalanceWork to handle both REAL32 and REAL64
 
 ### Changed
 
-- Updated `components.yaml` to match GEOSgcm v10.22.1
+- Updated `components.yaml` to match GEOSgcm v10.22.5 (actually a bit beyond)
   - ESMA_env v4.2.0 → v4.4.0 (Update to Intel 2022.1, Add TOSS4 Support at NAS)
   - ESMA_cmake v3.17.0 → v3.18.0 (Updates to CPack and Provisional M2 Support)
 
 ### Removed
 
 - Removed `LatLonGridFactory_basic` factory constructor (dead code)
-
-### Deprecated
-
 ## [2.24.0] - 2022-08-08
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.24.0
+  VERSION 2.25.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
Trivial PR to fix up CHANGELOG.md and CMakeLists for a 2.25 release.