### PR TITLE
fixes #2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug in climatologies with ExtDataV2 when wrapping around the year
+
 ### Removed
 
 ### Deprecated

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -83,31 +83,37 @@ MODULE ExtDataUtRoot_GridCompMod
                long_name='na' , &
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
-               vlocation = MAPL_VLocationCenter, _RC)
+               vlocation = MAPL_VLocationNone, _RC)
          call MAPL_AddInternalSpec(GC,&
                short_name='lats', &
                long_name='na' , &
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
-               vlocation = MAPL_VLocationCenter, _RC)
+               vlocation = MAPL_VLocationNone, _RC)
          call MAPL_AddInternalSpec(GC,&
                short_name='lons', &
                long_name='na' , &
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
-               vlocation = MAPL_VLocationCenter, _RC)
+               vlocation = MAPL_VLocationNone, _RC)
          call MAPL_AddInternalSpec(GC,&
                short_name='i_index', &
                long_name='na' , &
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
-               vlocation = MAPL_VLocationCenter, _RC)
+               vlocation = MAPL_VLocationNone, _RC)
          call MAPL_AddInternalSpec(GC,&
                short_name='j_index', &
                long_name='na' , &
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
-               vlocation = MAPL_VLocationCenter, _RC)
+               vlocation = MAPL_VLocationNone, _RC)
+         call MAPL_AddInternalSpec(GC,&
+               short_name='doy', &
+               long_name='day_since_start_of_year' , &
+               units = 'na', &
+               dims = MAPL_DimsHorzOnly, &
+               vlocation = MAPL_VLocationNone, _RC)
 
          call MAPL_GenericSetServices ( GC, _RC)
 
@@ -237,7 +243,7 @@ MODULE ExtDataUtRoot_GridCompMod
             call FillState(internal,export,currTime,grid,synth,_RC)
             call CompareState(import,export,0.001,_RC) 
 
-         case(runModeFillImport)
+         case(runModeFillImport) 
 ! Nothing to do, we are just letting ExtData run
 
          case(runModeFillExportFromImport)
@@ -470,7 +476,7 @@ MODULE ExtDataUtRoot_GridCompMod
       real, pointer                       :: Exptr2(:,:) => null()
       integer :: itemcount
       character(len=ESMF_MAXSTR), allocatable :: outNameList(:)
-      type(ESMF_Field) :: expf,farray(5)
+      type(ESMF_Field) :: expf,farray(6)
       type(ESMF_State) :: pstate
       character(len=:), pointer :: fexpr
       integer :: i1,in,j1,jn,ldims(3),i,j
@@ -497,12 +503,15 @@ MODULE ExtDataUtRoot_GridCompMod
             exPtr2(i,j)=j1+j-1
          enddo
       enddo
+      call MAPL_GetPointer(inState,exPtr2,'doy',_RC)
+      exPtr2 = compute_doy(time,_RC)
 
       call ESMF_StateGet(inState,'time',farray(1),_RC)
       call ESMF_StateGet(inState,'lons',farray(2),_RC)
       call ESMF_StateGet(inState,'lats',farray(3),_RC)
       call ESMF_StateGet(inState,'i_index',farray(4),_RC)
       call ESMF_StateGet(inState,'j_index',farray(5),_RC)
+      call ESMF_StateGet(inState,'doy',farray(6),_RC)
       pstate = ESMF_StateCreate(_RC)
       call ESMF_StateAdd(pstate,farray,_RC)
 
@@ -611,6 +620,25 @@ MODULE ExtDataUtRoot_GridCompMod
          _RETURN(ESMF_SUCCESS)
 
       end subroutine ForceAllocation
+
+      function compute_doy(time,rc) result(doy)
+         real(ESMF_KIND_R8) :: doy
+         type(ESMF_Time), intent(in) :: time
+         integer, optional, intent(out) :: rc
+
+         type(ESMF_Time) :: start_0z, current_0z
+         integer :: status
+         type(ESMF_TimeInterval) :: tint
+
+         integer :: year,month,day,hour,minute,second
+
+         call ESMF_TimeGet(time,yy=year,mm=month,dd=day,h=hour,m=minute,s=second,_RC)
+         call ESMF_TimeSet(start_0z,yy=year,mm=1,dd=1,h=0,m=0,s=0,_RC)
+         call ESMF_TimeSet(current_0z,yy=year,mm=month,dd=day,h=hour,m=minute,s=second,_RC)
+         tint = current_0z-start_0z
+         call ESMF_TimeIntervalGet(tint,d_r8=doy,_RC)
+         _RETURN(_SUCCESS)
+      end function
 
 end module ExtDataUtRoot_GridCompMod
 


### PR DESCRIPTION
fixes #2018 
This fixes another bug found with climatologies. I also add a new option to the ExtDataDriver.x testing framework to be able to produce a variable that is the day relative to the start of the year, rather than an absolute reference time which I needed to confirm that the climatology was doing what it should.

I have not added a new test case yet as I'm not sure how to implement a case to test this.

I confirmed it was working by essentially using ExtDataDriver.x to create a climatology set for a year where I put the day of the year relative to the start of the year in the files.

I could then look, that indeed when the files were reinvested and time interpolated into the ExtDataDriver.x component,  they indeed had the right values over a several year run of ExtDataDriver.x

Tried with both a climatology representing a leap year and non-leap year

I'll try to think of a way to update the tests, but want this fix 
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
