### PR TITLE
Update Label Enforcer and Changelog Enforcer for Dependabot

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'Skip Changelog,0 diff trivial,automatic,dependencies'
+        skipLabels: 'Skip Changelog,0 diff trivial,automatic,dependencies,github_actions'
         missingUpdateErrorMessage: >
             No update to CHANGELOG.md found! Please add a changelog
             entry to it describing your change.  Please note that the

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled"
+          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,github_actions"
           add_comment: true
   blocking-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As seen in #1861, the label and changelog enforcers don't know anything about the dependabot label: `github_actions`. This adds it as a "good" label for MAPL. 