### PR TITLE
Add stricter debugging flags when building MAPL as Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `components.yaml`
+  - ESMA_cmake v3.22.0 (defines stricter debug flags for Intel)
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-Added `MAPL_find_bounds => find_bounds` and `MAPL_Interval => Interval` to `MAPL.F90` for use when doing component level OpenMP
+
+- Added `MAPL_find_bounds => find_bounds` and `MAPL_Interval => Interval` to `MAPL.F90` for use when doing component level OpenMP
+- Added CMake code to apply stricter debug flags when building MAPL as Debug
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,33 @@ if (NOT Baselibs_FOUND)
   endif ()
 endif ()
 
+# We wish to add extra flags when compiling as Debug. We should only
+# do this if we are using esma_cmake since the flags are defined
+# there. Note that some flags like STANDARD_F18 might be available on
+# all compilers, but others might only be needed for, say, Intel, since,
+# for example, GNU does not allow if(integer) no matter what
+if (COMMAND esma)
+  set (STRICT_DEBUG_FLAGS
+    ${STANDARD_F18}
+    ${ERROR_IF_INTEGER}
+    ${ERROR_LOGICAL_SET_TO_INTEGER}
+    ${DISABLE_LONG_LINE_LENGTH_WARNING}
+    )
+
+  # Are we compiling Fortran?
+  set (is_fortran "$<COMPILE_LANGUAGE:Fortran>")
+  # and is our build type Debug?
+  set (is_build_type_debug "$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>")
+  # set the logical AND
+  set (meets_requirements "$<AND:${is_fortran},${is_build_type_debug}>")
+
+  foreach (flag ${STRICT_DEBUG_FLAGS})
+    # We use SHELL to avoid de-duplication and preserve spaces:
+    #   https://cmake.org/cmake/help/latest/command/target_compile_options.html?highlight=target_compile_options#option-de-duplication
+    add_compile_options("SHELL:$<${meets_requirements}:${flag}>")
+  endforeach ()
+endif ()
+
 if (BUILD_WITH_PFLOGGER)
   add_definitions(-DBUILD_WITH_PFLOGGER)
 else ()

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.21.0
+  tag: v3.22.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds some CMake code to apply additional flags when building MAPL as Debug.

This also updates the ESMA_cmake in the `components.yaml` to 3.22.0 which defines these new flags. Note that if you don't have this version of ESMA_cmake, then it's just a no-op as all the variables are empty.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The extra flags are good since Intel is often "too loose" and at least it will throw a lot of warnings and not allow things like `if(integer)` or setting a logical to an integer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built and ran GEOS. If it builds...that's good enough!

I've also checked and the flags only appear if Debug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
