### PR TITLE
Prepare for MAPL 2.37 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New feature in History to allow the accumulation in non-instataneous colletions to be reset independently of the writing frequency if requested.
-- new macro `_RETURN_IF(cond)` to provide a succinct early return in procedures with return codes.
-
 ### Changed
 
 ### Fixed
 
-- Fixed bug in CubedSphereGridFactory when constructing a grid from a file
-- Cleaned up cubed-sphere grid factory and NCIO so the produce files with consistent capitalization and types for the stretching factor
-
 ### Removed
 
 ### Deprecated
+
+## [2.37.0] - 2023-04-03
+
+### Added
+
+- New feature in History to allow the accumulation in non-instantaneous collections to be reset independently of the writing frequency if requested.
+- new macro `_RETURN_IF(cond)` to provide a succinct early return in procedures with return codes.
+
+### Fixed
+
+- Fixed bug in CubedSphereGridFactory when constructing a grid from a file
+- Cleaned up cubed-sphere grid factory and NCIO to produce files with consistent capitalization and types for the stretching factor
 
 ## [2.36.0] - 2023-03-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.36.0
+  VERSION 2.37.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the default build type to release


### PR DESCRIPTION
This is a PR to prepare for a MAPL 2.37 release. This is mainly to get the stretched grid fixes into a tag for Bill.

Keeping draft until it can be tested.