### PR TITLE
Refactor MAPL_GetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can also provide the MEAN value (without EOT) via FORCE_MLSHA=.TRUE. optional argument.
 
 ### Changed
-
+- Moved most of the MAPL_GetResource generic subroutine to a new module, MAPL_ResourceMod, in base.
+  The specific subroutines remain in MAPL_GenericMod to maintain the interface in one module, but
+  most of the functionality is in MAPL_ResourceMod now.
 ### Fixed
 
 - Added the correct values to halo corner of LatLon grid  

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -53,6 +53,7 @@ set (srcs
   TimeStringConversion.F90
   MAPL_ISO8601_DateTime_ESMF.F90
   FieldUtilities.F90
+  MAPL_ResourceMod.F90
   # Orphaned program: should not be in this library.
   # tstqsat.F90
   )

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -53,7 +53,7 @@ set (srcs
   TimeStringConversion.F90
   MAPL_ISO8601_DateTime_ESMF.F90
   FieldUtilities.F90
-  MAPL_ResourceMod.F90
+  MAPL_Resource.F90
   # Orphaned program: should not be in this library.
   # tstqsat.F90
   )

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -61,7 +61,8 @@ set (srcs
 
 esma_add_library(
   ${this} SRCS ${srcs}
-  DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 PFLOGGER::pflogger GFTL_SHARED::gftl-shared
+  DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 PFLOGGER::pflogger 
+               GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE ${MAPL_LIBRARY_TYPE})
 

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -9,46 +9,46 @@
 #  undef SET_VAL
 #endif
 
-#define SET_VAL(T) \
+#define SET_VAL(T, VAL) \
 type is (T) ;\
    if (default_is_present .and. .not. label_is_present) then ;\
       select type(default) ;\
       type is(T) ;\
-         val = default ;\
+         VAL = default ;\
       class default ;\
-         _FAIL("Type of 'default' does not match type of 'val'.") ;\
+         _FAIL("Type of 'default' does not match type of 'VAL'.") ;\
       end select ;\
    else ;\
-      call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC) ;\
+      call ESMF_ConfigGetAttribute(config, VAL, label = actual_label, _RC) ;\
    end if
 
 #ifdef SET_VALS
 #  undef SET_VALS
 #endif
 
-#define SET_VALS(T) \
+#define SET_VALS(T, VALS) \
 type is (T) ;\
    if (default_is_present .and. .not. label_is_present) then ;\
       select type(default) ;\
       type is(T) ;\
-         vals = default ;\
+         VALS = default ;\
       class default ;\
-         _FAIL("Type of 'default' does not match type of 'vals'.") ;\
+         _FAIL("Type of 'default' does not match type of 'VALS'.") ;\
       end select ;\
    else ;\
-      call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC) ;\
+      call ESMF_ConfigGetAttribute(config, valuelist = VALS, count = count, label = actual_label, _RC) ;\
    end if
 
 #ifdef SET_STRINGS
 #  undef SET_STRINGS
 #endif
 
-#define SET_STRINGS(T, TS, TF) \
+#define SET_STRINGS(T, TSTR, TFMT) \
 type is (T) ;\
-   type_str = TS ;\
-   val_str = intrinsic_to_string(val, TF) ;\
+   type_str = TSTR ;\
+   val_str = intrinsic_to_string(val, TFMT) ;\
    if (present(default)) then ;\
-      default_str = intrinsic_to_string(default, TF) ;\
+      default_str = intrinsic_to_string(default, TFMT) ;\
    end if
 
 !=============================================================================
@@ -171,12 +171,12 @@ contains
       end if
 
       select type(val)
-      SET_VAL(integer(int32))
-      SET_VAL(integer(int64))
-      SET_VAL(real(real32))
-      SET_VAL(real(real64))
-      SET_VAL(character(len=*))
-      SET_VAL(logical)
+      SET_VAL(integer(int32), val)
+      SET_VAL(integer(int64), val)
+      SET_VAL(real(real32), val)
+      SET_VAL(real(real64), val)
+      SET_VAL(character(len=*), val)
+      SET_VAL(logical, val)
       class default
          _FAIL( "Unupported type")
       end select
@@ -232,12 +232,12 @@ contains
       count = size(vals)
 
       select type(vals)
