### PR TITLE
Fixes #1784. Fix build issue at NAS

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -15,16 +15,18 @@ install (PROGRAMS
   TYPE SYSCONF
   )
 
-ecbuild_add_executable (TARGET Regrid_Util.x SOURCES Regrid_Util.F90 DEPENDS esmf )
-target_link_libraries (Regrid_Util.x PRIVATE MAPL ${MPI_Fortran_LIBRARIES})
+ecbuild_add_executable (TARGET Regrid_Util.x SOURCES Regrid_Util.F90)
+target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran esmf)
+target_include_directories (Regrid_Util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-           target_link_libraries(Regrid_Util.x PRIVATE OpenMP::OpenMP_Fortran)
-   endif ()
+  target_link_libraries(Regrid_Util.x PRIVATE OpenMP::OpenMP_Fortran)
+endif ()
 
-ecbuild_add_executable (TARGET time_ave_util.x SOURCES time_ave_util.F90 DEPENDS esmf )
-target_link_libraries (time_ave_util.x PRIVATE MAPL ${MPI_Fortran_LIBRARIES})
+ecbuild_add_executable (TARGET time_ave_util.x SOURCES time_ave_util.F90)
+target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran esmf)
+target_include_directories (time_ave_util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-           target_link_libraries(time_ave_util.x PRIVATE OpenMP::OpenMP_Fortran)
-   endif ()
+  target_link_libraries(time_ave_util.x PRIVATE OpenMP::OpenMP_Fortran)
+endif ()

--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -1428,7 +1428,7 @@ contains
       real, allocatable ::   qg(:,:)
       real, allocatable :: buf(:,:)
       real :: qsum
-      integer :: mpi_status(mpi_status_size)
+      integer :: mpistatus(mpi_status_size)
       integer, allocatable :: ims(:),jms(:)
       integer j,n,peid,peid0,i1,j1,in,jn,mypet,i_start,i_end,isum
       type(ESMF_VM) :: vm
@@ -1453,7 +1453,7 @@ contains
          do n=1,nx-1
             allocate(buf(ims(n+1),jm))
             peid = mypet + n
-            call mpi_recv(buf,ims(n+1)*jm,MPI_FLOAT,peid,peid,MPI_COMM_WORLD,mpi_status,status)
+            call mpi_recv(buf,ims(n+1)*jm,MPI_FLOAT,peid,peid,MPI_COMM_WORLD,mpistatus,status)
             _VERIFY(status)
             i_start=i_end+1
             i_end = i_start+ims(n)-1
@@ -1484,7 +1484,7 @@ contains
             _VERIFY(status)
          enddo
       else
-         call mpi_recv(qz,jm,MPI_FLOAT,peid0,peid0,MPI_COMM_WORLD,mpi_status,status)
+         call mpi_recv(qz,jm,MPI_FLOAT,peid0,peid0,MPI_COMM_WORLD,mpistatus,status)
          _VERIFY(status)
       end if
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.30.1] - 2022-11-07
+
+### Fixed
+
+- Fix for building `time_ave_util.x` at NAS using MPT
+
 ## [2.30.0] - 2022-11-03
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.30.0
+  VERSION 2.30.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -82,7 +82,7 @@ foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
 endforeach()
 
 ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS esmf MAPL.shared)
-target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio ${MPI_Fortran_LIBRARIES})
+target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(cub2latlon.x PRIVATE OpenMP::OpenMP_Fortran)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes a build issue at NAS using GNU + MPT. The error is:

```
/nobackup/mathomp4/SystemTests/builds/AGCM_GNUMAPLDEV/CURRENT/GEOSgcm/src/Shared/@MAPL/Apps/time_ave_util.F90:1456:77:

 1456 |             call mpi_recv(buf,ims(n+1)*jm,MPI_FLOAT,peid,peid,MPI_COMM_WORLD,mpi_status,status)
      |                                                                             1
Error: Derived type ‘mpi_status’ is used as an actual argument at (1)
/nobackup/mathomp4/SystemTests/builds/AGCM_GNUMAPLDEV/CURRENT/GEOSgcm/src/Shared/@MAPL/Apps/time_ave_util.F90:1487:66:

 1487 |          call mpi_recv(qz,jm,MPI_FLOAT,peid0,peid0,MPI_COMM_WORLD,mpi_status,status)
      |                                                                  1
Error: Derived type ‘mpi_status’ is used as an actual argument at (1)
```
and I think the main issue is that `mpi_status` is an [actual type in MPI_F08](https://rookiehpc.github.io/mpi/docs/mpi_status/index.html) and this is bleeding into things because MPT + GNU at NAS is weird (I have to build the Fortran modules myself!). 🤷🏼 

Still, in other bits of MAPL, this sort of thing is called `mpstatus`:

https://github.com/GEOS-ESM/MAPL/blob/723999d3c730bbb18e89df2ae6f4076be3dc1f57/base/MAPL_LocStreamMod.F90#L2234

https://github.com/GEOS-ESM/MAPL/blob/723999d3c730bbb18e89df2ae6f4076be3dc1f57/base/MAPL_LocStreamMod.F90#L2297-L2300

I called mine `mpistatus` because I like it better.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1784 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Lets MAPL `develop` build at NAS but technically this is a bug in `main` so...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It builds, so I assume it works. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
