### PR TITLE
Remove comment saying throughput report will be removed

### DIFF
--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -26,11 +26,11 @@ module MAPL_CapMod
       character(:), allocatable :: name
       procedure(), nopass, pointer :: set_services => null()
       logical :: non_dso = .false.
-      integer :: comm_world 
+      integer :: comm_world
       integer :: rank
       integer :: npes_member
       character(:), allocatable :: root_dso
- 
+
       type (MAPL_CapOptions), allocatable :: cap_options
       ! misc
       logical :: mpi_already_initialized = .false.
@@ -60,7 +60,7 @@ module MAPL_CapMod
       procedure :: get_cap_gc
       procedure :: get_cap_rc_file
       procedure :: get_egress_file
-           
+
    end type MAPL_Cap
 
    interface MAPL_Cap
@@ -85,7 +85,7 @@ contains
       class (KeywordEnforcer),  optional, intent(in) :: unusable
       type ( MAPL_CapOptions), optional, intent(in) :: cap_options
       integer, optional, intent(out) :: rc
-      integer :: status    
+      integer :: status
 
       cap%name = name
       cap%set_services => set_services
@@ -112,7 +112,7 @@ contains
                            rc=status)
       _VERIFY(status)
 
-      _RETURN(_SUCCESS)     
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
 
     end function new_MAPL_Cap_from_set_services
@@ -123,7 +123,7 @@ contains
       class (KeywordEnforcer),  optional, intent(in) :: unusable
       type ( MAPL_CapOptions), optional, intent(in) :: cap_options
       integer, optional, intent(out) :: rc
-      integer :: status    
+      integer :: status
 
       cap%name = name
 
@@ -148,12 +148,12 @@ contains
                            rc=status)
       _VERIFY(status)
 
-      _RETURN(_SUCCESS)     
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
 
     end function new_MAPL_Cap_from_dso
 
-   
+
    ! 3. Run the ensemble (default is 1 member)
    ! 4. Finalize MPI if initialized locally.
    subroutine run(this, unusable, rc)
@@ -162,7 +162,7 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
 !
-   
+
 
       _UNUSED_DUMMY(unusable)
 
@@ -172,7 +172,7 @@ contains
       _RETURN(_SUCCESS)
 
     end subroutine run
-    
+
 
    ! This layer splits the communicator to support running a
    ! multi-member ensemble.
@@ -185,7 +185,7 @@ contains
       integer :: subcommunicator
 
       _UNUSED_DUMMY(unusable)
-      
+
       subcommunicator = this%create_member_subcommunicator(this%comm_world, rc=status); _VERIFY(status)
       if (subcommunicator /= MPI_COMM_NULL) then
          call this%initialize_io_clients_servers(subcommunicator, rc = status); _VERIFY(status)
@@ -195,7 +195,7 @@ contains
       end if
 
       _RETURN(_SUCCESS)
-      
+
    end subroutine run_ensemble
 
 
@@ -214,7 +214,7 @@ contains
      end select
      call this%cap_server%finalize()
      _RETURN(_SUCCESS)
- 
+
    end subroutine finalize_io_clients_servers
 
    subroutine initialize_io_clients_servers(this, comm, unusable, rc)
@@ -241,14 +241,14 @@ contains
      _RETURN(_SUCCESS)
 
    end subroutine initialize_io_clients_servers
-     
+
    ! This layer splits the communicator to support separate i/o servers
    ! and runs the model via a CapGridComp.
    subroutine run_member(this, rc)
       use MAPL_CFIOMod
       class (MAPL_Cap), intent(inout) :: this
       integer, optional, intent(out) :: rc
-      
+
       integer :: status
       type(SplitCommunicator) :: split_comm
 
@@ -257,7 +257,7 @@ contains
       case('model')
          call this%run_model(comm=split_comm%get_subcommunicator(), rc=status); _VERIFY(status)
       end select
-                  
+
      _RETURN(_SUCCESS)
 
    end subroutine run_member
@@ -273,7 +273,7 @@ contains
       integer(kind=INT64) :: start_tick, stop_tick, tick_rate
       integer :: status
       class(Logger), pointer :: lgr
