### PR TITLE
Feature/pnorris/#1915 all MAPL orbital parameters now encapsulated in Sun_Mod in MAPL_sun_uc.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   solar noon via the EXAMPLE OF USE in the subroutine header. See DESCRIPTION in code for more
   details. Provides the TRUE local solar hour angle (i.e., with equation of time included), but
   can also provide the MEAN value (without EOT) via FORCE_MLSHA=.TRUE. optional argument.
+- Changed call to MAPL_SunOrbitCreate() inside MAPL_Generic.F90 to new MAPL_SunOrbitCreateFromConfig,
+  the latter which get the orbital parameters from the MAPL state's Config. In this way no default
+  orbital parameter values need appear in MAPL_Generic.F90. Rather, these default values are encap-
+  sulated where they belong in Sun_Mod in base/MAPL_sun_uc.F90 and are now explicitly named and
+  commented at the head of the module. This is a structural zero-diff change.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added subroutine `MAPL_SunGetLocalSolarHourAngle()` in `base/MAPL_sun_uc.F90`. This provides a
-  convenient local solar hour angle diagnostic which will be used to detect local
-  solar noon via the EXAMPLE OF USE in the subroutine header. See DESCRIPTION in code for more
-  details. Provides the TRUE local solar hour angle (i.e., with equation of time included), but
-  can also provide the MEAN value (without EOT) via FORCE_MLSHA=.TRUE. optional argument.
-- Changed call to MAPL_SunOrbitCreate() inside MAPL_Generic.F90 to new MAPL_SunOrbitCreateFromConfig,
-  the latter which get the orbital parameters from the MAPL state's Config. In this way no default
-  orbital parameter values need appear in MAPL_Generic.F90. Rather, these default values are encap-
-  sulated where they belong in Sun_Mod in base/MAPL_sun_uc.F90 and are now explicitly named and
-  commented at the head of the module. This is a structural zero-diff change.
+- Added subroutine `MAPL_SunGetLocalSolarHourAngle()` in `base/MAPL_sun_uc.F90`. This
+  provides a convenient local solar hour angle diagnostic which will be used to detect local
+  solar noon via the `EXAMPLE OF USE` in the subroutine header. See `DESCRIPTION` in code
+  for more details. Provides the TRUE local solar hour angle (i.e., with equation of time
+  included), but can also provide the MEAN value (without EOT) via `FORCE_MLSHA=.TRUE.`
+  optional argument.
 
 ### Changed
+
+- Changed call to `MAPL_SunOrbitCreate()` inside `MAPL_Generic.F90` to call to new function
+  `MAPL_SunOrbitCreateFromConfig()`, the latter which get the orbital parameters from the MAPL
+  state's Config. In this way no default orbital parameter values need appear in `MAPL_Generic.F90`.
+  Rather, these default values are encapsulated where they belong in `Sun_Mod` in `base/MAPL_sun_uc.F90`
+  and are now explicitly named and commented on at the head of the module. This is a structural
+  zero-diff change.
 
 ### Fixed
 

--- a/base/MAPL_sun_uc.F90
+++ b/base/MAPL_sun_uc.F90
@@ -65,9 +65,9 @@ module MAPL_SunMod
    ! Parameters of old orbital system (tabularized intercalation cycle)
    ! ------------------------------------------------------------------
    real, parameter    :: DEFAULT_ORBIT_ECCENTRICITY     = 0.0167
-   real, parameter    :: DEFAULT_ORBIT_OBLIQUITY        = 23.45
-   real, parameter    :: DEFAULT_ORBIT_PERIHELION       = 102.0
-   integer, parameter :: DEFAULT_ORBIT_EQUINOX          = 80
+   real, parameter    :: DEFAULT_ORBIT_OBLIQUITY        = 23.45   ! degrees
+   real, parameter    :: DEFAULT_ORBIT_PERIHELION       = 102.0   ! degrees
+   integer, parameter :: DEFAULT_ORBIT_EQUINOX          = 80      ! days
 
    ! Parameters of new orbital system (analytic two-body), which allows some
    ! time-varying behavior, namely, linear variation in LAMBDAP, ECC, and OBQ.

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -4031,20 +4031,9 @@ contains
       character(len=ESMF_MAXSTR), parameter :: IAm = "MAPL_GenericStateGet"
       integer                               :: status
 
-!     real                                  :: ECC
-!     real                                  :: OB
-!     real                                  :: PER
-!     integer                               :: EQNX
       logical                               :: FIX_SUN
       character(len=ESMF_MAXSTR)            :: gname
 
