### PR TITLE
Handmerge of develop into MAPL3 2022-Nov-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- Added assert to NetCDF4_get_var.H to print variable name if data retrieval fails
 
 ### Changed
+
+-  When a grid is received from outside of MAPL (e.g., NOAA UFS), MAPL must provide a mechanism to specify a grid-type for internal processing.
+Add an option to set_grid to set GridType explicitly.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,12 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--  When a grid is received from outside of MAPL (e.g., NOAA UFS), MAPL must provide a mechanism to specify a grid-type for internal processing.
-Add an option to set_grid to set GridType explicitly.
-
 ### Removed
 
 ### Deprecated
+
+## [2.30.2] - 2022-11-09
+
+### Fixed
+
+-  When a grid is received from outside of MAPL (e.g., NOAA UFS), MAPL must provide a mechanism to specify a grid-type for internal processing.
+Add an option to set_grid to set GridType explicitly.
 
 ## [2.30.1] - 2022-11-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.30.1
+  VERSION 2.30.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -1537,6 +1537,7 @@ contains
 
      type(ESMF_Grid)           :: mapl_grid
      type(ExternalGridFactory) :: external_grid_factory
+     type(ESMF_Info)           :: infoh
      integer                   :: status
 
      _UNUSED_DUMMY(unusable)
@@ -1546,7 +1547,8 @@ contains
      ! grid_type is an optional parameter that allows GridType to be set explicitly.
      if (present(grid_type)) then
         if (grid_manager%is_valid_prototype(grid_type)) then
-           call ESMF_AttributeSet(mapl_grid, 'GridType', grid_type, _RC)
+           call ESMF_InfoGetFromHosts(mapl_grid, infoh, _RC)
+           call ESMF_InfoSet(infoh, 'GridType', grid_type, _RC)
         else
            _RETURN(_FAILURE)
         end if

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -1527,11 +1527,12 @@ contains
 
   end subroutine get_field_from_internal
 
-  subroutine set_grid(this, grid, unusable, lm, rc)
+  subroutine set_grid(this, grid, unusable, lm, grid_type, rc)
      class(MAPL_CapGridComp),          intent(inout) :: this
      type(ESMF_Grid),                  intent(in   ) :: grid
      class(KeywordEnforcer), optional, intent(in   ) :: unusable
      integer,                optional, intent(in   ) :: lm
+     character(len=*),       optional, intent(in)    :: grid_type
      integer,                optional, intent(  out) :: rc
 
      type(ESMF_Grid)           :: mapl_grid
@@ -1542,7 +1543,14 @@ contains
 
      external_grid_factory = ExternalGridFactory(grid=grid, lm=lm, _RC)
      mapl_grid = grid_manager%make_grid(external_grid_factory, _RC)
-
+     ! grid_type is an optional parameter that allows GridType to be set explicitly.
+     if (present(grid_type)) then
+        if (grid_manager%is_valid_prototype(grid_type)) then
+           call ESMF_AttributeSet(mapl_grid, 'GridType', grid_type, _RC)
+        else
+           _RETURN(_FAILURE)
+        end if
+     end if
      call ESMF_GridCompSet(this%gc, grid=mapl_grid, _RC)
 
      _RETURN(_SUCCESS)

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -1547,7 +1547,7 @@ contains
      ! grid_type is an optional parameter that allows GridType to be set explicitly.
      if (present(grid_type)) then
         if (grid_manager%is_valid_prototype(grid_type)) then
-           call ESMF_InfoGetFromHosts(mapl_grid, infoh, _RC)
+           call ESMF_InfoGetFromHost(mapl_grid, infoh, _RC)
            call ESMF_InfoSet(infoh, 'GridType', grid_type, _RC)
         else
            _RETURN(_FAILURE)

--- a/pfio/NetCDF4_get_var.H
+++ b/pfio/NetCDF4_get_var.H
@@ -34,7 +34,7 @@
       status = nf90_get_var(this%ncid, varid, values, start, count)
 #endif
      !$omp end critical
-      _VERIFY(status)
+      _ASSERT(status==0,"Unable to get variable: "//trim(var_name))
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)


### PR DESCRIPTION
Handmerge of `develop` into `release/MAPL-v3`. I'm doing this because I translated an `ESMF_Attribute` call into an `ESMF_Info` call and want to make sure it at least builds. Once it's in, might be good for @darianboggs to test MAPL3 and make sure it works.

Supersedes #1798 