### PR TITLE
remove unnecessary DSO lib name assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed unnecessary DSO extension assert
 - Fixed bug that required a /dev/null ExtData entry to still have a file variable name
 
 ### Added

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -4826,10 +4826,8 @@ contains
       call child_meta%t_profiler%start(__RC__)
       call child_meta%t_profiler%start('SetService',__RC__)
 
-      extension = get_file_extension(SharedObj)
-      _ASSERT(is_supported_dso_name(SharedObj), "AddChildFromDSO: Unsupported shared library extension '"//extension//",.")
-
       if (.not. is_valid_dso_name(SharedObj)) then
+         extension = get_file_extension(SharedObj)
          lgr => logging%get_logger('MAPL.GENERIC')
          call lgr%warning("AddChildFromDSO: changing shared library extension from %a~ to system specific extension %a~", &
               "'"//extension//"'", "'"//SYSTEM_DSO_EXTENSION//"'")
@@ -4893,10 +4891,8 @@ contains
       call child_meta%t_profiler%start(__RC__)
       call child_meta%t_profiler%start('SetService',__RC__)
 
-      extension = get_file_extension(SharedObj)
-      _ASSERT(is_supported_dso_name(SharedObj), "AddChildFromDSO: Unsupported shared library extension '"//extension//",.")
-
       if (.not. is_valid_dso_name(SharedObj)) then
+         extension = get_file_extension(SharedObj)
          lgr => logging%get_logger('MAPL.GENERIC')
          call lgr%warning("AddChildFromDSO: changing shared library extension from %a~ to system specific extension %a~", &
               "'"//extension//"'", "'"//SYSTEM_DSO_EXTENSION//"'")


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
Removed unnecessary ASSERT. If a wrong extension name of DSO lib is given, the assertion stops the program. it defeats the purpose of adjusting the extension a few lines below. It addresses issue #1663 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
