### PR TITLE
Add ability to pass extra arguments to FLAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Coupled MOM6 GCM run to CI (ifort only)
+- Added ability to pass in extra options to FLAP CLI arguments
 
 ### Changed
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR provides the ability to pass extra options to FLAP beyond those used in Cap. This was requested by @JulesKouatchou for his work with the LIS.

To do this, you must add a new argument to the `MAPL_FlapCLI` call:
```fortran
      cli = MAPL_FlapCLI(description = 'GEOS AGCM', &
                         authors     = 'GMAO', &
                         extra = extra_options)
```

and provide a new subroutine in the program:
```fortran
   subroutine extra_options(options, rc)
      type(command_line_interface), intent(inout) :: options
      integer, optional, intent(out) :: rc

      integer :: status

      call options%add(switch='--file', &
         switch_ab='-f', &
         help='Name of the input file', &
         required=.false., &
         def='default.txt', &
         act='store', &
         error=status)

   end subroutine
```
and finally you need to pull out the new option into a variable:

```fortran
      character(1024) :: buffer, extra_file
...
      call cli%cli_options%get(val=buffer, switch='--file', error=status); _VERIFY(status)
      extra_file = trim(buffer)
```

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Allows users of MAPL to add extra command line options without needing to change MAPL itself.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran with GEOSgcm and it was zero-diff.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
