### PR TITLE
Fixes #1194. Fix return macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add define for `-Dsys${CMAKE_SYSTEM_NAME}` to fix build issue with macOS and Intel (#1695)
+- Fix handling of return macros for programs and subroutines (#1194)
 
 ### Added
 

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -1186,7 +1186,6 @@ end module SupportMod
 ! throw an exception and RETURN.
 
 ! The main program.   Misleadingly simple.
-#undef MAPL_ErrLog_DONE
 #define I_AM_MAIN
 #include "MAPL_Generic.h"
 program main
@@ -1253,6 +1252,8 @@ program main
 contains
 
 
+#undef I_AM_MAIN
+#include "MAPL_Generic.h"
 
    subroutine check_resources(rc)
       use SupportMod

--- a/base/tests/mapl_bundleio_test.F90
+++ b/base/tests/mapl_bundleio_test.F90
@@ -172,7 +172,6 @@ CONTAINS
 ! This is how you can "reset" the MAPL_Generic.h verify bits for a program.
 ! Program must be at the end of the file to do this and everything else in a module
 
-#undef MAPL_ErrLog_DONE
 #define I_AM_MAIN
 #include "MAPL_Generic.h"
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,5 +6,8 @@ set( MAPL_PUBLIC_HEADERS
    NUOPC_ErrLog.h
    unused_dummy.H
    )
-file(COPY ${MAPL_PUBLIC_HEADERS} DESTINATION ${esma_include}/MAPL)
+
+foreach( _header ${MAPL_PUBLIC_HEADERS} )
+  configure_file( ${_header} ${esma_include}/MAPL/${_header} COPYONLY )
+endforeach()
 

--- a/include/MAPL_ErrLog.h
+++ b/include/MAPL_ErrLog.h
@@ -4,11 +4,6 @@
 ! on the ESMF logger.  For now these macros provide simple
 ! traceback capability.
 
-#ifndef MAPL_ErrLog_DONE
-
-
-#  define MAPL_ErrLog_DONE
-
 #  ifdef RETURN_
 #    undef RETURN_
 #  endif
@@ -112,9 +107,6 @@
 #    define _FAIL(msg) _ASSERT(.false.,msg)
 
 #  endif
-
-
-#endif
 
 
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes issues with return macros in programs where there are both main programs and "non-main" programs units (modules, procedures, etc.). The issue was you needed to `#undef MAPL_ErrLog_DONE` to get it to work as expected:

```fortran
#define I_AM_MAIN
#include "MAPL_ErrLog.h"

program main
...

contains

#undef MAPL_ErrLog_DONE
#undef I_AM_MAIN
#include "MAPL_ErrLog.h"

  subroutine foo
  ...
  end subroutine foo

end program main
```

However, experiments by @tclune and myself show this doesn't see to be needed. Maybe back in the olden days it was expensive to include a file twice? Not sure.

This PR also has a minor CMake fix for the `include` directory as well for file copy handling.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1194 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Makes for cleaner code. One `#undef` is better than two.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran with GEOSgcm and was zero-diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
