### PR TITLE
Add module to process NetCDF datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note: Due to bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the
     formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90))
 - Add geom subdirectory and contents for MAPL Geom framework
+- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
 
 ### Changed
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -55,6 +55,7 @@ set (srcs
   FieldUtilities.F90
   MAPL_Resource.F90
   MAPL_XYGridFactory.F90
+  MAPL_NetCDF.F90
   # Orphaned program: should not be in this library.
   # tstqsat.F90
   )

--- a/base/MAPL_NetCDF.F90
+++ b/base/MAPL_NetCDF.F90
@@ -1,3 +1,13 @@
+!wdb todo
+!I also have another request: Do we have a subroutine to convert
+!From:
+!integer: array(2) = [ 20010101 (YYYYMMDD) 010101 (HHMMSS) ]
+!
+!To:
+!ESMF_TIME: with gregorian calendar
+!
+!And vice versa.
+
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
 module MAPL_NetCDF.F90
@@ -222,8 +232,9 @@ contains
 
    end subroutine convert_NetCDF_DateTimeString_to_ESMF_Time
 
-   logical function is_time_unit(tunit)
+   function is_time_unit(tunit)
       character(len=*), intent(in) :: tunit
+      logical :: is_time_unit
       integer :: i
 
       is_time_unit = .TRUE.
@@ -242,8 +253,9 @@ contains
 
    end function lr_trim
 
-   integer function get_shift_sign(preposition)
+   function get_shift_sign(preposition)
       character(len=*), intent(in) :: preposition
+      integer :: get_shift_sign
       integer, parameter :: POSITIVE = 1
       get_shift_sign = 0
       if(lr_trim(preposition) == 'since') get_shift_sign = POSITIVE

--- a/base/MAPL_NetCDF.F90
+++ b/base/MAPL_NetCDF.F90
@@ -1,0 +1,363 @@
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+module MAPL_NetCDF.F90
+
+   use MAPL_ExceptionHandling
+   use MAPL_KeywordEnforcerMod
+   use MAPL_DateTimeParsing.F90
+   use ESMF
+
+   implicit none
+   public :: convert_NetCDF_DateTime_to_ESMF
+   public :: convert_ESMF_to_NetCDF_DateTime
+
+   character, parameter :: PART_DELIM = ' '
+   character, parameter :: ISO_DELIM = 'T'
+   integer, parameter :: LEN_DATE = len('YYYY-MM-DD')
+   integer, parameter :: LEN_TIME = len('hh:mm:ss')
+   character(len=*), parameter :: TIME_UNITS =  ['years', 'months', 'days', 'hours', 'minutes', 'seconds', 'milliseconds']
+   character, parameter :: SPACE = ' '
+
+contains
+
+! wdb split into two subroutines todo
+   subroutine convert_NetCDF_DateTime_to_ESMF(int_time, units_string, interval, time0, unusable, time1, tunit, rc)
+      integer, intent(in) :: int_time
+      character(len=*), intent(in) :: units_string
+      type(ESMF_TimeInterval), intent(out) :: interval
+      type(ESMF_Time), intent(out) :: time0
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_Time), optional, intent(out) :: time1
+      character(len=:), allocatable, optional, intent(out) :: tunit
+      integer, optional, intent(out) :: rc
+      character(len=:), allocatable :: tunit_
+      character(len=:), allocatable :: datetime_string
+      character(len=len_trim(units_string)) :: parts(2)
+      integer :: span, factor
+      integer :: status
+
+      _UNUSED_DUMMY(unusable)
+
+      _ASSERT(int_time >= 0, 'Negative span not supported')
+      _ASSERT((len(lr_trim(units_string)) > 0), 'units empty')
+
+      ! get time unit, tunit
+      parts = split(lr_trim(units_string), PART_DELIM)
+      tunit_ = lr_trim(parts(1))
+      _ASSERT(is_time_unit(tunit_), 'Unrecognized time unit')
+      if(present(tunit)) tunit = tunit_
+
+      ! get span
+      parts = split(lr_trim(parts(2)), PART_DELIM)
+      factor = get_shift_sign(parts(1))
+      _ASSERT(factor /= 0, 'Unrecognized preposition')
+      span = factor * int_time
+
+      call convert_NetCDF_DateTimeString_to_ESMF_Time(lr_trim(parts(2)), t0, _RC)
+      call make_ESMF_TimeInterval(span, tunit_, t0, interval, _RC)
+
+      ! get t1
+      if(present(t1)) t1 = t0 + interval
+
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_NetCDF_DateTime_to_ESMF
+
+! wdb split into two subroutines todo
+   subroutine convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
+      character(len=*), intent(in) :: tunit
+      type(ESMF_Time),  intent(in) :: t0
+      integer, intent(out) :: int_time
+      character(len=*), intent(out) :: units_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_Time), optional, intent(in) :: t1
+      type(ESMF_TimeInterval), optional, intent(in) :: interval
+      integer, optional, intent(out) :: rc
+      type(ESMF_TimeInterval) :: interval_
+      integer(ESMF_KIND_I4) :: yy, mm, d, h, m, s
+      integer :: status
+
+      _UNUSED_DUMMY(unusable)
+
+      if(present(interval)) then
+         interval_ = interval
+      elseif(present(t1)) then
+         interval_ = t1 - t0
+      else
+         _ASSERT(has_two_inputs, 'Only one input argument present')
+      end if
+
+      call make_NetCDF_DateTime_int_time(interval_, t0, tunit_, int_time, rc)
+      call make_NetCDF_DateTime_units_string(interval_, t0, tunit_, units_string, rc)
+
+      _RETURN(_SUCCESS)
+      
+   end subroutine convert_ESMF_to_NetCDF_DateTime
+
+   subroutine make_ESMF_TimeInterval(span, tunit, t0, interval, unusable, rc)
+      integer, intent(in) :: span
+      character(len=*), intent(in) :: tunit
+      type(ESMF_Time), intent(in) :: t0
+      type(ESMF_TimeInterval), intent(out) :: interval
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      select case(lr_trim(tunit)) 
+         case('years')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 yy=span, _RC)
+         case('months')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 mm=span, _RC)
+         case('days')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 d=span, _RC)
+         case('hours')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 h=span, _RC)
+         case('minutes')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 m=span, _RC)
+         case('seconds')
+            call ESMF_TimeIntervalSet(interval, startTime=t0 s=span, _RC)
+         case default
+            _FAIL('Unrecognized unit')
+      end select
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_ESMF_TimeInterval
+
+   subroutine make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, unusable, rc)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      type(ESMF_Time), intent(in) :: t0
+      character(len=*), intent(in) :: tunit
+      integer, intent(out) :: int_time
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      ! get int_time
+      select case(lr_trim(tunit)) 
+         case('years')
+            call ESMF_TimeIntervalGet(interval, t0, yy=int_time, _RC)
+         case('months')
+            call ESMF_TimeIntervalGet(interval, t0, mm=int_time, _RC)
+         case('days')
+            call ESMF_TimeIntervalGet(interval, t0, d=int_time, _RC)
+         case('hours')
+            call ESMF_TimeIntervalGet(interval, t0, h=int_time, _RC)
+         case('minutes')
+            call ESMF_TimeIntervalGet(interval, t0, m=int_time, _RC)
+         case('seconds')
+            call ESMF_TimeIntervalGet(interval, t0, s=int_time, _RC)
+         case default
+            _FAIL('Unrecognized unit')
+      end select
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_NetCDF_DateTime_int_time
+
+   subroutine make_NetCDF_DateTime_units_string(interval, t0, tunit, units_string, unusable, rc)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      type(ESMF_Time), intent(in) :: t0
+      character(len=*), intent(in) :: tunit
+      character(len=:), intent(out) :: units_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      character(len=*), parameter :: preposition = 'since'
+      character(len=:), allocatable :: datetime_string
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      ! make units_string
+      call convert_ESMF_Time_to_NetCDF_DateTimeString(t0, datetime_string, _RC)
+      units_string = tunit //SPACE// preposition //SPACE// datetime_string
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_NetCDF_DateTime_units_string
+
+   subroutine convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, datetime_string, unusable, rc)
+      type(ESMF_Time), intent(in) :: esmf_datetime
+      character(len=:), allocatable, intent(out) :: datetime_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      character(len=:), allocatable :: parts(2)
+      character(len=:), allocatable :: date_string
+      character(len=:), allocatable :: time_string
+      integer :: status
+
+      _UNUSED_DUMMY(unusable)
+
+      call ESMF_TimeGet(esmf_datetime, timeString=datetime_string, _RC)
+      parts = split(datetime_string, ISO_DELIM)
+      date_string = lr_trim(parts(1))
+      time_string = lr_trim(parts(2))
+      _ASSERT(len(date_string) == LEN_DATE, 'Incorrect date width')
+      _ASSERT(len(time_string) >= LEN_TIME, 'Incorrect time width')
+      time_string = time_string(1:LEN_TIME)
+      datetime_string = date_string //PART_DELIM// time_string
+      
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_ESMF_Time_to_NetCDF_DateTimeString
+   
+   subroutine convert_NetCDF_DateTimeString_to_ESMF_Time(datetime_string, datetime, unusable, rc)
+      character(len=*), intent(in) :: datetime_string
+      type(ESMF_Time), intent(out) :: datetime
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      character(len=len(datetime_string)) :: iso_string
+      integer :: status 
+
+      _UNUSED_DUMMY(unusable)
+
+      call convert_to_ISO8601DateTime(datetime_string, iso_string, _RC)
+      call ESMF_TimeSet(datetime, trim(iso_string), _RC)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_NetCDF_DateTimeString_to_ESMF_Time
+
+   logical function is_time_unit(tunit)
+      character(len=*), intent(in) :: tunit
+      integer :: i
+
+      is_time_unit = .TRUE.
+      do i = 1, size(TIME_UNITS)
+         if(lr_trim(tunit) == lr_trim(TIME_UNITS(i))) return
+      end do
+      is_time_unit = .FALSE.
+
+   end function is_time_unit
+
+   function lr_trim(string)
+      character(len=*), intent(in) :: string
+      character(len=:), allocatable :: lr_trim
+
+      lr_trim = trim(adjustl(string))
+
+   end function lr_trim
+
+   integer function get_shift_sign(preposition)
+      character(len=*), intent(in) :: preposition
+      integer, parameter :: POSITIVE = 1
+      get_shift_sign = 0
+      if(lr_trim(preposition) == 'since') get_shift_sign = POSITIVE
+   end function get_shift_sign
+
+   function split(string, delimiter)
+      character(len=*), intent(in) :: string
+      character(len=*), intent(in) :: delimiter
+      character(len=len(string) :: split(2)
+      integer start
+ 
+      split = [string, '']
+      start = index(string, delimiter)
+      if(start < 1) return
+      split = [string(1:start - 1), string(start+len(delimiter),len(string))]
+   end function split
+
+   function split_all(s, d) result(parts)
+      character(len=*), intent(in) :: s
+      character(len=*), intent(in) :: d
+      character(len=:), allocatable :: parts(:)
+      integer :: start
+
+      start = index(s, d)
+
+      if(start == 0) then
+         parts = [s]
+      else
+         parts = [s(1:(start-1)), split_all(s((start+len(d)):len(s)), d)] 
+      end if
+
+   end function split_all
+
+   function join(strings, delimiter)
+      character(len=*), intent(in) :: strings(:)
+      character(len=*), intent(in) :: delimiter
+      character(len=:), allocatable :: join
+      integer :: i
+
+      join = strings(1)
+      do i=2, size(strings)
+         join = delimiter  // join
+      end do
+
+   end function join
+end module MAPL_NetCDF.F90
+
+!   logical function has_delimiter(string, delimiter)
+!      character(len=*), intent(in) :: string
+!      character(len=*), intent(in) :: delimiter
+!
+!      has_delimiter = (index(string, delimiter) > 0)
+!   end function has_delimiter
+!   character, parameter :: DATE_DELIM :: '-'
+!   character, parameter :: TIME_DELIM :: ':'
+
+!   subroutine make_ESMF_DateTime(datetime_string, datetime, rc)
+!      character(len=*), intent(in) :: datetime_string
+!      type(ESMF_Time), intent(out) :: datetime
+!      integer, optional, intent(out) :: rc
+!      character(len=len(datetime_string)) :: parts(2)
+!      type(date_fields) :: date
+!      type(time_fields) :: time
+!      integer, parameter :: HAS_DATE = 1
+!      integer, parameter :: HAS_TIME = 2
+!      integer, parameter :: HAS_DATETIME = HAS_DATE + HAS_TIME
+!      integer :: i, case_
+!      integer :: status
+!
+!      parts = split(lr_trim(datetime_string), PART_DELIM)
+!      _ASSERT((len(parts(1)) == 0), 'First datetime fields missing')
+!
+!      count_ = 0
+!      i = 1
+!      if(has_delimiter(parts(i), DATE_DELIM)) then
+!         date = date_fields(lr_trim(parts(i)), DATE_DELIM)
+!         _ASSERT(.not. date % is_null(), 'Invalid date')
+!         case_ = case_ + HAS_DATE
+!         i = 2
+!      end if
+!
+!      if(has_delimiter(parts(i), TIME_DELIM)) then
+!         time = time_fields(lr_trim(parts(i), TIME_DELIM)
+!         _ASSERT(.not. time % is_null(), 'Invalid time')
+!         case_ = case_ + HAS_TIME
+!      end if
+!
+!      _ASSERT((count_ > 0) .and. (count_ <= HAS_DATETIME), 'No date or time')
+!
+!      select case(case_)
+!         case(HAS_DATE)
+!            call ESMF_TimeSet(datetime, yy = date % year(), mm = date % month(), dd = date % day(), _RC)
+!         case(HAS_TIME)
+!            call ESMF_TimeSet(datetime, hh = time % hour(), m = time % minute(), s = time % second(), _RC)
+!         case(HAS_DATETIME)
+!            call ESMF_TimeSet(datetime, yy = date % year(), mm = date % month(), dd = date % day(), &
+!               hh = time % hour(), m = time % minute(), s = time % second(), _RC)
+!         case default
+!            _FAIL('No date or time')
+!      end select
+!      
+!      _RETURN(_SUCCESS)
+
+!   end function make_ESMF_DateTime
+
+!   function parse_timeunit(timeunit_name) result(timeunit)
+!      character(len=*), intent(in) :: timeunit_name
+!      type(time_unit) :: timeunit
+!      character(len=len(timeunit_name)) :: adj_name
+!      integer :: trimmed_length
+!
+!      adj_name = adjustl(timeunit_name)
+!      trimmed_length = len_trim(adj_name)
+!      if(adj_name(trimmed_length:trimmed_length)
+!      timeunit = get_time_unit(trim(timeunit_name))      
+!
+!   end function parse_timeunit

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set (TEST_SRCS
     Test_MAPL_Config.pf
     test_DirPath.pf
     test_TimeStringConversion.pf
+#   test_MAPL_NetCDF.pf
 #    test_MAPL_ISO8601_DateTime_ESMF.pf
   )
 

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set (TEST_SRCS
     Test_MAPL_Config.pf
     test_DirPath.pf
     test_TimeStringConversion.pf
-#   test_MAPL_NetCDF.pf
+    test_MAPL_NetCDF.pf
 #    test_MAPL_ISO8601_DateTime_ESMF.pf
   )
 

--- a/base/tests/test_MAPL_NetCDF.pf
+++ b/base/tests/test_MAPL_NetCDF.pf
@@ -1,100 +1,308 @@
-!subroutine convert_NetCDF_DateTime_to_ESMF(int_time, units_string, interval, time0, unusable, time1, tunit, rc)
-!subroutine convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
-!subroutine make_ESMF_TimeInterval(span, tunit, t0, interval, unusable, rc)
-!subroutine make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, unusable, rc)
-!subroutine make_NetCDF_DateTime_units_string(interval, t0, tunit, units_string, unusable, rc)
-!subroutine convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, datetime_string, unusable, rc)
-!subroutine convert_NetCDF_DateTimeString_to_ESMF_Time(datetime_string, datetime, unusable, rc)
-!function is_time_unit(tunit)
-!function lr_trim(string)
-!function get_shift_sign(preposition)
-!function split(string, delimiter)
-!function split_all(s, d) result(parts)
-!function join(strings, delimiter)
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
 module test_MAPL_NetCDF
    use MAPL_ExceptionHandling
-
-   use MAPL_KeywordEnforcerMod
-   use MAPL_DateTimeParsing.F90
+   use MAPL_NetCDF
    use ESMF
+   use pfunit
 
    implicit none
 
+   type(ESMF_CalKind_Flag), parameter :: CALKIND_FLAG_DEF = ESMF_CALKIND_GREGORIAN
+
 contains
 
-subroutine test_convert_NetCDF_DateTime_to_ESMF()
-!(int_time, units_string, interval, time0, unusable, time1, tunit, rc)
+   @Before
+   subroutine set_up()
+      integer :: status
 
-end subroutine test_convert_NetCDF_DateTime_to_ESMF
+      call ESMF_CalendarSetDefault(CALKIND_FLAG_DEF, rc=status)
+      if(status /= 0) write(*, *) 'Failed to set ESMF_Calendar'
 
-subroutine test_convert_ESMF_to_NetCDF_DateTime()
-!(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
+   end subroutine set_up
 
-end subroutine test_convert_ESMF_to_NetCDF_DateTime
+   @Test
+   subroutine test_convert_NetCDF_DateTime_to_ESMF()
+      character(len=*), parameter :: expected_tunit = 'seconds'
+      integer, parameter :: int_time = 1800
+      character(len=*), parameter :: units_string = expected_tunit // ' since 2012-08-26 12:36:37'
+      character(len=*), parameter :: t0_iso_string = '2012-08-26T12:36:37'
+      character(len=*), parameter :: t1_iso_string = '2012-08-26T13:06:37'
+      type(ESMF_TimeInterval) :: expected_interval
+      type(ESMF_Time) :: expected_time0
+      type(ESMF_Time) :: expected_time1
 
-subroutine test_make_ESMF_TimeInterval()
-!(span, tunit, t0, interval, unusable, rc)
+      type(ESMF_TimeInterval) :: interval
+      type(ESMF_Time) :: time0
+      type(ESMF_Time) :: time1
+      character(len=:), allocatable :: tunit
+      integer :: rc, status
 
-end subroutine test_make_ESMF_TimeInterval
+      call ESMF_TimeSet(expected_time0, timeString=t0_iso_string, _RC)
+      call ESMF_TimeSet(expected_time1, timeString=t1_iso_string, _RC)
+      call ESMF_TimeIntervalSet(expected_interval, startTime=expected_time0, s=int_time, _RC)
 
-subroutine test_make_NetCDF_DateTime_int_time()
-!(interval, t0, tunit, int_time, unusable, rc)
+      call convert_NetCDF_DateTime_to_ESMF(int_time, units_string, interval, time0, time1=time1, tunit=tunit, _RC)
+      @assertTrue(expected_time0 == time0, 'Mismatch for time0')
+      @assertTrue(expected_time1 == time1, 'Mismatch for time1')
+      @assertTrue(expected_interval == interval, 'Mismatch for interval')
+      
+   end subroutine test_convert_NetCDF_DateTime_to_ESMF
 
-end subroutine test_make_NetCDF_DateTime_int_time
+   @Test
+   subroutine test_convert_ESMF_to_NetCDF_DateTime()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: t0_iso_string = '2013-08-26T12:34:56'
+      type(ESMF_Time) :: t0
+      character(len=*), parameter :: t1_iso_string = '2013-08-26T13:04:56'
+      type(ESMF_Time) :: t1
+      type(ESMF_TimeInterval) :: interval
+      integer, parameter :: span = 1800
+      character(len=*), parameter :: expected_units_string = tunit // ' since 2013-08-26 12:34:56'
+      integer, parameter :: expected_int_time = span
+      integer :: int_time
+      character(len=:), allocatable :: units_string
+      integer :: rc, status
 
-subroutine test_make_NetCDF_DateTime_units_string()
-!(interval, t0, tunit, units_string, unusable, rc)
+      call ESMF_TimeSet(t0, t0_iso_string, _RC)
+      call ESMF_TimeSet(t1, t1_iso_string, _RC)
+      call ESMF_TimeIntervalSet(interval, startTime=t0, s=span, _RC)
 
-end subroutine test_make_NetCDF_DateTime_units_string
+      call convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, t1=t1, _RC)
+      @assertEqual(expected_int_time, int_time, 'Using t1, expected_int_time /= int_time')
+      @assertEqual(expected_units_string, units_string, 'Using t1, expected_units_strin g/= units_string')
 
-subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString()
-!(esmf_datetime, datetime_string, unusable, rc)
+      call convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, interval=interval, _RC)
+      @assertEqual(expected_int_time, int_time, 'Using interval, expected_int_time /= int_time')
+      @assertEqual(expected_units_string, units_string, 'Using interval, expected_units_strin g/= units_string')
 
