### PR TITLE
Handmerge develop into release/MAPL-v3 2022-Oct-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add define for `-Dsys${CMAKE_SYSTEM_NAME}` to fix build issue with macOS and Intel (#1695)
+- Fix handling of return macros for programs and subroutines (#1194)
 
 ### Added
 
 - Add Coupled MOM6 GCM run to CI (ifort only)
+- Added ability to pass in extra options to FLAP CLI arguments
 
 ### Changed
 

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -1186,7 +1186,6 @@ end module SupportMod
 ! throw an exception and RETURN.
 
 ! The main program.   Misleadingly simple.
-#undef MAPL_ErrLog_DONE
 #define I_AM_MAIN
 #include "MAPL_Generic.h"
 program main
@@ -1253,6 +1252,8 @@ program main
 contains
 
 
+#undef I_AM_MAIN
+#include "MAPL_Generic.h"
 
    subroutine check_resources(rc)
       use SupportMod

--- a/base/tests/mapl_bundleio_test.F90
+++ b/base/tests/mapl_bundleio_test.F90
@@ -172,7 +172,6 @@ CONTAINS
 ! This is how you can "reset" the MAPL_Generic.h verify bits for a program.
 ! Program must be at the end of the file to do this and everything else in a module
 
-#undef MAPL_ErrLog_DONE
 #define I_AM_MAIN
 #include "MAPL_Generic.h"
 

--- a/gridcomps/Cap/FlapCLI.F90
+++ b/gridcomps/Cap/FlapCLI.F90
@@ -20,13 +20,22 @@ module MAPL_FlapCLIMod
       procedure :: fill_cap_options
    end type FlapCLI_Type
 
+   abstract interface
+      subroutine I_extraoptions(options, rc)
+         import command_line_interface
+         type(command_line_interface), intent(inout) :: options
+         integer, optional, intent(out) :: rc
+      end subroutine
+   end interface
+
 contains
 
-   function FlapCLI(unusable, description, authors, rc) result (cap_options)
+   function FlapCLI(unusable, description, authors, extra, rc) result (cap_options)
       class(KeywordEnforcer), optional, intent(in) :: unusable
       type (MAPL_CapOptions) :: cap_options
       character(*), intent(in) :: description
       character(*), intent(in) :: authors
+      procedure(I_extraoptions), optional :: extra
       integer, optional, intent(out) :: rc
       integer :: status
 
@@ -38,6 +47,10 @@ contains
 
       call flap_cli%add_command_line_options(flap_cli%cli_options, rc=status)
       _VERIFY(status)
+
+      if (present(extra)) then
+         call extra(flap_cli%cli_options, _RC)
+      end if
 
       call flap_cli%cli_options%parse(error=status); _VERIFY(status)
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,5 +6,8 @@ set( MAPL_PUBLIC_HEADERS
    NUOPC_ErrLog.h
    unused_dummy.H
    )
-file(COPY ${MAPL_PUBLIC_HEADERS} DESTINATION ${esma_include}/MAPL)
+
+foreach( _header ${MAPL_PUBLIC_HEADERS} )
+  configure_file( ${_header} ${esma_include}/MAPL/${_header} COPYONLY )
+endforeach()
 

--- a/include/MAPL_ErrLog.h
+++ b/include/MAPL_ErrLog.h
@@ -4,9 +4,6 @@
 ! on the ESMF logger.  For now these macros provide simple
 ! traceback capability.
 
-#ifndef MAPL_ErrLog_DONE
-
-#  define MAPL_ErrLog_DONE
 #  ifdef RETURN_
 #    undef RETURN_
 #  endif
@@ -116,9 +113,6 @@
 #    define _FAIL(msg) _ASSERT(.false.,msg)
 
 #  endif
-
-
-#endif
 
 
 


### PR DESCRIPTION
This is a handmerge of `develop` into `release/MAPL-v3`. I'm mainly doing it this way to make sure CI says I did the merge right.

Supersedes #1762 