### PR TITLE
Fixes #2072

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add option to GriddedIO class so that if an unitilized time object is passed, the resulting file will not depend on time
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add option to GriddedIO class so that if an unitilized time object is passed, the resulting file will not depend on time
+- Add logic to GriddedIO class so that if an unitialized time object is passed, the resulting file will not depend on time
 
 ### Fixed
 

--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -246,10 +246,8 @@ contains
           tdim = this%ntime
        end if
        call metadata%add_dimension('time',tdim)
-       v = this%define_time_variable(rc=status)
-       _VERIFY(status)
-       call metadata%add_variable('time',v,rc=status)
-       _VERIFY(status)
+       v = this%define_time_variable(_RC)
+       call metadata%add_variable('time',v,_RC)
     end if
     _RETURN(_SUCCESS)
 

--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -20,6 +20,7 @@ module MAPL_TimeDataMod
      type(ESMF_TimeInterval) :: offset
      character(len=:), allocatable :: funits
      logical :: integer_time
+     logical :: is_initialized = .false.
    contains
      procedure :: add_time_to_metadata
      procedure :: define_time_variable
@@ -27,6 +28,7 @@ module MAPL_TimeDataMod
      procedure :: get_start_time
      procedure :: get
      procedure :: setFrequency
+     procedure :: am_i_initialized
   end type timeData
 
   interface timeData
@@ -34,6 +36,12 @@ module MAPL_TimeDataMod
   end interface timeData
 contains
 
+  function am_i_initialized(this) result(logical_temp)
+     logical  :: logical_temp
+     class(TimeData), intent(inout) :: this
+     logical_temp = this%is_initialized
+  end
+     
   function new_time_data(clock,ntime,frequency,offset,funits,integer_time,rc) result(tData)
     type(timeData) :: tData
     type(ESMF_Clock),intent(inout) :: clock
@@ -44,6 +52,7 @@ contains
     logical, optional, intent(in) :: integer_time
     integer, optional, intent(Out) :: rc
 
+    tData%is_initialized = .true.
     tdata%clock=clock
     tdata%ntime=ntime
     tdata%frequency=frequency
@@ -230,16 +239,19 @@ contains
     integer :: tdim
     integer :: status
 
-    if (this%ntime==-1) then
-       tdim = pFIO_UNLIMITED
-    else
-       tdim = this%ntime
+    if (this%is_initialized) then
+       if (this%ntime==-1) then
+          tdim = pFIO_UNLIMITED
+       else
+          tdim = this%ntime
+       end if
+       call metadata%add_dimension('time',tdim)
+       v = this%define_time_variable(rc=status)
+       _VERIFY(status)
+       call metadata%add_variable('time',v,rc=status)
+       _VERIFY(status)
     end if
-    call metadata%add_dimension('time',tdim)
-    v = this%define_time_variable(rc=status)
-    _VERIFY(status)
-    call metadata%add_variable('time',v,rc=status)
-    _VERIFY(status)
+    _RETURN(_SUCCESS)
 
   end subroutine add_time_to_metadata
 

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -421,8 +421,7 @@ module MAPL_GriddedIOMod
         integer :: status
 
         if (this%timeInfo%is_initialized) then
-           v = this%timeInfo%define_time_variable(rc=status)
-           _VERIFY(status)
+           v = this%timeInfo%define_time_variable(_RC)
            call this%metadata%modify_variable('time',v,rc=status)
            _VERIFY(status)
            if (present(oClients)) then

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -423,6 +423,8 @@ module MAPL_GriddedIOMod
               call oClients%modify_metadata(this%write_collection_id, var_map=var_map, rc=status)
               _VERIFY(status)
            end if
+        else
+           _FAIL("Time was not initialized for the GriddedIO class instance")
         end if
         _RETURN(ESMF_SUCCESS)
 
@@ -435,8 +437,12 @@ module MAPL_GriddedIOMod
 
         integer :: status
 
-        call this%timeInfo%setFrequency(frequency, rc=status)
-        _VERIFY(status)
+        if (this%timeInfo%is_initialized) then
+           call this%timeInfo%setFrequency(frequency, rc=status)
+           _VERIFY(status)
+        else
+           _FAIL("Time was not initialized for the GriddedIO class instance")
+        end if
 
         _RETURN(ESMF_SUCCESS)
 

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -355,12 +355,22 @@ module MAPL_GriddedIOMod
            units = 'unknown'
         endif
         grid_dims = factory%get_grid_vars()
-        if (fieldRank==2) then
-           vdims=grid_dims//",time"
-        else if (fieldRank==3) then
-           vdims=grid_dims//",lev,time"
+        if (this%timeInfo%is_initialized) then
+           if (fieldRank==2) then
+              vdims=grid_dims//",time"
+           else if (fieldRank==3) then
+              vdims=grid_dims//",lev,time"
+           else
+              _FAIL( 'Unsupported field rank')
+           end if
         else
