### PR TITLE
Add netCDF quantize support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.5.0
+baselibs_version: &baselibs_version v7.6.0
 bcs_version: &bcs_version v10.23.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.6.0
+baselibs_version: &baselibs_version v7.6.1
 bcs_version: &bcs_version v10.23.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.6.0-openmpi_4.1.4-gcc_12.1.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.6.1-openmpi_4.1.4-gcc_12.1.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -77,7 +77,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.6.0-intelmpi_2021.6.0-intel_2021.6.0
+      image: gmao/ubuntu20-geos-env:v7.6.1-intelmpi_2021.6.0-intel_2022.1.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.5.0-openmpi_4.1.2-gcc_11.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.6.0-openmpi_4.1.4-gcc_12.1.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -77,7 +77,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.5.0-intelmpi_2021.3.0-intel_2021.3.0
+      image: gmao/ubuntu20-geos-env:v7.6.0-intelmpi_2021.6.0-intel_2021.6.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/Apps/Regrid_Util.F90
+++ b/Apps/Regrid_Util.F90
@@ -428,7 +428,7 @@ CONTAINS
 
          call ESMF_ClockSet(clock,currtime=time,_RC)
          if (.not. writer_created) then
-            call newWriter%create_from_bundle(bundle,clock,n_steps=tsteps,time_interval=tint,nbits=support%shave,deflate=support%deflate,vertical_data=vertical_data,quantize_algorithm=support%quantize_algorithm,quantize_level=support%quantize_level,_RC)
+            call newWriter%create_from_bundle(bundle,clock,n_steps=tsteps,time_interval=tint,nbits_to_keep=support%shave,deflate=support%deflate,vertical_data=vertical_data,quantize_algorithm=support%quantize_algorithm,quantize_level=support%quantize_level,_RC)
             writer_created=.true.
          end if
 

--- a/Apps/Regrid_Util.F90
+++ b/Apps/Regrid_Util.F90
@@ -24,6 +24,7 @@
       real :: cs_stretch_param(3)
       real :: lon_range(2), lat_range(2)
       integer :: deflate, shave
+      integer :: quantize_algorithm
       integer :: quantize_level
    contains
       procedure :: create_grid
@@ -94,6 +95,7 @@
     this%lat_range=uninit
     this%shave=64
     this%deflate=0
+    this%quantize_algorithm=1
     this%quantize_level=0
     nargs = command_argument_count()
     do i=1,nargs
@@ -151,6 +153,9 @@
       case('-deflate')
          call get_command_argument(i+1,astr)
          read(astr,*)this%deflate
+      case('-quantize_algorithm')
+         call get_command_argument(i+1,astr)
+         read(astr,*)this%quantize_algorithm
       case('-quantize_level')
          call get_command_argument(i+1,astr)
          read(astr,*)this%quantize_level
@@ -423,7 +428,7 @@ CONTAINS
 
          call ESMF_ClockSet(clock,currtime=time,_RC)
          if (.not. writer_created) then
-            call newWriter%create_from_bundle(bundle,clock,n_steps=tsteps,time_interval=tint,nbits=support%shave,deflate=support%deflate,vertical_data=vertical_data,quantize_level=support%quantize_level,_RC)
+            call newWriter%create_from_bundle(bundle,clock,n_steps=tsteps,time_interval=tint,nbits=support%shave,deflate=support%deflate,vertical_data=vertical_data,quantize_algorithm=support%quantize_algorithm,quantize_level=support%quantize_level,_RC)
             writer_created=.true.
          end if
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for netCDF bitgrooming. Note this requires netCDF-C v4.9.0 and netCDF-Fortran v4.6.0, but our CMake does have a test
-  to make sure the netCDF library was compiled with support.
+- Add support for netCDF quantize.
+  - Note this requires netCDF-C v4.9.0 and netCDF-Fortran v4.6.0, but our CMake does have a test
+    to make sure the netCDF library was compiled with support. This test uses `NETCDF_INCLUDE_DIRS` and as such
+    within GEOS requires the use of ESMA_cmake v3.20.0 or later to (possibly) succeed.
 
 ### Changed
+
+- Updated to ESMA_cmake v3.20.0
+  - This is to support the `NETCDF_INCLUDE_DIRS` used in the quantize support test
+- Updated to ESMA_env v4.7.0
+  - This has many updates including moving to netCDF-C v4.9.0 and netCDF-Fortran v4.6.0. The other updates:
+    - Baselibs v7.6.0
+      - ESMF v8.4.0
+      - zlib 1.2.13
+      - curl 7.86.0
+      - netCDF-C 4.9.0
+      - netCDF-Fortran 4.6.0
+      - NCO 5.1.1
+      - CDO 2.1.0
+- Removed some unneeded `use` statements in `ExtDataGridCompNG.F90`. This seemed to let this new quantize support build with Intel
+- Changed `nbits` internally to be `nbits_to_keep`. Note that externally, you still use `nbits:` in `HISTORY.rc`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for netCDF bitgrooming. Note this requires netCDF-C v4.9.0 and netCDF-Fortran v4.6.0, but our CMake does have a test
+  to make sure the netCDF library was compiled with support.
+
 ### Changed
 
 ### Removed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.30.3
+  VERSION 2.31.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.5.0
+  tag: v4.7.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.19.0
+  tag: v3.20.0
   develop: develop
 
 ecbuild:

--- a/gridcomps/ExtData2G/ExtDataGridCompNG.F90
+++ b/gridcomps/ExtData2G/ExtDataGridCompNG.F90
@@ -32,9 +32,8 @@
    use MAPL_VarSpecMod
    use MAPL_CFIOMod
    use MAPL_NewArthParserMod
-   use MAPL_ConstantsMod, only: MAPL_PI,MAPL_PI_R8,MAPL_RADIANS_TO_DEGREES
-   use MAPL_IOMod, only: MAPL_NCIOParseTimeUnits
-   use, intrinsic :: iso_fortran_env, only: REAL64
+   use MAPL_ConstantsMod, only: MAPL_RADIANS_TO_DEGREES
+   use, intrinsic :: iso_fortran_env, only: REAL32
    use linearVerticalInterpolation_mod
    use ESMF_CFIOCollectionVectorMod
    use ESMF_CFIOCollectionMod
@@ -460,7 +459,7 @@ CONTAINS
       item%initialized = .true.
 
       item%pfioCollection_id = MAPL_DataAddCollection(item%file_template)
-      call create_primary_field(item,self%ExtDataState,_RC) 
+      call create_primary_field(item,self%ExtDataState,_RC)
       if (item%isConst) then
          call set_constant_field(item,self%extDataState,_RC)
          cycle
@@ -993,7 +992,7 @@ CONTAINS
 
      call ESMF_StateGet(state,item%vcomp1,field,_RC)
      call item%modelGridFields%comp1%interpolate_to_time(field,time,_RC)
-     block 
+     block
         character(len=1024) :: fname
         integer :: rank
         call ESMF_FieldGet(field,name=fname,rank=rank,_RC)
@@ -1722,7 +1721,7 @@ CONTAINS
 
 
      call ESMF_AttributeGet(field,name="derived_source",value=derived_field_name,_RC)
