### PR TITLE
Fixes the regridding of vertor field with subdomains without DE. Also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
--Fixed the handling of vector regridding for a subdomain with a local DE. Also fixed the no-de case involving vertical regridding
+### Fixed
+- Fixed the handling of vector regridding for a subdomain with a local DE. 
+- Fixed the no-de case involving vertical regridding
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+-Fixed the handling of vector regridding for a subdomain with a local DE. Also fixed the no-de case involving vertical regridding
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fixed the handling of vector regridding for a subdomain with a local DE. 
-- Fixed the no-de case involving vertical regridding
+- Fixed the handling of vector regridding for a subdomain with no-DE. 
+- Fixed the no-DE case related to vertical regridding.
 
 ### Added
 

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -942,8 +942,6 @@ contains
      _ASSERT(km == size(v_in,3),'inconsistent array shape')
       if (size(u_out) /= 0) then
          _ASSERT(km == size(u_out,3),'inconsistent array shape')
-      end if
-      if (size(u_out) /= 0) then
          _ASSERT(km == size(v_out,3),'inconsistent array shape')
       end if
 

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -825,8 +825,12 @@ contains
 
       km = size(u_in,3)
       _ASSERT(km == size(v_in,3),'inconsistent array shape')
-      _ASSERT(km == size(u_out,3),'inconsistent array shape')
-      _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(u_out,3),'inconsistent array shape')
+      end if
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      end if
 
       im_src = size(u_in,1)
       jm_src = size(u_in,2)
@@ -938,8 +942,12 @@ contains
 
      km = size(u_in,3)
      _ASSERT(km == size(v_in,3),'inconsistent array shape')
-     _ASSERT(km == size(u_out,3),'inconsistent array shape')
-     _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(u_out,3),'inconsistent array shape')
+      end if
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      end if
 
      im_src = size(u_in,1)
      jm_src = size(u_in,2)
@@ -1046,8 +1054,12 @@ contains
 
       km = size(u_in,3)
       _ASSERT(km == size(v_in,3),'inconsistent array shape')
-      _ASSERT(km == size(u_out,3),'inconsistent array shape')
-      _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(u_out,3),'inconsistent array shape')
+      end if
+      if (size(u_out) /= 0) then
+         _ASSERT(km == size(v_out,3),'inconsistent array shape')
+      end if
 
       im_src = size(u_in,1)
       jm_src = size(u_in,2)

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -1052,8 +1052,6 @@ contains
       _ASSERT(km == size(v_in,3),'inconsistent array shape')
       if (size(u_out) /= 0) then
          _ASSERT(km == size(u_out,3),'inconsistent array shape')
-      end if
-      if (size(u_out) /= 0) then
          _ASSERT(km == size(v_out,3),'inconsistent array shape')
       end if
 

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -827,8 +827,6 @@ contains
       _ASSERT(km == size(v_in,3),'inconsistent array shape')
       if (size(u_out) /= 0) then
          _ASSERT(km == size(u_out,3),'inconsistent array shape')
-      end if
-      if (size(u_out) /= 0) then
          _ASSERT(km == size(v_out,3),'inconsistent array shape')
       end if
 

--- a/base/MAPL_VerticalMethods.F90
+++ b/base/MAPL_VerticalMethods.F90
@@ -293,14 +293,21 @@ module MAPL_VerticalDataMod
 
         integer :: rank,k,status
         real, pointer :: ptr(:,:,:)
+        type(ESMF_FieldStatus_Flag)     :: fieldStatus
 
         _ASSERT(allocated(this%surface_level),"class not setup to do topography correction")
         if (this%regrid_type == VERTICAL_METHOD_ETA2LEV) then
            call ESMF_FieldGet(field,rank=rank,rc=status)
            _VERIFY(status)
            if (rank==3) then
-              call ESMF_FieldGet(field,0,farrayptr=ptr,rc=status)
-              _VERIFY(status)
+              call ESMF_FieldGet(field, status=fieldStatus, rc=status)
+              _VERIFY(STATUS)
+              if (fieldStatus == ESMF_FIELDSTATUS_COMPLETE) then
+                 call ESMF_FieldGet(field,0,farrayptr=ptr,rc=status)
+                 _VERIFY(status)
+              else
+                 allocate(ptr(0,0,0),_STAT)
+              end if
               do k=1,size(ptr,3)
                  if (this%ascending) then
                     where(this%surface_level<this%scaled_levels(k)) ptr(:,:,k)=MAPL_UNDEF


### PR DESCRIPTION
fixes no DE case for vertical regridding

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
