### PR TITLE
move the call ioserver_profiler%stop to the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Move ioserver_profler%stop call to the right palce
 - Caught an untrapped error condition when writing to NetCDF
 
 ### Removed

--- a/base/ServerManager.F90
+++ b/base/ServerManager.F90
@@ -282,15 +282,16 @@ contains
    subroutine finalize(this,rc)
       class(ServerManager), intent(inout) :: this
       integer, optional, intent(out) :: rc
+      integer :: status
       ! reporting here is for client_server in the same process which don't call start()
       ! problem here: all servers should coordinate to report one by one to avoid messy output
       if (associated(this%i_server)) then
-         call this%i_server%report_profile()
+         call this%i_server%report_profile(_RC)
          deallocate(this%i_server)
       endif
 
       if (associated(this%o_server)) then
-         call this%o_server%report_profile()
+         call this%o_server%report_profile(_RC)
          deallocate(this%o_server)
       endif
       call this%directory_service%free_directory_resources()

--- a/pfio/AbstractServer.F90
+++ b/pfio/AbstractServer.F90
@@ -424,12 +424,13 @@ contains
       character(:), allocatable :: report_lines(:)
       type (ProfileReporter) :: reporter
       character(1) :: empty(0)
-      integer :: i
+      integer :: i, status
 
       if ( .not. associated(ioserver_profiler)) then
          _RETURN(_SUCCESS)
       endif
 
+      call ioserver_profiler%stop(_RC)
       call ioserver_profiler%reduce()
 
       reporter = ProfileReporter(empty)
@@ -445,7 +446,7 @@ contains
       report_lines = reporter%generate_report(ioserver_profiler)
 
       if (this%rank == 0) then
-         write(*,'(a)')'Final profile'
+         write(*,'(a)')'Final io_server profile'
          write(*,'(a)')'============='
          do i = 1, size(report_lines)
             write(*,'(a)') report_lines(i)

--- a/pfio/MpiServer.F90
+++ b/pfio/MpiServer.F90
@@ -82,9 +82,6 @@ contains
       call this%threads%clear()
       deallocate(mask)
 
-      if (associated(ioserver_profiler)) then
-        call ioserver_profiler%stop(_RC)
-      endif
       call this%report_profile(_RC)
 
       _RETURN(_SUCCESS)

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -244,9 +244,6 @@ contains
          call this%threads%clear()
          call this%terminate_backend_server(_RC)
 
-         if (associated(ioserver_profiler)) then
-            call ioserver_profiler%stop(_RC)
-         endif
          call this%report_profile(_RC)
 
          deallocate(mask)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
The program crashed at the end when reporting ioserver_profiler in debug mode. It turns out the stop method is not in the right place when io server is on the same processes as the model.
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