-     call ESMF_StateGet(ExtDataState,trim(derived_field_name),derived_field,_RC) 
+     call ESMF_StateGet(ExtDataState,trim(derived_field_name),derived_field,_RC)
      call ESMF_FieldGet(derived_field,grid=grid,_RC)
 
      call ESMF_StateRemove(ExtDataState,[trim(item%name)],_RC)
@@ -1749,7 +1748,7 @@ CONTAINS
         type(ESMF_Grid), intent(in) :: grid
         integer, intent(in) :: num_levels
         integer, optional, intent(out) :: rc
- 
+
         integer :: status
         if (num_levels ==0) then
            new_field=ESMF_FieldCreate(grid,name=field_name,typekind=ESMF_TYPEKIND_R4,_RC)
@@ -1758,7 +1757,7 @@ CONTAINS
         end if
         _RETURN(_SUCCESS)
      end function
-        
+
   end subroutine create_primary_field
 
 

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -72,8 +72,9 @@ module MAPL_HistoryCollectionMod
      character(len=ESMF_MAXSTR)         :: vvars(2)
      integer                            :: regrid_method
      integer                            :: voting
-     integer                            :: nbits
+     integer                            :: nbits_to_keep
      integer                            :: deflate
+     character(len=ESMF_MAXSTR)         :: quantize_algorithm_string
      integer                            :: quantize_algorithm
      integer                            :: quantize_level
      integer                            :: slices

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -74,6 +74,7 @@ module MAPL_HistoryCollectionMod
      integer                            :: voting
      integer                            :: nbits
      integer                            :: deflate
+     integer                            :: quantize_algorithm
      integer                            :: quantize_level
      integer                            :: slices
      integer                            :: Root

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -74,6 +74,7 @@ module MAPL_HistoryCollectionMod
      integer                            :: voting
      integer                            :: nbits
      integer                            :: deflate
