### PR TITLE
Fixes #1888. Set regrid_method to identity for native collections

### DIFF
--- a/Apps/Regrid_Util.F90
+++ b/Apps/Regrid_Util.F90
@@ -171,7 +171,7 @@
     if (.not.allocated(this%tripolar_file_out)) then
        this%tripolar_file_out = "empty"
     end if
-    this%regridMethod = get_regrid_method(regridMth)
+    this%regridMethod = regrid_method_string_to_int(regridMth)
     _ASSERT(this%regridMethod/=UNSPECIFIED_REGRID_METHOD,"improper regrid method chosen")
 
     this%filenames = split_string(cfilenames,',')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `get_regrid_method` and `translate_regrid_method` to `regrid_method_string_to_int` and `regrid_method_int_to_string`
+  respectively in `RegridMethods.F90`. This was done so we could add `get_regrid_method` to the AbstractRegridder. The new names
+  more accurately reflect what the RegridMethods functions do.
+
 ### Fixed
 
 - Added the correct values to halo corner of LatLon grid
 - Fixed range in halo of LatLonGridFactory
-- Corrected issue with native output having metadata saying it was bilinearly regridded
+- Corrected issue with native output having metadata saying it was bilinearly regridded. Now sets these files to have
+  `regrid_method: identity`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Added the correct values to halo corner of LatLon grid  
+- Added the correct values to halo corner of LatLon grid
 - Fixed range in halo of LatLonGridFactory
+- Corrected issue with native output having metadata saying it was bilinearly regridded
 
 ### Removed
 

--- a/base/MAPL_AbstractRegridder.F90
+++ b/base/MAPL_AbstractRegridder.F90
@@ -11,7 +11,7 @@ module MAPL_AbstractRegridderMod
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    implicit none
    private
-   
+
    public :: AbstractRegridder
 
    type, abstract :: AbstractRegridder
@@ -29,7 +29,7 @@ module MAPL_AbstractRegridderMod
       procedure :: get_spec
       procedure :: set_spec
       procedure :: isTranspose
-      
+
       procedure :: regrid_scalar_2d_real32
       procedure :: regrid_scalar_2d_real64
       procedure :: regrid_scalar_3d_real32
@@ -44,7 +44,7 @@ module MAPL_AbstractRegridderMod
       ! interfaces.
       procedure :: regrid_esmf_fields_scalar
       procedure :: regrid_esmf_fields_vector
-      
+
       ! Generic overload
       generic :: regrid => regrid_esmf_fields_scalar
       generic :: regrid => regrid_esmf_fields_vector
@@ -90,6 +90,7 @@ module MAPL_AbstractRegridderMod
       procedure :: get_undef_value
       procedure :: clear_undef_value
       procedure :: has_undef_value
+      procedure :: get_regrid_method
 
    end type AbstractRegridder
 
@@ -105,7 +106,7 @@ module MAPL_AbstractRegridderMod
          class (KeywordEnforcer), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_subclass
-         
+
    end interface
 
    character(len=*), parameter :: MOD_NAME = 'MAPL_AbstractRegridder::'
@@ -272,7 +273,7 @@ contains
       type (ESMF_Field), intent(in) :: f_in
       type (ESMF_Field), intent(in) :: f_out
       integer, optional, intent(out) :: rc
-      
+
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_esmf_fields'
       integer :: rank_in
       type (ESMF_TypeKind_Flag) :: typekind_in
@@ -298,7 +299,7 @@ contains
 
             block
               real(REAL32), pointer :: q_in(:,:), q_out(:,:)
-              
+
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_out , 0, q_out, rc=status)
@@ -311,7 +312,7 @@ contains
 
             block
               real(REAL64), pointer :: q_in(:,:), q_out(:,:)
-              
+
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_out , 0, q_out, rc=status)
@@ -356,13 +357,13 @@ contains
          case default ! unsupported type/kind
             _FAIL( 'unsupported type kind')
          end select
