### PR TITLE
Handmerge Develop into MAPL3 - 2022-Jan-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added subroutine MAPL_MethodAdd to MAPL_Generic.F90
+- Added subrutines get_callbacks and copy_callbacks to OpenMP_Support.F90
+- These added subroutines are to support "callback" procedures when inside OpenMP parallel region  for mini states for component level threading.
+
+### Added
 
 - Added `MAPL_find_bounds => find_bounds` and `MAPL_Interval => Interval` to `MAPL.F90` for use when doing component level OpenMP
 - Added requirement for ESMF 8.4.0 in `find_package()` call

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -51,7 +51,11 @@ set (srcs
 
   RunEntryPoint.F90
   EntryPointVector.F90
+
+  MAPL_ESMF_Interfaces.F90
+  CallbackMap.F90
   )
+
 if (BUILD_WITH_PFLOGGER)
   find_package(PFLOGGER REQUIRED)
 endif ()

--- a/generic/CallbackMap.F90
+++ b/generic/CallbackMap.F90
@@ -1,0 +1,19 @@
+module mapl_CallbackMap
+
+   use mapl_ESMF_Interfaces
+
+#define Key __CHARACTER_DEFERRED
+#define T CallbackMethodWrapper
+#define Map CallbackMap
+#define Pair CallbackPair
+#define MapIterator CallbackMapIterator
+
+#include "map/template.inc"
+
+#undef MapIterator
+#undef Pair
+#undef Map
+#undef T
+#undef Key
+
+end module mapl_CallbackMap

--- a/generic/MAPL_ESMF_Interfaces.F90
+++ b/generic/MAPL_ESMF_Interfaces.F90
@@ -1,0 +1,22 @@
+! This module is a collection of abstract interfaces that enforce
+! interfaces of user routines that are passed to ESMF.
+
+module mapl_ESMF_Interfaces
+   implicit none
+   private ! except
+   public :: I_CallBackMethod
+   public :: CallbackMethodWrapper
+
+   abstract interface
+      subroutine I_CallBackMethod(state, rc)
+         use ESMF
+         type(ESMF_State) :: state
+         integer, intent(out) :: rc
+      end subroutine I_CallBackMethod
+   end interface
+
+   type CallbackMethodWrapper
+      procedure(I_CallBackMethod), pointer, nopass :: userRoutine
+   end type CallbackMethodWrapper
+
+end module mapl_ESMF_Interfaces

--- a/generic/MaplGenericComponent.F90
+++ b/generic/MaplGenericComponent.F90
@@ -22,8 +22,6 @@ module mapl_MaplGenericComponent
    public :: MaplGenericComponent
    public :: get_grid
 
-   procedure(), pointer :: user_method => null()
-
    type SubComponent
       type(ESMF_GridComp) :: gridcomp
       type(ESMF_State) :: internal_state

--- a/generic/OpenMP_Support.F90
+++ b/generic/OpenMP_Support.F90
@@ -21,6 +21,7 @@ module MAPL_OpenMP_Support
     public :: subset_array
     public :: get_current_thread
     public :: get_num_threads
+    public :: get_callbacks
 
     type :: Interval
         integer :: min
@@ -464,7 +465,7 @@ module MAPL_OpenMP_Support
 
     recursive function make_substates_from_num_grids(state, num_subgrids, unusable, rc) result(substates)
       type(ESMF_State), allocatable :: substates(:)
-      type(ESMF_State), intent(in) :: state
+      type(ESMF_State), intent(inout) :: state
       integer, intent(in) :: num_subgrids
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
@@ -526,6 +527,9 @@ module MAPL_OpenMP_Support
             end do
          end if
       end do
+
+      call copy_callbacks(state, substates, _RC)
+
       _RETURN(0)
     end function make_substates_from_num_grids
 
@@ -554,19 +558,20 @@ module MAPL_OpenMP_Support
         character(len=ESMF_MAXSTR) :: comp_name
         character(len=:), allocatable :: labels(:)
         integer :: phase
+        type(ESMF_Config) :: CF
 
         allocate(subgridcomps(num_grids))
 
         call ESMF_VMGetCurrent(vm, _RC)
         call ESMF_VMGet(vm, localPET=myPET, _RC)
 
-        call ESMF_GridCompGet(GridComp, name=comp_name, _RC)
+        call ESMF_GridCompGet(GridComp, config=CF, name=comp_name, _RC)
         call ESMF_InternalStateGet(GridComp, labelList=labels, _RC)
         if(myPET==0) print*,__FILE__,__LINE__, 'internal states labels : <',trim(comp_name), (trim(labels(i)),i=1,size(labels)), '>'
         print*,__FILE__,__LINE__, 'splitting component: <',trim(comp_name),'>'
         do i = 1, num_grids
           associate (gc => subgridcomps(i) )