+     integer                            :: quantize_level
      integer                            :: slices
      integer                            :: Root
      integer                            :: Psize

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -866,6 +866,9 @@ contains
        call ESMF_ConfigGetAttribute ( cfg, list(n)%deflate, default=0, &
                                       label=trim(string) // 'deflate:' ,rc=status )
        _VERIFY(STATUS)
+       call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_level, default=0, &
+                                      label=trim(string) // 'quantize_level:' ,rc=status )
+       _VERIFY(STATUS)
 
        tm_default = -1
        call ESMF_ConfigGetAttribute ( cfg, list(n)%tm, default=tm_default, &
@@ -2489,6 +2492,8 @@ ENDDO PARSER
           end if
           call list(n)%mGriddedIO%set_param(deflation=list(n)%deflate,rc=status)
           _VERIFY(status)
+          call list(n)%mGriddedIO%set_param(quantize_level=list(n)%quantize_level,rc=status)
+          _VERIFY(status)
           call list(n)%mGriddedIO%set_param(chunking=list(n)%chunkSize,rc=status)
           _VERIFY(status)
           call list(n)%mGriddedIO%set_param(nbits=list(n)%nbits,rc=status)
@@ -2548,6 +2553,7 @@ ENDDO PARSER
          print *, '       Nbits: ',       list(n)%nbits
          print *, '      Slices: ',       list(n)%Slices
          print *, '     Deflate: ',       list(n)%deflate
+         print *, '    Quantize: ',       list(n)%quantize_level
          if (associated(list(n)%chunksize)) then
             print *, '   ChunkSize: ',       list(n)%chunksize
          end if

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -866,6 +866,9 @@ contains
        call ESMF_ConfigGetAttribute ( cfg, list(n)%deflate, default=0, &
                                       label=trim(string) // 'deflate:' ,rc=status )
        _VERIFY(STATUS)
+       call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_algorithm, default=1, &
+                                      label=trim(string) // 'quantize_algorithm:' ,rc=status )
+       _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_level, default=0, &
                                       label=trim(string) // 'quantize_level:' ,rc=status )
        _VERIFY(STATUS)
@@ -2492,6 +2495,8 @@ ENDDO PARSER
           end if
           call list(n)%mGriddedIO%set_param(deflation=list(n)%deflate,rc=status)
           _VERIFY(status)
+          call list(n)%mGriddedIO%set_param(quantize_algorithm=list(n)%quantize_algorithm,rc=status)
+          _VERIFY(status)
           call list(n)%mGriddedIO%set_param(quantize_level=list(n)%quantize_level,rc=status)
           _VERIFY(status)
           call list(n)%mGriddedIO%set_param(chunking=list(n)%chunkSize,rc=status)
@@ -2553,7 +2558,8 @@ ENDDO PARSER
          print *, '       Nbits: ',       list(n)%nbits
          print *, '      Slices: ',       list(n)%Slices
          print *, '     Deflate: ',       list(n)%deflate
-         print *, '    Quantize: ',       list(n)%quantize_level
+         print *, 'Quantize Alg: ',       list(n)%quantize_algorithm
+         print *, 'Quantize Lvl: ',       list(n)%quantize_level
          if (associated(list(n)%chunksize)) then
             print *, '   ChunkSize: ',       list(n)%chunksize
          end if

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -873,7 +873,7 @@ contains
        _VERIFY(STATUS)
 
        ! Uppercase the algorithm string just to allow for any case
-       uppercase_algorithm = ESMF_UtilStringUpperCase(list(n)%quantize_algorithm_string,rc=status)
+       uppercase_algorithm = ESMF_UtilStringUpperCase(list(n)%quantize_algorithm_string,_RC)
        select case (trim(uppercase_algorithm))
        case ('NONE')
           list(n)%quantize_algorithm = MAPL_Quantize_Disabled

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -427,6 +427,7 @@ contains
     character(len=ESMF_MAXSTR) :: name,regrid_method
     logical :: has_conservative_keyword, has_regrid_keyword
     integer :: create_mode
+    character(len=:), allocatable :: uppercase_algorithm
 
 ! Begin
 !------
@@ -860,18 +861,51 @@ contains
        call ESMF_ConfigGetAttribute ( cfg, list(n)%vunit, default="", &
                                       label=trim(string) // 'vunit:'  ,rc=status )
        _VERIFY(STATUS)
-       call ESMF_ConfigGetAttribute ( cfg, list(n)%nbits, default=100, &
+       call ESMF_ConfigGetAttribute ( cfg, list(n)%nbits_to_keep, default=MAPL_NBITS_NOT_SET, &
                                       label=trim(string) // 'nbits:' ,rc=status )
        _VERIFY(STATUS)
        call ESMF_ConfigGetAttribute ( cfg, list(n)%deflate, default=0, &
                                       label=trim(string) // 'deflate:' ,rc=status )
        _VERIFY(STATUS)
-       call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_algorithm, default=1, &
+
+       call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_algorithm_string, default='NONE', &
                                       label=trim(string) // 'quantize_algorithm:' ,rc=status )
        _VERIFY(STATUS)
+
+       ! Uppercase the algorithm string just to allow for any case
+       uppercase_algorithm = ESMF_UtilStringUpperCase(list(n)%quantize_algorithm_string,rc=status)
+       select case (trim(uppercase_algorithm))
+       case ('NONE')
+          list(n)%quantize_algorithm = MAPL_Quantize_Disabled
+       case ('BITGROOM')
+          list(n)%quantize_algorithm = MAPL_Quantize_BitGroom
+       case ('GRANULARBR')
+          list(n)%quantize_algorithm = MAPL_Quantize_GranularBR
+       case ('BITROUND')
+          list(n)%quantize_algorithm = MAPL_Quantize_BitRound
+       case default
+          _FAIL('Invalid quantize_algorithm. Allowed values are NONE, BitGroom, GranularBR, BitRound')
+       end select
+
        call ESMF_ConfigGetAttribute ( cfg, list(n)%quantize_level, default=0, &
                                       label=trim(string) // 'quantize_level:' ,rc=status )
        _VERIFY(STATUS)
+
+       ! If nbits_to_keep < MAPL_NBITS_UPPER_LIMIT (24) and quantize_algorithm greater than 0, then a user might be doing different
+       ! shaving algorithms. We do not allow this
+       _ASSERT( .not. ( (list(n)%nbits_to_keep < MAPL_NBITS_UPPER_LIMIT) .and. (list(n)%quantize_algorithm > 0) ), 'nbits < 24 and quantize_algorithm > 0 is not allowed. Choose one bit grooming method.')
+
+       ! quantize_algorithm must be between 0 and 3 where 0 means not enabled
+       _ASSERT( (list(n)%quantize_algorithm >= 0) .and. (list(n)%quantize_algorithm <= 3), 'quantize_algorithm must be between 0 and 3, where 0 means not enabled')
+
+       ! Now we test in the case that a valid quantize algorithm is chosen
+       if (list(n)%quantize_algorithm == 0) then
+         ! If quantize_algorithm is 0, then quantize_level must be 0
+          _ASSERT( list(n)%quantize_level == 0, 'quantize_algorithm is 0, so quantize_level must be 0')
+       else
+         ! If quantize_algorithm is greater than 0, then quantize_level must be greater than or equal to 0
+         _ASSERT( list(n)%quantize_level >= 0, 'netCDF quantize has been enabled, so quantize_level must be greater than or equal to 0')
+       end if
 
        tm_default = -1
        call ESMF_ConfigGetAttribute ( cfg, list(n)%tm, default=tm_default, &
@@ -2501,7 +2535,7 @@ ENDDO PARSER
           _VERIFY(status)
           call list(n)%mGriddedIO%set_param(chunking=list(n)%chunkSize,rc=status)
           _VERIFY(status)
-          call list(n)%mGriddedIO%set_param(nbits=list(n)%nbits,rc=status)
+          call list(n)%mGriddedIO%set_param(nbits_to_keep=list(n)%nbits_to_keep,rc=status)
           _VERIFY(status)
           call list(n)%mGriddedIO%set_param(regrid_method=list(n)%regrid_method,rc=status)
           _VERIFY(status)
@@ -2555,11 +2589,15 @@ ENDDO PARSER
          print *, '--------------------------- '
          print *, '      Format: ',  trim(list(n)%format)
          print *, '        Mode: ',  trim(list(n)%mode)
-         print *, '       Nbits: ',       list(n)%nbits
+         if (list(n)%nbits_to_keep < MAPL_NBITS_UPPER_LIMIT) then
+            print *, '       Nbits: ',       list(n)%nbits_to_keep
+         end if
          print *, '      Slices: ',       list(n)%Slices
          print *, '     Deflate: ',       list(n)%deflate
-         print *, 'Quantize Alg: ',       list(n)%quantize_algorithm
-         print *, 'Quantize Lvl: ',       list(n)%quantize_level
+         if (list(n)%quantize_algorithm > 0) then
+            print *, 'Quantize Alg: ',       trim(list(n)%quantize_algorithm_string)
+            print *, 'Quantize Lvl: ',       list(n)%quantize_level
+         end if
          if (associated(list(n)%chunksize)) then
             print *, '   ChunkSize: ',       list(n)%chunksize
          end if
@@ -5403,7 +5441,7 @@ ENDDO PARSER
     type(ESMF_Field) :: field
     real, pointer :: ptr1d(:), ptr2d(:,:), ptr3d(:,:,:)
 
-    if (list%nbits >=24) then
+    if (list%nbits_to_keep >=MAPL_NBITS_UPPER_LIMIT) then
        _RETURN(ESMF_SUCCESS)
     endif
 
@@ -5414,17 +5452,17 @@ ENDDO PARSER
        if (fieldRank ==1) then
           call ESMF_FieldGet(field, farrayptr=ptr1d, rc=status)
           _VERIFY(STATUS)
-          call pFIO_DownBit(ptr1d,ptr1d,list%nbits,undef=MAPL_undef,rc=status)
+          call pFIO_DownBit(ptr1d,ptr1d,list%nbits_to_keep,undef=MAPL_undef,rc=status)
           _VERIFY(STATUS)
        elseif (fieldRank ==2) then
           call ESMF_FieldGet(field, farrayptr=ptr2d, rc=status)
           _VERIFY(STATUS)
-          call pFIO_DownBit(ptr2d,ptr2d,list%nbits,undef=MAPL_undef,rc=status)
+          call pFIO_DownBit(ptr2d,ptr2d,list%nbits_to_keep,undef=MAPL_undef,rc=status)
           _VERIFY(STATUS)
        elseif (fieldRank ==3) then
           call ESMF_FieldGet(field, farrayptr=ptr3d, rc=status)
           _VERIFY(STATUS)
-          call pFIO_DownBit(ptr3d,ptr3d,list%nbits,undef=MAPL_undef,rc=status)
+          call pFIO_DownBit(ptr3d,ptr3d,list%nbits_to_keep,undef=MAPL_undef,rc=status)
           _VERIFY(STATUS)
        else
           _FAIL('The field rank is not implmented')

--- a/griddedio/FieldBundleWrite.F90
+++ b/griddedio/FieldBundleWrite.F90
@@ -85,7 +85,7 @@ module MAPL_ESMFFieldBundleWrite
             time_interval_=0
          end if
 
-         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_algorithm,quantize_level=quantize_level)
+         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level)
          time_info = TimeData(clock,file_steps,time_interval_,offset)
          call ESMF_FieldBundleGet(bundle, fieldCount=num_fields,rc=status)
          _VERIFY(status)

--- a/griddedio/FieldBundleWrite.F90
+++ b/griddedio/FieldBundleWrite.F90
@@ -29,26 +29,27 @@ module MAPL_ESMFFieldBundleWrite
 
    contains
 
-      subroutine write_bundle_single_time(bundle,clock,output_file,nbits,deflate,rc)
+      subroutine write_bundle_single_time(bundle,clock,output_file,nbits,deflate,quantize_level,rc)
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
          character(len=*), intent(in) :: output_file
          integer, optional, intent(in)  :: nbits
          integer, optional, intent(in)  :: deflate
+         integer, optional, intent(in)  :: quantize_level
          integer, optional, intent(out) :: rc
 
          integer :: status
 
          type(FieldBundleWriter) :: newWriter
 
-         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits=nbits,deflate=deflate,rc=status)
+         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits=nbits,deflate=deflate,quantize_level=quantize_level,rc=status)
          _VERIFY(status)
          call newWriter%write_to_file(rc=status)
          _VERIFY(status)
          _RETURN(_SUCCESS)
       end subroutine write_bundle_single_time
 
-      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits,deflate,rc)
+      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits,deflate,quantize_level,rc)
          class(FieldBundleWRiter), intent(inout) :: this
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
@@ -58,6 +59,7 @@ module MAPL_ESMFFieldBundleWrite
          integer, optional, intent(in)  :: time_interval
          integer, optional, intent(in)  :: nbits
          integer, optional, intent(in)  :: deflate
+         integer, optional, intent(in)  :: quantize_level
          integer, optional, intent(out) :: rc
 
          type(TimeData) :: time_info
@@ -81,7 +83,7 @@ module MAPL_ESMFFieldBundleWrite
             time_interval_=0
          end if
 
-         call this%cfio%set_param(nbits=nbits,deflation=deflate)
+         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_level=quantize_level)
          time_info = TimeData(clock,file_steps,time_interval_,offset)
          call ESMF_FieldBundleGet(bundle, fieldCount=num_fields,rc=status)
          _VERIFY(status)

--- a/griddedio/FieldBundleWrite.F90
+++ b/griddedio/FieldBundleWrite.F90
@@ -29,11 +29,11 @@ module MAPL_ESMFFieldBundleWrite
 
    contains
 
-      subroutine write_bundle_single_time(bundle,clock,output_file,nbits,deflate,quantize_algorithm,quantize_level,rc)
+      subroutine write_bundle_single_time(bundle,clock,output_file,nbits_to_keep,deflate,quantize_algorithm,quantize_level,rc)
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
          character(len=*), intent(in) :: output_file
-         integer, optional, intent(in)  :: nbits
+         integer, optional, intent(in)  :: nbits_to_keep
          integer, optional, intent(in)  :: deflate
          integer, optional, intent(in)  :: quantize_algorithm
          integer, optional, intent(in)  :: quantize_level
@@ -43,14 +43,14 @@ module MAPL_ESMFFieldBundleWrite
 
          type(FieldBundleWriter) :: newWriter
 
-         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits=nbits,deflate=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level,rc=status)
+         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits_to_keep=nbits_to_keep,deflate=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level,rc=status)
          _VERIFY(status)
          call newWriter%write_to_file(rc=status)
          _VERIFY(status)
          _RETURN(_SUCCESS)
       end subroutine write_bundle_single_time
 
