### PR TITLE
fix the option READ_RESTART_BY_FACE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The option READ_RESTART_BY_FACE now can read the grid-based output from WRITE_RESTART_BY_FACE. num_readers or num_writers should be multiple of 6
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The option READ_RESTART_BY_FACE now can read the grid-based output from WRITE_RESTART_BY_FACE. num_readers or num_writers should be multiple of 6
-
+- `READ_RESTART_BY_FACE` has been fixed and now can read restarts from full CS grids as well as restarts that have been separate by face via `WRITE_RESTART_BY_FACE`.    The current implementation requires that both `num_readers` and `num_writers` must be multiple of 6.
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `READ_RESTART_BY_FACE` has been fixed and now can read restarts from full CS grids as well as restarts that have been separate by face via `WRITE_RESTART_BY_FACE`.    The current implementation requires that both `num_readers` and `num_writers` must be multiple of 6.
+- `READ_RESTART_BY_FACE` has been fixed and now can read restarts from full CS grids as well as restarts that have been separated by face via `WRITE_RESTART_BY_FACE`.    The current implementation requires that both `num_readers` and `num_writers` must be multiple of 6.
 ### Removed
 
 ### Deprecated

--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -2760,7 +2760,7 @@ module NCIOMod
           call formatter%open(filename,pFIO_READ,rc=status)
           _VERIFY(STATUS)
        else
-          if(arrdes%read_restart_by_face) then
+          if(arrdes%read_restart_by_face .and. .not. arrdes%tile) then
              fname_by_face = get_fname_by_face(trim(filename),arrdes%face_index)
              call formatter%open(trim(fname_by_face),pFIO_READ,comm=arrdes%face_readers_comm,info=info,rc=status)
              _VERIFY(STATUS)
@@ -2851,8 +2851,10 @@ module NCIOMod
      _VERIFY(status)
      file_lon_size = metadata%get_dimension("lon")
      file_lat_size = metadata%get_dimension("lat")
+     if (metadata%has_attribute("Cubed_Sphere_Face_Index")) file_lat_size = file_lat_size*6
      file_lev_size = metadata%get_dimension("lev")
      file_tile_size = metadata%get_dimension("tile")
+
      if (file_tile_size > 0) then
         match = (file_tile_size == grid_dims(1))
      else
@@ -3881,6 +3883,7 @@ module NCIOMod
                 fname_by_face = get_fname_by_face(trim(filename),arrdes%face_index)
                 call formatter%create_par(trim(fname_by_face),comm=arrdes%face_writers_comm,info=info,rc=status)
                 _VERIFY(status)
+                call cf%add_attribute("Cubed_Sphere_Face_Index", arrdes%face_index, _RC)
              else
                 call formatter%create_par(trim(filename),comm=arrdes%writers_comm,info=info,rc=status)
                 _VERIFY(status)

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -5746,7 +5746,7 @@ contains
             call MPI_COMM_RANK(mpl%grid%writers_comm, io_rank, status)
             _VERIFY(status)
             if (io_rank == 0) then
-               print *,'Using parallel NetCDF for file: ',trim(FILENAME)
+               print *,'Using parallel NetCDF to write file: ',trim(FILENAME)
             end if
          endif
       else
@@ -5954,9 +5954,7 @@ contains
                     inquire(FILE = trim(fname_by_face), EXIST=fexist)
                     FileExists = FileExists .and. fexist
                  enddo
-                 if ( .not. FileExists) then
-                    _VERIFY(-1)
-                 else
+                 if (FileExists) then
                     ! just pick one face to deduce filetype, only in root
                     call MAPL_NCIOGetFileType(trim(fname_by_face),isNC4,rc=status)
                     _VERIFY(status)
@@ -5975,7 +5973,6 @@ contains
 
          call MAPL_CommsBcast(vm, fileExists, n=1, ROOT=MAPL_Root, rc=status)
          _VERIFY(status)
-
          if (FileExists) then
             !if (AmIRoot) then
             !   call MAPL_NCIOGetFileType(FNAME,isNC4,rc=status)
@@ -6146,7 +6143,7 @@ contains
             call MPI_COMM_RANK(mpl%grid%readers_comm, io_rank, status)
             _VERIFY(status)
             if (io_rank == 0) then
-               print *,'Using parallel NetCDF for file: ',trim(FNAME)
+               print *,'Using parallel NetCDF to read file: ',trim(FNAME)
             end if
          endif
       else


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

READ_RESTART_BY_FACE: YES now is working if the grid-based outputs are from WRITE_RESTART_BY_FACE ( by this PR). The restart names should be in the format like fvcore_internal_face_1_rst,  ie, adding _face_x_ before _rst. The grid_based restart file gwd_internal_rst should be split into 6 faces' file too. The NUM_READERS and NUM_WRITERS should be multiple of 6.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