-      SET_VALS(integer(int32))
-      SET_VALS(integer(int64))
-      SET_VALS(real(real32))
-      SET_VALS(real(real64))
-      SET_VALS(character(len=*))
-      SET_VALS(logical)
+      SET_VALS(integer(int32), vals)
+      SET_VALS(integer(int64), vals)
+      SET_VALS(real(real32), vals)
+      SET_VALS(real(real64), vals)
+      SET_VALS(character(len=*), vals)
+      SET_VALS(logical, vals)
       class default
          _FAIL( "Unsupported type")
       end select

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -1,0 +1,402 @@
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+
+!wdb TODO COMMENT if not needed
+#include "unused_dummy.H"
+!wdb end
+
+!=============================================================================
+
+
+module MAPL_ResourceMod
+
+   !BOP
+   ! !MODULE: MAPL_ResourceMod
+   !
+   ! !DESCRIPTION:  MAPL\_ResourceMod ...
+
+   ! !USES:
+
+!wdb TODO what is needed
+   !wdb Do I need ESMF and ESMF_Mod
+   use ESMF
+   use ESMFL_Mod
+   use MAPL_Constants, only: MAPL_CF_COMPONENT_SEPARATOR
+   use gFTL_StringVector
+   use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, int32, int64
+!wdb end
+
+   ! !PUBLIC MEMBER FUNCTIONS:
+
+   implicit none
+   private
+
+   public MAPL_GetResource_config_scalar
+
+contains
+
+   !wdb TODO where is ESMF_MAXSTR defined?
+   ! MAPL searches for labels with certain prefixes as well as just the label itself
+   pure function get_labels_with_prefix(compname, label) result(labels_with_prefix)
+      character(len=*), intent(in) :: compname, label
+      character(len=ESMF_MAXSTR) :: labels_with_prefix(4), component_type
+
+      component_type = component_name(index(component_name, ":") + 1:)
+
+      ! The order to search for labels in resource files
+      labels_with_prefix(1) = trim(component_name)//"_"//trim(label)
+      labels_with_prefix(2) = trim(component_type)//"_"//trim(label)
+      labels_with_prefix(3) = trim(label)
+      labels_with_prefix(4) = trim(component_name)//MAPL_CF_COMPONENT_SEPARATOR//trim(label)
+
+   end function get_labels_with_prefix
+
+   subroutine get_label_to_use(config, label, compname, label_is_present, label_to_use, rc)
+      type(ESMF_Config), intent(inout) :: config
+      character(len=*), intent(in) :: label
+      character(len=*), intent(in) :: compname
+      logical, intent(out) :: label_is_present
+      character(len=ESMF_MAXSTR), intent(out) :: label_to_use
+      integer, optional, intent(out) :: rc
+
+      character(len=ESMF_MAXSTR), allocatable :: labels_to_try(:)
+      integer :: status
+
+      label_is_present = .false.
+      labels_to_try = get_labels_with_prefix(compname, label)
+
+      do i = 1, size(labels_to_try)
+         label_to_use = trim(labels_to_try(i))
+         call ESMF_ConfigFindLabel(config, label = label_to_use, isPresent = label_is_present, _RC)
+
+         if (label_is_present) then
+            exit
+         end if
+      end do
+
+      _RETURN(_SUCCESS)
+
+   end subroutine get_label_to_use
+
+   subroutine MAPL_GetResource_config_scalar(config, compname, val, label_to_find, default, rc)
+      type(ESMF_Config), intent(inout) :: config
+      character(len=*), intent(in) :: compname
+      class(*), intent(inout) :: val
+      character(len=*), intent(in) :: label_to_find
+      class(*), optional, intent(in) :: default
+      integer, optional, intent(out) :: rc
+
+      integer :: status, printrc
+      logical :: default_is_present, label_is_present
+      character(len=:), allocatable :: label_to_print
+      character(len=:), allocatable :: label
+
+      default_is_present = present(default)
+
+      if (default_is_present) then
+         _ASSERT(same_type_as(val, default), "Value and default must have same type")
+      end if
+
+      call get_label_to_use(config, label_to_find, compname, label_is_present, label, _RC)
+
+      ! No default and not in config, error
+      if (.not. label_is_present .and. .not. default_is_present) then
+         if (present(rc)) rc = ESMF_FAILURE
+         return
+      end if
+
+      select type(val)
+      type is(integer(int32))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(int32))
+               val = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+      type is(integer(int64))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(int64))
+               val = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+      type is(real(real32))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(real(real32))
+               val = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+      type is (real(real64))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(real(real64))
+               val = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+      type is(character(len=*))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(character(len=*))
+               val = trim(default)
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+      type is(logical)
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(logical)
+               val = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, val, label = label, _RC)
+         end if
+         class default
+         _FAIL( "Unupported type")
+      end select
+
+      call ESMF_ConfigGetAttribute(config, printrc, label = 'PRINTRC:', default = 0, _RC)
+
+      ! Can set printrc to negative to not print at all
+      if (MAPL_AM_I_Root() .and. printrc >= 0) then
+         if (label_is_present) then
+            label_to_print = label
+         else
+            label_to_print = trim(label_to_find)
+         end if
+         call print_resource(printrc, label_to_print, val, default=default, _RC)
+      end if
+
+      _RETURN(ESMF_SUCCESS)
+
+   end subroutine MAPL_GetResource_config_scalar
+
+   subroutine MAPL_GetResource_config_array(config, compname, vals, label_to_find, default, rc)
+      type(ESMF_Config), intent(inout) :: config
+      character(len=*), intent(in) :: compname
+      character(len=*), intent(in) :: label_to_find
+      class(*), intent(inout) :: vals(:)
+      class(*), optional, intent(in) :: default(:)
+      integer, optional, intent(out) :: rc
+
+      character(len=ESMF_MAXSTR), allocatable :: labels_to_try(:)
+      character(len=:), allocatable :: label_to_use
+      integer :: i, status, count
+      logical :: label_is_present, default_is_present
+
+      default_is_present = present(default)
+
+      if (default_is_present) then
+         _ASSERT(same_type_as(vals, default), "Value and default must have same type")
+      end if
+
+      call get_label_to_use(config, label_to_find, compname, label_is_present, label_to_use, _RC)
+
+      ! No default and not in config, error
+      if (.not. label_is_present .and. .not. default_is_present) then
+         if (present(rc)) rc = ESMF_FAILURE
+         return
+      end if
+
+      count = size(vals)
+
+      select type(vals)
+      type is(integer(int32))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(int32))
+               if (.not. label_is_present) vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+      type is(integer(int64))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(int64))
+               vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+      type is(real(real32))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(real32))
+               vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+      type is (real(real64))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(integer(real64))
+               vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+      type is(character(len=*))
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(character(*))
+               vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+      type is(logical)
+         if (default_is_present .and. .not. label_is_present) then
+            select type(default)
+            type is(logical)
+               vals = default
+            end select
+         else
+            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = label_to_use, _RC)
+         end if
+         class default
+         _FAIL( "Unsupported type")
+      end select
+
+      _RETURN(ESMF_SUCCESS)
+
+   end subroutine MAPL_GetResource_config_array
+
+   subroutine print_resource(printrc, label, val, default, rc)
+      integer, intent(in) :: printrc
+      character(len=*), intent(in) :: label
+      class(*), intent(in) :: val
+      class(*), optional, intent(in) :: default
+      integer, optional, intent(out) :: rc
+
+      character(len=:), allocatable :: val_str, default_str, output_format, type_str, type_format
+      type(StringVector), pointer, save :: already_printed_labels => null()
+
+      if (.not. associated(already_printed_labels)) then
+         allocate(already_printed_labels)
+      end if
+
+      ! Do not print label more than once
+      if (.not. vector_contains_str(already_printed_labels, trim(label))) then
+         call already_printed_labels%push_back(trim(label))
+      else
+         return
+      end if
+
+      select type(val)
+      type is(integer(int32))
+         type_str = "'Integer*4 '"
+         type_format = '(i0.1)'
+         val_str = intrinsic_to_string(val, type_format)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, type_format)
+         end if
+      type is(integer(int64))
+         type_str = "'Integer*8 '"
+         type_format = '(i0.1)'
+         val_str = intrinsic_to_string(val, type_format)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, type_format)
+         end if
+      type is(real(real32))
+         type_str = "'Real*4 '"
+         type_format = '(f0.6)'
+         val_str = intrinsic_to_string(val, type_format)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, type_format)
+         end if
+      type is(real(real64))
+         type_str = "'Real*8 '"
+         type_format = '(f0.6)'
+         val_str = intrinsic_to_string(val, type_format)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, type_format)
+         end if
+      type is(logical)
+         type_str = "'Logical '"
+         type_format = '(l1)'
+         val_str = intrinsic_to_string(val, type_format)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, type_format)
+         end if
+      type is(character(len=*))
+         type_str = "'Character '"
+         val_str = trim(val)
+         if (present(default)) then
+            default_str = intrinsic_to_string(default, 'a')
+         end if
+         class default
+         _FAIL("Unsupported type")
+      end select
+
+      output_format = "(1x, " // type_str // ", 'Resource Parameter: '" // ", a"// ", a)"
+
+      ! printrc = 0 - Only print non-default values
+      ! printrc = 1 - Print all values
+      if (present(default)) then
+         if (trim(val_str) /= trim(default_str) .or. printrc == 1) then
+            print output_format, trim(label), trim(val_str)
+         end if
+      else
+         print output_format, trim(label), trim(val_str)
+      end if
+
+   end subroutine print_resource
+
+   logical function vector_contains_str(vector, string)
+      type(StringVector), intent(in) :: vector
+      character(len=*), intent(in) :: string
+      type(StringVectorIterator) :: iter
+
+      iter = vector%begin()
+
+      vector_contains_str = .false.
+
+      if (vector%size() /= 0) then
+         do while (iter /= vector%end())
+            if (trim(string) == iter%get()) then
+               vector_contains_str = .true.
+               return
+            end if
+            call iter%next()
+         end do
+      end if
+
+   end function vector_contains_str
+
+   function intrinsic_to_string(val, str_format, rc) result(formatted_str)
+      class(*), intent(in) :: val
+      character(len=*), intent(in) :: str_format
+      character(len=256) :: formatted_str
+      integer, optional, intent(out) :: rc
+
+      select type(val)
+      type is(integer(int32))
+         write(formatted_str, str_format) val
+      type is(integer(int64))
+         write(formatted_str, str_format) val
+      type is(real(real32))
+         write(formatted_str, str_format) val
+      type is(real(real64))
+         write(formatted_str, str_format) val
+      type is(logical)
+         write(formatted_str, str_format) val
+      type is(character(len=*))
+         formatted_str = trim(val)
+         class default
+         _FAIL( "Unsupported type in intrinsic_to_string")
+      end select
+
+   end function intrinsic_to_string
+
+end module MAPL_ResourceMod

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -212,6 +212,7 @@ contains
          _ASSERT(same_type_as(vals, default), "Value and default must have same type")
       end if
 