-!     logical :: EOT, ORBIT_ANAL2B
-!     integer :: ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
-!          ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS
-!     real :: ORB2B_YEARLEN, &
-!          ORB2B_ECC_REF, ORB2B_ECC_RATE, &
-!          ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
-!          ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE
       type(MaplGrid), pointer :: temp_grid
 
       if(present(IM)) then
@@ -4088,137 +4077,12 @@ contains
          CF=STATE%CF
       endif
 
-      ! pmn: There is one orbit is per STATE, so, for example, the MAPL states of the
-      ! solar and land gridded components can potentially have independent solar orbits.
-      ! Usually these "independent orbits" will be IDENTICAL because the configuration
-      ! resources such as "ECCENTRICITY:" or "EOT:" will not be qualified by the name
-      ! of the gridded component. But for example, if the resource file specifies
-      !   "EOT: .FALSE."
-      ! but
-      !   "SOLAR_EOT: .TRUE."
-      ! then only SOLAR will have an EOT correction. The same goes for the new orbital
-      ! system choice ORBIT_ANAL2B.
-      !   A state's orbit is actually created in this routine by requesting the ORBIT
-      ! object. If its not already created then it will be made below. GridComps that
-      ! don't needed an orbit and dont request one will not have one.
-
       if(present(ORBIT)) then
 
          if(.not.MAPL_SunOrbitCreated(STATE%ORBIT)) then
 
             call ESMF_GridGet(STATE%GRID%ESMFGRID,name=gname,_RC)
             FIX_SUN = (index(gname,"DP")>0) 
