### PR TITLE
Feature/pnorris/#1882 add local solar hour angle diagnostic

### DIFF
--- a/base/MAPL_sun_uc.F90
+++ b/base/MAPL_sun_uc.F90
@@ -3050,7 +3050,10 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
             _VERIFY(STATUS)
          end if
       end if
-      call ESMF_TimeGet (T, S=SEC_OF_DAY, RC=STATUS)
+
+      ! NB: include YY and dayOfYear here so that S is seconds WITHIN a day.
+      ! YEAR and DAY_OF_YEAR are used within the non-ANAL2B branch anyway.
+      call ESMF_TimeGet (T, YY=YEAR, dayOfYear=DAY_OF_YEAR, S=SEC_OF_DAY, RC=STATUS)
       _VERIFY(STATUS)
 
       ! fraction of day (0 at midnight)
@@ -3094,9 +3097,7 @@ subroutine  MAPL_SunOrbitQuery(ORBIT,           &
 
          else
 
-            ! get equation of time by from table interpolation
-            call ESMF_TimeGet (T, YY=YEAR, dayOfYear=DAY_OF_YEAR, RC=STATUS)
-            _VERIFY(STATUS)
+            ! get equation of time by table interpolation
             YEAR = mod(YEAR-1,ORBIT%YEARS_PER_CYCLE)
             IDAY = YEAR*int(ORBIT%YEARLEN)+DAY_OF_YEAR
             IDAYP1 = mod(IDAY,ORBIT%DAYS_PER_CYCLE) + 1


### PR DESCRIPTION
Adds a convenient local solar hour angle diagnostic which will be used by @adarmenov to detect local solar noon

## Description
See description and example of use sections in header of subroutine

## Related Issue
Solves issue #1882

## Motivation and Context
Provides a multi-use diagnostic subroutine to provide the local solar hour angle (the TRUE value with equation of time included, but can alse provide the MEAN value (without EOT) via FORCE_MLSHA=.TRUE. optional argument.

## How Has This Been Tested?
Has been tested to provide correct value of TRUE and MEAN local solar hour angle in test runs, and to give the corresponding noon detection capability via the 'EXAMPLE OF USE' method.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
- [ x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