-           _FAIL( 'Unsupported field rank')
+           if (fieldRank==2) then
+              vdims=grid_dims
+           else if (fieldRank==3) then
+              vdims=grid_dims//",lev"
+           else
+              _FAIL( 'Unsupported field rank')
+           end if
         end if
         v = Variable(type=PFIO_REAL32,dimensions=vdims,chunksizes=this%chunking,deflation=this%deflateLevel,quantize_algorithm=this%quantizeAlgorithm,quantize_level=this%quantizeLevel)
         call v%add_attribute('units',trim(units))
@@ -403,14 +413,16 @@ module MAPL_GriddedIOMod
         type(StringVariableMap) :: var_map
         integer :: status
 
-        v = this%timeInfo%define_time_variable(rc=status)
-        _VERIFY(status)
-        call this%metadata%modify_variable('time',v,rc=status)
-        _VERIFY(status)
-        if (present(oClients)) then
-           call var_map%insert('time',v)
-           call oClients%modify_metadata(this%write_collection_id, var_map=var_map, rc=status)
+        if (this%timeInfo%is_initialized) then
+           v = this%timeInfo%define_time_variable(rc=status)
            _VERIFY(status)
+           call this%metadata%modify_variable('time',v,rc=status)
+           _VERIFY(status)
+           if (present(oClients)) then
+              call var_map%insert('time',v)
+              call oClients%modify_metadata(this%write_collection_id, var_map=var_map, rc=status)
+              _VERIFY(status)
+           end if
         end if
         _RETURN(ESMF_SUCCESS)
 
@@ -443,15 +455,22 @@ module MAPL_GriddedIOMod
 
         type(GriddedIOitemVectorIterator) :: iter
         type(GriddedIOitem), pointer :: item
+        logical :: have_time
+  
+        have_time = this%timeInfo%am_i_initialized()
 
-        this%times = this%timeInfo%compute_time_vector(this%metadata,rc=status)
-        _VERIFY(status)
-        ref = ArrayReference(this%times)
-        call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref)
+        if (have_time) then
+           this%times = this%timeInfo%compute_time_vector(this%metadata,rc=status)
+           _VERIFY(status)
+           ref = ArrayReference(this%times)
+           call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref)
 
-        tindex = size(this%times)
-        if (tindex==1) then
-           call this%stage2DLatLon(filename,oClients=oClients,_RC)
+           tindex = size(this%times)
+           if (tindex==1) then
+              call this%stage2DLatLon(filename,oClients=oClients,_RC)
+           end if
+        else
+           tindex = -1
         end if
 
         if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
@@ -904,8 +923,13 @@ module MAPL_GriddedIOMod
         end if
         ref = factory%generate_file_reference2D(Ptr2D)
         allocate(localStart,source=[gridLocalStart,1])
-        allocate(globalStart,source=[gridGlobalStart,tindex])
-        allocate(globalCount,source=[gridGlobalCount,1])
+        if (tindex > -1) then
+           allocate(globalStart,source=[gridGlobalStart,tindex])
+           allocate(globalCount,source=[gridGlobalCount,1])
+        else
+           allocate(globalStart,source=gridGlobalStart)
+           allocate(globalCount,source=gridGlobalCount)
+        end if
       else if (fieldRank==3) then
          if (HasDE) then
             call ESMF_FieldGet(field,farrayPtr=ptr3d,rc=status)
@@ -920,8 +944,13 @@ module MAPL_GriddedIOMod
          end if
          ref = factory%generate_file_reference3D(Ptr3D)
          allocate(localStart,source=[gridLocalStart,1,1])
-         allocate(globalStart,source=[gridGlobalStart,1,tindex])
-         allocate(globalCount,source=[gridGlobalCount,lm,1])
+         if (tindex > -1) then
+            allocate(globalStart,source=[gridGlobalStart,1,tindex])
+            allocate(globalCount,source=[gridGlobalCount,lm,1])
+         else
+            allocate(globalStart,source=[gridGlobalStart,1])
+            allocate(globalCount,source=[gridGlobalCount,lm])
+         end if
       else
          _FAIL( "Rank not supported")
       end if


### PR DESCRIPTION
Fixes #2072

This adds an option to the MAPL_TimeUtilities class with a logical to know if the instantiation has been initialized via the constructor. If not, this can be detected by a layer like griddedIO and griddedIO can not add time as a dimension to variables for the swath sampler use case.
I've modified GriddedIO to act in this manner. If the TimeInfo object which is required to passed was not initialized, then it is simply ignored.
@metdyn can then use this for his swath sampling stuff and when he writes those files, don't pass an initialized time object that that will be that. No time as a dimension in the file and no variables can therefore depend on it as well.
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