-      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits,deflate,quantize_algorithm,quantize_level,rc)
+      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits_to_keep,deflate,quantize_algorithm,quantize_level,rc)
          class(FieldBundleWRiter), intent(inout) :: this
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
@@ -58,7 +58,7 @@ module MAPL_ESMFFieldBundleWrite
          type(VerticalData), optional, intent(inout) :: vertical_data
          integer, optional, intent(in)  :: n_steps
          integer, optional, intent(in)  :: time_interval
-         integer, optional, intent(in)  :: nbits
+         integer, optional, intent(in)  :: nbits_to_keep
          integer, optional, intent(in)  :: deflate
          integer, optional, intent(in)  :: quantize_algorithm
          integer, optional, intent(in)  :: quantize_level
@@ -85,7 +85,7 @@ module MAPL_ESMFFieldBundleWrite
             time_interval_=0
          end if
 
-         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level)
+         call this%cfio%set_param(nbits_to_keep=nbits_to_keep,deflation=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level)
          time_info = TimeData(clock,file_steps,time_interval_,offset)
          call ESMF_FieldBundleGet(bundle, fieldCount=num_fields,rc=status)
          _VERIFY(status)

--- a/griddedio/FieldBundleWrite.F90
+++ b/griddedio/FieldBundleWrite.F90
@@ -29,12 +29,13 @@ module MAPL_ESMFFieldBundleWrite
 
    contains
 
-      subroutine write_bundle_single_time(bundle,clock,output_file,nbits,deflate,quantize_level,rc)
+      subroutine write_bundle_single_time(bundle,clock,output_file,nbits,deflate,quantize_algorithm,quantize_level,rc)
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
          character(len=*), intent(in) :: output_file
          integer, optional, intent(in)  :: nbits
          integer, optional, intent(in)  :: deflate
+         integer, optional, intent(in)  :: quantize_algorithm
          integer, optional, intent(in)  :: quantize_level
          integer, optional, intent(out) :: rc
 
@@ -42,14 +43,14 @@ module MAPL_ESMFFieldBundleWrite
 
          type(FieldBundleWriter) :: newWriter
 
-         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits=nbits,deflate=deflate,quantize_level=quantize_level,rc=status)
+         call newWriter%create_from_bundle(bundle,clock,output_file=output_File,n_steps=1,time_interval=0,nbits=nbits,deflate=deflate,quantize_algorithm=quantize_algorithm,quantize_level=quantize_level,rc=status)
          _VERIFY(status)
          call newWriter%write_to_file(rc=status)
          _VERIFY(status)
          _RETURN(_SUCCESS)
       end subroutine write_bundle_single_time
 
-      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits,deflate,quantize_level,rc)
+      subroutine create_from_bundle(this,bundle,clock,output_file,vertical_data,n_steps,time_interval,nbits,deflate,quantize_algorithm,quantize_level,rc)
          class(FieldBundleWRiter), intent(inout) :: this
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Clock), intent(inout) :: clock
@@ -59,6 +60,7 @@ module MAPL_ESMFFieldBundleWrite
          integer, optional, intent(in)  :: time_interval
          integer, optional, intent(in)  :: nbits
          integer, optional, intent(in)  :: deflate
+         integer, optional, intent(in)  :: quantize_algorithm
          integer, optional, intent(in)  :: quantize_level
          integer, optional, intent(out) :: rc
 
@@ -83,7 +85,7 @@ module MAPL_ESMFFieldBundleWrite
             time_interval_=0
          end if
 
-         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_level=quantize_level)
+         call this%cfio%set_param(nbits=nbits,deflation=deflate,quantize_algorithm,quantize_level=quantize_level)
          time_info = TimeData(clock,file_steps,time_interval_,offset)
          call ESMF_FieldBundleGet(bundle, fieldCount=num_fields,rc=status)
          _VERIFY(status)

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -354,7 +354,7 @@ module MAPL_GriddedIOMod
         else
            _FAIL( 'Unsupported field rank')
         end if
-        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_algorithm=this%quantize_algorthm,quantize_level=this%quantizeLevel)
+        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_algorithm=this%quantizeAlgorithm,quantize_level=this%quantizeLevel)
         call v%add_attribute('units',trim(units))
         call v%add_attribute('long_name',trim(longName))
         call v%add_attribute('standard_name',trim(longName))

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -50,6 +50,7 @@ module MAPL_GriddedIOMod
      type(VerticalData) :: vdata
      type(GriddedIOitemVector) :: items
      integer :: deflateLevel = 0
+     integer :: quantizeLevel = 0
      integer, allocatable :: chunking(:)
      logical :: itemOrderAlphabetical = .true.
      integer :: fraction
@@ -205,9 +206,10 @@ module MAPL_GriddedIOMod
 
      end subroutine CreateFileMetaData
 
