### PR TITLE
Handmerge develop into MAPL3 2023-Apr-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- Added support for "depends_on" and "depends_on_children" for export_specs. The typical usage on this feature is when the calculation of a variable involves other export variables, either from the same component (DEPEND_ON specifies the list on such variables), or in the children (in this case the expectation is that all of the children have the SAME export). In both cases MAPL performs automatic allocation of these export variables.
 - Added support for use of pFlogger simTime in logging (only if `-DBUILD_WITH_PFLOGGER=ON`)
   - Note: Due to bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the
     formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90))
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed message in _ASSERT statement in ESMFL_Mod.F90
 - Fixed bug in CubedSphereGridFactory when constructing a grid from a file
 - Cleaned up cubed-sphere grid factory and NCIO to produce files with consistent capitalization and types for the stretching factor
 

--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -256,7 +256,7 @@ contains
 
       call ESMF_FieldBundleGet(BUNDLE, FIELDNAME=NameInBundle, isPresent=isPresent, rc=STATUS)
       _VERIFY(STATUS)
-      _ASSERT(.not. isPresent, trim(NameInBundle) // ' not found in bundle.')
+      _ASSERT(.not. isPresent, trim(NameInBundle) // ' found in bundle.')
 
 ! Get Field from State
 

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -75,7 +75,7 @@
 ! MAPL_GenericSetServices and MAPL_Generic IRF methods cannot create their own ESMF grid.
 ! The grid must be inherited from the parent or created by the component
 ! either in its own SetServices or in its Initialize, if it is writing one.
-! In any case, an important assumption of MAPL is that the grid must  already be 
+! In any case, an important assumption of MAPL is that the grid must  already be
 ! *present in the component and initialized* when MAPL_GenericSetServices is invoked.
 ! The same is true of the configuration.
 !
@@ -3114,7 +3114,8 @@ contains
         HALOWIDTH, PRECISION, DEFAULT, UNGRIDDED_DIMS,   &
         UNGRIDDED_UNIT, UNGRIDDED_NAME,     &
         UNGRIDDED_COORDS,                     &
-        FIELD_TYPE, STAGGERING, ROTATION, RC )
+        FIELD_TYPE, STAGGERING, ROTATION, &
+        DEPENDS_ON, DEPENDS_ON_CHILDREN, RC )
 
       !ARGUMENTS:
       type (ESMF_GridComp)            , intent(INOUT)   :: GC
@@ -3137,6 +3138,8 @@ contains
       integer            , optional   , intent(IN)      :: FIELD_TYPE
       integer            , optional   , intent(IN)      :: STAGGERING
       integer            , optional   , intent(IN)      :: ROTATION
+      logical            , optional   , intent(IN)      :: DEPENDS_ON_CHILDREN
+      character (len=*)  , optional   , intent(IN)      :: DEPENDS_ON(:)
       integer            , optional   , intent(OUT)     :: RC
       !EOPI
 
@@ -3201,6 +3204,8 @@ contains
            FIELD_TYPE = FIELD_TYPE,                                              &
            STAGGERING = STAGGERING,                                              &
            ROTATION = ROTATION,                                                  &
+           DEPENDS_ON = DEPENDS_ON, &
+           DEPENDS_ON_CHILDREN = DEPENDS_ON_CHILDREN, &
            RC=status  )
       _VERIFY(status)
 
@@ -3739,7 +3744,7 @@ contains
 !- **GIM** The childrens' IMPORT states.
 !- **GEX** The childrens' EXPORT states.
 !- **CCS** Array of child-to-child couplers.