-end subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString
+   end subroutine test_convert_ESMF_to_NetCDF_DateTime
 
-subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time()
-!(datetime_string, datetime, unusable, rc)
+   @Test
+   subroutine test_make_ESMF_TimeInterval()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: iso_string = '2013-08-26T12:34:56'
+      integer, parameter :: span = 1800
+      type(ESMF_TimeInterval) :: expected_interval
+      type(ESMF_Time) :: t0
+      type(ESMF_TimeInterval) :: interval
+      integer :: rc, status
 
-end subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time
+      call ESMF_TimeSet(t0, iso_string, _RC)
+      call ESMF_TimeIntervalSet(expected_interval, startTime=t0, s=span, _RC)
+      call make_ESMF_TimeInterval(span, tunit, t0, interval, _RC)
+      @assertTrue(expected_interval == interval, 'ESMF_TimeInterval variables do not match.')
 
-subroutine test_is_time_unit()
-!(tunit)
+   end subroutine test_make_ESMF_TimeInterval
 
-end subroutine test_is_time_unit
+   @Test
+   subroutine test_make_NetCDF_DateTime_int_time()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: iso_string = '2013-08-26T12:34:56'
+      type(ESMF_TimeInterval) :: interval
+      type(ESMF_Time) :: t0
+      integer, parameter :: expected_int_time = 1800
+      integer :: int_time
+      integer :: status, rc
 
-subroutine test_lr_trim()
-!(string)
+      call ESMF_TimeSet(t0, iso_string, _RC)
+      call ESMF_TimeIntervalSet(interval, startTime=t0, s=expected_int_time, _RC)
 
-end subroutine test_lr_trim
+      call make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, _RC)
+      @assertEqual(expected_int_time, int_time, 'int_time does not match.') 
 
-subroutine test_get_shift_sign()
-!(preposition)
+   end subroutine test_make_NetCDF_DateTime_int_time
 
-end subroutine test_get_shift_sign
+   @Test
+   subroutine test_make_NetCDF_DateTime_units_string()
+      type(ESMF_Time) :: t0
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: expected = tunit // ' since 2012-08-26 08:36:37'
+      character(len=:), allocatable :: actual
+      integer :: status, rc
 