-     subroutine set_param(this,deflation,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
+     subroutine set_param(this,deflation,quantize_level,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
         class (MAPL_GriddedIO), intent(inout) :: this
         integer, optional, intent(in) :: deflation
+        integer, optional, intent(in) :: quantize_level
         integer, optional, intent(in) :: chunking(:)
         integer, optional, intent(in) :: nbits
         integer, optional, intent(in) :: regrid_method
@@ -220,6 +222,7 @@ module MAPL_GriddedIOMod
         if (present(regrid_method)) this%regrid_method=regrid_method
         if (present(nbits)) this%nbits=nbits
         if (present(deflation)) this%deflateLevel = deflation
+        if (present(quantize_level)) this%quantizeLevel = quantize_level
         if (present(chunking)) then
            allocate(this%chunking,source=chunking,stat=status)
            _VERIFY(status)
@@ -348,7 +351,7 @@ module MAPL_GriddedIOMod
         else
            _FAIL( 'Unsupported field rank')
         end if
-        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel)
+        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_level=this%quantizeLevel)
         call v%add_attribute('units',trim(units))
         call v%add_attribute('long_name',trim(longName))
         call v%add_attribute('standard_name',trim(longName))

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -42,7 +42,7 @@ module MAPL_GriddedIOMod
      type(ESMF_FieldBundle) :: input_bundle
      type(ESMF_Time) :: startTime
      integer :: regrid_method = REGRID_METHOD_BILINEAR
-     integer :: nbits = 1000
+     integer :: nbits_to_keep = MAPL_NBITS_NOT_SET
      real, allocatable :: lons(:,:),lats(:,:)
      real, allocatable :: corner_lons(:,:),corner_lats(:,:)
      real, allocatable :: times(:)
@@ -207,13 +207,13 @@ module MAPL_GriddedIOMod
 
      end subroutine CreateFileMetaData
 
