### PR TITLE
Add status check after retrieving variable data from NetCDF file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- Added assert to NetCDF4_get_var.H to print variable name if data retrieval fails
 
 ### Changed
 

--- a/pfio/NetCDF4_get_var.H
+++ b/pfio/NetCDF4_get_var.H
@@ -34,7 +34,7 @@
       status = nf90_get_var(this%ncid, varid, values, start, count)
 #endif
      !$omp end critical
-      _VERIFY(status)
+      _ASSERT(status==0,"Unable to get variable: "//trim(var_name))
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
This PR expands the error handling in the macro within `NetCDF4_get_var.H` which retrieves data from netcdf files.

## Description
<!--- Describe your changes in detail -->
There is now an assert statement following the attempt to get values for a variable from file. If the status indicates a problem then a helpful message is printed containing the variable name that was trying to be accessed.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Corrupted input files may result in a bad status code after calling function nf90_get_var. Users get tripped up by this since there are no messages automatically printed that indicate the variable that is causing the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
GCHP testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