-! 
+!
    subroutine MAPL_GenericStateGet (STATE, IM, JM, LM, VERTDIM,                &
         NX, NY, NX0, NY0, LAYOUT,                  &
         GCNames,                                   &
@@ -10959,6 +10964,7 @@ contains
       ! TODO: Fix this is a terrible kludge.
       if (meta%compname /= 'CAP') then
          call process_connections(meta,_RC) ! needs better name
+         call process_spec_dependence(meta, _RC)
       end if
 
       call meta%t_profiler%stop(_RC)
@@ -11117,6 +11123,72 @@ contains
       end subroutine process_connections
 #undef LOWEST_
 
+     subroutine process_spec_dependence(meta, rc)
+       type (MAPL_MetaComp), target, intent(inout) :: meta
+       integer, optional, intent(out) :: rc
+
+       integer :: status
+       integer :: k, i, j, nc, nvars
+       logical :: depends_on_children
+       character(len=:), allocatable :: depends_on(:)
+       character(len=ESMF_MAXSTR) :: SHORT_NAME, NAME
+       type (MAPL_VarSpec), pointer :: ex_specs(:), c_ex_specs(:)
+       type (MAPL_MetaComp), pointer :: cmeta
+       type(ESMF_GridComp), pointer :: childgridcomp
+       logical :: found
+
+       ! get the export specs
+       call  MAPL_StateGetVarSpecs(meta, export=ex_specs, _RC)
+       ! allow for possibility we do not have export specs
+       _RETURN_IF(.not. associated(ex_specs))
+
+       ! check for DEPENDS_ON_CHILDREN
+       do K=1,size(EX_SPECS)
+          call MAPL_VarSpecGet(EX_SPECS(K), SHORT_NAME=SHORT_NAME, &
+               DEPENDS_ON_CHILDREN=DEPENDS_ON_CHILDREN, &
+               DEPENDS_ON=DEPENDS_ON, _RC)
+          if (DEPENDS_ON_CHILDREN) then
+!!!             mark SHORT_NAME in each child "alwaysAllocate"
+             nc = meta%get_num_children()
+             _ASSERT(nc > 0, 'DEPENDS_ON_CHILDREN requires at least 1 child')
+             do I=1, nc
+                childgridcomp => meta%get_child_gridcomp(i)
+                call MAPL_InternalStateRetrieve(childgridcomp, cmeta, _RC)
+                found = .false.
+                call  MAPL_StateGetVarSpecs(cmeta, export=c_ex_specs, _RC)
+                _ASSERT(associated(c_ex_specs), 'Component '//trim(cmeta%compname)//' must have a valid export spec')
+                ! find the "correct" export spec (i.e. has the same SHORT_NAME)
+                do j=1,size(c_ex_specs)
+                   call MAPL_VarSpecGet(c_ex_specs(j), SHORT_NAME=NAME, _RC)
+                   if (short_name == name) then
+                      call MAPL_VarSpecSet(c_ex_specs(j), alwaysAllocate=.true., _RC)
+                      found = .true.
+                      exit
+                   end if
+                end do ! spec loop
+                _ASSERT(found, 'All children must have '//trim(short_name))
+             end do
+          end if ! DEPENDS_ON_CHILDREN
+
+          if (allocated(depends_on)) then
+!!!             mark SHORT_NAME in each variable "alwaysAllocate"
+             nvars = size(depends_on)
+             _ASSERT(nvars > 0, 'DEPENDS_ON requires at least 1 var')
+             do I=1, nvars
+                ! find the "correct" export spec (i.e. has the same SHORT_NAME)
+                do j=1,size(ex_specs)
+                   call MAPL_VarSpecGet(ex_specs(j), SHORT_NAME=NAME, _RC)
+                   if (name == depends_on(i)) then
+                      call MAPL_VarSpecSet(ex_specs(j), alwaysAllocate=.true., _RC)
+                      exit
+                   end if
+                end do ! spec loop
+             end do
+          end if ! DEPENDS_ON
+       end do
+
+       _RETURN(ESMF_SUCCESS)
+     end subroutine process_spec_dependence
 
       subroutine register_generic_entry_points(gc, rc)
          type(ESMF_GridComp), intent(inout) :: gc

--- a/generic/StateSpecification.F90
+++ b/generic/StateSpecification.F90
@@ -98,6 +98,7 @@ contains
                              STAGGERING, &
                              ROTATION,   & 
                              GRID, &
+                             DEPENDS_ON, DEPENDS_ON_CHILDREN, &
                                                                    RC  )
 
     type (StateSpecification), intent(inout):: SPEC
@@ -131,6 +132,8 @@ contains
     integer            , optional   , intent(IN)      :: STAGGERING
     integer            , optional   , intent(IN)      :: ROTATION
     type(ESMF_Grid)    , optional   , intent(IN)      :: GRID
+    logical            , optional   , intent(IN)      :: DEPENDS_ON_CHILDREN
+    character (len=*)  , optional   , intent(IN)      :: DEPENDS_ON(:)
     integer            , optional   , intent(OUT)     :: RC
 
 
@@ -168,6 +171,8 @@ contains
     character(len=ESMF_MAXSTR) :: useableUngrd_Unit
     character(len=ESMF_MAXSTR) :: useableUngrd_Name
     real                      , pointer :: usableUNGRIDDED_COORDS(:) => NULL()
+    logical                    :: usableDEPENDS_ON_CHILDREN
+!    character (len=:), allocatable :: usableDEPENDS_ON(:)
 
     INTEGER :: I
     integer :: szINAMES, szRNAMES, szIVALUES, szRVALUES
@@ -334,6 +339,11 @@ contains
        usablePRECISION=kind(0.0) ! default "real" kind
       endif
 
+      usableDEPENDS_ON_CHILDREN = .false.
+      if(present(DEPENDS_ON_CHILDREN)) then
+         usableDEPENDS_ON_CHILDREN = DEPENDS_ON_CHILDREN
+      end if
+
 ! Sanity checks
       if (usablePRECISION /= ESMF_KIND_R4 .AND. usablePRECISION /= ESMF_KIND_R8) then
          ! only those 2 values are allowed
@@ -464,6 +474,12 @@ contains
       else
          NULLIFY(TMP%SPECPTR%ATTR_INAMES)
       endif
+
+      if(present(DEPENDS_ON)) then
+         TMP%SPECPTR%DEPENDS_ON = DEPENDS_ON
+      end if
+
+      TMP%SPECPTR%DEPENDS_ON_CHILDREN    =  usableDEPENDS_ON_CHILDREN
 
       call spec%var_specs%push_back(tmp)
       call spec%update_legacy()

--- a/generic/VarSpec.F90
+++ b/generic/VarSpec.F90
@@ -801,6 +801,8 @@ contains
         GRID,                                     &
         doNotAllocate,                            &
         alwaysAllocate,                           &
+        depends_on_children,                      &
+        depends_on,                               &
         RC )
 
       type (MAPL_VarSpec ),             intent(IN )     :: SPEC
@@ -838,6 +840,8 @@ contains
       type(ESMF_Grid)    , optional   , intent(OUT)     :: GRID
       logical            , optional   , intent(OUT)     :: doNotAllocate
       logical            , optional   , intent(OUT)     :: alwaysAllocate
+      logical            , optional   , intent(OUT)     :: depends_on_children
+      character(len=:), allocatable, optional, intent(OUT) :: depends_on(:)
       integer            , optional   , intent(OUT)     :: RC
 
 
@@ -982,6 +986,16 @@ contains
       if(present(alwaysAllocate)) then
          alwaysAllocate = SPEC%SPECPtr%alwaysAllocate
       endif
+
+      if(present(depends_on_children)) then
+         depends_on_children = SPEC%SPECPtr%depends_on_children
+      end if
+
+      if(present(depends_on)) then
+         if(allocated(SPEC%SPECPtr%depends_on)) then
+         depends_on =  SPEC%SPECPtr%depends_on
+         end if
+      end if
 
       _RETURN(ESMF_SUCCESS)
 

--- a/generic/VarSpecType.F90
+++ b/generic/VarSpecType.F90
@@ -55,6 +55,8 @@ module MAPL_VarSpecTypeMod
       logical                                  :: defaultProvided
       logical                                  :: doNotAllocate
       logical                                  :: alwaysAllocate ! meant for export specs
+      logical                                  :: depends_on_children
+      character(len=:), allocatable            :: depends_on(:)
       real                                     :: DEFAULT
       type(ESMF_Field), pointer                :: FIELD => null()
       type(ESMF_FieldBundle), pointer          :: BUNDLE => null()


### PR DESCRIPTION
This is a handmerge of `develop` into `release/MAPL-v3` due to the conflicts in #2101 due to changes from #2100. 

I'm going to test this, if it builds and doesn't crash, that's probably "success". The hard part was figuring out where to put:
```fortran
         call process_spec_dependence(meta, _RC)
```
I picked...somewhere. We'll see if it even compiles...