### PR TITLE
Fixes #1654. We check first if we actually need to allocate the field…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.25.0] - 2022-09-01
 
 ### Fixed
-
+- Change the logic to check if the field is already connected to a valid grid. If yes, we bypass the checks for tilegrid (issue #1654)
+	
 - Fix setting stretched grid target latitude and longitude from restart file metadata
 
 ### Added

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -6260,7 +6260,9 @@ contains
 
       integer :: range_(2)
       type(MAPL_VarSpec), pointer :: varspec
-
+      logical :: is_created
+      type(ESMF_Field) :: SPEC_FIELD
+      
       if (present(range)) then
          range_ = range
       else
@@ -6278,37 +6280,45 @@ contains
             GRD = GRID
          else
             ! choose the grid
-            Dimensionality: select case(DIMS)
+            call MAPL_VarSpecGet(SPEC%var_specs%of(L), FIELD=SPEC_FIELD, _RC)
+            isCreated = ESMF_FieldIsCreated(SPEC_FIELD, _RC)
+            if (isCreated) then
+               call ESMF_FieldGet(field, grid=GRD, _RC)
+            else
+             
 
-            case(MAPL_DimsHorzVert)
-               select case(LOCATION)
-               case(MAPL_VLocationCenter)
+               Dimensionality: select case(DIMS)
+                  
+               case(MAPL_DimsHorzVert)
+                  select case(LOCATION)
+                  case(MAPL_VLocationCenter)
+                     GRD = GRID
+                  case(MAPL_VLocationEdge  )
+                     GRD = GRID
+                  case default
+                     _RETURN(ESMF_FAILURE)
+                  end select
+               case(MAPL_DimsHorzOnly)
                   GRD = GRID
-               case(MAPL_VLocationEdge  )
+               case(MAPL_DimsVertOnly)
                   GRD = GRID
+               case(MAPL_DimsNone)
+                  GRD = GRID
+               case(MAPL_DimsTileOnly)
+                  if (.not. present(TILEGRID)) then
+                     _RETURN(ESMF_FAILURE)
+                  endif
+                  GRD = TILEGRID
+               case(MAPL_DimsTileTile)
+                  if (.not. present(TILEGRID)) then
+                     _RETURN(ESMF_FAILURE)
+                  endif
+                  GRD = TILEGRID
                case default
                   _RETURN(ESMF_FAILURE)
-               end select
-            case(MAPL_DimsHorzOnly)
-               GRD = GRID
-            case(MAPL_DimsVertOnly)
-               GRD = GRID
-            case(MAPL_DimsNone)
-               GRD = GRID
-            case(MAPL_DimsTileOnly)
-               if (.not. present(TILEGRID)) then
-                  _RETURN(ESMF_FAILURE)
-               endif
-               GRD = TILEGRID
-            case(MAPL_DimsTileTile)
-               if (.not. present(TILEGRID)) then
-                  _RETURN(ESMF_FAILURE)
-               endif
-               GRD = TILEGRID
-            case default
-               _RETURN(ESMF_FAILURE)
-            end select Dimensionality
-         end if
+               end select Dimensionality
+            end if ! if created
+         end if ! if ISTAT
 
          varspec => SPEC%var_specs%of(L)
          call MAPL_VarSpecSet(varspec, GRID=GRD, RC=status )


### PR DESCRIPTION
…, and only then require the grid to be set

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the field is already connected to a valid esmf field, we get the grid from it, and bypass the logic requiring tilegrid to be set
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