-     subroutine set_param(this,deflation,quantize_algorithm,quantize_level,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
+     subroutine set_param(this,deflation,quantize_algorithm,quantize_level,chunking,nbits_to_keep,regrid_method,itemOrder,write_collection_id,rc)
         class (MAPL_GriddedIO), intent(inout) :: this
         integer, optional, intent(in) :: deflation
         integer, optional, intent(in) :: quantize_algorithm
         integer, optional, intent(in) :: quantize_level
         integer, optional, intent(in) :: chunking(:)
-        integer, optional, intent(in) :: nbits
+        integer, optional, intent(in) :: nbits_to_keep
         integer, optional, intent(in) :: regrid_method
         logical, optional, intent(in) :: itemOrder
         integer, optional, intent(in) :: write_collection_id
@@ -222,7 +222,7 @@ module MAPL_GriddedIOMod
         integer :: status
 
         if (present(regrid_method)) this%regrid_method=regrid_method
-        if (present(nbits)) this%nbits=nbits
+        if (present(nbits_to_keep)) this%nbits_to_keep=nbits_to_keep
         if (present(deflation)) this%deflateLevel = deflation
         if (present(quantize_algorithm)) this%quantizeAlgorithm = quantize_algorithm
         if (present(quantize_level)) this%quantizeLevel = quantize_level
@@ -880,8 +880,8 @@ module MAPL_GriddedIOMod
         if (hasDE) then
            call ESMF_FieldGet(Field,farrayPtr=ptr2d,rc=status)
            _VERIFY(status)
-           if (this%nbits < 24) then
-              call pFIO_DownBit(ptr2d,ptr2d,this%nbits,undef=MAPL_undef,rc=status)
+           if (this%nbits_to_keep < MAPL_NBITS_UPPER_LIMIT) then
+              call pFIO_DownBit(ptr2d,ptr2d,this%nbits_to_keep,undef=MAPL_undef,rc=status)
               _VERIFY(status)
            end if
         else
@@ -895,8 +895,8 @@ module MAPL_GriddedIOMod
          if (HasDE) then
             call ESMF_FieldGet(field,farrayPtr=ptr3d,rc=status)
             _VERIFY(status)
-            if (this%nbits < 24) then
-               call pFIO_DownBit(ptr3d,ptr3d,this%nbits,undef=MAPL_undef,rc=status)
+            if (this%nbits_to_keep < MAPL_NBITS_UPPER_LIMIT) then
+               call pFIO_DownBit(ptr3d,ptr3d,this%nbits_to_keep,undef=MAPL_undef,rc=status)
                _VERIFY(status)
             end if
          else

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -50,6 +50,7 @@ module MAPL_GriddedIOMod
      type(VerticalData) :: vdata
      type(GriddedIOitemVector) :: items
      integer :: deflateLevel = 0
+     integer :: quantizeAlgorithm = 1
      integer :: quantizeLevel = 0
      integer, allocatable :: chunking(:)
      logical :: itemOrderAlphabetical = .true.
@@ -206,9 +207,10 @@ module MAPL_GriddedIOMod
 
      end subroutine CreateFileMetaData
 
-     subroutine set_param(this,deflation,quantize_level,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
+     subroutine set_param(this,deflation,quantize_algorithm,quantize_level,chunking,nbits,regrid_method,itemOrder,write_collection_id,rc)
         class (MAPL_GriddedIO), intent(inout) :: this
         integer, optional, intent(in) :: deflation
+        integer, optional, intent(in) :: quantize_algorithm
         integer, optional, intent(in) :: quantize_level
         integer, optional, intent(in) :: chunking(:)
         integer, optional, intent(in) :: nbits
@@ -222,6 +224,7 @@ module MAPL_GriddedIOMod
         if (present(regrid_method)) this%regrid_method=regrid_method
         if (present(nbits)) this%nbits=nbits
         if (present(deflation)) this%deflateLevel = deflation
+        if (present(quantize_algorithm)) this%quantizeAlgorithm = quantize_algorithm
         if (present(quantize_level)) this%quantizeLevel = quantize_level
         if (present(chunking)) then
            allocate(this%chunking,source=chunking,stat=status)
@@ -351,7 +354,7 @@ module MAPL_GriddedIOMod
         else
            _FAIL( 'Unsupported field rank')
         end if
-        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_level=this%quantizeLevel)
+        v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_algorithm=this%quantize_algorthm,quantize_level=this%quantizeLevel)
         call v%add_attribute('units',trim(units))
         call v%add_attribute('long_name',trim(longName))
         call v%add_attribute('standard_name',trim(longName))

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -96,7 +96,7 @@ set (srcs
 ###############################################################
 
 include(CheckCSourceCompiles)
-set(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+set(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIRS})
 check_c_source_compiles("
   #include <netcdf_meta.h>
   #if !NC_HAS_QUANTIZE
@@ -110,6 +110,8 @@ check_c_source_compiles("
 if (NETCDF_HAS_QUANTIZE)
   message(STATUS "netCDF has quantize capability")
   add_definitions(-DNF_HAS_QUANTIZE)
+else ()
+  message(STATUS "netCDF does not have quantize capability")
 endif ()
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -91,6 +91,27 @@ set (srcs
   StringVectorUtil.F90
   )
 
+###############################################################
+# Check to see if quantize capability is present in netcdf-c. #
+###############################################################
+
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_INCLUDES ${NETCDF_INCLUDE_DIR})
+check_c_source_compiles("
+  #include <netcdf_meta.h>
+  #if !NC_HAS_QUANTIZE
+  choke me
+  #endif
+  int main(void) {
+    return 0;
+  }
+  "
+  NETCDF_HAS_QUANTIZE)
+if (NETCDF_HAS_QUANTIZE)
+  message(STATUS "netCDF has quantize capability")
+  add_definitions(-DNF_HAS_QUANTIZE)
+endif ()
+
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL_SHARED::gftl-shared PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -732,11 +732,6 @@ contains
          end if
 
          quantize_algorithm = var%get_quantize_algorithm()
-         ! There are only three algorithms, 1,2,3 and currently netCDF-Fortran has
-         ! a named constant for one. But for now, we assert that quantize_algorithm
-         ! is between 1 and 3.
-         _ASSERT(quantize_algorithm >= 1 .and. quantize_algorithm <= 3, "quantize_algorithm must be between 1 and 3")
-
          quantize_level = var%get_quantize_level()
          if (quantize_level /= 0) then
 #ifdef NF_HAS_QUANTIZE

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -80,7 +80,7 @@ module pFIO_NetCDF4_FileFormatterMod
       procedure :: ___SUB(put_var,real64,2)
       procedure :: ___SUB(put_var,real64,3)
       procedure :: ___SUB(put_var,real64,4)
-      
+
 
       generic :: get_var => ___SUB(get_var,int32,0)
       generic :: get_var => ___SUB(get_var,int32,1)
@@ -123,7 +123,7 @@ module pFIO_NetCDF4_FileFormatterMod
       generic :: put_var => ___SUB(put_var,real64,4)
 
 #include "undo_overload.macro"
-      
+
       procedure, private :: def_dimensions
       procedure, private :: put_attributes
       procedure, private :: put_var_attributes
@@ -165,7 +165,7 @@ contains
       case (pFIO_NOCLOBBER)
          mode_ = NF90_NOCLOBBER
       end select
-         
+
       !$omp critical
       status = nf90_create(file, IOR(mode_, NF90_NETCDF4), this%ncid)
       !$omp end critical
@@ -315,10 +315,10 @@ contains
 
       call this%def_variables(cf, rc=status)
       _VERIFY(status)
-      
+
       call this%put_attributes(cf, NF90_GLOBAL, rc=status)
       _VERIFY(status)
- 
+
       !$omp critical
       status= nf90_enddef(this%ncid)
       !$omp end critical
@@ -347,7 +347,7 @@ contains
       integer, pointer :: dim_len
 
       integer :: nf90_len
-      
+
       dims => cf%get_dimensions()
       iter = dims%begin()
       do while (iter /= dims%end())
@@ -396,7 +396,7 @@ contains
          p_attribute => iter%value()
          shp = p_attribute%get_shape()
 
-         if (size(shp) > 0) then 
+         if (size(shp) > 0) then
            attr_values => p_attribute%get_values()
            _ASSERT(associated(attr_values), "should have values")
 
@@ -506,7 +506,7 @@ contains
                status = _FAILURE
             end select
          end if
-         call var_iter%next() 
+         call var_iter%next()
       enddo
 
       _UNUSED_DUMMY(unusable)
@@ -557,7 +557,7 @@ contains
                status = _FAILURE
             end select
          end if
-         call var_iter%next() 
+         call var_iter%next()
 
       enddo
 
@@ -613,7 +613,7 @@ contains
                !$omp critical
                status = nf90_put_att(this%ncid, varid, attr_name, q)
                !$omp end critical
-            type is (stringWrap) 
+            type is (stringWrap)
                !$omp critical
                status = nf90_put_att(this%ncid, varid, attr_name, q%value)
                !$omp end critical
@@ -672,6 +672,7 @@ contains
       integer, allocatable :: dimids(:)
       integer, pointer :: chunksizes(:)
       integer :: deflation
+      integer :: quantize_level
       character(len=:), pointer :: var_name
       character(len=:), pointer :: dim_name
       class (Variable), pointer :: var
@@ -722,16 +723,28 @@ contains
          end if
 
          deflation = var%get_deflation()
-         if (deflation > 0) then 
+         if (deflation > 0) then
             !$omp critical
            status = nf90_def_var_deflate(this%ncid, varid, 1, 1, deflation)
            !$omp end critical
            _VERIFY(status)
          end if
 
+         quantize_level = var%get_quantize_level()
+         if (quantize_level /= 0) then
+#ifdef NF_HAS_QUANTIZE
+           !$omp critical
+           status = nf90_def_var_quantize(this%ncid, varid, NF90_QUANTIZE_BITGROOM, quantize_level)
+           !$omp end critical
+           _VERIFY(status)
+#else
+           _FAIL("netcdf was not built with quantize support")
+#endif
+         end if
+
          call this%put_var_attributes(var, varid, rc=status)
          _VERIFY(status)
-         
+
          deallocate(dimids)
 
          call var_iter%next()
@@ -795,7 +808,7 @@ contains
 
       return
    end function get_fio_type
-   
+
    function read(this, unusable, rc) result(cf)
       type (FileMetadata), target :: cf
       class (NetCDF4_FileFormatter), intent(inout) :: this
@@ -860,7 +873,7 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      
+
       integer :: attnum, nAttributes
       integer :: xtype
       integer :: len
@@ -929,7 +942,7 @@ contains
             deallocate(str)
          case (NF90_STRING)
             ! W.Y. Note: pfio only supports global string attributes.
-            ! varid is not passed in. NC_GLOBAL is used inside the call 
+            ! varid is not passed in. NC_GLOBAL is used inside the call
             !$omp critical
             status = pfio_get_att_string(this%ncid, trim(attr_name), str)
             !$omp end critical
@@ -939,7 +952,7 @@ contains
          case default
             _RETURN(_FAILURE)
          end select
-            
+
       end do
 
       _RETURN(_SUCCESS)
@@ -955,7 +968,7 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      
+
       integer :: attnum, nAttributes
       integer :: xtype
       integer :: len
@@ -1039,7 +1052,7 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine inq_var_attributes
 
-   
+
    subroutine inq_variables(this, cf, unusable, rc)
       class (NetCDF4_FileFormatter), intent(inout) :: this
       type (FileMetadata), target, intent(inout) :: cf
@@ -1079,7 +1092,7 @@ contains
          status = nf90_inquire_variable(this%ncid, varid, name=var_name, xtype=xtype, ndims=ndims)
          !$omp end critical
          _VERIFY(status)
-         
+
          allocate(dimids(ndims))
          !$omp critical
          status = nf90_inquire_variable(this%ncid, varid, dimids=dimids)
@@ -1228,7 +1241,7 @@ contains
 #    include "NetCDF4_put_var.H"
 #  undef _RANK
 #undef _VARTYPE
-   
+
    ! REAL64
 #define _VARTYPE 5
 #  define _RANK 0
@@ -1252,8 +1265,8 @@ contains
 #    include "NetCDF4_put_var.H"
 #  undef _RANK
 #undef _VARTYPE
-   
-   
+
+
 #undef _TYPE
 
 
@@ -1272,7 +1285,7 @@ contains
       status = nf90_inq_dimid(this%ncid, name=dim_name, dimid=dimid)
       !$omp end critical
       _VERIFY(status)
-      
+
       length = 0
       !$omp critical
       status = nf90_inquire_dimension(this%ncid, dimid, len=length)
@@ -1298,7 +1311,7 @@ contains
 
       ! Sucess means that a dimension exists of the name name
       is_coordinate_dimension = (status == 0)
-      
+
    end function is_coordinate_dimension
 
 end module pFIO_NetCDF4_FileFormatterMod

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -672,6 +672,7 @@ contains
       integer, allocatable :: dimids(:)
       integer, pointer :: chunksizes(:)
       integer :: deflation
+      integer :: quantize_algorithm
       integer :: quantize_level
       character(len=:), pointer :: var_name
       character(len=:), pointer :: dim_name
@@ -730,11 +731,17 @@ contains
            _VERIFY(status)
          end if
 
+         quantize_algorithm = var%get_quantize_algorithm()
+         ! There are only three algorithms, 1,2,3 and currently netCDF-Fortran has
+         ! a named constant for one. But for now, we assert that quantize_algorithm
+         ! is between 1 and 3.
+         _ASSERT(quantize_algorithm >= 1 .and. quantize_algorithm <= 3, "quantize_algorithm must be between 1 and 3")
+
          quantize_level = var%get_quantize_level()
          if (quantize_level /= 0) then
 #ifdef NF_HAS_QUANTIZE
            !$omp critical
-           status = nf90_def_var_quantize(this%ncid, varid, NF90_QUANTIZE_BITGROOM, quantize_level)
+           status = nf90_def_var_quantize(this%ncid, varid, quantize_algorithm, quantize_level)
            !$omp end critical
            _VERIFY(status)
 #else

--- a/pfio/Variable.F90
+++ b/pfio/Variable.F90
@@ -367,9 +367,10 @@ contains
       buffer = [buffer, tmp_buffer]
       call this%const_value%serialize(tmp_buffer, status)
       _VERIFY(status)
-      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%deflation)]
-      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%quantize_algorithm)]
-      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%quantize_level)]
+      buffer = [buffer, tmp_buffer]
+      buffer = [buffer, serialize_intrinsic(this%deflation)]
+      buffer = [buffer, serialize_intrinsic(this%quantize_algorithm)]
+      buffer = [buffer, serialize_intrinsic(this%quantize_level)]
 
       if( .not. allocated(this%chunksizes)) then
         buffer =[buffer,[1]]