-
-!           ! Fixed parameters of standard orbital system (tabularized intercalation cycle)
-!           ! -----------------------------------------------------------------------------
-
-!           call MAPL_GetResource(STATE, ECC, Label="ECCENTRICITY:", default=0.0167, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           call MAPL_GetResource(STATE, OB, Label="OBLIQUITY:", default=23.45, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           call MAPL_GetResource(STATE, PER, Label="PERIHELION:", default=102.0, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           call MAPL_GetResource(STATE, EQNX, Label="EQUINOX:", default=80, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Apply Equation of Time correction?
-!           ! ----------------------------------
-!           call MAPL_GetResource(STATE, EOT, Label="EOT:", default=.FALSE., &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! New orbital system (analytic two-body) allows some time-varying
-!           ! behavior, namely, linear variation in LAMBDAP, ECC, and OBQ.
-!           ! ---------------------------------------------------------------
-
-!           call MAPL_GetResource(STATE, &
-!                ORBIT_ANAL2B, Label="ORBIT_ANAL2B:", default=.FALSE., &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Fixed anomalistic year length in mean solar days
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_YEARLEN, Label="ORB2B_YEARLEN:", default=365.2596, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Reference date and time for orbital parameters
-!           ! (defaults to J2000 = 01Jan2000 12:00:00 TT = 11:58:56 UTC)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_REF_YYYYMMDD, Label="ORB2B_REF_YYYYMMDD:", default=20000101, &
-!                RC=status)
-!           _VERIFY(status)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_REF_HHMMSS, Label="ORB2B_REF_HHMMSS:", default=115856, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Orbital eccentricity at reference date
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_ECC_REF, Label="ORB2B_ECC_REF:", default=0.016710, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Rate of change of orbital eccentricity per Julian century
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_ECC_RATE, Label="ORB2B_ECC_RATE:", default=-4.2e-5, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Earth's obliquity (axial tilt) at reference date [degrees]
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_OBQ_REF, Label="ORB2B_OBQ_REF:", default=23.44, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Rate of change of obliquity [degrees per Julian century]
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_OBQ_RATE, Label="ORB2B_OBQ_RATE:", default=-1.3e-2, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Longitude of perihelion at reference date [degrees]
-!           !   (from March equinox to perihelion in direction of earth's motion)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_LAMBDAP_REF, Label="ORB2B_LAMBDAP_REF:", default=282.947, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! Rate of change of LAMBDAP [degrees per Julian century]
-!           !   (Combines both equatorial and ecliptic precession)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_LAMBDAP_RATE, Label="ORB2B_LAMBDAP_RATE:", default=1.7195, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! March Equinox date and time
-!           ! (defaults to March 20, 2000 at 07:35:00 UTC)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_EQUINOX_YYYYMMDD, Label="ORB2B_EQUINOX_YYYYMMDD:", default=20000320, &
-!                RC=status)
-!           _VERIFY(status)
-!           call MAPL_GetResource(STATE, &
-!                ORB2B_EQUINOX_HHMMSS, Label="ORB2B_EQUINOX_HHMMSS:", default=073500, &
-!                RC=status)
-!           _VERIFY(status)
-
-!           ! create the orbit object
-!           STATE%ORBIT = MAPL_SunOrbitCreate(STATE%CLOCK, ECC, OB, PER, EQNX, &
-!                EOT, ORBIT_ANAL2B, ORB2B_YEARLEN, &
-!                ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
-!                ORB2B_ECC_REF, ORB2B_ECC_RATE, &
-!                ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
-!                ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE, &
-!                ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS, &
-!                FIX_SUN=FIX_SUN,RC=status)
-!           _VERIFY(status)
 
             ! create the orbit object
             STATE%ORBIT = MAPL_SunOrbitCreateFromConfig (STATE%CF, STATE%CLOCK, FIX_SUN, _RC)

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -4035,8 +4035,8 @@ contains
 !     real                                  :: OB
 !     real                                  :: PER
 !     integer                               :: EQNX
-!     logical                               :: FIX_SUN
-!     character(len=ESMF_MAXSTR)            :: gname
+      logical                               :: FIX_SUN
+      character(len=ESMF_MAXSTR)            :: gname
 
 !     logical :: EOT, ORBIT_ANAL2B
 !     integer :: ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
@@ -4106,13 +4106,8 @@ contains
 
          if(.not.MAPL_SunOrbitCreated(STATE%ORBIT)) then
 
-!           call ESMF_GridGet(STATE%GRID%ESMFGRID,name=gname,rc=status)
-!           _VERIFY(status)
-!           if (index(gname,"DP")>0) then
-!              FIX_SUN=.true.
-!           else
-!              FIX_SUN=.false.
-!           end if
+            call ESMF_GridGet(STATE%GRID%ESMFGRID,name=gname,_RC)
+            FIX_SUN = (index(gname,"DP")>0) 
 
 !           ! Fixed parameters of standard orbital system (tabularized intercalation cycle)
 !           ! -----------------------------------------------------------------------------
@@ -4226,7 +4221,7 @@ contains
 !           _VERIFY(status)
 
             ! create the orbit object
-            STATE%ORBIT = MAPL_SunOrbitCreateFromResource (STATE, _RC)
+            STATE%ORBIT = MAPL_SunOrbitCreateFromConfig (STATE%CF, STATE%CLOCK, FIX_SUN, _RC)
 
          end if
          ORBIT=STATE%ORBIT

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -4031,20 +4031,20 @@ contains
       character(len=ESMF_MAXSTR), parameter :: IAm = "MAPL_GenericStateGet"
       integer                               :: status
 
-      real                                  :: ECC
-      real                                  :: OB
-      real                                  :: PER
-      integer                               :: EQNX
-      logical                               :: FIX_SUN
-      character(len=ESMF_MAXSTR)            :: gname
+!     real                                  :: ECC
+!     real                                  :: OB
+!     real                                  :: PER
+!     integer                               :: EQNX
+!     logical                               :: FIX_SUN
+!     character(len=ESMF_MAXSTR)            :: gname
 
-      logical :: EOT, ORBIT_ANAL2B
-      integer :: ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
-           ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS
-      real :: ORB2B_YEARLEN, &
-           ORB2B_ECC_REF, ORB2B_ECC_RATE, &
-           ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
-           ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE
+!     logical :: EOT, ORBIT_ANAL2B
+!     integer :: ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
+!          ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS
+!     real :: ORB2B_YEARLEN, &
+!          ORB2B_ECC_REF, ORB2B_ECC_RATE, &
+!          ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
+!          ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE
       type(MaplGrid), pointer :: temp_grid
 
       if(present(IM)) then
@@ -4106,124 +4106,127 @@ contains
 
          if(.not.MAPL_SunOrbitCreated(STATE%ORBIT)) then
 
-            call ESMF_GridGet(STATE%GRID%ESMFGRID,name=gname,rc=status)
-            _VERIFY(status)
-            if (index(gname,"DP")>0) then
-               FIX_SUN=.true.
-            else
-               FIX_SUN=.false.
-            end if
+!           call ESMF_GridGet(STATE%GRID%ESMFGRID,name=gname,rc=status)
+!           _VERIFY(status)
+!           if (index(gname,"DP")>0) then
+!              FIX_SUN=.true.
+!           else
+!              FIX_SUN=.false.
+!           end if
 
-            ! Fixed parameters of standard orbital system (tabularized intercalation cycle)
-            ! -----------------------------------------------------------------------------
+!           ! Fixed parameters of standard orbital system (tabularized intercalation cycle)
+!           ! -----------------------------------------------------------------------------
 
-            call MAPL_GetResource(STATE, ECC, Label="ECCENTRICITY:", default=0.0167, &
-                 RC=status)
-            _VERIFY(status)
+!           call MAPL_GetResource(STATE, ECC, Label="ECCENTRICITY:", default=0.0167, &
+!                RC=status)
+!           _VERIFY(status)
 
-            call MAPL_GetResource(STATE, OB, Label="OBLIQUITY:", default=23.45, &
-                 RC=status)
-            _VERIFY(status)
+!           call MAPL_GetResource(STATE, OB, Label="OBLIQUITY:", default=23.45, &
+!                RC=status)
+!           _VERIFY(status)
 
-            call MAPL_GetResource(STATE, PER, Label="PERIHELION:", default=102.0, &
-                 RC=status)
-            _VERIFY(status)
+!           call MAPL_GetResource(STATE, PER, Label="PERIHELION:", default=102.0, &
+!                RC=status)
+!           _VERIFY(status)
 
-            call MAPL_GetResource(STATE, EQNX, Label="EQUINOX:", default=80, &
-                 RC=status)
-            _VERIFY(status)
+!           call MAPL_GetResource(STATE, EQNX, Label="EQUINOX:", default=80, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Apply Equation of Time correction?
-            ! ----------------------------------
-            call MAPL_GetResource(STATE, EOT, Label="EOT:", default=.FALSE., &
-                 RC=status)
-            _VERIFY(status)
+!           ! Apply Equation of Time correction?
+!           ! ----------------------------------
+!           call MAPL_GetResource(STATE, EOT, Label="EOT:", default=.FALSE., &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! New orbital system (analytic two-body) allows some time-varying
-            ! behavior, namely, linear variation in LAMBDAP, ECC, and OBQ.
-            ! ---------------------------------------------------------------
+!           ! New orbital system (analytic two-body) allows some time-varying
+!           ! behavior, namely, linear variation in LAMBDAP, ECC, and OBQ.
+!           ! ---------------------------------------------------------------
 
-            call MAPL_GetResource(STATE, &
-                 ORBIT_ANAL2B, Label="ORBIT_ANAL2B:", default=.FALSE., &
-                 RC=status)
-            _VERIFY(status)
+!           call MAPL_GetResource(STATE, &
+!                ORBIT_ANAL2B, Label="ORBIT_ANAL2B:", default=.FALSE., &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Fixed anomalistic year length in mean solar days
-            call MAPL_GetResource(STATE, &
-                 ORB2B_YEARLEN, Label="ORB2B_YEARLEN:", default=365.2596, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Fixed anomalistic year length in mean solar days
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_YEARLEN, Label="ORB2B_YEARLEN:", default=365.2596, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Reference date and time for orbital parameters
-            ! (defaults to J2000 = 01Jan2000 12:00:00 TT = 11:58:56 UTC)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_REF_YYYYMMDD, Label="ORB2B_REF_YYYYMMDD:", default=20000101, &
-                 RC=status)
-            _VERIFY(status)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_REF_HHMMSS, Label="ORB2B_REF_HHMMSS:", default=115856, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Reference date and time for orbital parameters
+!           ! (defaults to J2000 = 01Jan2000 12:00:00 TT = 11:58:56 UTC)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_REF_YYYYMMDD, Label="ORB2B_REF_YYYYMMDD:", default=20000101, &
+!                RC=status)
+!           _VERIFY(status)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_REF_HHMMSS, Label="ORB2B_REF_HHMMSS:", default=115856, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Orbital eccentricity at reference date
-            call MAPL_GetResource(STATE, &
-                 ORB2B_ECC_REF, Label="ORB2B_ECC_REF:", default=0.016710, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Orbital eccentricity at reference date
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_ECC_REF, Label="ORB2B_ECC_REF:", default=0.016710, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Rate of change of orbital eccentricity per Julian century
-            call MAPL_GetResource(STATE, &
-                 ORB2B_ECC_RATE, Label="ORB2B_ECC_RATE:", default=-4.2e-5, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Rate of change of orbital eccentricity per Julian century
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_ECC_RATE, Label="ORB2B_ECC_RATE:", default=-4.2e-5, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Earth's obliquity (axial tilt) at reference date [degrees]
-            call MAPL_GetResource(STATE, &
-                 ORB2B_OBQ_REF, Label="ORB2B_OBQ_REF:", default=23.44, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Earth's obliquity (axial tilt) at reference date [degrees]
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_OBQ_REF, Label="ORB2B_OBQ_REF:", default=23.44, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Rate of change of obliquity [degrees per Julian century]
-            call MAPL_GetResource(STATE, &
-                 ORB2B_OBQ_RATE, Label="ORB2B_OBQ_RATE:", default=-1.3e-2, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Rate of change of obliquity [degrees per Julian century]
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_OBQ_RATE, Label="ORB2B_OBQ_RATE:", default=-1.3e-2, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Longitude of perihelion at reference date [degrees]
-            !   (from March equinox to perihelion in direction of earth's motion)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_LAMBDAP_REF, Label="ORB2B_LAMBDAP_REF:", default=282.947, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Longitude of perihelion at reference date [degrees]
+!           !   (from March equinox to perihelion in direction of earth's motion)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_LAMBDAP_REF, Label="ORB2B_LAMBDAP_REF:", default=282.947, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! Rate of change of LAMBDAP [degrees per Julian century]
-            !   (Combines both equatorial and ecliptic precession)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_LAMBDAP_RATE, Label="ORB2B_LAMBDAP_RATE:", default=1.7195, &
-                 RC=status)
-            _VERIFY(status)
+!           ! Rate of change of LAMBDAP [degrees per Julian century]
+!           !   (Combines both equatorial and ecliptic precession)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_LAMBDAP_RATE, Label="ORB2B_LAMBDAP_RATE:", default=1.7195, &
+!                RC=status)
+!           _VERIFY(status)
 
-            ! March Equinox date and time
-            ! (defaults to March 20, 2000 at 07:35:00 UTC)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_EQUINOX_YYYYMMDD, Label="ORB2B_EQUINOX_YYYYMMDD:", default=20000320, &
-                 RC=status)
-            _VERIFY(status)
-            call MAPL_GetResource(STATE, &
-                 ORB2B_EQUINOX_HHMMSS, Label="ORB2B_EQUINOX_HHMMSS:", default=073500, &
-                 RC=status)
-            _VERIFY(status)
+!           ! March Equinox date and time
+!           ! (defaults to March 20, 2000 at 07:35:00 UTC)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_EQUINOX_YYYYMMDD, Label="ORB2B_EQUINOX_YYYYMMDD:", default=20000320, &
+!                RC=status)
+!           _VERIFY(status)
+!           call MAPL_GetResource(STATE, &
+!                ORB2B_EQUINOX_HHMMSS, Label="ORB2B_EQUINOX_HHMMSS:", default=073500, &
+!                RC=status)
+!           _VERIFY(status)
+
+!           ! create the orbit object
+!           STATE%ORBIT = MAPL_SunOrbitCreate(STATE%CLOCK, ECC, OB, PER, EQNX, &
+!                EOT, ORBIT_ANAL2B, ORB2B_YEARLEN, &
+!                ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
+!                ORB2B_ECC_REF, ORB2B_ECC_RATE, &
+!                ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
+!                ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE, &
+!                ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS, &
+!                FIX_SUN=FIX_SUN,RC=status)
+!           _VERIFY(status)
 
             ! create the orbit object
-            STATE%ORBIT = MAPL_SunOrbitCreate(STATE%CLOCK, ECC, OB, PER, EQNX, &
-                 EOT, ORBIT_ANAL2B, ORB2B_YEARLEN, &
-                 ORB2B_REF_YYYYMMDD, ORB2B_REF_HHMMSS, &
-                 ORB2B_ECC_REF, ORB2B_ECC_RATE, &
-                 ORB2B_OBQ_REF, ORB2B_OBQ_RATE, &
-                 ORB2B_LAMBDAP_REF, ORB2B_LAMBDAP_RATE, &
-                 ORB2B_EQUINOX_YYYYMMDD, ORB2B_EQUINOX_HHMMSS, &
-                 FIX_SUN=FIX_SUN,RC=status)
-            _VERIFY(status)
+            STATE%ORBIT = MAPL_SunOrbitCreateFromResource (STATE, _RC)
 
          end if
          ORBIT=STATE%ORBIT


### PR DESCRIPTION
## Description
- Changed call to MAPL_SunOrbitCreate() inside MAPL_Generic.F90 to new MAPL_SunOrbitCreateFromConfig,
  the latter which get the orbital parameters from the MAPL state's Config. In this way no default
  orbital parameter values need appear in MAPL_Generic.F90. Rather, these default values are encap-
  sulated where they belong in Sun_Mod in base/MAPL_sun_uc.F90 and are now explicitly

## Related Issue
issue #1915

## Motivation and Context
It cleans up the code so hardwired orbital parameter default values no longer appear in MAPL_Generic. It was decided 
it would be better to place them directly in Sun_Mod. This makes the code more encapsulated. To expose them instead
in a Physical Constants file would be both incorrect (they are epoch relevant values not constants) and might expose 
them more easily to inappropriate changes.

## How Has This Been Tested?
Tested to be zero-diff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
