### PR TITLE
Handmerge of TerribleNews/geos-patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed issues with alarms when clocks are run in reverse.
 
 ### Added
-
+- Added option to run in reverse
+	
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - Fixed issues with alarms when clocks are run in reverse.
 
 ### Added
+
 - Added option to run in reverse
-	
+
 ### Changed
 
 ### Removed

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -177,7 +177,9 @@ module MAPL_GenericMod
    public MAPL_RequestService
 
    ! MAPL_Util
-   !public MAPL_GenericStateClockAdd
+   public MAPL_GenericStateClockOn
+   public MAPL_GenericStateClockOff
+   public MAPL_GenericStateClockAdd
    public MAPL_TimerOn
    public MAPL_TimerOff
    public MAPL_TimerAdd

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2362,6 +2362,13 @@ ENDDO PARSER
                   if (allocated(ungridded_coord)) deallocate(ungridded_coord)
 
                else
+               
+                  if (.false. .and. MAPL_AM_I_ROOT()) THEN
+                     WRITE(*,*) 'REFRESH = ', REFRESH, ' AVGINT = ', AVGINT
+                     WRITE(*,*) 'acc_int = ', MAPL_nsecf(list(n)%acc_interval), &
+                          ' freq = ', MAPL_nsecf(list(n)%frequency)
+                  
+                  endif
 
                   call MAPL_VarSpecCreateInList(INTSTATE%SRCS(n)%SPEC,     &
                        SHORT_NAME = SHORT_NAME,                            &


### PR DESCRIPTION
## NOTE: This is a hand-merge version of #1166 by @TerribleNews due to the age of that PR versus newer MAPL. I'll repeat all the text from there. Unfortunately, this means @TerribleNews might not get the commit credit!

---

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


This change adds a time loop to CapGridComp run the clock forward before the time loop that actually executes the grid components. There are also some small changes to handle issues with alarms not ringing properly in reverse.


## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1144 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This feature is to support to adjoint development in GCHP, which requires running the model in reverse. There may be other advantages to a generic capability to run MAPL in reverse as well.

This will be my first merge request to the team, so I am submitting mostly to start the conversation and get guidance / feedback.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unfortunately, because GCHP uses a fork of MAPL it is non-trivial to test code changes with the latest version. All these changes are patterned after changes that have been tested in GCHP using the verison of MAPL that is there, which is based on 2.6.3. Is there a way for me to test these exact changes?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