--- a/pfio/Variable.F90
+++ b/pfio/Variable.F90
@@ -286,7 +286,7 @@ contains
       class (Variable), target, intent(In) :: this
       integer :: quantizeAlgorithm
 
-      quantizeAlgorithm=this%quantizeAlgorithm
+      quantizeAlgorithm=this%quantize_algorithm
    end function get_quantize_algorithm
 
    function get_quantize_level(this) result(quantizeLevel)

--- a/pfio/Variable.F90
+++ b/pfio/Variable.F90
@@ -22,7 +22,7 @@ module pFIO_VariableMod
    public :: Variable_deserialize
 
    integer, parameter :: Variable_SERIALIZE_TYPE = 100
- 
+
    type :: Variable
       private
       integer :: type = -1
@@ -30,6 +30,7 @@ module pFIO_VariableMod
       type (StringAttributeMap) :: attributes
       type (UnlimitedEntity) :: const_value
       integer :: deflation = 0 ! default no compression
+      integer :: quantize_level = 0 ! default no quantize_level
       integer, allocatable :: chunksizes(:)
    contains
       procedure :: get_type
@@ -47,6 +48,7 @@ module pFIO_VariableMod
 
       procedure :: get_chunksizes
       procedure :: get_deflation
+      procedure :: get_quantize_level
       procedure :: is_attribute_present
       generic :: operator(==) => equal
       generic :: operator(/=) => not_equal
@@ -65,7 +67,7 @@ module pFIO_VariableMod
 contains
 
 
-   function new_Variable(unusable, type, dimensions, chunksizes,const_value, deflation, rc) result(var)
+   function new_Variable(unusable, type, dimensions, chunksizes,const_value, deflation, quantize_level, rc) result(var)
       type (Variable) :: var
       integer, optional, intent(in) :: type
       class (KeywordEnforcer), optional, intent(in) :: unusable
@@ -73,12 +75,14 @@ contains
       integer, optional, intent(in) :: chunksizes(:)
       type (UnlimitedEntity), optional, intent(in) :: const_value
       integer, optional, intent(in) :: deflation
+      integer, optional, intent(in) :: quantize_level
       integer, optional, intent(out) :: rc
 
       integer:: empty(0)
 
       var%type = -1
       var%deflation = 0
+      var%quantize_level = 0
       var%chunksizes = empty
       var%dimensions = StringVector()
       var%attributes = StringAttributeMap()
@@ -87,7 +91,7 @@ contains
       if (present(type)) then
          var%type = type
       endif
- 
+
       if (present(dimensions)) then
          call parse_dimensions()
       end if
@@ -99,11 +103,15 @@ contains
       if (present(const_value)) then
          var%const_value = const_value
       endif
- 
+
       if (present(deflation)) then
          var%deflation = deflation
       endif
- 
+
+      if (present(quantize_level)) then
+         var%quantize_level = quantize_level
+      endif
+
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    contains
@@ -121,8 +129,8 @@ contains
             dim_string = dim_string(idx+1:) ! do not forget to skip separator !
          end do
       end subroutine parse_dimensions
-      
-      
+
+
    end function new_Variable
 
 
@@ -150,13 +158,13 @@ contains
       _UNUSED_DUMMY(unusable)
 
    end function get_ith_dimension
-   
+
    function get_dimensions(this) result(dimensions)
       class (Variable), target, intent(in) :: this
       type (StringVector), pointer :: dimensions
 
       dimensions => this%dimensions
-      
+
    end function get_dimensions
 
 
@@ -165,7 +173,7 @@ contains
       type (StringAttributeMap), pointer :: attributes
 
       attributes => this%attributes
-      
+
    end function get_attributes
 
 
@@ -184,7 +192,7 @@ contains
          call attr%set(q)
          call this%attributes%insert(attr_name, attr)
       end select
-         
+
       _RETURN(_SUCCESS)
    end subroutine add_attribute_0d
 
@@ -245,8 +253,8 @@ contains
 
       const_value =>this%const_value
 
-   end function get_const_value 
- 
+   end function get_const_value
+
    function get_chunksizes(this) result(chunksizes)
       class (Variable), target, intent(in) :: this
       integer, pointer :: chunksizes(:)
@@ -266,6 +274,13 @@ contains
       deflateLevel=this%deflation
    end function get_deflation
 
+   function get_quantize_level(this) result(quantizeLevel)
+      class (Variable), target, intent(In) :: this
+      integer :: quantizeLevel
+
+      quantizeLevel=this%quantize_level
+   end function get_quantize_level
+
    logical function equal(a, b)
       class (Variable), target, intent(in) :: a
       type (Variable), target, intent(in) :: b