-      
+
       _UNUSED_DUMMY(unusable)
 
       call start_timer()
@@ -306,7 +306,6 @@ contains
       _VERIFY(status)
       call stop_timer()
 
-      ! W.J note : below reporting will be remove soon
       call report_throughput()
 
       _RETURN(_SUCCESS)
@@ -339,11 +338,11 @@ contains
             lgr => logging%get_logger('MAPL')
             call lgr%info("Model Throughput: %f12.3 days per day", model_days_per_day)
          end if
-         
+
       end subroutine report_throughput
 
    end subroutine run_model
-   
+
    subroutine initialize_cap_gc(this, unusable, n_run_phases, rc)
      class(MAPL_Cap), intent(inout) :: this
      class (KeywordEnforcer), optional, intent(in) :: unusable
@@ -357,7 +356,7 @@ contains
      if (this%non_dso) then
         call MAPL_CapGridCompCreate(this%cap_gc, this%get_cap_rc_file(), &
            this%name, this%get_egress_file(), n_run_phases=n_run_phases, root_set_services = this%set_services,rc=status)
-     else 
+     else
         _ASSERT(this%cap_options%root_dso /= 'none',"No set services specified, must pass a dso")
         call MAPL_CapGridCompCreate(this%cap_gc, this%get_cap_rc_file(), &
            this%name, this%get_egress_file(), n_run_phases=n_run_phases, root_dso = this%cap_options%root_dso,rc=status)
@@ -365,7 +364,7 @@ contains
      _VERIFY(status)
      _RETURN(_SUCCESS)
    end subroutine initialize_cap_gc
-   
+
 
    subroutine step_model(this, rc)
      class(MAPL_Cap), intent(inout) :: this
@@ -374,7 +373,7 @@ contains
      call this%cap_gc%step(rc = status); _VERIFY(status)
      _RETURN(_SUCCESS)
    end subroutine step_model
-  
+
    subroutine rewind_model(this, time, rc)
      class(MAPL_Cap), intent(inout) :: this
      type(ESMF_Time), intent(inout) :: time
@@ -382,14 +381,14 @@ contains
      integer :: status
      call this%cap_gc%rewind_clock(time,rc = status); _VERIFY(status)
      _RETURN(_SUCCESS)
-   end subroutine rewind_model 
+   end subroutine rewind_model
 
    integer function create_member_subcommunicator(this, comm, unusable, rc) result(subcommunicator)
       class (MAPL_Cap), intent(inout) :: this
       integer, intent(in) :: comm
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
-      
+
       type (SplitCommunicator) :: split_comm
 
       integer :: status
@@ -397,7 +396,7 @@ contains
 !!$      external :: chdir
 
       _UNUSED_DUMMY(unusable)
-      
+
       subcommunicator = MPI_COMM_NULL ! in case of failure
       this%splitter = SimpleCommSplitter(comm, this%cap_options%n_members, this%npes_member, base_name=this%cap_options%ensemble_subdir_prefix)
       split_comm = this%splitter%split(rc=status); _VERIFY(status)
@@ -408,9 +407,9 @@ contains
          status = c_chdir(dir_name)
          _VERIFY(status)
       end if
-      
+
       _RETURN(_SUCCESS)
-      
+
    end function create_member_subcommunicator
 
 
@@ -459,13 +458,13 @@ contains
       character(*) :: path
       integer, optional, intent(out) :: err
       integer :: loc_err
-      
+
       loc_err =  c_chdir(path//c_null_char)
-      
+
       if (present(err)) err = loc_err
-      
+
    end subroutine chdir
-   
+
    subroutine finalize_mpi(this, unusable, rc)
       class (MAPL_Cap), intent(in) :: this
       class (KeywordEnforcer), optional, intent(in) :: unusable
@@ -488,7 +487,7 @@ contains
      integer :: npes_model
      npes_model = this%cap_options%npes_model
    end function get_npes_model
-    
+
    function get_comm_world(this) result(comm_world)
      class(MAPL_Cap), intent(in) :: this
      integer :: comm_world


### PR DESCRIPTION
Per #1930, remove comment sayings we'll remove a useful throughput timer output.

Note: skipping the changelog because, this doesn't need to be noted in there. 😄 