+      _ASSERT(present(compname), "Component name is present but not present.")
       call get_actual_label(config, label, compname, label_is_present, actual_label, _RC)
 
       ! No default and not in config, error

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -405,7 +405,7 @@ contains
          class default
          _FAIL( "Unsupported type in intrinsic_to_string")
       end select
-
+_RETURN(_SUCCESS)
    end function intrinsic_to_string
 
 end module MAPL_ResourceMod

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -1,9 +1,6 @@
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
-
-!wdb TODO COMMENT if not needed
 #include "unused_dummy.H"
-!wdb end
 
 !=============================================================================
 
@@ -17,8 +14,6 @@ module MAPL_ResourceMod
 
    ! !USES:
 
-!wdb TODO what is needed
-   !wdb Do I need ESMF and ESMF_Mod
    use ESMF
    use ESMFL_Mod
    use gFTL_StringVector
@@ -26,7 +21,6 @@ module MAPL_ResourceMod
    use MAPL_Constants, only: MAPL_CF_COMPONENT_SEPARATOR
    use MAPL_ExceptionHandling
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, int32, int64
-!wdb end
 
    ! !PUBLIC MEMBER FUNCTIONS:
 
@@ -38,7 +32,6 @@ module MAPL_ResourceMod
 
 contains
 
-   !wdb TODO where is ESMF_MAXSTR defined?
    ! MAPL searches for labels with certain prefixes as well as just the label itself
    pure function get_labels_with_prefix(compname, label) result(labels_with_prefix)
       character(len=*), intent(in) :: compname, label
@@ -54,6 +47,8 @@ contains
 
    end function get_labels_with_prefix
 
+   ! If possible, find label or label with prefix. Out: logical to if label found, 
+   ! version of label found,
    subroutine get_label_to_use(config, label, compname, label_is_present, label_to_use, rc)
       type(ESMF_Config), intent(inout) :: config
       character(len=*), intent(in) :: label
@@ -82,6 +77,7 @@ contains
 
    end subroutine get_label_to_use
 
+   ! Find value of scalar variable in config
    subroutine MAPL_GetResource_config_scalar(config, val, label_to_find, default, compname, rc)
       type(ESMF_Config), intent(inout) :: config
       class(*), intent(inout) :: val
