### PR TITLE
Update error codes to match _FAILURE macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Error codes in `shared/MAPL_Error_Handling.F90` are now consistent with `_FAILURE = 1` in `include/MAPL_ErrLog.h`
 
 ### Removed
 

--- a/shared/MAPL_ErrorHandling.F90
+++ b/shared/MAPL_ErrorHandling.F90
@@ -13,31 +13,31 @@ module MAPL_ErrorHandlingMod
    public :: MAPL_abort
 
 
-   public :: MAPL_UNKNOWN_ERROR
    public :: MAPL_SUCCESS
 
+   public :: MAPL_UNKNOWN_ERROR
    public :: MAPL_NO_SUCH_PROPERTY
    public :: MAPL_NO_SUCH_VARIABLE
    public :: MAPL_TYPE_MISMATCH
    public :: MAPL_UNSUPPORTED_TYPE
-   public :: MAPL_VALUE_NOT_SUPPORTED
 
+   public :: MAPL_VALUE_NOT_SUPPORTED
    public :: MAPL_NO_DEFAULT_VALUE
    public :: MAPL_DUPLICATE_KEY
    public :: MAPL_STRING_TOO_SHORT
 
    enum, bind(c)
-      enumerator :: MAPL_UNKNOWN_ERROR = -1
       enumerator :: MAPL_SUCCESS       = 0
 
       ! 001-005
+      enumerator :: MAPL_UNKNOWN_ERROR
       enumerator :: MAPL_NO_SUCH_PROPERTY
       enumerator :: MAPL_NO_SUCH_VARIABLE
       enumerator :: MAPL_TYPE_MISMATCH
       enumerator :: MAPL_UNSUPPORTED_TYPE
-      enumerator :: MAPL_VALUE_NOT_SUPPORTED
 
       ! 006-010
+      enumerator :: MAPL_VALUE_NOT_SUPPORTED
       enumerator :: MAPL_NO_DEFAULT_VALUE
       enumerator :: MAPL_DUPLICATE_KEY
       enumerator :: MAPL_STRING_TOO_SHORT


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
Update error codes so that the `_FAILURE = 1` matches the error codes
## Description
<!--- Describe your changes in detail -->
`_FAILURE = 1` and `MAPL_UNKNOWN_ERROR = 1` (enumerator) for consistency. The remain error codes (enumerators) are incremented to accommodate `MAIL_UNKNOWN_ERROR`. `MAPL_SUCCESS = 0` is unchanged.
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1734

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, `_FAILURE = 1` was not consistent with error code `MAPL_UNKNOWN_ERROR = -1` while `MAPL_NO_SUCH_PROPERTY = 1`. This change makes them consistent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran a cmpscratch diff-0 test between this branch (pull request) and main successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