-            gc = ESMF_GridCompCreate(name=trim(comp_name), petlist=[myPet], &
+            gc = ESMF_GridCompCreate(name=trim(comp_name), config=CF, petlist=[myPet], &
                  & contextflag=ESMF_CONTEXT_OWN_VM, _RC)
             call ESMF_GridCompSetServices(gc, set_services, userrc=user_status, _RC)
             _VERIFY(user_status)
@@ -579,7 +584,6 @@ module MAPL_OpenMP_Support
            do i = 1, num_grids
               associate (gc => subgridcomps(i) )
                 if (has_private_state) then
-                   !print *, __FILE__, __LINE__, myPET, ilabel, i, trim(comp_name), trim(labels(ilabel)), has_private_state
                    call ESMF_UserCompSetInternalState(gc, trim(labels(ilabel)), wrap, status)
                    _VERIFY(status)
                 end if
@@ -605,6 +609,72 @@ module MAPL_OpenMP_Support
             end do
            _RETURN(ESMF_SUCCESS)
         end subroutine set_services
+
     end function make_subgridcomps
+
+    subroutine copy_callbacks(state, multi_states, rc)
+       use mapl_ESMF_Interfaces
+       use mapl_CallbackMap
+       type(ESMF_State), intent(inout) :: state
+       type(ESMF_State), intent(inout) :: multi_states(:)
+       integer, optional, intent(out) :: rc
+
+       integer :: n_multi, i
+       integer :: status
+       type(CallbackMethodWrapper), pointer :: wrapper
+       type(CallbackMap), pointer :: callbacks
+       type(CallbackMapIterator) :: iter
+
+       n_multi = size(multi_states)
+       call get_callbacks(state, callbacks, _RC)
+       _ASSERT(associated(callbacks), 'callbacks must be associated')
+       associate( e => callbacks%end())
+          iter = callbacks%begin()
+          do while (iter /= e)
+             wrapper => iter%second()
+             do i = 1, n_multi
+                call ESMF_MethodAdd(multi_states(i), label=iter%first(), userRoutine=wrapper%userRoutine, _RC)
+             end do
+             call iter%next()
+          end do
+       end associate
+
+       _RETURN(ESMF_SUCCESS)
+
+    end subroutine copy_callbacks
+
+    subroutine get_callbacks(state, callbacks, rc)
+       use mapl_ESMF_Interfaces
+       use mapl_CallbackMap
+       type(ESMF_State), intent(inout) :: state
+       type(CallbackMap), pointer, intent(out) :: callbacks
+       integer, optional, intent(out) :: rc
+
+       integer :: status
+       integer(kind=ESMF_KIND_I4), allocatable :: valueList(:)
+       logical :: isPresent
+
+       type CallbackMapWrapper
+          type(CallbackMap), pointer :: map
+       end type
+       type(CallbackMapWrapper) :: wrapper
+
+       call ESMF_AttributeGet(state, name='MAPL_CALLBACK_MAP', isPresent=isPresent, _RC)
+       if (.not. isPresent) then ! create callback map for this state
+          allocate(callbacks)
+          wrapper%map => callbacks
+          valueList = transfer(wrapper, valueList)
+          call ESMF_AttributeSet(state, name='MAPL_CALLBACK_MAP', valueList=valueList, _RC)
+       end if
+
+       ! Ugly hack to decode ESMF attribute as a gFTL map
+       valueList = transfer(wrapper, valueList)
+       call ESMF_AttributeGet(state, name='MAPL_CALLBACK_MAP', valueList=valueList, _RC)
+       wrapper = transfer(valueList, wrapper)
+       callbacks => wrapper%map
+
+       _RETURN(ESMF_SUCCESS)
+
+    end subroutine get_callbacks
 
 end module MAPL_OpenMP_Support

--- a/generic/OpenMP_Support.F90
+++ b/generic/OpenMP_Support.F90
@@ -653,23 +653,25 @@ module MAPL_OpenMP_Support
        integer :: status
        integer(kind=ESMF_KIND_I4), allocatable :: valueList(:)
        logical :: isPresent
+       type(ESMF_Info) :: infoh
 
        type CallbackMapWrapper
           type(CallbackMap), pointer :: map
        end type
        type(CallbackMapWrapper) :: wrapper
 
-       call ESMF_AttributeGet(state, name='MAPL_CALLBACK_MAP', isPresent=isPresent, _RC)
+       call ESMF_InfoGetFromHost(state, infoh, _RC)
+       isPresent = ESMF_InfoIsPresent(infoh,'MAPL_CALLBACK_MAP',_RC)
        if (.not. isPresent) then ! create callback map for this state
           allocate(callbacks)
           wrapper%map => callbacks
           valueList = transfer(wrapper, valueList)
-          call ESMF_AttributeSet(state, name='MAPL_CALLBACK_MAP', valueList=valueList, _RC)
+          call ESMF_InfoSet(infoh, key='MAPL_CALLBACK_MAP', values=valueList, _RC)
        end if
 
        ! Ugly hack to decode ESMF attribute as a gFTL map
        valueList = transfer(wrapper, valueList)
-       call ESMF_AttributeGet(state, name='MAPL_CALLBACK_MAP', valueList=valueList, _RC)
+       call ESMF_InfoGet(infoh, key='MAPL_CALLBACK_MAP', values=valueList, _RC)
        wrapper = transfer(valueList, wrapper)
        callbacks => wrapper%map
 


### PR DESCRIPTION
This is a handmerge of `develop` into `release/MAPL-v3` because I had to convert some `ESMF_Attribute` calls to `ESMF_Info` (see 63e7100bdb9c5c1cb36e20268a2c4628fae0bfa1).

I think I did this right, but you never know. At least the CI here will let me know if I screwed anything up build wise.