-      
+
       case default ! unsupported rank
          _FAIL( 'unsupported rank')
       end select
 
       _RETURN(_SUCCESS)
-      
+
    end subroutine regrid_esmf_fields_scalar
 
 
@@ -377,7 +378,7 @@ contains
       type (ESMF_Field), intent(in) :: f_in(NUM_DIM)
       type (ESMF_Field), intent(in) :: f_out(NUM_DIM)
       integer, optional, intent(out) :: rc
-      
+
       character(len=*), parameter :: Iam = MOD_NAME//'regrid_esmf_fields'
       integer :: rank_in(NUM_DIM)
       type (ESMF_TypeKind_Flag) :: typekind_in(NUM_DIM)
@@ -413,7 +414,7 @@ contains
             block
               real(REAL32), pointer :: u_in(:,:), v_in(:,:)
               real(REAL32), pointer :: u_out(:,:), v_out(:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -431,7 +432,7 @@ contains
             block
               real(REAL64), pointer :: u_in(:,:), v_in(:,:)
               real(REAL64), pointer :: u_out(:,:), v_out(:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -455,7 +456,7 @@ contains
             block
               real(REAL32), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL32), pointer :: u_out(:,:,:), v_out(:,:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -473,7 +474,7 @@ contains
             block
               real(REAL64), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL64), pointer :: u_out(:,:,:), v_out(:,:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -489,19 +490,19 @@ contains
          case default ! unsupported type/kind
             _FAIL( 'unsupported type-kind')
          end select
-      
+
       case default ! unsupported rank
          _FAIL( 'unsupported rank')
       end select
 
       _RETURN(_SUCCESS)
-      
+
 
    end subroutine regrid_esmf_fields_vector
 
 
    ! Begin - transpose interfaces
-   
+
    subroutine transpose_regrid_scalar_2d_real32(this, q_in, q_out, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: q_in(:,:)
@@ -531,7 +532,7 @@ contains
       _RETURN(_FAILURE)
    end subroutine transpose_regrid_scalar_2d_real64
 
-   
+
    subroutine transpose_regrid_scalar_3d_real32(this, q_in, q_out, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: q_in(:,:,:)
@@ -563,7 +564,7 @@ contains
 
    end subroutine transpose_regrid_scalar_3d_real64
 
-   
+
    subroutine transpose_regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
       class (AbstractRegridder), intent(in) :: this
       real(kind=REAL32), intent(in) :: u_in(:,:)
@@ -585,7 +586,7 @@ contains
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
-      
+
    end subroutine transpose_regrid_vector_2d_real32
 
 
@@ -610,7 +611,7 @@ contains
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
-      
+
    end subroutine transpose_regrid_vector_2d_real64
 
 
@@ -635,7 +636,7 @@ contains
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
-      
+
    end subroutine transpose_regrid_vector_3d_real32
 
 
@@ -658,7 +659,7 @@ contains
       u_out = 0
       v_out = 0
       _RETURN(_FAILURE)
-      
+
    end subroutine transpose_regrid_vector_3d_real64
 
 
@@ -672,7 +673,7 @@ contains
       type (ESMF_Field), intent(in) :: f_in
       type (ESMF_Field), intent(in) :: f_out
       integer, optional, intent(out) :: rc
-      
+
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_esmf_fields'
       integer :: rank_in
       type (ESMF_TypeKind_Flag) :: typekind_in
@@ -698,7 +699,7 @@ contains
 
             block
               real(REAL32), pointer :: q_in(:,:), q_out(:,:)
-              
+
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_out , 0, q_out, rc=status)
@@ -711,7 +712,7 @@ contains
 
             block
               real(REAL64), pointer :: q_in(:,:), q_out(:,:)
-              
+
               call ESMF_FieldGet(f_in , 0, q_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_out , 0, q_out, rc=status)
@@ -756,13 +757,13 @@ contains
          case default ! unsupported type/kind
             _FAIL( 'unsupported typekind')
          end select
-      
+
       case default ! unsupported rank
          _FAIL( 'unsupported rank')
       end select
 
       _RETURN(_SUCCESS)
-      
+
    end subroutine transpose_regrid_esmf_fields_scalar
 
 
@@ -777,7 +778,7 @@ contains
       type (ESMF_Field), intent(in) :: f_in(NUM_DIM)
       type (ESMF_Field), intent(in) :: f_out(NUM_DIM)
       integer, optional, intent(out) :: rc
-      
+
       character(len=*), parameter :: Iam = MOD_NAME//'transpose_regrid_esmf_fields'
       integer :: rank_in(NUM_DIM)
       type (ESMF_TypeKind_Flag) :: typekind_in(NUM_DIM)
@@ -813,7 +814,7 @@ contains
             block
               real(REAL32), pointer :: u_in(:,:), v_in(:,:)
               real(REAL32), pointer :: u_out(:,:), v_out(:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -831,7 +832,7 @@ contains
             block
               real(REAL64), pointer :: u_in(:,:), v_in(:,:)
               real(REAL64), pointer :: u_out(:,:), v_out(:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -855,7 +856,7 @@ contains
             block
               real(REAL32), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL32), pointer :: u_out(:,:,:), v_out(:,:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -873,7 +874,7 @@ contains
             block
               real(REAL64), pointer :: u_in(:,:,:), v_in(:,:,:)
               real(REAL64), pointer :: u_out(:,:,:), v_out(:,:,:)
-              
+
               call ESMF_FieldGet(f_in(1) , 0, u_in, rc=status)
               _VERIFY(status)
               call ESMF_FieldGet(f_in(2) , 0, v_in, rc=status)
@@ -889,13 +890,13 @@ contains
          case default ! unsupported type/kind
             _FAIL( 'unsupported typekind')
          end select
-      
+
       case default ! unsupported rank
          _FAIL( 'unsupported rank')
       end select
 
       _RETURN(_SUCCESS)
-      
+
 
    end subroutine transpose_regrid_esmf_fields_vector
 
@@ -940,7 +941,7 @@ contains
       class (AbstractRegridder), intent(in) :: this
       spec = this%spec
    end function get_spec
-   
+
    subroutine set_spec(this, spec)
       class(AbstractRegridder), intent(inout) :: this
       type(RegridderSpec), intent(in) :: spec
@@ -974,7 +975,7 @@ contains
       _RETURN(_SUCCESS)
 
    end subroutine initialize_base
-         
+
    function clone(this)
       class (AbstractRegridder), allocatable :: clone
       class (AbstractRegridder), intent(in) :: this
@@ -999,5 +1000,10 @@ contains
       _RETURN(_SUCCESS)
 
    end function supports
+
+   integer function get_regrid_method(this) result(method)
+      class (AbstractRegridder), intent(in) :: this
+      method = this%spec%regrid_method
+   end function get_regrid_method
 
 end module MAPL_AbstractRegridderMod

--- a/base/MAPL_IdentityRegridder.F90
+++ b/base/MAPL_IdentityRegridder.F90
@@ -45,12 +45,16 @@ contains
    function identity_regridder() result(regridder)
       use ESMF
       type (IdentityRegridder), pointer :: regridder
-      type (RegridderSpec), pointer :: spec
+      type (RegridderSpec) :: spec
 
       regridder => singleton
 
-      spec => regridder%get_spec()
-      spec%regrid_method = REGRID_METHOD_IDENTITY
+      ! Due to how MAPL is set up, the default regrid_method is
+      ! bilinear. But if an identity regridder is requested, we
+      ! want to reflect that in the metadata by updating the spec.
+      spec = regridder%get_spec()
+      call spec%set_regrid_method(REGRID_METHOD_IDENTITY)
+      call regridder%set_spec(spec)
     end function identity_regridder
 
 

--- a/base/MAPL_IdentityRegridder.F90
+++ b/base/MAPL_IdentityRegridder.F90
@@ -53,7 +53,7 @@ contains
       ! bilinear. But if an identity regridder is requested, we
       ! want to reflect that in the metadata by updating the spec.
       spec = regridder%get_spec()
-      call spec%set_regrid_method(REGRID_METHOD_IDENTITY)
+      spec%regrid_method = REGRID_METHOD_IDENTITY
       call regridder%set_spec(spec)
     end function identity_regridder
 

--- a/base/MAPL_IdentityRegridder.F90
+++ b/base/MAPL_IdentityRegridder.F90
@@ -8,7 +8,7 @@ module MAPL_IdentityRegridderMod
    use mapl_ErrorHandlingMod
    use mapl_RegridMethods
    use ESMF
-   
+
    use, intrinsic :: iso_fortran_env, only: REAL32
    use, intrinsic :: iso_fortran_env, only: REAL64
    implicit none
@@ -38,15 +38,19 @@ module MAPL_IdentityRegridderMod
    character(len=*), parameter :: MOD_NAME = 'MAPL_IdentityRegridder::'
 
    type (IdentityRegridder), save, target :: singleton
-   
+
 contains
 
 
    function identity_regridder() result(regridder)
       use ESMF
       type (IdentityRegridder), pointer :: regridder
+      type (RegridderSpec), pointer :: spec
 
       regridder => singleton
+
+      spec => regridder%get_spec()
+      spec%regrid_method = REGRID_METHOD_IDENTITY
     end function identity_regridder
 
 
@@ -63,7 +67,7 @@ contains
       q_out = q_in
 
       _RETURN(_SUCCESS)
-      
+
    end subroutine regrid_scalar_2d_real32
 
 
@@ -85,7 +89,7 @@ contains
       q_out = q_in
 
       _RETURN(_SUCCESS)
-      
+
    end subroutine regrid_scalar_3d_real32
 
    subroutine regrid_vector_2d_real32(this, u_in, v_in, u_out, v_out, rotate, rc)
@@ -169,5 +173,5 @@ contains
       _UNUSED_DUMMY(rc)
 
    end subroutine initialize_subclass
-   
+
 end module MAPL_IdentityRegridderMod

--- a/base/RegridMethods.F90
+++ b/base/RegridMethods.F90
@@ -18,8 +18,8 @@ module mapl_RegridMethods
    public :: REGRID_METHOD_CONSERVE_HFLUX
    public :: UNSPECIFIED_REGRID_METHOD
    public :: TILING_METHODS
-   public :: get_regrid_method
-   public :: translate_regrid_method
+   public :: regrid_method_string_to_int
+   public :: regrid_method_int_to_string
 
    enum, bind(c)
       enumerator :: REGRID_METHOD_IDENTITY
@@ -41,7 +41,7 @@ module mapl_RegridMethods
 
    contains
 
-   function get_regrid_method(string_regrid_method) result(int_regrid_method)
+   function regrid_method_string_to_int(string_regrid_method) result(int_regrid_method)
       integer :: int_regrid_method
       character(len=*), intent(in) :: string_regrid_method
 
@@ -78,7 +78,7 @@ module mapl_RegridMethods
       end select
    end function
 
-   function translate_regrid_method(int_regrid_method) result(string_regrid_method)
+   function regrid_method_int_to_string(int_regrid_method) result(string_regrid_method)
       integer, intent(in) :: int_regrid_method
       character(len=:), allocatable :: string_regrid_method
 

--- a/base/RegridderSpec.F90
+++ b/base/RegridderSpec.F90
@@ -24,7 +24,6 @@ module mapl_RegridderSpec
       generic :: operator (==) => equals
       procedure :: less_than
       generic :: operator (<) => less_than
-      procedure :: set_regrid_method
    end type RegridderSpec
 
 
@@ -157,13 +156,6 @@ contains
       return
 
    end function less_than
-
-   subroutine set_regrid_method(this, regrid_method)
-      class (RegridderSpec), intent(inout) :: this
-      integer, intent(in) :: regrid_method
-
-      this%regrid_method = regrid_method
-   end subroutine set_regrid_method
 
 end module MAPL_RegridderSpec
 #undef _UNUSED_DUMMY

--- a/base/RegridderSpec.F90
+++ b/base/RegridderSpec.F90
@@ -10,7 +10,7 @@ module mapl_RegridderSpec
    implicit none
    private
 
-      
+
    public :: RegridderSpec
 
    type :: RegridderSpec
@@ -24,8 +24,9 @@ module mapl_RegridderSpec
       generic :: operator (==) => equals
       procedure :: less_than
       generic :: operator (<) => less_than
+      procedure :: set_regrid_method
    end type RegridderSpec
-   
+
 
    interface RegridderSpec
       module procedure newRegridderSpec
@@ -109,7 +110,7 @@ contains
       integer (kind=INT64) :: a_out_id, b_out_id
 
       integer :: a_esmf_method, b_esmf_method
-      
+
       select case (a%regrid_method)
       case (REGRID_METHOD_CONSERVE, REGRID_METHOD_VOTE, REGRID_METHOD_FRACTION)
          a_esmf_method = REGRID_METHOD_CONSERVE
@@ -141,7 +142,7 @@ contains
          less_than = .true.
          return
       end if
-         
+
       a_out_id = get_factory_id(a%grid_out)
       b_out_id = get_factory_id(b%grid_out)
       if (a_out_id > b_out_id) then
@@ -154,8 +155,15 @@ contains
 
       less_than = .false.
       return
-         
+
    end function less_than
+
+   subroutine set_regrid_method(this, regrid_method)
+      class (RegridderSpec), intent(inout) :: this
+      integer, intent(in) :: regrid_method
+
+      this%regrid_method = regrid_method
+   end subroutine set_regrid_method
 
 end module MAPL_RegridderSpec
 #undef _UNUSED_DUMMY

--- a/gridcomps/ExtData2G/ExtDataOldTypesCreator.F90
+++ b/gridcomps/ExtData2G/ExtDataOldTypesCreator.F90
@@ -54,7 +54,7 @@ module MAPL_ExtDataOldTypesCreator
       _RETURN(_SUCCESS)
    end function new_ExtDataOldTypesCreator
 
-   
+
    subroutine fillin_primary(this,item_name,base_name,primary_item,time,clock,unusable,rc)
       class(ExtDataOldTypesCreator), intent(inout) :: this
       character(len=*), intent(in) :: item_name
@@ -77,7 +77,7 @@ module MAPL_ExtDataOldTypesCreator
       _UNUSED_DUMMY(unusable)
       rule => this%rule_map%at(trim(item_name))
       time_sample => this%sample_map%at(rule%sample_key)
-      
+
       if(.not.associated(time_sample)) then
         call default_time_sample%set_defaults()
         time_sample=>default_time_sample
@@ -106,14 +106,14 @@ module MAPL_ExtDataOldTypesCreator
          primary_item%fileVars%itemType = ItemTypeScalar
          primary_item%fileVars%xname  = trim(rule%file_var)
       end if
-      
+
       ! regrid method
       if (index(rule%regrid_method,"FRACTION;")>0) then
          semi_pos = index(rule%regrid_method,";")
          read(rule%regrid_method(semi_pos+1:),*) primary_item%fracVal
          primary_item%trans = REGRID_METHOD_FRACTION
       else
-         primary_item%trans = get_regrid_method(rule%regrid_method)
+         primary_item%trans = regrid_method_string_to_int(rule%regrid_method)
       end if
       _ASSERT(primary_item%trans/=UNSPECIFIED_REGRID_METHOD,"improper regrid method chosen")
 
@@ -131,7 +131,7 @@ module MAPL_ExtDataOldTypesCreator
       call primary_item%update_freq%create_from_parameters(time_sample%refresh_time, &
            time_sample%refresh_frequency, time_sample%refresh_offset, time, clock, _RC)
 
-      disable_interpolation =  .not.time_sample%time_interpolation 
+      disable_interpolation =  .not.time_sample%time_interpolation
       exact = time_sample%exact
 
       call primary_item%modelGridFields%comp1%set_parameters(linear_trans=rule%linear_trans,disable_interpolation=disable_interpolation,exact=exact)
@@ -185,7 +185,7 @@ module MAPL_ExtDataOldTypesCreator
 
       _UNUSED_DUMMY(unusable)
       rule => this%derived_map%at(trim(item_name))
-  
+
       derived_item%name = trim(item_name)
       derived_item%expression = rule%expression
       if (allocated(rule%sample_key)) then
@@ -204,7 +204,7 @@ module MAPL_ExtDataOldTypesCreator
       end if
 
       _RETURN(_SUCCESS)
- 
+
    end subroutine fillin_derived
 
 end module MAPL_ExtDataOldTypesCreator

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -931,7 +931,7 @@ contains
           call ESMF_ConfigGetAttribute ( cfg, regrid_method, default="REGRID_METHOD_BILINEAR", &
                                          label=trim(string) // 'regrid_method:'  ,rc=status )
           _VERIFY(STATUS)
-           list(n)%regrid_method = get_regrid_method(trim(regrid_method))
+           list(n)%regrid_method = regrid_method_string_to_int(trim(regrid_method))
        end if
 
 ! Get an optional file containing a 1-D track for the output

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -125,7 +125,6 @@ module MAPL_GriddedIOMod
         integer :: metadataVarsSize
         type(StringStringMapIterator) :: s_iter
         character(len=:), pointer :: attr_name, attr_val
-        integer (kind=ESMF_KIND_I8) :: id_in, id_out
         integer :: status
 
         this%items = items

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -144,9 +144,10 @@ module MAPL_GriddedIOMod
         this%regrid_handle => new_regridder_manager%make_regridder(input_grid,this%output_grid,this%regrid_method,rc=status)
         _VERIFY(status)
 
-        ! We get the regrid_method here because we default to bilinear even in the case
-        ! of input_grid and this%output_grid being the same. But if the regrid_handle
-        ! is the identity regridder, then this will set it to REGRID_METHOD_IDENTITY
+        ! We get the regrid_method here because in the case of Identity, we set it to
+        ! REGRID_METHOD_IDENTITY in the regridder constructor if identity. Now we need
+        ! to change the regrid_method in the GriddedIO object to be the same as the
+        ! the regridder object.
         this%regrid_method = this%regrid_handle%get_regrid_method()
 
         call ESMF_FieldBundleSet(this%output_bundle,grid=this%output_grid,rc=status)
@@ -373,7 +374,7 @@ module MAPL_GriddedIOMod
         call v%add_attribute('add_offset',0.0)
         call v%add_attribute('_FillValue',MAPL_UNDEF)
         call v%add_attribute('valid_range',(/-MAPL_UNDEF,MAPL_UNDEF/))
-        call v%add_attribute('regrid_method', translate_regrid_method(this%regrid_method))
+        call v%add_attribute('regrid_method', regrid_method_int_to_string(this%regrid_method))
         call factory%append_variable_metadata(v)
         call this%metadata%add_variable(trim(varName),v,rc=status)
         _VERIFY(status)

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -144,11 +144,10 @@ module MAPL_GriddedIOMod
         this%regrid_handle => new_regridder_manager%make_regridder(input_grid,this%output_grid,this%regrid_method,rc=status)
         _VERIFY(status)
 
-        id_in = get_factory_id(input_grid,_RC)
-        id_out = get_factory_id(this%output_grid,_RC)
-        if (id_in == id_out) then
-           this%regrid_method = REGRID_METHOD_IDENTITY
-        end if
+        ! We get the regrid_method here because we default to bilinear even in the case
+        ! of input_grid and this%output_grid being the same. But if the regrid_handle
+        ! is the identity regridder, then this will set it to REGRID_METHOD_IDENTITY
+        this%regrid_method = this%regrid_handle%get_regrid_method()
 
         call ESMF_FieldBundleSet(this%output_bundle,grid=this%output_grid,rc=status)
         _VERIFY(status)
@@ -1010,11 +1009,6 @@ module MAPL_GriddedIOMod
      if (filegrid/=output_grid) then
         this%regrid_handle => new_regridder_manager%make_regridder(filegrid,output_grid,this%regrid_method,rc=status)
         _VERIFY(status)
-        id_in = get_factory_id(input_grid,_RC)
-        id_out = get_factory_id(this%output_grid,_RC)
-        if (id_in == id_out) then
-           this%regrid_method = REGRID_METHOD_IDENTITY
-        end if
      end if
      call MAPL_GridGet(filegrid,globalCellCountPerdim=dims,rc=status)
      _VERIFY(status)

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -125,6 +125,7 @@ module MAPL_GriddedIOMod
         integer :: metadataVarsSize
         type(StringStringMapIterator) :: s_iter
         character(len=:), pointer :: attr_name, attr_val
+        integer (kind=ESMF_KIND_I8) :: id_in, id_out
         integer :: status
 
         this%items = items
@@ -142,6 +143,13 @@ module MAPL_GriddedIOMod
         end if
         this%regrid_handle => new_regridder_manager%make_regridder(input_grid,this%output_grid,this%regrid_method,rc=status)
         _VERIFY(status)
+
+        id_in = get_factory_id(input_grid,_RC)
+        id_out = get_factory_id(this%output_grid,_RC)
+        if (id_in == id_out) then
+           this%regrid_method = REGRID_METHOD_IDENTITY
+        end if
+
         call ESMF_FieldBundleSet(this%output_bundle,grid=this%output_grid,rc=status)
         _VERIFY(status)
         factory => get_factory(this%output_grid,rc=status)
@@ -1002,6 +1010,11 @@ module MAPL_GriddedIOMod
      if (filegrid/=output_grid) then
         this%regrid_handle => new_regridder_manager%make_regridder(filegrid,output_grid,this%regrid_method,rc=status)
         _VERIFY(status)
+        id_in = get_factory_id(input_grid,_RC)
+        id_out = get_factory_id(this%output_grid,_RC)
+        if (id_in == id_out) then
+           this%regrid_method = REGRID_METHOD_IDENTITY
+        end if
      end if
      call MAPL_GridGet(filegrid,globalCellCountPerdim=dims,rc=status)
      _VERIFY(status)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR makes it so that if you have a native history collection, the `regrid_method` is set to `identity`. Before it was mistakenly set to `bilinear`. See #1888 

Example:

```
        float H(time, lev, nf, Ydim, Xdim) ;
                H:_FillValue = 1.e+15f ;
                H:add_offset = 0.f ;
                H:coordinates = "lons lats" ;
                H:fmissing_value = 1.e+15f ;
                H:grid_mapping = "cubed_sphere" ;
                H:long_name = "edge_heights" ;
                H:missing_value = 1.e+15f ;
                H:regrid_method = "identity" ;
                H:scale_factor = 1.f ;
                H:standard_name = "edge_heights" ;
                H:units = "m" ;
                H:valid_range = -1.e+15f, 1.e+15f ;
                H:vmax = 1.e+15f ;
                H:vmin = -1.e+15f ;
```

Also, note to @bena-nasa I also changed the names of a couple of routines to get around a name clash as I wanted to add a `get_regrid_method` to the abstractregridder.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1888 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Makes our output correct!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran with GEOSgcm. Zero-diff save for metadata change. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