-subroutine test_split()
-!(string, delimiter)
+      call ESMF_TimeSet(t0, yy=2012, mm=08, dd=26, h=08, m=36, s=37, _RC)
+      call make_NetCDF_DateTime_units_string(t0, tunit, actual, _RC)
+      @assertEqual(expected, actual, 'Strings don''t match: ' // expected // '/=' // actual)
+   end subroutine test_make_NetCDF_DateTime_units_string
 
-end subroutine test_split
+   @Test
+   subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString()
+      type(ESMF_Time) :: esmf_datetime
+      character(len=*), parameter :: expected = '2022-08-26 07:30:37'
+      integer, parameter :: yy = 2022
+      integer, parameter :: mm = 08
+      integer, parameter :: dd  = 26
+      integer, parameter :: h  = 07
+      integer, parameter :: m  = 30
+      integer, parameter :: s  = 37
+      character(len=:), allocatable :: actual
+      integer :: status, rc
 
-subroutine test_split_all()
-!(s, d) result(parts)
+      call ESMF_TimeSet(esmf_datetime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      call convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, actual, _RC)
+      @assertEqual(expected, actual, 'Strings don''t match: ' // expected  // '/=' // actual)
+   end subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString
 
-end subroutine test_split_all
+   @Test
+   subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time()
+      character(len=19), parameter:: netcdf_string='2023-01-31 14:04:37'
+      type(ESMF_Time) :: esmf_time
+      integer :: yy, mm, dd, h, m, s
+      integer :: status, rc
 
-subroutine test_join()
-   character(len=:), allocatable :: strings
-   character(len=:), allocatable :: delimiter
-   character(len=:), allocatable :: join
+      call convert_NetCDF_DateTimeString_to_ESMF_Time(netcdf_string, esmf_time, _RC)
+      call ESMF_TimeGet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      @assertEqual(2023, yy, 'Incorrect year')
+      @assertEqual(01, mm, 'Incorrect month')
+      @assertEqual(31, dd, 'Incorrect day')
+      @assertEqual(14, h, 'Incorrect hour')
+      @assertEqual(04, m, 'Incorrect minute')
+      @assertEqual(37, s, 'Incorrect second')
 
-   strings = ['doe', 'ray', 'mi']
-   delimiter = ' '
-   join = join(strings, delimiter)
-   @asssertEqual(join, 'doe ray mi', 'Incorrect joined string')
+   end subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time
 
-end subroutine test_join
+!   @Test
+   subroutine test_is_time_unit()
 
+      @assertTrue(is_time_unit('years'))
+      @assertTrue(is_time_unit('months'))
+      @assertTrue(is_time_unit('days'))
+      @assertTrue(is_time_unit('hours'))
+      @assertTrue(is_time_unit('minutes'))
+      @assertTrue(is_time_unit('seconds'))
+      @assertTrue(is_time_unit('milliseconds'))
+      @assertTrue(is_time_unit(' milliseconds '))
+
+      @assertFalse(is_time_unit('nanoseconds'))
+      @assertFalse(is_time_unit('year'))
+
+   end subroutine test_is_time_unit
+
+!   @Test
+   subroutine test_lr_trim()
+      @assertEqual('word', lr_trim(' word'))
+      @assertEqual('word', lr_trim('word '))
+      @assertEqual('word', lr_trim(' word '))
+   end subroutine test_lr_trim
+
+!   @test
+   subroutine test_get_shift_sign()
+      character(len=:), allocatable :: preposition
+      integer, parameter :: expected = 1
+
+      preposition = 'since'
+      @assertEqual(expected, get_shift_sign(preposition))
+      preposition = 'before'
+      @assertFalse(get_shift_sign(preposition) == expected)
+      preposition = ''
+      @assertFalse(get_shift_sign(preposition) == expected)
+   end subroutine test_get_shift_sign
+
+!   @test
+   subroutine test_split()
+      character(len=*), parameter :: head = 'head'
+      character(len=*), parameter :: tail = 'tail'
+      character(len=*), parameter :: delim = '::'
+      character(len=*), parameter :: test_string = head // delim // tail
+      character(len=:), allocatable :: parts(:)
+
+      parts = split_all(test_string, delim)
+      @assertEqual(2, size(parts))
+      @assertEqual(head, parts(1))
+      @assertEqual(tail, parts(2))
+
+   end subroutine test_split
+
+!   @test
+   subroutine test_split_all()
+      character(len=4), parameter :: chunk(6) = ['mice', 'dogs', 'rats', 'fish', 'deer', 'pigs']
+      character(len=*), parameter :: dlm = '::'
+      character(len=:), allocatable :: test_string
+      character(len=:), allocatable :: parts(:)
+      integer :: i
+
+      test_string = chunk(1)
+      do i = 2, size(chunk)
+         test_string = test_string // dlm // chunk(i)
+      end do
+
+      parts = split_all(test_string, dlm)
+      @assertEqual(size(parts), size(chunk))
+      do i = 1, size(chunk)
+         @assertEqual(chunk(i), parts(i))
+      end do
+
+   end subroutine test_split_all
+ 
+!   @test
+   subroutine test_is_valid_netcdf_datetime_string()
+      character(len=:), allocatable :: string
+
+!      string = ''
+!      @assertTrue(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01 23:59:59'
+      @assertTrue(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01  23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970:01-01 23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01 23-59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01T23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+   end subroutine test_is_valid_netcdf_datetime_string
+
+!   @test
+   subroutine test_convert_to_integer()
+      character(len=:), allocatable :: str
+      integer :: expected, actual, status
+      integer, parameter :: SUCCESSFUL = 0
+
+      expected = 2023
+      str = '2023'
+      call convert_to_integer(str, actual, rc = status)
+      @assertEqual(SUCCESSFUL, status, 'Unsuccessful conversion: ' // str)
+      @assertEqual(expected, actual, 'Incorrect conversion: ' // str)
+
+   end subroutine test_convert_to_integer
+!   function get_integer_from_string(string, first_index, last_index) result(ival)
+!      character(len=*), intent(in) :: string
+!      integer, intent(in) :: first_index, last_index
+!      integer :: ival, stat
+!      character(len=(last_index-first_index+1)) :: substring
+!
+!      substring = string(first_index:last_index)
+!      read(substring, fmt='(i)', iostat=stat) ival
+!      if(stat == 0) return 
+!      ival = -1
+!
+!   end function get_integer_from_string
+!
+!   @test
+!   subroutine test_esmf_time_from_iso_string()
+!      type(ESMF_Time) :: esmf_time
+!      character(len=*), parameter :: iso_string = '2012-10-24T18:00:00'
+!      integer(kind=ESMF_KIND_I4) :: yy, mm, dd, h, m, s
+!      type(ESMF_CalKind_Flag) :: CALKIND_FLAG_DEF = ESMF_CALKIND_GREGORIAN
+!      integer :: rc, status
+!
+!      yy = get_integer_from_string(iso_string, 1, 4)
+!      mm = get_integer_from_string(iso_string, 6, 7)
+!      dd =  get_integer_from_string(iso_string, 9, 10)
+!      h =  get_integer_from_string(iso_string, 12, 13)
+!      m =  get_integer_from_string(iso_string, 15, 16)
+!      s =  get_integer_from_string(iso_string, 18, 19)
+!
+!      call ESMF_TimeSet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, calkindflag=CALKIND_FLAG_DEF, _RC)
+!      call ESMF_TimeSet(esmf_time, timeString='2012-10-24T18:00:00', _RC)
+!
+!   end subroutine test_esmf_time_from_iso_string
 
 end module test_MAPL_NetCDF

--- a/base/tests/test_MAPL_NetCDF.pf
+++ b/base/tests/test_MAPL_NetCDF.pf
@@ -1,0 +1,100 @@
+!subroutine convert_NetCDF_DateTime_to_ESMF(int_time, units_string, interval, time0, unusable, time1, tunit, rc)
+!subroutine convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
+!subroutine make_ESMF_TimeInterval(span, tunit, t0, interval, unusable, rc)
+!subroutine make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, unusable, rc)
+!subroutine make_NetCDF_DateTime_units_string(interval, t0, tunit, units_string, unusable, rc)
+!subroutine convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, datetime_string, unusable, rc)
+!subroutine convert_NetCDF_DateTimeString_to_ESMF_Time(datetime_string, datetime, unusable, rc)
+!function is_time_unit(tunit)
+!function lr_trim(string)
+!function get_shift_sign(preposition)
+!function split(string, delimiter)
+!function split_all(s, d) result(parts)
+!function join(strings, delimiter)
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+module test_MAPL_NetCDF
+   use MAPL_ExceptionHandling
+
+   use MAPL_KeywordEnforcerMod
+   use MAPL_DateTimeParsing.F90
+   use ESMF
+
+   implicit none
+
+contains
+
+subroutine test_convert_NetCDF_DateTime_to_ESMF()
+!(int_time, units_string, interval, time0, unusable, time1, tunit, rc)
+
+end subroutine test_convert_NetCDF_DateTime_to_ESMF
+
+subroutine test_convert_ESMF_to_NetCDF_DateTime()
+!(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
+
+end subroutine test_convert_ESMF_to_NetCDF_DateTime
+
+subroutine test_make_ESMF_TimeInterval()
+!(span, tunit, t0, interval, unusable, rc)
+
+end subroutine test_make_ESMF_TimeInterval
+
+subroutine test_make_NetCDF_DateTime_int_time()
+!(interval, t0, tunit, int_time, unusable, rc)
+
+end subroutine test_make_NetCDF_DateTime_int_time
+
+subroutine test_make_NetCDF_DateTime_units_string()
+!(interval, t0, tunit, units_string, unusable, rc)
+
+end subroutine test_make_NetCDF_DateTime_units_string
+
+subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString()
+!(esmf_datetime, datetime_string, unusable, rc)
+
+end subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString
+
+subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time()
+!(datetime_string, datetime, unusable, rc)
+
+end subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time
+
+subroutine test_is_time_unit()
+!(tunit)
+
+end subroutine test_is_time_unit
+
+subroutine test_lr_trim()
+!(string)
+
+end subroutine test_lr_trim
+
+subroutine test_get_shift_sign()
+!(preposition)
+
+end subroutine test_get_shift_sign
+
+subroutine test_split()
+!(string, delimiter)
+
+end subroutine test_split
+
+subroutine test_split_all()
+!(s, d) result(parts)
+
+end subroutine test_split_all
+
+subroutine test_join()
+   character(len=:), allocatable :: strings
+   character(len=:), allocatable :: delimiter
+   character(len=:), allocatable :: join
+
+   strings = ['doe', 'ray', 'mi']
+   delimiter = ' '
+   join = join(strings, delimiter)
+   @asssertEqual(join, 'doe ray mi', 'Incorrect joined string')
+
+end subroutine test_join
+
+
+end module test_MAPL_NetCDF

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -25,6 +25,7 @@ set (srcs
     FileSystemUtilities.F90
     DSO_Utilities.F90
     MAPL_ISO8601_DateTime.F90
+    MAPL_DateTime_Parsing.F90
     DownBit.F90
     ShaveMantissa.c
 # Fortran submodules

--- a/shared/MAPL_DateTime_Parsing.F90
+++ b/shared/MAPL_DateTime_Parsing.F90
@@ -683,4 +683,25 @@ contains
 
    end subroutine convert_to_ISO8601DateTime 
 
+   function is_valid_datestring(datestring, string_format) result(tval)
+      character(len=*), intent(in) :: datestring
+      character(len=*), intent(in) :: string_format
+      logical :: tval
+      integer :: i
+
+      tval = .false.
+
+      if(len(datestring) /= len(string_format)) return
+
+      do i = 1, len_trim(string_format)
+         if(is_digit(string_format(i:i))) then
+            if(.not. is_digit(datestring(i:i))) return
+         else
+            if(datestring(i:i) /= string_format(i:i)) return
+         end if
+      end do
+
+      tval = .true.
+
+   end function is_valid_datestring
 end module MAPL_DateTime_Parsing

--- a/shared/MAPL_DateTime_Parsing.F90
+++ b/shared/MAPL_DateTime_Parsing.F90
@@ -1,0 +1,605 @@
+! MAPL Date/Time Parsing
+!
+! This module implements general parsing of strings representing dates and times
+! Zero-padded strings must be zero padded to their full width, unless
+! otherwise specified.
+! In the following:
+! ? is either a zero-width character or a delimiter like '-' or ':'
+!
+! Date
+!      YYYY
+! Years are represented by 4 numerical characters (Y).
+! The range is: '0000' to '9999' representing the years 1 BCE ('0000') to
+! 9999 CE ('9999').
+!
+! These date formats are supported.
+!      YYYY?MM?DD or YYYYMMDD
+!      YYYY?MM (but not YYYYMM)
+! YYYY is the year as specified above.
+! MM is the zero-padded month from '01' (January) to '12' (December).
+! DD is the zero-padded day of the month from '01' (1) to '31' (31).
+! The range of allowed DD strings varies according to the actual
+! calendar, though the first day is always '01'.
+!
+! Time
+! This module supports fractional seconds. (currently only milliseconds)
+!      hh?mm?ss.sss	or	Thhmmss.sss
+!      hh?mm?ss	or	Thhmmss
+!      hh?mm	or	Thhmm
+!      hh
+! hh is the zero-padded hour (24 hour system).
+! mm is the zero-padded minute. 
+! ss is the zero-padded second.
+! sss is the fractional second. It represents an arbitrary number of digits (currrently limited to 3).
+!
+! Fully-formed time with time zone. Local time not-supported
+!      <time>Z
+
+!wdb fixme need to enforce private (see commented out private statements and add to other type/variables
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+module MAPL_DateTime_Parsing
+   use MAPL_KeywordEnforcerMod
+   use MAPL_ExceptionHandling
+   implicit none
+
+!   private 
+   public :: date_fields
+   public :: time_fields
+
+   interface operator(.divides.)
+      module procedure :: divides
+   end interface
+
+   interface operator(.in.)
+      module procedure :: is_in_closed_interval
+   end interface
+
+   interface operator(.between.)
+      module procedure :: is_in_open_interval
+   end interface 
+
+   ! Error handling
+   integer, parameter :: INVALID = -1
+
+   ! parameters for processing date, time, and datetime strings
+   character(len=10), parameter :: DIGIT_CHARACTERS = '0123456789'
+
+   ! Timezone offset for Timezone Z !wdb keep for now
+   integer, parameter :: Z = 0
+
+   ! Derived type for communicating date fields internally
+   type :: date_fields
+      integer :: year_
+      integer :: month_
+      integer :: day_
+      logical :: is_valid_ = .FALSE.
+   contains
+      procedure, public, pass(this) :: year => get_year_field
+      procedure, public, pass(this) :: month => get_month_field
+      procedure, public, pass(this) :: day => get_day_field
+      procedure, public, pass(this) :: is_valid => are_valid_date_fields
+   end type date_fields
+
+   interface date_fields
+      module procedure :: construct_date_fields_default
+      module procedure :: construct_date_fields_null
+   end interface date_fields
+
+   ! Derived type for communicating time fields internally
+   type :: time_fields
+      integer :: hour_
+      integer :: minute_
+      integer :: second_
+      integer :: millisecond_
+      integer :: timezone_offset_
+      logical :: is_valid_ = .FALSE.
+   contains
+      procedure, public, pass(this) :: hour => get_hour_field
+      procedure, public, pass(this) :: minute => get_minute_field
+      procedure, public, pass(this) :: second => get_second_field
+      procedure, public, pass(this) :: millisecond => get_millisecond_field
+      procedure, public, pass(this) :: timezone_offset => get_timezone_offset_field
+      procedure, public, pass(this) :: is_valid => are_valid_time_fields
+   end type time_fields
+
+   interface time_fields
+      module procedure :: construct_time_fields_default
+      module procedure :: construct_time_fields_null
+   end interface time_fields
+
+contains
+
+! NUMBER HANDLING PROCEDURES
+
+   ! Return true if factor divides dividend evenly, false otherwise
+   pure logical function divides(factor, dividend)
+      integer, intent(in) :: factor
+      integer, intent(in) :: dividend
+      ! mod returns the remainder of dividend/factor, and if it is 0, factor divides dividend evenly
+      if(factor /= 0) then ! To avoid divide by 0
+          divides = mod(dividend, factor)==0
+      else
+          divides = .FALSE.
+      endif
+   end function divides
+
+   pure logical function is_in_closed_interval(n, clint)
+      integer, intent(in) :: n
+      integer, intent(in) :: clint(2)
+      is_in_closed_interval = .not. ((n < clint(1)) .or. (n > clint(2)))
+   end function is_in_closed_interval
+
+   pure logical function is_in_open_interval(n, opint)
+      integer, intent(in) :: n
+      integer, intent(in) :: opint(2)
+      is_in_open_interval = (n > opint(1)) .and. (n < opint(2))
+   end function is_in_open_interval
+
+   ! Check if c is a digit character
+   elemental pure logical function is_digit(c)
+      character, intent(in) :: c
+      is_digit = scan(c, DIGIT_CHARACTERS) > 0
+   end function is_digit
+
+   ! Check if n is an integer >= 0
+   pure logical function is_whole_number(n)
+      integer, intent(in) :: n
+      is_whole_number = .not. (n < 0)
+   end function is_whole_number
+
+   ! Convert c from digit character to integer
+   pure integer function get_integer_digit(c)
+      character, intent(in) :: c
+      get_integer_digit = index(DIGIT_CHARACTERS, c) - 1
+   end function get_integer_digit
+
+   ! Convert index i character from s to integer
+   pure integer function get_integer_digit_from_string(s, i)
+      character(len=*), intent(in) :: s
+      integer, intent(in) :: i
+
+      if((i>0) .and. (i<len(s)+1)) then
+         get_integer_digit_from_string = get_integer_digit(s(i:i))
+      else
+         get_integer_digit_from_string = INVALID
+      end if
+   end function get_integer_digit_from_string
+
+   ! Convert string to whole number
+   pure integer function read_whole_number(string)
+      character(len=*), intent(in) :: string
+      read_whole_number = read_whole_number_indexed(string, 1, len(string))
+   end function read_whole_number
+
+   ! Convert string(istart: istop) to whole number
+   pure integer function read_whole_number_indexed(string, istart, istop)
+      character(len=*), intent(in) :: string
+      integer, intent(in) :: istart
+      integer, intent(in) :: istop
+      integer, parameter :: BASE=10
+      integer :: n
+      integer :: i
+      integer :: place_value
+      integer :: digit_value
+
+      read_whole_number_indexed = INVALID
+
+      ! Check indices
+      if((istart < 1) .or. (istart > istop) .or. (istop > len(string))) return
+
+      ! Convert characters from string, last to first, to integers,
+      ! multiplies by place value, and adds
+      place_value = 1
+      n = 0
+      do i= istop, istart, -1
+         digit_value = get_integer_digit_from_string(string, i)
+         if(is_whole_number(digit_value)) then
+            n = n + digit_value * place_value
+            place_value = place_value * BASE
+         else
+            n = INVALID
+            exit
+         end if
+      end do
+      read_whole_number_indexed = n
+   end function read_whole_number_indexed
+
+! END NUMBER HANDLING PROCEDURES
+
+! LOW-LEVEL STRING PROCESSING PROCEDURES
+
+   ! Strip delimiter from string
+   !wdb todo should this be more than 1 character
+   pure function undelimit(string, delimiter) result(undelimited)
+      character(len=*), intent(in) :: string
+      character, optional, intent(in) :: delimiter
+      character(len=len(string)) :: undelimited
+      integer :: i
+      integer :: j
+      
+      undelimited = string
+      if(.not. present(delimiter)) return
+      if(len_trim(delimiter) <= 0) return
+
+      undelimited = ''
+      j = 0
+      do i=1,len(string)
+        if(string(i:i) == delimiter) cycle
+        j = j + 1
+        undelimited(j:j) = string(i:i)
+      end do
+   end function undelimit
+
+! END LOW-LEVEL STRING PROCESSING PROCEDURES
+
+
+! LOW-LEVEL DATE & TIME PROCESSING PROCEDURES
+
+   ! Return true if y is a leap year, false otherwise
+   pure logical function is_leap_year(y)
+      integer, intent(in) :: y
+      ! Leap years are years divisible by 400 or (years divisible by 4 and not divisible by 100)
+      is_leap_year = (400 .divides. y) .or. ((4 .divides. y) .and. .not. (100 .divides. y))
+   end function is_leap_year
+
+   ! Return the last day numbers of each month based on the year
+   pure function get_month_ends(y) result(month_ends)
+      integer, intent(in) :: y
+      integer, parameter :: NUM_MONTHS = 12
+      integer, dimension(NUM_MONTHS) :: month_ends
+      ! last day numbers of months for leap years
+      integer, dimension(NUM_MONTHS) :: MONTH_END_LEAP
+      ! last day numbers of months for regular years
+      integer, dimension(NUM_MONTHS) :: MONTH_END
+      MONTH_END = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+      MONTH_END_LEAP = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+      if(is_leap_year(y)) then
+         month_ends = MONTH_END_LEAP
+      else
+         month_ends = MONTH_END
+      endif
+   end function get_month_ends
+
+   ! Return the last day number of month m in year y
+   pure integer function get_month_end(y, m)
+      integer, intent(in) :: y
+      integer, intent(in) :: m
+      integer, dimension(:), allocatable :: month_ends
+
+      month_ends = get_month_ends(y)
+      get_month_end = month_ends(m)
+
+   end function get_month_end
+
+   ! Verify that y is a valid year
+   pure logical function is_valid_year(y)
+      integer, intent(in) :: y
+
+      is_valid_year = y .in. [0, 9999]
+   end function is_valid_year
+
+   ! Verify that m is a valid month number
+   pure logical function is_valid_month(m)
+      integer, intent(in) :: m
+      is_valid_month = m .in. [1, 12]
+   end function is_valid_month
+
+   ! Verify that day d in in month m of year y
+   pure logical function is_valid_day(y, m, d)
+      integer, intent(in) :: y
+      integer, intent(in) :: m
+      integer, intent(in) :: d
+      is_valid_day = d .in.  [1, get_month_end(y, m)]
+   end function is_valid_day
+
+   ! Verify that hour is a valid hour
+   pure logical function is_valid_hour(hour)
+      integer, intent(in) :: hour
+      is_valid_hour = hour .in. [0, 23]
+   end function is_valid_hour
+
+   ! Verify that minute is a valid minute
+   pure logical function is_valid_minute(minute)
+      integer, intent(in) :: minute
+      is_valid_minute = minute .in. [0, 59]
+   end function is_valid_minute
+
+   ! Verify that second is a valid second
+   pure logical function is_valid_second(second)
+      integer, intent(in) :: second
+      is_valid_second = second .in. [0, 60]
+   end function is_valid_second
+
+   ! Verify that millisecond is a valid millisecond values
+   pure logical function is_valid_millisecond(millisecond)
+      integer, intent(in) :: millisecond
+      is_valid_millisecond = millisecond .in. [0, 999]
+   end function is_valid_millisecond
+
+   ! Verify that the timezone offset is valid
+   ! Not strict. Just looks for a 'reasonable' offset (+/- 1440 minutes = 24 * 60 minutes)
+   pure logical function is_valid_timezone_offset(timezone_offset)
+      integer, parameter :: MAX_OFFSET = 1440
+      integer, intent(in) :: timezone_offset
+      is_valid_timezone_offset = timezone_offset .in. [-MAX_OFFSET, MAX_OFFSET]
+   end function is_valid_timezone_offset
+
+! END LOW-LEVEL DATE & TIME PROCESSING PROCEDURES
+
+
+! DATE & TIME VERIFICATION
+
+   ! Verify all the date fields are valid
+   pure logical function is_valid_date(date)
+      type(date_fields), intent(in) :: date
+
+      is_valid_date = is_valid_year(date%year()) .and. &
+         is_valid_month(date%month()) .and. &
+         is_valid_day(date%year(), date%month(), date%day())
+
+   end function is_valid_date
+
+   ! Verify all the time fields are valid
+   pure logical function is_valid_time(time)
+      type(time_fields), intent(in) :: time
+
+      is_valid_time = is_valid_hour(time%hour()) .and. &
+         is_valid_minute(time%minute()) .and. &
+         is_valid_second(time%second()) .and. &
+         is_valid_millisecond(time%millisecond()) .and. &
+         is_valid_timezone_offset(time%timezone_offset())
+
+   end function is_valid_time
+
+! END DATE & TIME VERIFICATION
+
+
+! STRING PARSERS
+
+   ! parse string representing a timezone offset (absolute value)
+   ! return integer offset in minutes, or on error return negative number
+   pure function parse_timezone_offset(offset, field_width) result(tzo)
+      character(len=*), intent(in) :: offset
+      integer, intent(in) :: field_width
+      integer :: tzo
+      integer, parameter :: MINUTES_PER_HOUR = 60
+      integer :: offset_length
+      integer :: minutes
+      integer :: hours
+
+      offset_length = len_trim(offset)
+
+      if(offset_length == field_width) then
+         ! Offset with hours only
+         hours = read_whole_number(offset)
+         tzo = hours*MINUTES_PER_HOUR
+      elseif (offset_length == 2*field_width) then
+         ! Offset with hours and minutes
+         hours = read_whole_number(offset(1:field_width))
+         minutes = read_whole_number(offset(field_width+1:len(offset)))
+         if(is_whole_number(hours) .and. is_whole_number(minutes)) then
+            tzo = hours*MINUTES_PER_HOUR + minutes
+         else
+            tzo = INVALID
+         end if
+      else
+         tzo = INVALID
+      end if
+
+   end function parse_timezone_offset
+
+   ! Parse ISO 8601 Date string into date fields, check if valid date
+   ! and set is_valid_ flag
+   pure function parse_date(datestring, delimiter) result(fields)
+      character(len=*), intent(in) :: datestring
+      character, intent(in) :: delimiter
+      type(date_fields) :: fields
+      integer, parameter :: LENGTH = 8
+      integer, parameter :: YEAR_POSITION = 1
+      integer, parameter :: MONTH_POSITION = 5
+      integer, parameter :: DAY_POSITION = 7
+      integer :: year, month, day
+      character(len=LENGTH) :: undelimited
+
+      ! initialize fields to empty (is_valid_ .FALSE.)
+      fields = date_fields()
+
+      ! Eliminate delimiters so that there is one parsing block
+      undelimited=undelimit(datestring, DELIMITER)
+
+      if(len(undelimited) /= LENGTH) return
+
+      year = read_whole_number(undelimited(YEAR_POSITION:MONTH_POSITION-1))
+      month = read_whole_number(undelimited(MONTH_POSITION:DAY_POSITION-1))
+      day = read_whole_number(undelimited(DAY_POSITION:LENGTH))
+      fields = date_fields(year, month, day)
+
+   end function parse_date
+
+   ! Parse ISO 8601 Time string into time fields, check if valid time
+   ! and set is_valid_ flag
+   pure function parse_time(timestring, delimiter) result(fields)
+      character(len=*), intent(in) :: timestring
+      character, optional, intent(in) :: delimiter
+      type(time_fields) :: fields
+
+      character(len=:), allocatable :: timestring_
+      integer, parameter :: LENGTH = 6
+      character, parameter :: DECIMAL_POINT = '.'
+      integer, parameter :: FIELDWIDTH = 2
+      integer, parameter :: MS_WIDTH = 3
+      integer :: pos
+      character(len=:), allocatable :: undelimited
+      character :: c
+      character(len=LENGTH) :: offset
+      integer :: offset_minutes
+      integer :: undelimited_length
+      integer :: signum
+      integer :: hour
+      integer :: minute
+      integer :: second
+      integer :: millisecond
+      integer :: timezone_offset
+
+      fields = time_fields()
+      
+      timestring_ = trim(timestring)
+
+      ! Get timezone
+      ! Find timezone portion
+      pos = scan(timestring_, '-Z+')
+
+      if(.not. pos > 0) return
+
+      c = timestring_(pos:pos)
+
+      ! Check first character of timezone portion
+      select case(c)
+         case('Z')
+            signum = 0
+         case('-')
+            signum = -1
+         case('+')
+            signum = +1
+         case default
+            return
+      end select
+
+      ! Set timezone offset
+      if(signum == 0) then
+         if(pos /= len(timestring_)) return
+         timezone_offset = Z
+      else
+         offset = timestring_(pos+1:len(timestring_))
+         offset = undelimit(offset, delimiter)
+         offset_minutes = parse_timezone_offset(offset, FIELDWIDTH)
+         if(.not. is_whole_number(offset_minutes)) return
+         timezone_offset = signum * offset_minutes
+      end if
+
+      ! Select portion starting at fields%hour and ending before timezone
+      undelimited = adjustl(timestring_(1:pos-1))
+
+      ! Remove delimiter and decimal point
+      undelimited = undelimit(undelimited, delimiter)
+      undelimited=trim(undelimit(undelimited, DECIMAL_POINT))
+      undelimited_length = len(undelimited)
+
+      ! Check length of undelimited string with or without milliseconds
+      select case(undelimited_length)
+         case(LENGTH)
+            millisecond = 0
+         case(LENGTH+MS_WIDTH)
+            millisecond = read_whole_number(undelimited(7:9))
+         case default
+            return
+      end select
+
+      ! Read time fields      
+      hour = read_whole_number(undelimited(1:2))
+      minute = read_whole_number(undelimited(3:4))
+      second = read_whole_number(undelimited(5:6))
+
+      fields = time_fields(hour, minute, second, millisecond, timezone_offset)
+
+   end function parse_time
+! END STRING PARSERS
+
+
+! CONSTRUCTORS
+
+   pure function construct_date_fields_default(year, month, day) result(fields)
+      integer, intent(in) :: year
+      integer, intent(in) :: month
+      integer, intent(in) :: day
+      type(date_fields) :: fields
+      fields%year_ = year
+      fields%month_ = month
+      fields%day_ = day
+      fields%is_valid_ = is_valid_date(fields)
+   end function construct_date_fields_default
+
+   pure function construct_date_fields_null() result(fields)
+      type(date_fields) :: fields
+      fields%is_valid_ = .FALSE.
+   end function construct_date_fields_null
+
+   pure function construct_time_fields_default(hour, minute, second, millisecond, &
+      timezone_offset) result(fields)
+      integer, intent(in) :: hour
+      integer, intent(in) :: minute
+      integer, intent(in) :: second
+      integer, intent(in) :: millisecond
+      integer, intent(in) :: timezone_offset
+      type(time_fields) :: fields
+      fields%hour_ = hour
+      fields%minute_ = minute
+      fields%second_ = second
+      fields%millisecond_ = millisecond
+      fields%timezone_offset_ = timezone_offset
+      fields%is_valid_ = is_valid_time(fields)
+   end function construct_time_fields_default
+
+   pure function construct_time_fields_null() result(fields)
+      type(time_fields) :: fields
+      fields%is_valid_ = .FALSE.
+   end function construct_time_fields_null
+
+! END CONSTRUCTORS
+
+
+! TYPE-BOUND METHODS
+
+   pure integer function get_year_field(this)
+      class(date_fields), intent(in) :: this
+      get_year_field = this%year_
+   end function get_year_field
+
+   pure integer function get_month_field(this)
+      class(date_fields), intent(in) :: this
+      get_month_field = this%month_
+   end function get_month_field
+
+   pure integer function get_day_field(this)
+      class(date_fields), intent(in) :: this
+      get_day_field = this%day_
+   end function get_day_field
+
+   pure logical function are_valid_date_fields(this)
+      class(date_fields), intent(in) :: this
+      are_valid_date_fields = this%is_valid_
+   end function are_valid_date_fields
+
+   pure integer function get_hour_field(this)
+      class(time_fields), intent(in) :: this
+      get_hour_field = this%hour_
+   end function get_hour_field
+
+   pure integer function get_minute_field(this)
+      class(time_fields), intent(in) :: this
+      get_minute_field = this%minute_
+   end function get_minute_field
+
+   pure integer function get_second_field(this)
+      class(time_fields), intent(in) :: this
+      get_second_field = this%second_
+   end function get_second_field
+
+   pure integer function get_millisecond_field(this)
+      class(time_fields), intent(in) :: this
+      get_millisecond_field = this%millisecond_
+   end function get_millisecond_field
+
+   pure integer function get_timezone_offset_field(this)
+      class(time_fields), intent(in) :: this
+      get_timezone_offset_field = this%timezone_offset_
+   end function get_timezone_offset_field
+
+   pure logical function are_valid_time_fields(this)
+      class(time_fields), intent(in) :: this
+      are_valid_time_fields = this%is_valid_
+   end function are_valid_time_fields
+
+end module MAPL_DateTime_Parsing

--- a/shared/MAPL_ISO8601_DateTime.F90
+++ b/shared/MAPL_ISO8601_DateTime.F90
@@ -64,6 +64,7 @@
 !      Rn/<interval>
 !      R/<interval>
 
+!wdb fixme need to enforce private (see commented out private statements and add to other type/variables
 !#define STRICT_ISO8601 !Uncomment for strict ISO8601 compliance
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
@@ -78,21 +79,18 @@ module MAPL_ISO8601_DateTime
    public :: convert_ISO8601_to_integer_time
    public :: convert_ISO8601_to_integer_date
 
-   interface operator(.divides.)
+   interface operator(.divides.) !wdb todo move
       module procedure :: divides
    end interface
 
    ! Error handling
-   integer, parameter :: INVALID = -1
+   integer, parameter :: INVALID = -1 !wdb todo move
 
    ! parameters for processing date, time, and datetime strings
-   integer, parameter :: NUM_DATE_FIELDS = 3
-   integer, parameter :: NUM_TIME_FIELDS = 5
-   character(len=10), parameter :: DIGIT_CHARACTERS = '0123456789'
+   character(len=10), parameter :: DIGIT_CHARACTERS = '0123456789' !wdb todo move
    character, parameter :: TIME_PREFIX = 'T'
-   integer, parameter :: MINUTES_PER_HOUR = 60
 
-   ! Timezone offset for Timezone Z
+   ! Timezone offset for Timezone Z wdb todo move
    integer, parameter :: Z = 0
 
    ! Constants for converting ISO 8601 datetime to integer format
@@ -122,7 +120,7 @@ module MAPL_ISO8601_DateTime
       module procedure :: construct_ISO8601Date
    end interface ISO8601Date
 
-   ! Derived type for communicating date fields internally
+   ! Derived type for communicating date fields internally wdbo todo move public
    type :: date_fields
       integer :: year_
       integer :: month_
@@ -135,21 +133,21 @@ module MAPL_ISO8601_DateTime
       procedure, public, pass(this) :: is_valid => valid_date
    end type date_fields
 
-   interface date_fields
+   interface date_fields !wdb todo move public
       module procedure :: construct_date_fields_default
       module procedure :: construct_date_fields_null
    end interface date_fields
 
    ! Derived type used to store fields from ISO 8601 Times
    type :: ISO8601Time
-      private
+!      private
       integer :: hour_
       integer :: minute_
       integer :: second_
       integer :: millisecond_
       ! Timezone is stored as offset from Z timezone in minutes
       ! Currently, only timezone Z offset is used.
-      integer :: timezone_offset_ = Z
+      integer :: timezone_offset_ = 0
    contains
       procedure, public :: get_hour
       procedure, public :: get_minute
@@ -162,7 +160,7 @@ module MAPL_ISO8601_DateTime
       module procedure :: construct_ISO8601Time
    end interface ISO8601Time
 
-   ! Derived type for communicating time fields internally
+   ! Derived type for communicating time fields internally wdb todo move public
    type :: time_fields
       integer :: hour_
       integer :: minute_
@@ -179,14 +177,14 @@ module MAPL_ISO8601_DateTime
       procedure, public, pass(this) :: is_valid => valid_time
    end type time_fields
 
-   interface time_fields
+   interface time_fields !wdb todo move public
       module procedure :: construct_time_fields_default
       module procedure :: construct_time_fields_null
    end interface time_fields
 
    ! Derived type used to store fields from ISO 8601 DateTimes
    type :: ISO8601DateTime
-      private
+!      private
       type(ISO8601Date) :: date_
       type(ISO8601Time) :: time_
    contains
@@ -209,7 +207,7 @@ module MAPL_ISO8601_DateTime
    ! Derived type used to store fields from ISO 8601 Durations
    ! Note that ISO 8601 Duration corresponds to ESMF Interval.
    type :: ISO8601Duration
-      private
+!      private
       integer :: years_
       integer :: months_
       integer :: days_
@@ -233,7 +231,7 @@ module MAPL_ISO8601_DateTime
    ! Note that ISO 8601 Interval is different than ESMF Interval.
    ! This has not been fully implemented
    type :: ISO8601Interval
-      private
+!      private
       type(ISO8601DateTime) :: start_datetime_
       type(ISO8601DateTime) :: end_datetime_
       integer :: repetitions_ = 1
@@ -252,6 +250,7 @@ contains
 
 ! NUMBER HANDLING PROCEDURES
 
+! wdb todo move START
    ! Return true if factor divides dividend evenly, false otherwise
    pure logical function divides(factor, dividend)
       integer, intent(in) :: factor
@@ -342,12 +341,12 @@ contains
    end function read_whole_number_indexed
 
 ! END NUMBER HANDLING PROCEDURES
-
+! wdb todo move all END
 
 ! LOW-LEVEL STRING PROCESSING PROCEDURES
 
    ! Strip delimiter from string
-   !wdb should this be more than 1 character PICKUP HERE
+   !wdb todo should this be more than 1 character
    pure function undelimit(string, delimiter) result(undelimited)
       character(len=*), intent(in) :: string
       character, optional, intent(in) :: delimiter
@@ -410,7 +409,7 @@ contains
 
    end function get_month_end
 
-   ! Verify that y is a valid year according the ISO 8601 specification
+   ! Verify that y is a valid year according the ISO 8601 specification wdb fixme move?
    pure logical function is_valid_year(y)
       integer, intent(in) :: y
 ! Strict ISO8601 compliance does not allow years before 1583
@@ -449,7 +448,7 @@ contains
    end function is_valid_minute
 
    ! Verify that second is a valid second
-   ! ISO 8601 allows second=60 (for leap seconds)
+   ! ISO 8601 allows second=60 (for leap seconds) wdb fixme move?
    ! This function does not check if it is a valid leap second.
    pure logical function is_valid_second(second)
       integer, intent(in) :: second
@@ -460,7 +459,7 @@ contains
 
    ! Verify that millisecond is a valid millisecond values
    ! ISO 8601 allows fractional seconds, but it does not limit the fractional
-   ! part to millisecond.
+   ! part to millisecond. wdb fixme move?
    pure logical function is_valid_millisecond(millisecond)
       integer, intent(in) :: millisecond
       integer, parameter :: LB_MILLISECOND = -1
@@ -513,8 +512,9 @@ contains
    pure function parse_timezone_offset(offset, field_width) result(tzo)
       character(len=*), intent(in) :: offset
       integer, intent(in) :: field_width
-      integer :: offset_length
       integer :: tzo
+      integer, parameter :: MINUTES_PER_HOUR = 60
+      integer :: offset_length
       integer :: minutes
       integer :: hours
 
@@ -785,7 +785,7 @@ contains
       minute = read_whole_number(undelimited(3:4))
       second = read_whole_number(undelimited(5:6))
 
-      fields = time_fields(hour, minute, second, millisecond)
+      fields = time_fields(hour, minute, second, millisecond, timezone_offset)
 
    end function parse_time_general
 ! END STRING PARSERS
@@ -797,7 +797,7 @@ contains
       integer, intent(out) :: rc
       type(ISO8601Date) :: date
       type(date_fields) :: fields
-      integer :: status
+
       fields = parse_date(trim(adjustl(isostring)))
       if(fields%is_valid_) then
          date%year_ = fields%year()
@@ -813,7 +813,7 @@ contains
       integer, intent(inout) :: rc
       type(ISO8601Time) :: time
       type(time_fields) :: fields
-      integer :: status
+
       fields = parse_time(trim(adjustl(isostring)))
       if(fields%is_valid_) then
          time%hour_ = fields%hour_
@@ -986,8 +986,8 @@ contains
 
 
 ! LOW-LEVEL CONSTRUCTORS
-
-   function construct_date_fields_default(year, month, day) result(fields)
+!wdb todo move all
+   pure function construct_date_fields_default(year, month, day) result(fields)
       integer, intent(in) :: year
       integer, intent(in) :: month
       integer, intent(in) :: day
@@ -998,7 +998,7 @@ contains
       fields%is_valid_ = is_valid_date(fields)
    end function construct_date_fields_default
 
-   function construct_date_fields_null() result(fields)
+   pure function construct_date_fields_null() result(fields)
       type(date_fields) :: fields
       fields%is_valid_ = .FALSE.
    end function construct_date_fields_null
@@ -1040,7 +1040,7 @@ contains
 
    integer function get_month(self)
       class(ISO8601Date), intent(in) :: self
-      get_month = self%month()
+      get_month = self%month_
    end function get_month
 
    integer function get_day(self)
@@ -1215,54 +1215,55 @@ contains
 
 ! END HIGH-LEVEL CONVERSION PROCEDURES
 
-   integer function get_year_field(this)
+!wdb todo move all
+   pure integer function get_year_field(this)
       class(date_fields), intent(in) :: this
       get_year_field = this%year_
    end function get_year_field
 
-   integer function get_month_field(this)
+   pure integer function get_month_field(this)
       class(date_fields), intent(in) :: this
       get_month_field = this%month_
    end function get_month_field
 
-   integer function get_day_field(this)
+   pure integer function get_day_field(this)
       class(date_fields), intent(in) :: this
-      get_month_field = this%day_
+      get_day_field = this%day_
    end function get_day_field
 
-   logical function valid_date(this)
+   pure logical function valid_date(this)
       class(date_fields), intent(in) :: this
       valid_date = this%is_valid_
    end function valid_date
 
-   integer function get_hour_field(this)
-      class(time_fields) :: intent(in) :: this
+   pure integer function get_hour_field(this)
+      class(time_fields), intent(in) :: this
       get_hour_field = this%hour_
-   end function
+   end function get_hour_field
 
-   integer function get_minute_field(this)
-      class(time_fields) :: intent(in) :: this
+   pure integer function get_minute_field(this)
+      class(time_fields), intent(in) :: this
       get_minute_field = this%minute_
-   end function
+   end function get_minute_field
 
-   integer function get_second_field(this)
-      class(time_fields) :: intent(in) :: this
+   pure integer function get_second_field(this)
+      class(time_fields), intent(in) :: this
       get_second_field = this%second_
-   end function
+   end function get_second_field
 
-   integer function get_millisecond_field(this)
-      class(time_fields) :: intent(in) :: this
+   pure integer function get_millisecond_field(this)
+      class(time_fields), intent(in) :: this
       get_millisecond_field = this%millisecond_
-   end function
+   end function get_millisecond_field
 
-   integer function get_timezone_offset_field(this)
-      class(time_fields) :: intent(in) :: this
+   pure integer function get_timezone_offset_field(this)
+      class(time_fields), intent(in) :: this
       get_timezone_offset_field = this%timezone_offset_
-   end function
+   end function get_timezone_offset_field
 
-   logical function valid_time(this)
-      class(time_fields) :: intent(in) :: this
+   pure logical function valid_time(this)
+      class(time_fields), intent(in) :: this
       valid_time = this%is_valid_
-   end function
+   end function valid_time
 
 end module MAPL_ISO8601_DateTime

--- a/shared/tests/CMakeLists.txt
+++ b/shared/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set (test_srcs
     test_DSO_Utilities.pf
     test_FileSystemUtilities.pf
 #    test_MAPL_ISO8601_DateTime.pf
+    test_MAPL_DateTime_Parsing.pf
   )
 
 

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -6,7 +6,7 @@
 ! tested are not working completely.
 module test_MAPL_DateTime_Parsing
       use MAPL_ExceptionHandling
-      use MAPL_DateTime_Parsing
+      use MAPL_DateTime_Parsing 
       use pfunit
       implicit none
 
@@ -202,6 +202,28 @@ contains
       @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit(UNDELIMITED_TIME1,':')))
       @assertEqual('', trim(undelimit('',':')))
    end subroutine test_undelimit
+
+   @test
+   subroutine test_undelimit_all()
+      character(len=32), parameter :: UNDELIMITED_DATE = '20220720'
+      character(len=32), parameter :: DATE ='2022-07-20' 
+      character(len=32), parameter :: UNDELIMITED_TIME1 = '153437'
+      character(len=32), parameter :: TIME1 = '15:34:37'
+      character(len=32), parameter :: UNDELIMITED_TIME2 = '153437421'
+      character(len=32), parameter :: TIME2 = '15:34:37.421'
+      integer, parameter :: DATEWIDTH = len_trim(UNDELIMITED_DATE)
+      integer, parameter :: TIMEWIDTH1 = len_trim(UNDELIMITED_TIME1)
+      integer, parameter :: TIMEWIDTH2 = len_trim(UNDELIMITED_TIME2)
+
+      @assertEqual(trim(UNDELIMITED_DATE), trim(undelimit_all(DATE)))
+      @assertEqual(DATEWIDTH, len_trim(UNDELIMITED_DATE)) 
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit_all(TIME1)))
+      @assertEqual(TIMEWIDTH1, len_trim(UNDELIMITED_TIME1))
+      @assertEqual(trim(UNDELIMITED_TIME2), trim(undelimit_all(TIME2)))
+      @assertEqual(TIMEWIDTH2, len_trim(UNDELIMITED_TIME2))
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit_all(UNDELIMITED_TIME1)))
+      @assertEqual('', trim(undelimit_all('')))
+   end subroutine test_undelimit_all
 
    @test
    subroutine test_is_leap_year()
@@ -549,18 +571,19 @@ contains
 
    @test
    subroutine test_convert_to_ISO8601DateTime()
-      character, parameter :: t = 'T'
-      character, parameter :: f = 'F'
-      character, parameter :: r = 'R'
-      integer, parameter :: sz(2) = [7,3]
+      integer, parameter :: N = MAX_LEN
+      character(len=N), parameter :: t = 'T'
+      character(len=N), parameter :: f = 'F'
+      character(len=N), parameter :: r = 'R'
+      integer, parameter :: sz(2) = [3,6]
       integer :: i, status
-      character(len=24) :: input, expected, actual, runtest
-      character(len=24) :: STRINGS(sz(1),sz(2)) = reshape([ &
+      character(len=:), allocatable :: output
+      character(len=N) :: input, expected, actual, runtest
+      character(len=N) :: STRINGS(sz(1),sz(2)) = reshape([ &
             '2023-04-23 21:05:37     ' ,  '2023-04-23T21:05:37     ',   t, &
             '20230423 210537         ' ,  '2023-04-23T21:05:37     ',   t, &
-            '2023-04-23 21:5:37      ' ,  '2023-04-23T21:05:37     ',   r, &
             '2023-4-23 21:05:37      ' ,  '2023-04-23T21:05:37     ',   r, &
-            '2023-4-23 21:5:37       ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-04-23 21:5:37      ' ,  '2023-04-23T21:05:37     ',   r, &
             '2023-04-23 21:05:37.337 ' ,  '2023-04-23T21:05:37.337 ',   t, &
             '20230423210537337       ' ,  '2023-04-23T21:05:37.337 ',   t  ], sz)
 
@@ -568,11 +591,14 @@ contains
          input = trim(STRINGS(1,i))
          expected = trim(STRINGS(2, i))
          runtest = trim(STRINGS(3, i))
-         call convert_to_ISO8601DateTime(input, actual, rc = status)
+         call convert_to_ISO8601DateTime(input, output, rc = status)
+         actual = trim(output)
          select case(runtest)
             case(t)
+               @assertEqual(status, 0, 'Convert failed')
                @assertEqual(expected, trim(actual), 'Datetime strings do not match.')
             case(f)
+               @assertEqual(status, 0, 'Convert failed')
                @assertFalse(expected == trim(actual), 'Datetime strings do match.')
             case(r)
                @assertFalse(status == 0, 'Failed to catch illegal value.')
@@ -582,28 +608,3 @@ contains
    end subroutine test_convert_to_ISO8601DateTime
 
 end module test_MAPL_DateTime_Parsing
-
-!   @test
-!   subroutine test_is_in_open_interval()
-!      integer, parameter :: lower = 36
-!      integer, parameter :: upper = 48
-!      integer, parameter :: delta = 6
-!      @assertTrue(is_in_open_interval(lower + delta [lower, upper]))
-!      @assertFalse(is_in_open_interval(lower, [lower, upper]))
-!      @assertFalse(is_in_open_interval(lower - 1, [lower, upper]))
-!      @assertFalse(is_in_open_interval(upper, [lower, upper]))
-!      @assertFalse(is_in_open_interval(upper + 1, [lower, upper]))
-!   end subroutine test_is_in_open_interval
-
-!   @test
-!   subroutine test_is_in_closed_interval()
-!      integer, parameter :: lower = 36
-!      integer, parameter :: upper = 48
-!      integer, parameter :: delta = 6
-!      @assertTrue(is_in_closed_interval(lower + delta [lower, upper]))
-!      @assertTrue(is_in_closed_interval(lower, [lower, upper]))
-!      @assertFalse(is_in_closed_interval(lower - 1, [lower, upper]))
-!      @assertTrue(is_in_closed_interval(upper, [lower, upper]))
-!      @assertFalse(is_in_closed_interval(upper + 1, [lower, upper]))
-!   end subroutine test_is_in_closed_interval
-!

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -1,0 +1,575 @@
+#include "MAPL_Exceptions.h"
+
+! Test suite
+! Not complete
+! Some portions are commented out because corresponding procedures to be
+! tested are not working completely.
+module test_MAPL_DateTime_Parsing
+      use MAPL_ExceptionHandling
+      use MAPL_DateTime_Parsing
+      use pfunit
+      implicit none
+
+      character(len=*), parameter :: DATE_DELIMITER = '-'
+      character(len=*), parameter :: TIME_DELIMITER = ':'
+      integer, dimension(12), parameter :: ENDS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+      integer, dimension(size(ENDS)), parameter :: ENDS_LEAP = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+      integer, parameter :: SUCCESS = _SUCCESS
+      integer, parameter :: FAILURE = _FAILURE
+
+contains
+
+   @test
+   subroutine test_divides()
+      @assertTrue(divides(7, 21))
+      @assertFalse(divides(7, 22))
+      @assertTrue(7 .divides. 21)
+      @assertFalse(7 .divides. 22)
+   end subroutine test_divides
+
+   @test
+   subroutine test_between_op()
+      integer, parameter :: lower = 36
+      integer, parameter :: upper = 48
+      integer, parameter :: delta = 6
+      @assertTrue((lower + delta) .between. [lower, upper])
+      @assertFalse(lower .between. [lower, upper])
+      @assertFalse((lower - 1) .between. [lower, upper])
+      @assertFalse(upper .between. [lower, upper])
+      @assertFalse((upper + 1) .between. [lower, upper])
+   end subroutine test_between_op
+
+   @test
+   subroutine test_in_op()
+      integer, parameter :: lower = 36
+      integer, parameter :: upper = 48
+      integer, parameter :: delta = 6
+      @assertTrue((lower + delta) .between. [lower, upper])
+      @assertFalse(lower .between. [lower, upper])
+      @assertFalse((lower - 1) .between. [lower, upper])
+      @assertFalse(upper .between. [lower, upper])
+      @assertFalse((upper + 1) .between. [lower, upper])
+   end subroutine test_in_op
+
+   @test
+   subroutine test_is_digit()
+      integer :: i = -1
+      integer, parameter :: imin = 0
+      integer, parameter :: imax = 127
+      integer, parameter :: i1 = iachar('0') - 1
+      integer, parameter :: i2 = iachar('9') + 1
+      integer, parameter :: acodes(*) = [(i, i = imin, i1), (i, i = i2, imax)]
+      integer :: i0 = iachar('0')
+
+      do i = 0, 9
+         @assertTrue(is_digit(achar(i0+i)))
+      end do
+
+      do i = 1, size(acodes)
+         @assertFalse(is_digit(achar(acodes(i))))
+      end do
+
+   end subroutine test_is_digit
+
+   @test
+   subroutine test_is_whole_number()
+      integer :: n
+
+      do n= 0, 9
+         @assertTrue(is_whole_number(n))
+      end do
+
+      do n= 1, 9
+         @assertFalse(is_whole_number(-n))
+      end do
+
+   end subroutine test_is_whole_number
+
+   @test
+   subroutine test_get_integer_digit()
+      integer :: n
+      integer, parameter :: NONDIGIT = -1
+      integer, parameter :: ASCII_MIN = 0
+      integer, parameter :: ASCII_MAX = 127
+      integer, parameter :: ASCII_LT0 = iachar('0') - 1
+      integer, parameter :: ASCII_GT9 = iachar('9') + 1
+      character(len=10), parameter :: digit = '0123456789'
+      character :: c
+
+      do n = 1, len(digit)
+         @assertEqual(n-1, get_integer_digit(digit(n:n)))
+      end do
+
+      do n = ASCII_MIN, ASCII_LT0
+         c = achar(n)
+         @assertEqual(NONDIGIT, get_integer_digit(c))
+      end do
+
+      do n = ASCII_GT9, ASCII_MAX
+         c = achar(n)
+         @assertEqual(NONDIGIT, get_integer_digit(c))
+      end do
+   end subroutine test_get_integer_digit
+
+   @test
+   subroutine test_get_integer_digit_from_string
+      integer :: i
+      integer, parameter :: NONDIGIT = -1
+      character(len=5), parameter :: digit = '19150'
+      integer, dimension(5) :: values = [1, 9, 1, 5, 0]
+
+      @assertEqual(1, get_integer_digit_from_string('19150', 1))
+
+      do i= 1, len(digit)
+         @assertEqual(values(i), get_integer_digit_from_string(digit, i))
+      end do
+
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, 0))
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, -1))
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, len(digit)+1))
+   end subroutine test_get_integer_digit_from_string
+
+   @test
+   subroutine test_read_whole_number()
+      character(len=*), parameter :: NUM_STRING = '01234'
+      integer, parameter :: WHOLE_NUMBER = 1234
+      integer, parameter :: NOT_WHOLE_NUMBER = -1
+      character(len=*), parameter :: LETTERS = 'ABCDEFG'
+      character(len=*), parameter :: ALPHA_NUMERICS = '9B4D3F7'
+      character(len=*), parameter :: NEGATIVE_INTEGER = '-' // NUM_STRING
+      character(len=*), parameter :: SYMBOLS = '100%'
+      character(len=*), parameter :: FLOATING_POINT = '10.07'
+      character(len=*), parameter :: POSITIVE_INTEGER = '+' // NUM_STRING
+
+      @assertEqual(WHOLE_NUMBER, read_whole_number(NUM_STRING))
+
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(LETTERS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(ALPHA_NUMERICS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(NEGATIVE_INTEGER))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(SYMBOLS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(FLOATING_POINT))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(POSITIVE_INTEGER))
+   end subroutine test_read_whole_number
+
+   @test
+   subroutine test_read_whole_number_indexed()
+      character(len=11), parameter :: STRING = '12345678901'
+      character(len=15), parameter :: BAD_STRING = '18The3.1415...'
+      integer, parameter :: NOT_WHOLE_NUMBER = -1
+
+      @assertEqual(12, read_whole_number_indexed(STRING, 1, 2))
+      @assertEqual(90, read_whole_number_indexed(STRING, 9, 10))
+      @assertEqual(7, read_whole_number_indexed(STRING, 7, 7))
+      @assertEqual(1, read_whole_number_indexed(STRING, 10, 11))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 2, 1))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 1, 12))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, -1, 9))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 1, -1))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 0, 2))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 2, 0))
+      @assertEqual(18, read_whole_number_indexed(BAD_STRING, 1, 2))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 2, 3))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 3, 5))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 5, 5))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 5, 6))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 6, 11))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 7, 7))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 7, 8))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed('+800', 1, 3))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed('-800', 1, 3))
+   end subroutine test_read_whole_number_indexed
+
+   @test
+   subroutine test_undelimit()
+      character(len=32), parameter :: UNDELIMITED_DATE = '20220720'
+      character(len=32), parameter :: DATE ='2022-07-20' 
+      character(len=32), parameter :: UNDELIMITED_TIME1 = '153437'
+      character(len=32), parameter :: TIME1 = '15:34:37'
+      character(len=32), parameter :: UNDELIMITED_TIME2 = '153437421'
+      character(len=32), parameter :: TIME2 = '15:34:37.421'
+      integer, parameter :: DATEWIDTH = len_trim(UNDELIMITED_DATE)
+      integer, parameter :: TIMEWIDTH1 = len_trim(UNDELIMITED_TIME1)
+      integer, parameter :: TIMEWIDTH2 = len_trim(UNDELIMITED_TIME2)
+
+      @assertEqual(trim(UNDELIMITED_DATE), trim(undelimit(DATE,'-')))
+      @assertEqual(DATEWIDTH, len_trim(UNDELIMITED_DATE)) 
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit(TIME1,':')))
+      @assertEqual(TIMEWIDTH1, len_trim(UNDELIMITED_TIME1))
+      @assertEqual(trim(UNDELIMITED_TIME2), trim(undelimit(undelimit(TIME2,':'),'.')))
+      @assertEqual(TIMEWIDTH2, len_trim(UNDELIMITED_TIME2))
+      @assertTrue(trim(UNDELIMITED_TIME1) /= trim(undelimit(TIME1,'.')))
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit(UNDELIMITED_TIME1,':')))
+      @assertEqual('', trim(undelimit('',':')))
+   end subroutine test_undelimit
+
+   @test
+   subroutine test_is_leap_year()
+      @assertTrue(is_leap_year(2024))
+      @assertFalse(is_leap_year(2023))
+      @assertFalse(is_leap_year(2022))
+      @assertFalse(is_leap_year(2021))
+      @assertFalse(is_leap_year(2100))
+      @assertTrue(is_leap_year(2000))
+   end subroutine test_is_leap_year
+
+   @test
+   subroutine test_get_month_ends()
+      integer, dimension(size(ENDS)) :: actual
+      integer :: i = -1
+
+      actual = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+      actual = get_month_ends(2022)
+      do i = 1, size(actual)
+         @assertEqual(ENDS(i), actual(i))
+      end do
+
+      actual = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+      actual = get_month_ends(2020)
+      do i = 1, size(actual)
+         @assertEqual(ENDS_LEAP(i), actual(i))
+      end do
+   end subroutine test_get_month_ends
+
+   @test
+   subroutine test_get_month_end()
+      integer, parameter :: year = 2022
+      integer, parameter :: leap_year = 2020
+      integer :: i
+
+      do i = 1, 12
+         @assertEqual(ENDS(i), get_month_end(year, i))
+         @assertEqual(ENDS_LEAP(i), get_month_end(leap_year, i))
+      end do
+
+   end subroutine test_get_month_end
+
+   @test
+   subroutine test_is_valid_year()
+      integer :: i
+
+      @assertFalse(is_valid_year(-1))
+      @assertFalse(is_valid_year(10000))
+      do i = 0, 9999
+         @assertTrue(is_valid_year(i))
+      end do
+   end subroutine test_is_valid_year
+
+   @test
+   subroutine test_is_valid_month()
+      integer :: i
+
+      @assertFalse(is_valid_month(0))
+      @assertFalse(is_valid_month(-1))
+      @assertFalse(is_valid_month(13))
+      do i = 1, 12
+         @assertTrue(is_valid_month(i))
+      end do
+   end subroutine test_is_valid_month
+
+   @test
+   subroutine test_is_valid_day()
+      character(len=*), parameter :: FMT = '("day (",i4,", ",i2,", ",i2,")",a)'
+      character(len=*), parameter :: SHOULD = ' should be valid.'
+      character(len=*), parameter :: SHOULD_NOT = ' should not be valid.'
+      character(len=255) :: error_message
+
+      integer :: d, m, y
+      d = 30; m = 4; y = 2023
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+      d = 31
+      write(error_message, fmt=FMT) y, m, d, SHOULD_NOT
+      @assertFalse(is_valid_day(y, m, d), trim(error_message))
+      d = 29
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+      m = 2
+      write(error_message, fmt=FMT) y, m, d, SHOULD_NOT
+      @assertFalse(is_valid_day(y, m, d), trim(error_message))
+      y = 2024
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+   end subroutine test_is_valid_day
+
+   @test
+   subroutine test_is_valid_hour()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 23
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_hour(i))
+      end do
+      @assertFalse(is_valid_hour(IMAX+1))
+      @assertFalse(is_valid_hour(IMIN-1))
+   end subroutine test_is_valid_hour
+
+   subroutine test_is_valid_minute()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 59
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_minute(i))
+      end do
+      @assertFalse(is_valid_minute(IMAX+1))
+      @assertFalse(is_valid_minute(IMIN-1))
+   end subroutine test_is_valid_minute
+
+   subroutine test_is_valid_second()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 60
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_second(i))
+      end do
+      @assertFalse(is_valid_second(IMAX+1))
+      @assertFalse(is_valid_second(IMIN-1))
+   end subroutine test_is_valid_second
+
+   @test
+   subroutine test_is_valid_millisecond()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 999
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_millisecond(i))
+      end do
+      @assertFalse(is_valid_millisecond(IMAX+1))
+      @assertFalse(is_valid_millisecond(IMIN-1))
+   end subroutine test_is_valid_millisecond
+
+   @test
+   subroutine test_is_valid_timezone_offset()
+      integer, parameter :: GOOD_TZ = 0
+      integer, parameter :: BAD_TZ = 60
+      @assertTrue(is_valid_timezone_offset(0))
+      @assertTrue(is_valid_timezone_offset(60))
+      @assertTrue(is_valid_timezone_offset(-60))
+      @assertFalse(is_valid_timezone_offset(4320))
+      @assertFalse(is_valid_timezone_offset(-1441))
+   end subroutine test_is_valid_timezone_offset
+
+   @test
+   subroutine test_is_valid_date()
+      type(date_fields) :: valid_date
+      type(date_fields) :: invalid_date
+      valid_date = date_fields(2022, 7, 7)
+      invalid_date = date_fields(2022, 6, 31)
+      @assertTrue(is_valid_date(valid_date))
+      @assertFalse(is_valid_date(invalid_date))
+   end subroutine test_is_valid_date
+
+   @test
+   subroutine test_is_valid_time()
+      type(time_fields) :: valid_time
+      type(time_fields) :: invalid_time
+      valid_time = time_fields(9, 41, 33, 456, 0)
+      invalid_time = time_fields(24, 41, 33, 456, 0)
+      @assertTrue(is_valid_time(valid_time))
+      @assertFalse(is_valid_time(invalid_time))
+   end subroutine test_is_valid_time
+
+   @test
+   subroutine test_parse_timezone_offset()
+      integer, parameter :: FIELD_WIDTH = 2
+      integer, parameter :: INVALID_OFFSET = -1
+
+      character(len=*), parameter :: HOUR_ONLY = '15'
+      character(len=*), parameter :: HOUR_MINUTE00 = '1500'
+      character(len=*), parameter :: HOUR_MINUTE = '1530'
+      integer, parameter :: OFFSET1500 = 15*60
+      integer, parameter :: OFFSET1530 = 15*60 + 30
+
+      character(len=*), parameter :: NARROW1 = '1'
+      character(len=*), parameter :: NARROW3 = '153'
+      character(len=*), parameter :: WIDE5 = '15307'
+      character(len=*), parameter :: GARBAGE = '1T3R'
+
+      character(len=*), parameter :: NEG_HOUR = '-15'
+      character(len=*), parameter :: NEG_HOURMIN00 = '-1500'
+      character(len=*), parameter :: NEG_HOURMIN = '-1530'
+      integer, parameter :: OFFSETM1500 = -1*(15*60)
+      integer, parameter :: OFFSETM1530 = -1*(15*60 + 30)
+
+      @assertEqual(OFFSET1500, parse_timezone_offset(HOUR_ONLY, FIELD_WIDTH))
+      @assertEqual(OFFSET1500, parse_timezone_offset(HOUR_MINUTE00, FIELD_WIDTH))
+      @assertEqual(OFFSET1530, parse_timezone_offset(HOUR_MINUTE, FIELD_WIDTH))
+
+      @assertTrue(parse_timezone_offset(NARROW1, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(NARROW3, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(WIDE5, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(GARBAGE, FIELD_WIDTH) < 0)
+
+   end subroutine test_parse_timezone_offset
+
+   @test
+   subroutine test_parse_date()
+      type(date_fields) :: date
+
+      date = parse_date('2022-07-07', DATE_DELIMITER)
+      @assertTrue(date%is_valid_)
+      @assertEqual(2022, date%year_)
+      @assertEqual(7, date%month_)
+      @assertEqual(7, date%day_)
+
+      date = parse_date('20220707', DATE_DELIMITER)
+      @assertTrue(date%is_valid_)
+      @assertEqual(2022, date%year_)
+      @assertEqual(7, date%month_)
+      @assertEqual(7, date%day_)
+   end subroutine test_parse_date
+
+   @test
+   subroutine test_parse_time()
+      type(time_fields) :: time
+
+      time = parse_time('17:41:07.513Z', TIME_DELIMITER)
+      @assertTrue(time%is_valid_)
+      @assertEqual(17, time%hour_)
+      @assertEqual(41, time%minute_)
+      @assertEqual(7, time%second_)
+      @assertEqual(513, time%millisecond_)
+      @assertEqual(0, time%timezone_offset_)
+
+      time = parse_time('174107.513Z', TIME_DELIMITER)
+      @assertTrue(time%is_valid_)
+      @assertEqual(17, time%hour_)
+      @assertEqual(41, time%minute_)
+      @assertEqual(7, time%second_)
+      @assertEqual(513, time%millisecond_)
+      @assertEqual(0, time%timezone_offset_)
+
+   end subroutine test_parse_time
+
+   @test
+   subroutine test_construct_date_fields_null()
+      type(date_fields) :: df
+      df = date_fields()
+      @assertFalse(df % is_valid(), 'null df should not be valid.')
+   end subroutine test_construct_date_fields_null
+
+   @test
+   subroutine test_construct_time_fields_null()
+      type(time_fields) :: tf
+      tf = time_fields()
+      @assertFalse(tf % is_valid(), 'null tf should not be valid.')
+   end subroutine test_construct_time_fields_null
+
+   @test
+   subroutine test_get_year_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(y, df % year(), 'Wrong year')
+   end subroutine test_get_year_field
+
+   @test
+   subroutine test_get_month_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(m, df % month(), 'Wrong month')
+   end subroutine test_get_month_field
+
+   @test
+   subroutine test_get_day_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(d, df % day(), 'Wrong month')
+   end subroutine test_get_day_field
+
+   @test
+   subroutine test_are_valid_date_fields
+      type(date_fields) :: df
+      df = date_fields(2023, 4, 25) 
+      @assertTrue(df % is_valid(), 'df should be valid.')
+      df = date_fields(2023, 4, 31)
+      @assertFalse(df % is_valid(), 'df should not be valid.')
+   end subroutine test_are_valid_date_fields
+
+   @test
+   subroutine test_get_hour_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(h, tf % hour())
+   end subroutine test_get_hour_field
+
+   @test
+   subroutine test_get_minute_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(m, tf % minute())
+   end subroutine test_get_minute_field
+
+   @test
+   subroutine test_get_second_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(s, tf % second())
+   end subroutine test_get_second_field
+
+   @test
+   subroutine test_get_millisecond_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(ms, tf % millisecond())
+   end subroutine test_get_millisecond_field
+
+   @test
+   subroutine test_get_timezone_offset_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(tzo, tf % timezone_offset())
+   end subroutine test_get_timezone_offset_field
+
+   @test
+   subroutine test_are_valid_time_fields
+      type(time_fields) :: tf
+      tf = time_fields(13, 43, 37, 100, 0)
+      @assertTrue(tf % is_valid(), 'tf should be valid.')
+      tf = time_fields(13, 63, 37, 100, 0)
+      @assertFalse(tf % is_valid(), 'tf should not be valid.')
+   end subroutine test_are_valid_time_fields
+
+end module test_MAPL_DateTime_Parsing
+
+!   @test
+!   subroutine test_is_in_open_interval()
+!      integer, parameter :: lower = 36
+!      integer, parameter :: upper = 48
+!      integer, parameter :: delta = 6
+!      @assertTrue(is_in_open_interval(lower + delta [lower, upper]))
+!      @assertFalse(is_in_open_interval(lower, [lower, upper]))
+!      @assertFalse(is_in_open_interval(lower - 1, [lower, upper]))
+!      @assertFalse(is_in_open_interval(upper, [lower, upper]))
+!      @assertFalse(is_in_open_interval(upper + 1, [lower, upper]))
+!   end subroutine test_is_in_open_interval
+
+!   @test
+!   subroutine test_is_in_closed_interval()
+!      integer, parameter :: lower = 36
+!      integer, parameter :: upper = 48
+!      integer, parameter :: delta = 6
+!      @assertTrue(is_in_closed_interval(lower + delta [lower, upper]))
+!      @assertTrue(is_in_closed_interval(lower, [lower, upper]))
+!      @assertFalse(is_in_closed_interval(lower - 1, [lower, upper]))
+!      @assertTrue(is_in_closed_interval(upper, [lower, upper]))
+!      @assertFalse(is_in_closed_interval(upper + 1, [lower, upper]))
+!   end subroutine test_is_in_closed_interval
+!

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -547,6 +547,40 @@ contains
       @assertFalse(tf % is_valid(), 'tf should not be valid.')
    end subroutine test_are_valid_time_fields
 
+   @test
+   subroutine test_convert_to_ISO8601DateTime()
+      character, parameter :: t = 'T'
+      character, parameter :: f = 'F'
+      character, parameter :: r = 'R'
+      integer, parameter :: sz(2) = [7,3]
+      integer :: i, status
+      character(len=:), allocatable :: input, expected, actual, runtest
+      character(len=24) :: STRINGS(sz(1),sz(2)) = reshape([ &
+            '2023-04-23 21:05:37     ' ,  '2023-04-23T21:05:37     ',   t, &
+            '20230423 210537         ' ,  '2023-04-23T21:05:37     ',   t, &
+            '2023-04-23 21:5:37      ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-4-23 21:05:37      ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-4-23 21:5:37       ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-04-23 21:05:37.337 ' ,  '2023-04-23T21:05:37.337 ',   t, &
+            '20230423210537337       ' ,  '2023-04-23T21:05:37.337 ',   t  ], sz)
+
+      do i = 1, size(STRINGS, 2)
+         input = trim(STRINGS(1,i))
+         expected = trim(STRINGS(2, i))
+         runtest = trim(STRINGS(3, i))
+         call convert_to_ISO8601DateTime(input, actual, rc = status)
+         select case(runtest)
+            case(t)
+               @assertEqual(expected, trim(actual), 'Datetime strings do not match.')
+            case(f)
+               @assertFalse(expected == trim(actual), 'Datetime strings do match.')
+            case(r)
+               @assertFalse(status == 0, 'Failed to catch illegal value.')
+         end select
+      end do
+
+   end subroutine test_convert_to_ISO8601DateTime
+
 end module test_MAPL_DateTime_Parsing
 
 !   @test

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -554,7 +554,7 @@ contains
       character, parameter :: r = 'R'
       integer, parameter :: sz(2) = [7,3]
       integer :: i, status
-      character(len=:), allocatable :: input, expected, actual, runtest
+      character(len=24) :: input, expected, actual, runtest
       character(len=24) :: STRINGS(sz(1),sz(2)) = reshape([ &
             '2023-04-23 21:05:37     ' ,  '2023-04-23T21:05:37     ',   t, &
             '20230423 210537         ' ,  '2023-04-23T21:05:37     ',   t, &


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Process NetCDF datetimes in the form of an integer span and a string, containing the time unit and start time, to an ESMF_Time (start time) and an ESMF_TimeInterval (time span), with optional output of the time unit (as a string) and the end time (ESMF_Time). The end time is the time expressed by the NetCDF integer and string

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This functionality allow better parsing of datetimes in NetCDF files

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The MAPL base and shared test suites completed successfully. This is a new feature, so it doesn't affect existing MAPL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
