### PR TITLE
Prepare for MAPL 2.26.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.26.0] - 2022-09-16
+
+### Fixed
+
 - Removed unnecessary DSO extension assert
 - Fixed bug that required a /dev/null ExtData entry to still have a file variable name
 - Fixed bug with checking for duplicate alias in collection
@@ -25,8 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed unused code from History GridComp
-
-### Deprecated
 
 ## [2.25.0] - 2022-09-01
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.25.0
+  VERSION 2.26.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
Updating the usual files for 2.26 release.