### PR TITLE
Update dependabot to target develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,11 @@ updates:
     directory: "/" # Dependabot knows to look in .github/workflows for GitHub Actions
     schedule:
       interval: "daily"
+    target-branch: "develop"
 
   # Enable daily updates for Docker
   - package-ecosystem: "docker"
     directory: "/.docker" # Location of Dockerfile
     schedule:
       interval: "daily"
+    target-branch: "develop"


### PR DESCRIPTION
This updates the dependabot to target develop, not main as we do most development there.