@@ -101,6 +97,8 @@ contains
          _ASSERT(same_type_as(val, default), "Value and default must have same type")
       end if
 
+      ! If compname is present, find label in some form in config. Else search
+      ! for exact label
       if (present(compname)) then
          call get_label_to_use(config, label_to_find, compname, label_is_present, label, _RC)
       else
@@ -109,6 +107,7 @@ contains
       end if
 
       ! No default and not in config, error
+      ! label or default must be present
       if (.not. label_is_present .and. .not. default_is_present) then
          if (present(rc)) rc = ESMF_FAILURE
          return
@@ -189,6 +188,7 @@ contains
 
    end subroutine MAPL_GetResource_config_scalar
 
+   ! Find value of array variable in config
    subroutine MAPL_GetResource_config_array(config, compname, vals, label_to_find, default, rc)
       type(ESMF_Config), intent(inout) :: config
       character(len=*), intent(in) :: compname
@@ -210,6 +210,7 @@ contains
       call get_label_to_use(config, label_to_find, compname, label_is_present, label_to_use, _RC)
 
       ! No default and not in config, error
+      ! label or default must be present
       if (.not. label_is_present .and. .not. default_is_present) then
          if (present(rc)) rc = ESMF_FAILURE
          return

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -10,16 +10,16 @@
 #endif
 
 #define SET_VAL(T) \
-type is (T) \
-   if (default_is_present .and. .not. label_is_present) then \
-      select type(default) \
-      type is(T) \
-         val = default \
-      class default
-         _FAIL("Type of 'default' does not match type of 'val'.")
-      end select \
-   else \
-      call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC) \
+type is (T) ;\
+   if (default_is_present .and. .not. label_is_present) then ;\
+      select type(default) ;\
+      type is(T) ;\
+         val = default ;\
+      class default ;\
+         _FAIL("Type of 'default' does not match type of 'val'.") ;\
+      end select ;\
+   else ;\
+      call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC) ;\
    end if
 
 #ifdef SET_VALS
@@ -27,16 +27,16 @@ type is (T) \
 #endif
 
 #define SET_VALS(T) \
-type is (T) \
-   if (default_is_present .and. .not. label_is_present) then \
-      select type(default) \
-      type is(T) \
-         vals = default \
-      class default
-         _FAIL("Type of 'default' does not match type of 'vals'.")
-      end select \
-   else \
-      call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC) \
+type is (T) ;\
+   if (default_is_present .and. .not. label_is_present) then ;\
+      select type(default) ;\
+      type is(T) ;\
+         vals = default ;\
+      class default ;\
+         _FAIL("Type of 'default' does not match type of 'vals'.") ;\
+      end select ;\
+   else ;\
+      call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC) ;\
    end if
 
 #ifdef SET_STRINGS
@@ -44,11 +44,11 @@ type is (T) \
 #endif
 
 #define SET_STRINGS(T, TS, TF) \
-type is (T) \
-   type_str = TS \
-   val_str = intrinsic_to_string(val, TF) \
-   if (present(default)) then \
-      default_str = intrinsic_to_string(default, TF) \
+type is (T) ;\
+   type_str = TS ;\
+   val_str = intrinsic_to_string(val, TF) ;\
+   if (present(default)) then ;\
+      default_str = intrinsic_to_string(default, TF) ;\
    end if
 
 !=============================================================================

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -193,12 +193,13 @@ contains
    end subroutine MAPL_GetResource_config_scalar
 
    ! Find value of array variable in config
-   subroutine MAPL_GetResource_config_array(config, compname, vals, label, default, rc)
+   subroutine MAPL_GetResource_config_array(config, vals, label, unusable, default, compname, rc)
       type(ESMF_Config), intent(inout) :: config
-      character(len=*), intent(in) :: compname
       character(len=*), intent(in) :: label
       class(*), intent(inout) :: vals(:)
+      class(KeywordEnforcer), optional, intent(in) :: unusable
       class(*), optional, intent(in) :: default(:)
+      character(len=*), optional, intent(in) :: compname
       integer, optional, intent(out) :: rc
 
       character(len=:), allocatable :: actual_label

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -227,7 +227,7 @@ contains
          if (default_is_present .and. .not. label_is_present) then
             select type(default)
             type is(integer(int32))
-               if (.not. label_is_present) vals = default
+               vals = default
             end select
          else
             call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -3,6 +3,55 @@
 #include "unused_dummy.H"
 
 !=============================================================================
+!FPP macros for repeated (type-dependent) code
+
+#ifdef SET_VAL
+#  undef SET_VAL
+#endif
+
+#define SET_VAL(T) \
+type is (T) \
+   if (default_is_present .and. .not. label_is_present) then \
+      select type(default) \
+      type is(T) \
+         val = default \
+      class default
+         _FAIL("Type of 'default' does not match type of 'val'.")
+      end select \
+   else \
+      call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC) \
+   end if
+
+#ifdef SET_VALS
+#  undef SET_VALS
+#endif
+
+#define SET_VALS(T) \
+type is (T) \
+   if (default_is_present .and. .not. label_is_present) then \
+      select type(default) \
+      type is(T) \
+         vals = default \
+      class default
+         _FAIL("Type of 'default' does not match type of 'vals'.")
+      end select \
+   else \
+      call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC) \
+   end if
+
+#ifdef SET_STRINGS
+#  undef SET_STRINGS
+#endif
+
+#define SET_STRINGS(T, TS, TF) \
+type is (T) \
+   type_str = TS \
+   val_str = intrinsic_to_string(val, TF) \
+   if (present(default)) then \
+      default_str = intrinsic_to_string(default, TF) \
+   end if
+
+!=============================================================================
 
 
 module MAPL_ResourceMod
@@ -122,61 +171,13 @@ contains
       end if
 
       select type(val)