@@ -281,11 +296,11 @@ contains
       equal = ( a%dimensions%size() == 0 .and. &
                 b%dimensions%size() == 0 .and. &
                 a%attributes%size() == 0 .and. &
-                b%attributes%size() == 0 ) 
+                b%attributes%size() == 0 )
 
       if (equal) return
 
-      equal = (a%type == b%type)      
+      equal = (a%type == b%type)
       if (.not. equal) return
 
       equal = (a%dimensions == b%dimensions)
@@ -310,7 +325,7 @@ contains
          call iter%next()
       end do
 
-      
+
    end function equal
 
    logical function not_equal(a, b)
@@ -329,15 +344,16 @@ contains
       integer :: status
 
       if(allocated(buffer)) deallocate(buffer)
-      
+
       call StringVector_serialize(this%dimensions, tmp_buffer)
       buffer =[serialize_intrinsic(this%type), tmp_buffer]
       call StringAttributeMap_serialize(this%attributes, tmp_buffer, status)
       _VERIFY(status)
-      buffer = [buffer, tmp_buffer] 
+      buffer = [buffer, tmp_buffer]
       call this%const_value%serialize(tmp_buffer, status)
       _VERIFY(status)
-      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%deflation)] 
+      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%deflation)]
+      buffer = [buffer, tmp_buffer,serialize_intrinsic(this%quantize_level)]
 
       if( .not. allocated(this%chunksizes)) then
         buffer =[buffer,[1]]
@@ -347,7 +363,7 @@ contains
 
       length = serialize_buffer_length(length) + serialize_buffer_length(Variable_SERIALIZE_TYPE) + size(buffer)
       buffer = [serialize_intrinsic(length), serialize_intrinsic(Variable_SERIALIZE_TYPE), buffer]
-      _RETURN(_SUCCESS) 
+      _RETURN(_SUCCESS)
    end subroutine
 
    subroutine Variable_deserialize(buffer, var, rc)
@@ -367,7 +383,7 @@ contains
          integer :: n,length, v_type
          type (UnlimitedEntity) :: const
          integer :: status
- 
+
          n = 1
          call deserialize_intrinsic(buffer(n:),length)
          _ASSERT(length == size(buffer), "length does not match")
@@ -397,6 +413,9 @@ contains
          n = n + length
          call deserialize_intrinsic(buffer(n:),this%deflation)
          length = serialize_buffer_length(this%deflation)
+         n = n + length
+         call deserialize_intrinsic(buffer(n:),this%quantize_level)
+         length = serialize_buffer_length(this%quantize_level)
          n = n + length
          call deserialize_intrinsic(buffer(n:),this%chunksizes)
          _RETURN(_SUCCESS)

--- a/pfio/pFIO_ShaveMantissa.c
+++ b/pfio/pFIO_ShaveMantissa.c
@@ -73,14 +73,14 @@ int pFIO_ShaveMantissa32 ( float32 a[], float32 ain[], int32 len, int xbits, int
 //  the baby with the bathwater", for variables, such as Kelvin temperatures
 //  or geopotentials, that may have large offsets.
 //
-//  The number of bits retained is {\tt nbits = 24 - xbits}, given that
+//  The number of bits retained is {\tt nbits_to_keep = 24 - xbits}, given that
 //  32-bit floats in IEEE representation reserves only 24 bits for the
 //  mantissa. The purpose of this precision degradation is to promote
 //  internal GZIP compression by HDF-4.
 //
 //  For variables without large offsets, this algorithm produces very
 //  similar results as the standard GRIB encoding with fixed number of bits
-//  ({\tt nbits = 24 - xbits}) and power of 2 binary scaling. For most files,
+//  ({\tt nbits_to_keep = 24 - xbits}) and power of 2 binary scaling. For most files,
 //  it produces comparable compression to GRIB while using only standard
 //  compression techniques (e.g. GZIP).
 //

--- a/shared/Constants/InternalConstants.F90
+++ b/shared/Constants/InternalConstants.F90
@@ -131,18 +131,18 @@ module MAPL_InternalConstantsMod
       enumerator MAPL_FifthPhase
    endenum
 
-   integer, parameter :: MAPL_Ocean              = 0  
-   integer, parameter :: MAPL_Lake               = 19 
-   integer, parameter :: MAPL_LandIce            = 20 
+   integer, parameter :: MAPL_Ocean              = 0
+   integer, parameter :: MAPL_Lake               = 19
+   integer, parameter :: MAPL_LandIce            = 20
    integer, parameter :: MAPL_Land               = 100
    integer, parameter :: MAPL_Vegetated          = 101
-   integer, parameter :: MAPL_NumVegTypes        = 6 
+   integer, parameter :: MAPL_NumVegTypes        = 6
 
    enum, bind(c)
       enumerator MAPL_AGrid
       enumerator MAPL_CGrid
       enumerator MAPL_DGrid
-   endenum 
+   endenum
 
    enum, bind(c)
       enumerator MAPL_RotateLL
@@ -164,6 +164,15 @@ module MAPL_InternalConstantsMod
       enumerator MAPL_RestartSkipInitial
    endenum
 
+   integer, parameter :: MAPL_NBITS_NOT_SET = 1000
+   integer, parameter :: MAPL_NBITS_UPPER_LIMIT = 24
+   ! Constants for netCDF quantize
+   enum, bind(c)
+      enumerator MAPL_Quantize_Disabled
+      enumerator MAPL_Quantize_BitGroom
+      enumerator MAPL_Quantize_GranularBR
+      enumerator MAPL_Quantize_BitRound
+   endenum
 !EOP
 
 end module MAPL_InternalConstantsMod


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

First, this is all zero-diff as it can't affect the state. Obviously it is non-zero-diff for History if you enable it.

This PR adds quantize support to pFIO. See #1779 for more about this.

This PR has some requirements:

1. Baselibs v7.6.0+ (aka ESMA_env 4.7.0+) as this has the updated netCDF
2. ESMA_cmake v3.20.0 for an update CMake variable for netCDF

If you don't have these, I *think* it should still compile and run, it'll just crash if you try to use quantize.

Now, assuming you do have all the requirements, then you can enable it by adding to History things like:
```
  geosgcm_prog.quantize_level: 4,
  geosgcm_prog.quantize_algorithm: 'BitGroom',
...
  geosgcm_surf.quantize_level: 4,
  geosgcm_surf.quantize_algorithm: 'GranularBR',
...
  geosgcm_moist.quantize_level: 10,
  geosgcm_moist.quantize_algorithm: 'BitRound',
```

Note that for `BitGroom` and `GranularBR`, the `quantize_level` is number of significant _digits_, but for `BitRound` it is the number of significant _bits_. 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1779 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

netCDF introduced some cool new quantization options thanks to @czender, @edwardhartnett, @rkouznetsov, and more I have no doubt. MAPL does have its own bit-shaving code, but these routines are probably more advanced or, at the least, different and since they are part of netCDF, then the the shaving is more "standard".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested quite a bit on discover and tried out all options. Note I only tried with Intel so I'm sort of using this PR to see if/how I broke GNU!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
