### PR TITLE
Add support for pFLogger simTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for use of pFlogger simTime in logging (only if `-DBUILD_WITH_PFLOGGER=ON`)
+  - Note: Due to bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the
+    formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90))
+
 ### Changed
 
 ### Fixed

--- a/base/ApplicationSupport.F90
+++ b/base/ApplicationSupport.F90
@@ -80,6 +80,8 @@ module MAPL_ApplicationSupport
       use pflogger, only: StreamHandler, FileHandler, HandlerVector
       use pflogger, only: MpiLock, MpiFormatter
       use pflogger, only: INFO, WARNING
+      use PFL_Formatter, only: get_sim_time
+      use mapl_SimulationTime, only: fill_time_dict
 
       use, intrinsic :: iso_fortran_env, only: OUTPUT_UNIT
 
@@ -109,6 +111,7 @@ module MAPL_ApplicationSupport
       end if
 
       call pfl_initialize()
+      get_sim_time => fill_time_dict
 
       if (logging_configuration_file /= '') then
          call logging%load_file(logging_configuration_file)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -59,10 +59,14 @@ set (srcs
   # tstqsat.F90
   )
 
+# Add SimulationTime.F90 to srcs if we are building with pflogger
+if (BUILD_WITH_PFLOGGER)
+  list(APPEND srcs SimulationTime.F90)
+endif()
 
 esma_add_library(
   ${this} SRCS ${srcs}
-  DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 PFLOGGER::pflogger 
+  DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 PFLOGGER::pflogger
                GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
                esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE ${MAPL_LIBRARY_TYPE})

--- a/base/SimulationTime.F90
+++ b/base/SimulationTime.F90
@@ -1,0 +1,52 @@
+! This module allows pFlogger to access the current simulation time in
+! MAPL and thereby annotate log entries with the current simulation
+! time.  To accomplish this, the module hold a (shallow) copy
+! of the clock in CapGridComp.
+
+module mapl_SimulationTime
+   use pflogger, only: StringUnlimitedMap
+   use ESMF
+   implicit none
+   private
+
+   public :: set_reference_clock
+   public :: fill_time_dict
+
+   type(ESMF_Clock), save :: reference_clock
+
+contains
+
+   subroutine set_reference_clock(clock)
+      type(ESMF_Clock), intent(in) :: clock
+      reference_clock = clock
+   end subroutine set_reference_clock
+
+   subroutine fill_time_dict(dict)
+      type (StringUnlimitedmap), intent(out) :: dict
+
+      integer :: status
+      type(ESMF_Time) :: time
+
+      integer :: yy, mm, dd, h, m, s
+
+      call ESMF_ClockValidate(reference_clock, rc=status)
+      if (status /= 0) error stop "Must pass reference via set_reference_clock() before use."
+
+      call ESMF_ClockGet(reference_clock, currTime=time, rc=status)
+      if (status /= 0) error stop "could not get current time in SimulationTime.F90"
+
+      call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, rc=status)
+      if (status /= 0) error stop "Failed to get data from ESMF_TimeGet()."
+
+      call dict%insert('Y',yy)
+      call dict%insert('M',mm)
+      call dict%insert('D',dd)
+      call dict%insert('HH',h)
+      call dict%insert('MM',m)
+      call dict%insert('SS',s)
+      call dict%insert('MS',0)
+
+   end subroutine Fill_Time_Dict
+
+end module mapl_SimulationTime
+

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -31,7 +31,9 @@ module MAPL_CapGridCompMod
   use pflogger, only: logging, Logger
   use MAPL_TimeUtilsMod, only: is_valid_time, is_valid_date
   use MAPL_ExternalGCStorage
+#ifdef BUILD_WITH_PFLOGGER
   use mapl_SimulationTime, only: set_reference_clock
+#endif
 
   use iso_fortran_env
 

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -31,6 +31,7 @@ module MAPL_CapGridCompMod
   use pflogger, only: logging, Logger
   use MAPL_TimeUtilsMod, only: is_valid_time, is_valid_date
   use MAPL_ExternalGCStorage
+  use mapl_SimulationTime, only: set_reference_clock
 
   use iso_fortran_env
 