-      type is(integer(int32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int32))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-      type is(integer(int64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int64))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-      type is(real(real32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(real(real32))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-      type is (real(real64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(real(real64))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-      type is(character(len=*))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(character(len=*))
-               val = trim(default)
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-      type is(logical)
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(logical)
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = actual_label, _RC)
-         end if
-         class default
+      SET_VAL(integer(int32))
+      SET_VAL(integer(int64))
+      SET_VAL(real(real32))
+      SET_VAL(real(real64))
+      SET_VAL(character(len=*))
+      SET_VAL(logical)
+      class default
          _FAIL( "Unupported type")
       end select
 
@@ -231,61 +232,13 @@ contains
       count = size(vals)
 
       select type(vals)
-      type is(integer(int32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int32))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-      type is(integer(int64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int64))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-      type is(real(real32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(real32))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-      type is (real(real64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(real64))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-      type is(character(len=*))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(character(*))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-      type is(logical)
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(logical)
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, valuelist = vals, count = count, label = actual_label, _RC)
-         end if
-         class default
+      SET_VALS(integer(int32))
+      SET_VALS(integer(int64))
+      SET_VALS(real(real32))
+      SET_VALS(real(real64))
+      SET_VALS(character(len=*))
+      SET_VALS(logical)
+      class default
          _FAIL( "Unsupported type")
       end select
 
@@ -315,52 +268,17 @@ contains
       end if
 
       select type(val)
-      type is(integer(int32))
-         type_str = "'Integer*4 '"
-         type_format = '(i0.1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(integer(int64))
-         type_str = "'Integer*8 '"
-         type_format = '(i0.1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(real(real32))
-         type_str = "'Real*4 '"
-         type_format = '(f0.6)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(real(real64))
-         type_str = "'Real*8 '"
-         type_format = '(f0.6)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(logical)
-         type_str = "'Logical '"
-         type_format = '(l1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(character(len=*))
-         type_str = "'Character '"
-         val_str = trim(val)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, 'a')
-         end if
-         class default
+      SET_STRINGS(integer(int32), "'Integer*4 '", '(i0.1)')
+      SET_STRINGS(integer(int64), "'Integer*8 '", '(i0.1)')
+      SET_STRINGS(real(real32), "'Real*4 '" , '(f0.6)')
+      SET_STRINGS(real(real64), "'Real*8 '" , '(f0.6)')
+      SET_STRINGS(logical, "'Logical '" , '(l1)' )
+      SET_STRINGS(character(len=*),"'Character '", '(a)') 
+      class default
          _FAIL("Unsupported type")
       end select
 
-      output_format = "(1x, " // type_str // ", 'Resource Parameter: '" // ", a"// ", a)"
+      output_format = "(1x, " // type_str // ", 'Resource Parameter: '" // ", a"// ", a)a"
 
       ! printrc = 0 - Only print non-default values
       ! printrc = 1 - Print all values

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -93,10 +93,10 @@ contains
          component_type = component_name(index(component_name, ":") + 1:)
 
          ! The order to search for labels in resource files
-         labels_with_prefix = [  trim(component_name)//"_"//trim(label), &
-                                 trim(component_type)//"_"//trim(label), &
-                                 trim(label), &
-                                 trim(component_name)//MAPL_CF_COMPONENT_SEPARATOR//trim(label) ]
+         labels_with_prefix(1) = trim(component_name)//"_"//trim(label)
+         labels_with_prefix(2) = trim(component_type)//"_"//trim(label)
+         labels_with_prefix(3) = trim(label)
+         labels_with_prefix(4) = trim(component_name)//MAPL_CF_COMPONENT_SEPARATOR//trim(label)
       else
          labels_with_prefix = ''
          labels_with_prefix(1) = label

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -40,14 +40,14 @@ contains
       character(len=ESMF_MAXSTR) :: component_type
       character(len=ESMF_MAXSTR) :: labels_with_prefix(4)
 
-      if(present(commponent_name)) then
+      if(present(component_name)) then
          component_type = component_name(index(component_name, ":") + 1:)
 
          ! The order to search for labels in resource files
-         labels_with_prefix = [  trim(compname)//"_"//trim(label), &
+         labels_with_prefix = [  trim(component_name)//"_"//trim(label), &
                                  trim(component_type)//"_"//trim(label), &
                                  trim(label), &
-                                 trim(compname)//MAPL_CF_COMPONENT_SEPARATOR//trim(label) ]
+                                 trim(component_name)//MAPL_CF_COMPONENT_SEPARATOR//trim(label) ]
       else
          labels_with_prefix = ''
          labels_with_prefix(1) = label
@@ -193,13 +193,13 @@ contains
    end subroutine MAPL_GetResource_config_scalar
 
    ! Find value of array variable in config
-   subroutine MAPL_GetResource_config_array(config, vals, label, unusable, default, compname, rc)
+   subroutine MAPL_GetResource_config_array(config, vals, label, unusable, default, component_name, rc)
       type(ESMF_Config), intent(inout) :: config
       character(len=*), intent(in) :: label
       class(*), intent(inout) :: vals(:)
       class(KeywordEnforcer), optional, intent(in) :: unusable
       class(*), optional, intent(in) :: default(:)
-      character(len=*), optional, intent(in) :: compname
+      character(len=*), optional, intent(in) :: component_name
       integer, optional, intent(out) :: rc
 
       character(len=:), allocatable :: actual_label
@@ -212,8 +212,8 @@ contains
          _ASSERT(same_type_as(vals, default), "Value and default must have same type")
       end if
 
-      _ASSERT(present(compname), "Component name is present but not present.")
-      call get_actual_label(config, label, compname, label_is_present, actual_label, _RC)
+      _ASSERT(present(component_name), "Component name is present but not present.")
+      call get_actual_label(config, label, label_is_present, actual_label, component_name = component_name, _RC)
 
       ! No default and not in config, error
       ! label or default must be present

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -16,7 +16,7 @@ module MAPL_ResourceMod
 
    use ESMF
    use ESMFL_Mod
-   use gFTL_StringVector
+   use gFTL2_StringVector
    use MAPL_CommsMod
    use MAPL_Constants, only: MAPL_CF_COMPONENT_SEPARATOR
    use MAPL_ExceptionHandling
@@ -377,15 +377,13 @@ contains
 
       vector_contains_str = .false.
 
-      if (vector%size() /= 0) then
-         do while (iter /= vector%end())
-            if (trim(string) == iter%get()) then
-               vector_contains_str = .true.
-               return
-            end if
-            call iter%next()
-         end do
-      end if
+      do while (iter /= vector%end())
+         if (trim(string) == iter%of()) then
+            vector_contains_str = .true.
+            return
+         end if
+         call iter%next()
+      end do
 
    end function vector_contains_str
 

--- a/base/MAPL_Resource.F90
+++ b/base/MAPL_Resource.F90
@@ -69,6 +69,8 @@ contains
       integer :: i
       integer :: status
 
+      _UNUSED_DUMMY(unusable)
+
       label_is_present = .false.
 
       ! If component_name is present, find label in some form in config. Else search
@@ -101,6 +103,8 @@ contains
       logical :: default_is_present, label_is_present
       character(len=:), allocatable :: label_to_print
       character(len=:), allocatable :: actual_label
+
+      _UNUSED_DUMMY(unusable)
 
       default_is_present = present(default)
 
@@ -205,6 +209,8 @@ contains
       character(len=:), allocatable :: actual_label
       integer :: status, count
       logical :: label_is_present, default_is_present
+
+      _UNUSED_DUMMY(unusable)
 
       default_is_present = present(default)
 
@@ -366,6 +372,8 @@ contains
          print output_format, trim(label), trim(val_str)
       end if
 
+      _RETURN(_SUCCESS)
+
    end subroutine print_resource
 
    logical function vector_contains_str(vector, string)
@@ -409,7 +417,9 @@ contains
          class default
          _FAIL( "Unsupported type in intrinsic_to_string")
       end select
-_RETURN(_SUCCESS)
+
+      _RETURN(_SUCCESS)
+
    end function intrinsic_to_string
 
 end module MAPL_ResourceMod

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -8438,6 +8438,8 @@ contains
 
    end subroutine MAPL_GetResourceFromMAPL_scalar
 
+   ! This is a pass-through routine. It maintains the interface for
+   ! MAPL_GetResource as is instead of moving this subroutine to another module.
    subroutine MAPL_GetResourceFromConfig_scalar(config, val, label, default, rc)
       type(ESMF_Config), intent(inout) :: config
       character(len=*), intent(in) :: label

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -8326,7 +8326,7 @@ contains
 
       integer :: status
 
-      call MAPL_GetResource_config_array(state%cf, state%compname, vals, label, default, _RC)
+      call MAPL_GetResource_config_array(state%cf, vals, label, default = default, component_name = state%compname, _RC)
 
       _RETURN(ESMF_SUCCESS)
 

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -8294,7 +8294,7 @@ contains
 
       integer :: status
 
-      call MAPL_GetResource_config_scalar(state%cf, val, label, default, state%compname, _RC)
+      call MAPL_GetResource_config_scalar(state%cf, val, label, default = default, component_name = state%compname, _RC)
 
       _RETURN(_SUCCESS)
 
@@ -8311,7 +8311,7 @@ contains
 
       integer :: status
 
-      call MAPL_GetResource_config_scalar(config, val, label, default, _RC)
+      call MAPL_GetResource_config_scalar(config, val, label, default = default, _RC)
 
       _RETURN(ESMF_SUCCESS)
 

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -8432,15 +8432,14 @@ contains
 
       integer :: status
 
-      call MAPL_GetResourceFromConfig_scalar(state%cf, state%compname, val, label, default, _RC)
+      call MAPL_GetResource_config_scalar(state%cf, val, label, default, state%compname, _RC)
 
       _RETURN(_SUCCESS)
 
    end subroutine MAPL_GetResourceFromMAPL_scalar
 
-   subroutine MAPL_GetResourceFromConfig_scalar(config, compname, val, label, default, rc)
+   subroutine MAPL_GetResourceFromConfig_scalar(config, val, label, default, rc)
       type(ESMF_Config), intent(inout) :: config
-      character(*), intent(in) :: compname
       character(len=*), intent(in) :: label
       class(*), intent(inout) :: val
       class(*), optional, intent(in) :: default
@@ -8448,7 +8447,7 @@ contains
 
       integer :: status
 
-      call MAPL_GetResource_config_scalar(config, compname, val, label, default, _RC)
+      call MAPL_GetResource_config_scalar(config, val, label, default, _RC)
 
       _RETURN(ESMF_SUCCESS)
 

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -134,6 +134,7 @@ module MAPL_GenericMod
    use MaplShared, only: SYSTEM_DSO_EXTENSION, adjust_dso_name, is_valid_dso_name, is_supported_dso_name
    use MaplShared, only: get_file_extension
    use MAPL_RunEntryPoint
+   use MAPL_ResourceMod
    use, intrinsic :: ISO_C_BINDING
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, int32, int64
    use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
@@ -8422,22 +8423,6 @@ contains
       _RETURN(ESMF_SUCCESS)
    end subroutine MAPL_GenericConnCheck
 
-
-   ! MAPL searches for labels with certain prefixes as well as just the label itself
-   pure function get_labels_with_prefix(component_name, label) result(labels_with_prefix)
-      character(len=*), intent(in) :: component_name, label
-      character(len=ESMF_MAXSTR) :: labels_with_prefix(4), component_type
-
-      component_type = component_name(index(component_name, ":") + 1:)
-
-      ! The order to search for labels in resource files
-      labels_with_prefix(1) = trim(component_name)//"_"//trim(label)
-      labels_with_prefix(2) = trim(component_type)//"_"//trim(label)
-      labels_with_prefix(3) = trim(label)
-      labels_with_prefix(4) = trim(component_name)//MAPL_CF_COMPONENT_SEPARATOR//trim(label)
-   end function get_labels_with_prefix
-
-
    subroutine MAPL_GetResourceFromMAPL_scalar(state, val, label, default, rc)
       type(MAPL_MetaComp), intent(inout) :: state
       character(len=*), intent(in) :: label
@@ -8445,149 +8430,29 @@ contains
       class(*), optional, intent(in) :: default
       integer, optional, intent(out) :: rc
 
-      character(len=ESMF_MAXSTR), allocatable :: labels_to_try(:)
-      character(len=:), allocatable :: label_to_use
-      integer :: i, status
-      logical :: label_is_present, default_is_present
+      integer :: status
 
-      default_is_present = present(default)
-
-      if (default_is_present) then
-         _ASSERT(same_type_as(val, default), "Value and default must have same type")
-      end if
-
-      label_is_present = .false.
-      labels_to_try = get_labels_with_prefix(state%compname, label)
-
-      do i = 1, size(labels_to_try)
-         label_to_use = trim(labels_to_try(i))
-         call ESMF_ConfigFindLabel(state%cf, label = label_to_use, isPresent = label_is_present, rc = status)
-         _VERIFY(status)
-
-         if (label_is_present) then
-            exit
-         end if
-      end do
-
-      if (.not. label_is_present .and. .not. default_is_present) then
-         if (present(rc)) rc = ESMF_FAILURE
-         return
-      end if
-
-      if (label_is_present) then
-         call MAPL_GetResourceFromConfig_Scalar(state%cf,val,label_to_use,default,rc = status)
-         _VERIFY(status)
-      else
-         call MAPL_GetResourceFromConfig_Scalar(state%cf,val,label,default,rc = status)
-         _VERIFY(status)
-      end if
+      call MAPL_GetResourceFromConfig_scalar(state%cf, state%compname, val, label, default, _RC)
 
       _RETURN(_SUCCESS)
 
    end subroutine MAPL_GetResourceFromMAPL_scalar
 
-   subroutine MAPL_GetResourceFromConfig_scalar(config, val, label, default, rc)
+   subroutine MAPL_GetResourceFromConfig_scalar(config, compname, val, label, default, rc)
       type(ESMF_Config), intent(inout) :: config
+      character(*), intent(in) :: compname
       character(len=*), intent(in) :: label
       class(*), intent(inout) :: val
       class(*), optional, intent(in) :: default
       integer, optional, intent(out) :: rc
 
-      integer :: status, printrc
-      logical :: default_is_present, label_is_present
-      character(len=:), allocatable :: label_to_print
+      integer :: status
 
-      default_is_present = present(default)
-
-      if (default_is_present) then
-         _ASSERT(same_type_as(val, default), "Value and default must have same type")
-      end if
-
-      call ESMF_ConfigFindLabel(config, label = label, isPresent = label_is_present, rc = status)
-
-      select type(val)
-      type is(integer(int32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int32))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-      type is(integer(int64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int64))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-      type is(real(real32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(real(real32))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-      type is (real(real64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(real(real64))
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-      type is(character(len=*))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(character(len=*))
-               val = trim(default)
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-      type is(logical)
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(logical)
-               val = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(config, val, label = label, rc = status)
-            _VERIFY(status)
-         end if
-         class default
-         _FAIL( "Unupported type")
-      end select
-
-      call ESMF_ConfigGetAttribute(config, printrc, label = 'PRINTRC:', default = 0, rc = status)
-      _VERIFY(status)
-
-      ! Can set printrc to negative to not print at all
-      if (MAPL_AM_I_Root() .and. printrc >= 0) then
-         if (label_is_present) then
-            label_to_print = label
-         else
-            label_to_print = trim(label)
-         end if
-         call print_resource(printrc, label_to_print, val, default=default,rc=status)
-         _VERIFY(status)
-      end if
+      call MAPL_GetResource_config_scalar(config, compname, val, label, default, _RC)
 
       _RETURN(ESMF_SUCCESS)
 
    end subroutine MAPL_GetResourceFromConfig_scalar
-
 
    subroutine MAPL_GetResource_array(state, vals, label, default, rc)
       type(MAPL_MetaComp), intent(inout) :: state
@@ -8596,241 +8461,13 @@ contains
       class(*), optional, intent(in) :: default(:)
       integer, optional, intent(out) :: rc
 
-      character(len=ESMF_MAXSTR), allocatable :: labels_to_try(:)
-      character(len=:), allocatable :: label_to_use
-      integer :: i, status, count
-      logical :: label_is_present, default_is_present
+      integer :: status
 
-      default_is_present = present(default)
-
-      if (default_is_present) then
-         _ASSERT(same_type_as(vals, default), "Value and default must have same type")
-      end if
-
-      labels_to_try = get_labels_with_prefix(state%compname, label)
-      label_is_present = .false.
-
-      ! Try out the label variations to see which one exists in the ESMF_Config
-      do i = 1, size(labels_to_try)
-         label_to_use = trim(labels_to_try(i))
-
-         call ESMF_ConfigFindLabel(state%cf, label = label_to_use, isPresent = label_is_present, rc = status)
-         _VERIFY(status)
-
-         if (label_is_present) then
-            exit
-         end if
-      end do
-
-      ! No default and not in config, error
-      if (.not. label_is_present .and. .not. default_is_present) then
-         if (present(rc)) rc = ESMF_FAILURE
-         return
-      end if
-
-      count = size(vals)
-
-      select type(vals)
-      type is(integer(int32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int32))
-               if (.not. label_is_present) vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-      type is(integer(int64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(int64))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-      type is(real(real32))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(real32))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-      type is (real(real64))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(integer(real64))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-      type is(character(len=*))
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(character(*))
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-      type is(logical)
-         if (default_is_present .and. .not. label_is_present) then
-            select type(default)
-            type is(logical)
-               vals = default
-            end select
-         else
-            call ESMF_ConfigGetAttribute(state%cf, valuelist = vals, count = count, label = label_to_use, rc = status)
-            _VERIFY(status)
-         end if
-         class default
-         _FAIL( "Unsupported type")
-      end select
+      call MAPL_GetResource_config_array(state%cf, state%compname, vals, label, default, _RC)
 
       _RETURN(ESMF_SUCCESS)
 
    end subroutine MAPL_GetResource_array
-
-
-   subroutine print_resource(printrc, label, val, default, rc)
-      integer, intent(in) :: printrc
-      character(len=*), intent(in) :: label
-      class(*), intent(in) :: val
-      class(*), optional, intent(in) :: default
-      integer, optional, intent(out) :: rc
-
-      character(len=:), allocatable :: val_str, default_str, output_format, type_str, type_format
-      type(StringVector), pointer, save :: already_printed_labels => null()
-
-      if (.not. associated(already_printed_labels)) then
-         allocate(already_printed_labels)
-      end if
-
-      ! Do not print label more than once
-      if (.not. vector_contains_str(already_printed_labels, trim(label))) then
-         call already_printed_labels%push_back(trim(label))
-      else
-         return
-      end if
-
-      select type(val)
-      type is(integer(int32))
-         type_str = "'Integer*4 '"
-         type_format = '(i0.1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(integer(int64))
-         type_str = "'Integer*8 '"
-         type_format = '(i0.1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(real(real32))
-         type_str = "'Real*4 '"
-         type_format = '(f0.6)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(real(real64))
-         type_str = "'Real*8 '"
-         type_format = '(f0.6)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(logical)
-         type_str = "'Logical '"
-         type_format = '(l1)'
-         val_str = intrinsic_to_string(val, type_format)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, type_format)
-         end if
-      type is(character(len=*))
-         type_str = "'Character '"
-         val_str = trim(val)
-         if (present(default)) then
-            default_str = intrinsic_to_string(default, 'a')
-         end if
-         class default
-         _FAIL("Unsupported type")
-      end select
-
-      output_format = "(1x, " // type_str // ", 'Resource Parameter: '" // ", a"// ", a)"
-
-      ! printrc = 0 - Only print non-default values
-      ! printrc = 1 - Print all values
-      if (present(default)) then
-         if (trim(val_str) /= trim(default_str) .or. printrc == 1) then
-            print output_format, trim(label), trim(val_str)
-         end if
-      else
-         print output_format, trim(label), trim(val_str)
-      end if
-
-   contains
-
-      logical function vector_contains_str(vector, string)
-         type(StringVector), intent(in) :: vector
-         character(len=*), intent(in) :: string
-         type(StringVectorIterator) :: iter
-
-         iter = vector%begin()
-
-         vector_contains_str = .false.
-
-         if (vector%size() /= 0) then
-            do while (iter /= vector%end())
-               if (trim(string) == iter%get()) then
-                  vector_contains_str = .true.
-                  return
-               end if
-               call iter%next()
-            end do
-         end if
-
-      end function vector_contains_str
-
-   end subroutine print_resource
-
-
-   function intrinsic_to_string(val, str_format, rc) result(formatted_str)
-      class(*), intent(in) :: val
-      character(len=*), intent(in) :: str_format
-      character(len=256) :: formatted_str
-      integer, optional, intent(out) :: rc
-
-      select type(val)
-      type is(integer(int32))
-         write(formatted_str, str_format) val
-      type is(integer(int64))
-         write(formatted_str, str_format) val
-      type is(real(real32))
-         write(formatted_str, str_format) val
-      type is(real(real64))
-         write(formatted_str, str_format) val
-      type is(logical)
-         write(formatted_str, str_format) val
-      type is(character(len=*))
-         formatted_str = trim(val)
-         class default
-         _FAIL( "Unsupported type in intrinsic_to_string")
-      end select
-
-   end function intrinsic_to_string
-
-
 
    integer function MAPL_GetNumSubtiles(STATE, RC)
       type (MAPL_MetaComp),       intent(INOUT)    :: STATE


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR moves much of the code for MAPL_GetResource generic subroutine from `MAPL_GenericMod` to a new module `MAPL_ResourceMod` in `base`

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1918

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, `MAPL_GetResource` accessed `MAPL_MetaComp` and `ESMF_Config` types, and all the code was located in `MAPL_GenericMod` (`generic/MAPL_Generic.F90`). Most of the code does not need to access code in that directory. The refactored code places most of the code in a new module `MAPL_ResourceMod` in `base`. The specific subroutines that need access to `MAPL_MetaComp` type remain in `MAPL_GenericMod` (**MAPL_GetResourceFromMAPL_scalar** and **MAPL_GetResource_array**) in much abbreviated form. The **MAPL_GetResourceFromConfig_scalar** specific subroutine for `MAPL_GetResource` does not depend on `MAPL_MetaComp` types, so it could be located in `MAPL_ResourceMod`. However, `MAPL_GenericMod` contains the `MAPL_GetResource` interface for the generic subroutine. To avoid putting the **MAPL_GetResourceFromConfig_scalar** specific subroutine for `MAPL_GetResource` in a different module, an abbreviated **MAPL_GetResourceFromConfig_scalar** remains in `MAPL_GenericMod`. All three specific subroutines for  the `MAPL_GetResource` subroutine ( **MAPL_GetResourceFromConfig_scalar**, **MAPL_GetResourceFromMAPL_scalar**, and **MAPL_GetResource_array**) call subroutines in `MAPL_ResourceMod`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
0-diff test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