@@ -296,6 +297,10 @@ contains
         cap%nsteps = nsteps
         cap%compute_throughput = .true.
     end if
+
+#ifdef BUILD_WITH_PFLOGGER
+    call set_reference_clock(cap%clock)
+#endif
 
     call ESMF_ClockGet(cap%clock,currTime=cap%cap_restart_time,rc=status)
     _VERIFY(status)
@@ -1483,7 +1488,7 @@ contains
            _RETURN(_FAILURE)
         end if
      endif
-     
+
      call ESMF_GridCompSet(this%gc, grid=mapl_grid, _RC)
 
      _RETURN(_SUCCESS)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds support for using pFlogger `simTime` in MAPL's logging. This is only usable if MAPL is built with pFlogger.

Note: Due to a bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90)). See below for an example.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Well, it allows logging messages to say at what point in the simulation the logging message was emitted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this in GEOSgcm with the following added to `logging.yaml`. First I defined a formatter `simtime` that looked like the output of the throughput timer output:

```yaml

   simtime:
      class: Formatter
      format: '%(simtime)a~ %(short_name)a15~: %(level_name)a~: %(message)a'
      datefmt: ' AGCM Date: %(Y)i4.4~/%(M)i2.2~/%(D)i2.2  Time: %(HH)i2.2~:%(MM)i2.2~:%(SS)i2.2'
```
and I then defined a new handler:
```yaml
   console_simtime:
      class: streamhandler
      formatter: simtime
      unit: OUTPUT_UNIT
      level: DEBUG
```
and then told it to use this with `MAPL.GENERIC`:
```yaml
   MAPL.GENERIC:
      handlers: [console_simtime]
      propagate: FALSE
      level: WARNING
      root_level: DEBUG
```

When I did this, I saw:

```
...
 Character Resource Parameter: HIST_CF:HISTORY.rc
 Character Resource Parameter: MAPL_ENABLE_TIMERS:YES
 Logical Resource Parameter: USE_EXTDATA2G:T
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Adding logger for component GCM
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Started setServices() of the gridded component <GCM>
 Integer*4 Resource Parameter: USE_CICE_Thermo:0, (default value)
 Integer*4 Resource Parameter: USE_OCEANOBIOGEOCHEM:0, (default value)
 Integer*4 Resource Parameter: USE_DATAATM:0, (default value)
 Integer*4 Resource Parameter: USE_DATASEA:1, (default value)
 Logical Resource Parameter: SEAICE_THICKNESS_EXT_DATA:F, (default value)
 Character Resource Parameter: REPLAY_MODE:NoReplay, (default value)
 Integer*4 Resource Parameter: DUAL_OCEAN:0, (default value)
 Character Resource Parameter: CONVPAR_OPTION:GF
 Character Resource Parameter: AERO_PROVIDER:GOCART2G
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Adding logger for component AGCM
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Started setServices() of the gridded component <AGCM>
 Integer*4 Resource Parameter: ANALYZE_TS:0, (default value)
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Adding logger for component SUPERDYNAMICS
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Started setServices() of the gridded component <SUPERDYNAMICS>
 Character Resource Parameter: DYCORE:FV3, (default value)
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Adding logger for component DYN
...
```

And this does match pretty well the throughput output:
```
...
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Finished Run stage of the gridded component <OGCM>
 AGCM Date: 2000/04/14  Time: 21:00:00         GENERIC: DEBUG: Finished Run stage of the gridded component <GCM>
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Started Run stage of the gridded component <HIST>
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Finished Run stage of the gridded component <HIST>
 AGCM Date: 2000/04/14  Time: 21:01:15  Throughput(days/day)[Avg Tot Run]:          2.9          2.9          7.5  TimeRemaining(Est) 008:08:29   32.0% :  35.9% Mem Comm:Used
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Started Run stage of the gridded component <EXTDATA>
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Finished Run stage of the gridded component <EXTDATA>
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Started WriteRestart stage of the gridded component <GCM>
 AGCM Date: 2000/04/14  Time: 21:01:15         GENERIC: DEBUG: Started WriteRestart stage of the gridded component <AGCM>
...
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
