### PR TITLE
Process NetCDF datetimes to ESMF_Time and ESMF_TimeInterval and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Printed time to write files to the disk in MultiGroupServer
+- Added merge function to Filemetadata to merge two meta objects
+- Added support for "depends_on" and "depends_on_children" for export_specs. The typical usage on this feature is when the calculation of a variable involves other export variables, either from the same component (DEPEND_ON specifies the list on such variables), or in the children (in this case the expectation is that all of the children have the SAME export). In both cases MAPL performs automatic allocation of these export variables.
+- Added support for use of pFlogger simTime in logging (only if `-DBUILD_WITH_PFLOGGER=ON`)
+  - Note: Due to bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the
+    formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90))
+- Add geom subdirectory and contents for MAPL Geom framework
+- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
 
 ### Changed
 
@@ -29,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90)).
     This is fixed in pFlogger v1.10.0
 - Add geom subdirectory and contents for MAPL Geom framework
-- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Printed time to write files to the disk in MultiGroupServer
-- Added merge function to Filemetadata to merge two meta objects
-- Added support for "depends_on" and "depends_on_children" for export_specs. The typical usage on this feature is when the calculation of a variable involves other export variables, either from the same component (DEPEND_ON specifies the list on such variables), or in the children (in this case the expectation is that all of the children have the SAME export). In both cases MAPL performs automatic allocation of these export variables.
-- Added support for use of pFlogger simTime in logging (only if `-DBUILD_WITH_PFLOGGER=ON`)
-  - Note: Due to bug in pFlogger v1.9.3 and older, you *must* specify a `dateFmt` in your logging configuration file in the
-    formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90))
-- Add geom subdirectory and contents for MAPL Geom framework
-- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
-
 ### Changed
 
 ### Fixed
@@ -38,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     formatter when using `simTime` (see [pFlogger issue #90](https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/90)).
     This is fixed in pFlogger v1.10.0
 - Add geom subdirectory and contents for MAPL Geom framework
+- Added module to process datetime strings from NetCDF to ESMF\_Time and ESMF\_TimeInterval variables and vice versa
 
 ### Changed
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -55,6 +55,7 @@ set (srcs
   FieldUtilities.F90
   MAPL_Resource.F90
   MAPL_XYGridFactory.F90
+  MAPL_NetCDF.F90
   # Orphaned program: should not be in this library.
   # tstqsat.F90
   )

--- a/base/MAPL_NetCDF.F90
+++ b/base/MAPL_NetCDF.F90
@@ -275,7 +275,7 @@ contains
       integer, optional, intent(out) :: rc
       integer :: stat
 
-      read(string_in, '(I)', iostat=stat) int_out
+      read(string_in, '(I16)', iostat=stat) int_out
 
       if(present(rc)) rc = stat
 
@@ -396,10 +396,12 @@ contains
       character(len=len(string)) :: split(2)
       integer start
  
-      split = [string, '']
+      split = ['', '']
+      split(1) = string
       start = index(string, delimiter)
       if(start < 1) return
-      split = [string(1:(start - 1)), string((start+len(delimiter)):len(string))]
+      split(1) = string(1:(start - 1))
+      split(2) = string((start+len(delimiter)):len(string))
    end function split
 
    ! Split string into all substrings based on delimiter

--- a/base/MAPL_NetCDF.F90
+++ b/base/MAPL_NetCDF.F90
@@ -1,0 +1,422 @@
+!wdb todo
+!subroutine to convert
+!From: integer: array(2) = [ 20010101  010101 (HHMMSS) ] ![ (YYYYMMDD) (HHMMSS) ]
+!To: !ESMF_TIME: with gregorian calendar
+!And vice versa.
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+! Procedures to convert from NetCDF datetime to ESMF_Time and ESMF_TimeInterval
+! NetCDF datetime is: {integer, character(len=*)}
+! {1800, 'seconds since 2010-01-23 18:30:37'}
+! {TIME_SPAN, 'TIME_UNIT since YYYY-MM-DD hh:mm:ss'}
+module MAPL_NetCDF
+
+   use MAPL_ExceptionHandling
+   use MAPL_KeywordEnforcerMod
+   use MAPL_DateTime_Parsing
+   use ESMF
+
+   implicit none
+
+   public :: convert_NetCDF_DateTime_to_ESMF
+   public :: convert_ESMF_to_NetCDF_DateTime
+
+   private
+   public :: make_ESMF_TimeInterval
+   public :: make_NetCDF_DateTime_int_time
+   public :: make_NetCDF_DateTime_units_string
+   public :: convert_ESMF_Time_to_NetCDF_DateTimeString 
+   public :: convert_to_integer
+   public :: convert_NetCDF_DateTimeString_to_ESMF_Time
+   public :: is_time_unit
+   public :: is_valid_netcdf_datetime_string
+   public :: get_shift_sign
+   public :: split
+   public :: split_all
+   public :: lr_trim
+
+   character, parameter :: PART_DELIM = ' '
+   character, parameter :: ISO_DELIM = 'T'
+   character, parameter :: DATE_DELIM = '-'
+   character, parameter :: TIME_DELIM = ':'
+   character(len=*), parameter :: NETCDF_DATE = '0000' // DATE_DELIM // '00' // DATE_DELIM // '00'
+   character(len=*), parameter :: NETCDF_TIME = '00' // TIME_DELIM // '00' // TIME_DELIM // '00'
+   character(len=*), parameter :: NETCDF_DATETIME_FORMAT = NETCDF_DATE // PART_DELIM // NETCDF_TIME
+   integer, parameter :: LEN_DATE = len(NETCDF_DATE)
+   integer, parameter :: LEN_TIME = len(NETCDF_TIME)
+   integer, parameter :: LEN_NETCDF_DATETIME = len(NETCDF_DATETIME_FORMAT)
+   character(len=*), parameter :: TIME_UNITS(7) = &
+      [  'years       ', 'months      ', 'days        ', &
+         'hours       ', 'minutes     ', 'seconds     ', 'milliseconds'    ]
+   character, parameter :: SPACE = ' '
+   type(ESMF_CalKind_Flag), parameter :: CALKIND_FLAG = ESMF_CALKIND_GREGORIAN
+   integer, parameter :: MAX_WIDTH = 10
+
+contains
+
+   ! Convert NetCDF_DateTime {int_time, units_string} to
+   ! ESMF time variables {interval, time0, time1} and time unit {tunit}
+   ! time0 is the start time, and time1 is time0 + interval
+   subroutine convert_NetCDF_DateTime_to_ESMF(int_time, units_string, &
+         interval, time0, unusable, time1, tunit, rc)
+      integer, intent(in) :: int_time
+      character(len=*), intent(in) :: units_string
+      type(ESMF_TimeInterval), intent(inout) :: interval
+      type(ESMF_Time), intent(inout) :: time0
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_Time), optional, intent(inout) :: time1
+      character(len=:), allocatable, optional, intent(out) :: tunit
+      integer, optional, intent(out) :: rc
+      character(len=:), allocatable :: tunit_
+      character(len=len_trim(units_string)) :: parts(2)
+      character(len=len_trim(units_string)) :: head
+      character(len=len_trim(units_string)) :: tail
+      
+      integer :: span, factor
+      integer :: status
+
+      _UNUSED_DUMMY(unusable)
+
+      _ASSERT(int_time >= 0, 'Negative span not supported')
+      _ASSERT((len(lr_trim(units_string)) > 0), 'units empty')
+
+      ! get time unit, tunit
+      parts = split(lr_trim(units_string), PART_DELIM)
+      head = parts(1)
+      tail = parts(2)
+      tunit_ = lr_trim(head)
+      _ASSERT(is_time_unit(tunit_), 'Unrecognized time unit')
+      if(present(tunit)) tunit = tunit_
+
+      ! get span
+      parts = split(lr_trim(tail), PART_DELIM)
+      head = parts(1)
+      tail = parts(2)
+      
+      factor = get_shift_sign(head)
+      _ASSERT(factor /= 0, 'Unrecognized preposition')
+      span = factor * int_time
+
+      call convert_NetCDF_DateTimeString_to_ESMF_Time(lr_trim(tail), time0, _RC)
+      call make_ESMF_TimeInterval(span, tunit_, time0, interval, _RC)
+
+      ! get time1
+      if(present(time1)) time1 = time0 + interval
+
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_NetCDF_DateTime_to_ESMF
+
+   ! Convert ESMF time variables to an NetCDF datetime
+   subroutine convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, unusable, t1, interval, rc)
+      character(len=*), intent(in) :: tunit
+      type(ESMF_Time),  intent(inout) :: t0
+      integer, intent(out) :: int_time
+      character(len=:), allocatable, intent(out) :: units_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_Time), optional, intent(inout) :: t1
+      type(ESMF_TimeInterval), optional, intent(inout) :: interval
+      integer, optional, intent(out) :: rc
+      type(ESMF_TimeInterval) :: interval_
+      integer :: status
+
+      _UNUSED_DUMMY(unusable)
+
+      if(present(interval)) then
+         interval_ = interval
+      elseif(present(t1)) then
+         interval_ = t1 - t0
+      else
+         _FAIL( 'Only one input argument present')
+      end if
+
+      call make_NetCDF_DateTime_int_time(interval_, t0, tunit, int_time, _RC)
+      call make_NetCDF_DateTime_units_string(t0, tunit, units_string, _RC)
+
+      _RETURN(_SUCCESS)
+      
+   end subroutine convert_ESMF_to_NetCDF_DateTime
+
+   ! Make ESMF_TimeInterval from a span of time, time unit, and start time
+   subroutine make_ESMF_TimeInterval(span, tunit, t0, interval, unusable, rc)
+      integer, intent(in) :: span
+      character(len=*), intent(in) :: tunit
+      type(ESMF_Time), intent(inout) :: t0
+      type(ESMF_TimeInterval), intent(inout) :: interval
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      select case(lr_trim(tunit)) 
+         case('years')
+            call ESMF_TimeIntervalSet(interval, startTime=t0, yy=span, _RC)
+         case('months')
+            call ESMF_TimeIntervalSet(interval, startTime=t0, mm=span, _RC)
+         case('hours')
+            call ESMF_TimeIntervalSet(interval, startTime=t0, h=span, _RC)
+         case('minutes')
+            call ESMF_TimeIntervalSet(interval, startTime=t0, m=span, _RC)
+         case('seconds')
+            call ESMF_TimeIntervalSet(interval, startTime=t0, s=span, _RC)
+         case default
+            _FAIL('Unrecognized unit')
+      end select
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_ESMF_TimeInterval
+
+   ! Get time span from NetCDF datetime
+   subroutine make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, unusable, rc)
+      type(ESMF_TimeInterval), intent(inout) :: interval
+      type(ESMF_Time), intent(inout) :: t0
+      character(len=*), intent(in) :: tunit
+      integer, intent(out) :: int_time
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      ! get int_time
+      select case(lr_trim(tunit)) 
+         case('years')
+            call ESMF_TimeIntervalGet(interval, t0, yy=int_time, _RC)
+         case('months')
+            call ESMF_TimeIntervalGet(interval, t0, mm=int_time, _RC)
+         case('hours')
+            call ESMF_TimeIntervalGet(interval, t0, h=int_time, _RC)
+         case('minutes')
+            call ESMF_TimeIntervalGet(interval, t0, m=int_time, _RC)
+         case('seconds')
+            call ESMF_TimeIntervalGet(interval, t0, s=int_time, _RC)
+         case default
+            _FAIL('Unrecognized unit')
+      end select
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_NetCDF_DateTime_int_time
+
+   ! Make 'units' for NetCDF datetime
+   subroutine make_NetCDF_DateTime_units_string(t0, tunit, units_string, unusable, rc)
+      type(ESMF_Time), intent(inout) :: t0
+      character(len=*), intent(in) :: tunit
+      character(len=:), allocatable, intent(out) :: units_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      character(len=*), parameter :: preposition = 'since'
+      character(len=:), allocatable :: datetime_string
+      integer :: status
+      
+      _UNUSED_DUMMY(unusable)
+
+      ! make units_string
+      call convert_ESMF_Time_to_NetCDF_DateTimeString(t0, datetime_string, _RC)
+      units_string = tunit //SPACE// preposition //SPACE// datetime_string
+
+      _RETURN(_SUCCESS)
+
+   end subroutine make_NetCDF_DateTime_units_string
+
+   ! Convert ESMF_Time to a NetCDF datetime string (start datetime)
+   subroutine convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, datetime_string, unusable, rc)
+      type(ESMF_Time), intent(inout) :: esmf_datetime
+      character(len=:), allocatable, intent(out) :: datetime_string
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+ 
+      character(len=*), parameter :: ERR_PRE = 'Failed to write string: '
+      integer :: yy, mm, dd, h, m, s
+      character(len=10) :: FMT
+      character(len=4) :: yy_string
+      character(len=2) :: mm_string
+      character(len=2) :: dd_string
+      character(len=2) :: h_string
+      character(len=2) :: m_string
+      character(len=2) :: s_string
+      character(len=LEN_NETCDF_DATETIME) :: tmp_string
+      integer :: status, iostatus
+
+      _UNUSED_DUMMY(unusable)
+
+      call ESMF_TimeGet(esmf_datetime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+
+      FMT='(BZ, I2.2)'
+      write(s_string, fmt=FMT, iostat=iostatus) s
+      _ASSERT(iostatus == 0, ERR_PRE // 'second')
+      write(m_string, fmt=FMT, iostat=iostatus) m
+      _ASSERT(iostatus == 0, ERR_PRE // 'minute')
+      write(h_string, fmt=FMT, iostat=iostatus) h
+      _ASSERT(iostatus == 0, ERR_PRE // 'hour')
+      write(dd_string, fmt=FMT, iostat=iostatus) dd
+      _ASSERT(iostatus == 0, ERR_PRE // 'day')
+      write(mm_string, fmt=FMT, iostat=iostatus) mm
+      _ASSERT(iostatus == 0, ERR_PRE // 'month')
+      FMT='(BZ, I4.4)'
+      write(yy_string, fmt=FMT, iostat=iostatus) yy
+      _ASSERT(iostatus == 0, ERR_PRE // 'year')
+
+      tmp_string = yy_string // DATE_DELIM // mm_string // DATE_DELIM // dd_string // PART_DELIM // &
+         h_string // TIME_DELIM // m_string // TIME_DELIM // s_string
+
+      datetime_string = tmp_string
+      
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_ESMF_Time_to_NetCDF_DateTimeString
+
+   ! Convert string representing an integer to the integer
+   subroutine convert_to_integer(string_in, int_out, rc)
+      character(len=*), intent(in) :: string_in
+      integer, intent(out) :: int_out
+      integer, optional, intent(out) :: rc
+      integer :: stat
+
+      read(string_in, '(I)', iostat=stat) int_out
+
+      if(present(rc)) rc = stat
+
+   end subroutine convert_to_integer
+
+   ! Convert NetCDF datetime to ESMF_Time
+   subroutine convert_NetCDF_DateTimeString_to_ESMF_Time(datetime_string, datetime, unusable, rc)
+      character(len=*), intent(in) :: datetime_string
+      type(ESMF_Time), intent(inout) :: datetime
+      class (KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+      integer :: status 
+      integer :: yy, mm, dd, h, m, s, i, j 
+      character(len=4) :: part
+
+      _UNUSED_DUMMY(unusable)
+
+      _ASSERT(is_valid_netcdf_datetime_string(datetime_string), 'Invalid datetime string')
+
+      i = 1
+      j = i + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, yy, rc = status)
+      _ASSERT(status == 0, 'Unable to convert year string')
+
+      i = j + 2
+      j = j + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, mm, rc = status)
+      _ASSERT(status == 0, 'Unable to convert month string')
+
+      i = j + 2
+      j = j + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, dd, rc = status)
+      _ASSERT(status == 0, 'Unable to convert day string')
+
+      i = j + 2
+      j = j + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, h, rc = status)
+      _ASSERT(status == 0, 'Unable to convert hour string')
+
+      i = j + 2
+      j = j + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, m, rc = status)
+      _ASSERT(status == 0, 'Unable to convert minute string')
+
+      i = j + 2
+      j = j + 3
+      part = datetime_string(i:j)
+      call convert_to_integer(part, s, rc = status)
+      _ASSERT(status == 0, 'Unable to convert second string')
+      call ESMF_CalendarSetDefault(CALKIND_FLAG, _RC)
+      call ESMF_TimeSet(datetime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_NetCDF_DateTimeString_to_ESMF_Time
+
+   function is_valid_netcdf_datetime_string(string) result(tval)
+      character(len=*), parameter :: DIGITS = '0123456789'
+      character(len=*), intent(in) :: string
+      logical :: tval
+      integer :: i
+
+      tval = .false.
+      
+      if(len(string) /= len(NETCDF_DATETIME_FORMAT)) return
+
+      do i=1, len(string)
+         if(scan(NETCDF_DATETIME_FORMAT(i:i), DIGITS) > 0) then
+            if(scan(string(i:i), DIGITS) <= 0) return
+         else
+            if(string(i:i) /= NETCDF_DATETIME_FORMAT(i:i)) return
+         end if
+      end do
+      
+      tval = .true.
+
+   end function is_valid_netcdf_datetime_string
+
+   function is_time_unit(tunit)
+      character(len=*), intent(in) :: tunit
+      logical :: is_time_unit
+      integer :: i
+
+      is_time_unit = .TRUE.
+      do i = 1, size(TIME_UNITS)
+         if(lr_trim(tunit) == lr_trim(TIME_UNITS(i))) return
+      end do
+      is_time_unit = .FALSE.
+
+   end function is_time_unit
+
+   function lr_trim(string)
+      character(len=*), intent(in) :: string
+      character(len=:), allocatable :: lr_trim
+
+      lr_trim = trim(adjustl(string))
+
+   end function lr_trim
+
+   ! Get the sign of integer represening a time span based on preposition
+   function get_shift_sign(preposition)
+      character(len=*), intent(in) :: preposition
+      integer :: get_shift_sign
+      integer, parameter :: POSITIVE = 1
+      get_shift_sign = 0
+      if(lr_trim(preposition) == 'since') get_shift_sign = POSITIVE
+   end function get_shift_sign
+
+   ! Split string at delimiter
+   function split(string, delimiter)
+      character(len=*), intent(in) :: string
+      character(len=*), intent(in) :: delimiter
+      character(len=len(string)) :: split(2)
+      integer start
+ 
+      split = [string, '']
+      start = index(string, delimiter)
+      if(start < 1) return
+      split = [string(1:(start - 1)), string((start+len(delimiter)):len(string))]
+   end function split
+
+   ! Split string into all substrings based on delimiter
+   recursive function split_all(string, delimiter) result(parts)
+      character(len=*), intent(in) :: string
+      character(len=*), intent(in) :: delimiter
+      character(len=:), allocatable :: parts(:)
+      integer :: start
+
+      start = index(string, delimiter)
+
+      if(start == 0) then
+         parts = [string]
+      else
+         parts = [string(1:(start-1)), split_all(string((start+len(delimiter)):len(string)), delimiter)] 
+      end if
+
+   end function split_all
+
+end module MAPL_NetCDF

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set (TEST_SRCS
     Test_MAPL_Config.pf
     test_DirPath.pf
     test_TimeStringConversion.pf
+    test_MAPL_NetCDF.pf
 #    test_MAPL_ISO8601_DateTime_ESMF.pf
   )
 

--- a/base/tests/test_MAPL_NetCDF.pf
+++ b/base/tests/test_MAPL_NetCDF.pf
@@ -147,12 +147,12 @@ contains
    @Test
    subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time()
       character(len=19), parameter:: netcdf_string='2023-01-31 14:04:37'
-      type(ESMF_Time) :: esmf_time
+      type(ESMF_Time) :: etime
       integer :: yy, mm, dd, h, m, s
       integer :: status, rc
 
-      call convert_NetCDF_DateTimeString_to_ESMF_Time(netcdf_string, esmf_time, _RC)
-      call ESMF_TimeGet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      call convert_NetCDF_DateTimeString_to_ESMF_Time(netcdf_string, etime, _RC)
+      call ESMF_TimeGet(etime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
       @assertEqual(2023, yy, 'Incorrect year')
       @assertEqual(01, mm, 'Incorrect month')
       @assertEqual(31, dd, 'Incorrect day')

--- a/base/tests/test_MAPL_NetCDF.pf
+++ b/base/tests/test_MAPL_NetCDF.pf
@@ -272,37 +272,5 @@ contains
       @assertEqual(expected, actual, 'Incorrect conversion: ' // str)
 
    end subroutine test_convert_to_integer
-!   function get_integer_from_string(string, first_index, last_index) result(ival)
-!      character(len=*), intent(in) :: string
-!      integer, intent(in) :: first_index, last_index
-!      integer :: ival, stat
-!      character(len=(last_index-first_index+1)) :: substring
-!
-!      substring = string(first_index:last_index)
-!      read(substring, fmt='(i)', iostat=stat) ival
-!      if(stat == 0) return 
-!      ival = -1
-!
-!   end function get_integer_from_string
-!
-!   @test
-!   subroutine test_esmf_time_from_iso_string()
-!      type(ESMF_Time) :: esmf_time
-!      character(len=*), parameter :: iso_string = '2012-10-24T18:00:00'
-!      integer(kind=ESMF_KIND_I4) :: yy, mm, dd, h, m, s
-!      type(ESMF_CalKind_Flag) :: CALKIND_FLAG_DEF = ESMF_CALKIND_GREGORIAN
-!      integer :: rc, status
-!
-!      yy = get_integer_from_string(iso_string, 1, 4)
-!      mm = get_integer_from_string(iso_string, 6, 7)
-!      dd =  get_integer_from_string(iso_string, 9, 10)
-!      h =  get_integer_from_string(iso_string, 12, 13)
-!      m =  get_integer_from_string(iso_string, 15, 16)
-!      s =  get_integer_from_string(iso_string, 18, 19)
-!
-!      call ESMF_TimeSet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, calkindflag=CALKIND_FLAG_DEF, _RC)
-!      call ESMF_TimeSet(esmf_time, timeString='2012-10-24T18:00:00', _RC)
-!
-!   end subroutine test_esmf_time_from_iso_string
 
 end module test_MAPL_NetCDF

--- a/base/tests/test_MAPL_NetCDF.pf
+++ b/base/tests/test_MAPL_NetCDF.pf
@@ -1,0 +1,308 @@
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+module test_MAPL_NetCDF
+   use MAPL_ExceptionHandling
+   use MAPL_NetCDF
+   use ESMF
+   use pfunit
+
+   implicit none
+
+   type(ESMF_CalKind_Flag), parameter :: CALKIND_FLAG_DEF = ESMF_CALKIND_GREGORIAN
+
+contains
+
+   @Before
+   subroutine set_up()
+      integer :: status
+
+      call ESMF_CalendarSetDefault(CALKIND_FLAG_DEF, rc=status)
+      if(status /= 0) write(*, *) 'Failed to set ESMF_Calendar'
+
+   end subroutine set_up
+
+   @Test
+   subroutine test_convert_NetCDF_DateTime_to_ESMF()
+      character(len=*), parameter :: expected_tunit = 'seconds'
+      integer, parameter :: int_time = 1800
+      character(len=*), parameter :: units_string = expected_tunit // ' since 2012-08-26 12:36:37'
+      character(len=*), parameter :: t0_iso_string = '2012-08-26T12:36:37'
+      character(len=*), parameter :: t1_iso_string = '2012-08-26T13:06:37'
+      type(ESMF_TimeInterval) :: expected_interval
+      type(ESMF_Time) :: expected_time0
+      type(ESMF_Time) :: expected_time1
+
+      type(ESMF_TimeInterval) :: interval
+      type(ESMF_Time) :: time0
+      type(ESMF_Time) :: time1
+      character(len=:), allocatable :: tunit
+      integer :: rc, status
+
+      call ESMF_TimeSet(expected_time0, timeString=t0_iso_string, _RC)
+      call ESMF_TimeSet(expected_time1, timeString=t1_iso_string, _RC)
+      call ESMF_TimeIntervalSet(expected_interval, startTime=expected_time0, s=int_time, _RC)
+
+      call convert_NetCDF_DateTime_to_ESMF(int_time, units_string, interval, time0, time1=time1, tunit=tunit, _RC)
+      @assertTrue(expected_time0 == time0, 'Mismatch for time0')
+      @assertTrue(expected_time1 == time1, 'Mismatch for time1')
+      @assertTrue(expected_interval == interval, 'Mismatch for interval')
+      
+   end subroutine test_convert_NetCDF_DateTime_to_ESMF
+
+   @Test
+   subroutine test_convert_ESMF_to_NetCDF_DateTime()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: t0_iso_string = '2013-08-26T12:34:56'
+      type(ESMF_Time) :: t0
+      character(len=*), parameter :: t1_iso_string = '2013-08-26T13:04:56'
+      type(ESMF_Time) :: t1
+      type(ESMF_TimeInterval) :: interval
+      integer, parameter :: span = 1800
+      character(len=*), parameter :: expected_units_string = tunit // ' since 2013-08-26 12:34:56'
+      integer, parameter :: expected_int_time = span
+      integer :: int_time
+      character(len=:), allocatable :: units_string
+      integer :: rc, status
+
+      call ESMF_TimeSet(t0, t0_iso_string, _RC)
+      call ESMF_TimeSet(t1, t1_iso_string, _RC)
+      call ESMF_TimeIntervalSet(interval, startTime=t0, s=span, _RC)
+
+      call convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, t1=t1, _RC)
+      @assertEqual(expected_int_time, int_time, 'Using t1, expected_int_time /= int_time')
+      @assertEqual(expected_units_string, units_string, 'Using t1, expected_units_strin g/= units_string')
+
+      call convert_ESMF_to_NetCDF_DateTime(tunit, t0, int_time, units_string, interval=interval, _RC)
+      @assertEqual(expected_int_time, int_time, 'Using interval, expected_int_time /= int_time')
+      @assertEqual(expected_units_string, units_string, 'Using interval, expected_units_strin g/= units_string')
+
+   end subroutine test_convert_ESMF_to_NetCDF_DateTime
+
+   @Test
+   subroutine test_make_ESMF_TimeInterval()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: iso_string = '2013-08-26T12:34:56'
+      integer, parameter :: span = 1800
+      type(ESMF_TimeInterval) :: expected_interval
+      type(ESMF_Time) :: t0
+      type(ESMF_TimeInterval) :: interval
+      integer :: rc, status
+
+      call ESMF_TimeSet(t0, iso_string, _RC)
+      call ESMF_TimeIntervalSet(expected_interval, startTime=t0, s=span, _RC)
+      call make_ESMF_TimeInterval(span, tunit, t0, interval, _RC)
+      @assertTrue(expected_interval == interval, 'ESMF_TimeInterval variables do not match.')
+
+   end subroutine test_make_ESMF_TimeInterval
+
+   @Test
+   subroutine test_make_NetCDF_DateTime_int_time()
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: iso_string = '2013-08-26T12:34:56'
+      type(ESMF_TimeInterval) :: interval
+      type(ESMF_Time) :: t0
+      integer, parameter :: expected_int_time = 1800
+      integer :: int_time
+      integer :: status, rc
+
+      call ESMF_TimeSet(t0, iso_string, _RC)
+      call ESMF_TimeIntervalSet(interval, startTime=t0, s=expected_int_time, _RC)
+
+      call make_NetCDF_DateTime_int_time(interval, t0, tunit, int_time, _RC)
+      @assertEqual(expected_int_time, int_time, 'int_time does not match.') 
+
+   end subroutine test_make_NetCDF_DateTime_int_time
+
+   @Test
+   subroutine test_make_NetCDF_DateTime_units_string()
+      type(ESMF_Time) :: t0
+      character(len=*), parameter :: tunit = 'seconds'
+      character(len=*), parameter :: expected = tunit // ' since 2012-08-26 08:36:37'
+      character(len=:), allocatable :: actual
+      integer :: status, rc
+
+      call ESMF_TimeSet(t0, yy=2012, mm=08, dd=26, h=08, m=36, s=37, _RC)
+      call make_NetCDF_DateTime_units_string(t0, tunit, actual, _RC)
+      @assertEqual(expected, actual, 'Strings don''t match: ' // expected // '/=' // actual)
+   end subroutine test_make_NetCDF_DateTime_units_string
+
+   @Test
+   subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString()
+      type(ESMF_Time) :: esmf_datetime
+      character(len=*), parameter :: expected = '2022-08-26 07:30:37'
+      integer, parameter :: yy = 2022
+      integer, parameter :: mm = 08
+      integer, parameter :: dd  = 26
+      integer, parameter :: h  = 07
+      integer, parameter :: m  = 30
+      integer, parameter :: s  = 37
+      character(len=:), allocatable :: actual
+      integer :: status, rc
+
+      call ESMF_TimeSet(esmf_datetime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      call convert_ESMF_Time_to_NetCDF_DateTimeString(esmf_datetime, actual, _RC)
+      @assertEqual(expected, actual, 'Strings don''t match: ' // expected  // '/=' // actual)
+   end subroutine test_convert_ESMF_Time_to_NetCDF_DateTimeString
+
+   @Test
+   subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time()
+      character(len=19), parameter:: netcdf_string='2023-01-31 14:04:37'
+      type(ESMF_Time) :: esmf_time
+      integer :: yy, mm, dd, h, m, s
+      integer :: status, rc
+
+      call convert_NetCDF_DateTimeString_to_ESMF_Time(netcdf_string, esmf_time, _RC)
+      call ESMF_TimeGet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      @assertEqual(2023, yy, 'Incorrect year')
+      @assertEqual(01, mm, 'Incorrect month')
+      @assertEqual(31, dd, 'Incorrect day')
+      @assertEqual(14, h, 'Incorrect hour')
+      @assertEqual(04, m, 'Incorrect minute')
+      @assertEqual(37, s, 'Incorrect second')
+
+   end subroutine test_convert_NetCDF_DateTimeString_to_ESMF_Time
+
+!   @Test
+   subroutine test_is_time_unit()
+
+      @assertTrue(is_time_unit('years'))
+      @assertTrue(is_time_unit('months'))
+      @assertTrue(is_time_unit('days'))
+      @assertTrue(is_time_unit('hours'))
+      @assertTrue(is_time_unit('minutes'))
+      @assertTrue(is_time_unit('seconds'))
+      @assertTrue(is_time_unit('milliseconds'))
+      @assertTrue(is_time_unit(' milliseconds '))
+
+      @assertFalse(is_time_unit('nanoseconds'))
+      @assertFalse(is_time_unit('year'))
+
+   end subroutine test_is_time_unit
+
+!   @Test
+   subroutine test_lr_trim()
+      @assertEqual('word', lr_trim(' word'))
+      @assertEqual('word', lr_trim('word '))
+      @assertEqual('word', lr_trim(' word '))
+   end subroutine test_lr_trim
+
+!   @test
+   subroutine test_get_shift_sign()
+      character(len=:), allocatable :: preposition
+      integer, parameter :: expected = 1
+
+      preposition = 'since'
+      @assertEqual(expected, get_shift_sign(preposition))
+      preposition = 'before'
+      @assertFalse(get_shift_sign(preposition) == expected)
+      preposition = ''
+      @assertFalse(get_shift_sign(preposition) == expected)
+   end subroutine test_get_shift_sign
+
+!   @test
+   subroutine test_split()
+      character(len=*), parameter :: head = 'head'
+      character(len=*), parameter :: tail = 'tail'
+      character(len=*), parameter :: delim = '::'
+      character(len=*), parameter :: test_string = head // delim // tail
+      character(len=:), allocatable :: parts(:)
+
+      parts = split_all(test_string, delim)
+      @assertEqual(2, size(parts))
+      @assertEqual(head, parts(1))
+      @assertEqual(tail, parts(2))
+
+   end subroutine test_split
+
+!   @test
+   subroutine test_split_all()
+      character(len=4), parameter :: chunk(6) = ['mice', 'dogs', 'rats', 'fish', 'deer', 'pigs']
+      character(len=*), parameter :: dlm = '::'
+      character(len=:), allocatable :: test_string
+      character(len=:), allocatable :: parts(:)
+      integer :: i
+
+      test_string = chunk(1)
+      do i = 2, size(chunk)
+         test_string = test_string // dlm // chunk(i)
+      end do
+
+      parts = split_all(test_string, dlm)
+      @assertEqual(size(parts), size(chunk))
+      do i = 1, size(chunk)
+         @assertEqual(chunk(i), parts(i))
+      end do
+
+   end subroutine test_split_all
+ 
+!   @test
+   subroutine test_is_valid_netcdf_datetime_string()
+      character(len=:), allocatable :: string
+
+!      string = ''
+!      @assertTrue(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01 23:59:59'
+      @assertTrue(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01  23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970:01-01 23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01 23-59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+      string = '1970-01-01T23:59:59'
+      @assertFalse(is_valid_netcdf_datetime_string(string), string // ' is not a valid NetCDF datetime string.')
+
+   end subroutine test_is_valid_netcdf_datetime_string
+
+!   @test
+   subroutine test_convert_to_integer()
+      character(len=:), allocatable :: str
+      integer :: expected, actual, status
+      integer, parameter :: SUCCESSFUL = 0
+
+      expected = 2023
+      str = '2023'
+      call convert_to_integer(str, actual, rc = status)
+      @assertEqual(SUCCESSFUL, status, 'Unsuccessful conversion: ' // str)
+      @assertEqual(expected, actual, 'Incorrect conversion: ' // str)
+
+   end subroutine test_convert_to_integer
+!   function get_integer_from_string(string, first_index, last_index) result(ival)
+!      character(len=*), intent(in) :: string
+!      integer, intent(in) :: first_index, last_index
+!      integer :: ival, stat
+!      character(len=(last_index-first_index+1)) :: substring
+!
+!      substring = string(first_index:last_index)
+!      read(substring, fmt='(i)', iostat=stat) ival
+!      if(stat == 0) return 
+!      ival = -1
+!
+!   end function get_integer_from_string
+!
+!   @test
+!   subroutine test_esmf_time_from_iso_string()
+!      type(ESMF_Time) :: esmf_time
+!      character(len=*), parameter :: iso_string = '2012-10-24T18:00:00'
+!      integer(kind=ESMF_KIND_I4) :: yy, mm, dd, h, m, s
+!      type(ESMF_CalKind_Flag) :: CALKIND_FLAG_DEF = ESMF_CALKIND_GREGORIAN
+!      integer :: rc, status
+!
+!      yy = get_integer_from_string(iso_string, 1, 4)
+!      mm = get_integer_from_string(iso_string, 6, 7)
+!      dd =  get_integer_from_string(iso_string, 9, 10)
+!      h =  get_integer_from_string(iso_string, 12, 13)
+!      m =  get_integer_from_string(iso_string, 15, 16)
+!      s =  get_integer_from_string(iso_string, 18, 19)
+!
+!      call ESMF_TimeSet(esmf_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, calkindflag=CALKIND_FLAG_DEF, _RC)
+!      call ESMF_TimeSet(esmf_time, timeString='2012-10-24T18:00:00', _RC)
+!
+!   end subroutine test_esmf_time_from_iso_string
+
+end module test_MAPL_NetCDF

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -25,6 +25,7 @@ set (srcs
     FileSystemUtilities.F90
     DSO_Utilities.F90
     MAPL_ISO8601_DateTime.F90
+    MAPL_DateTime_Parsing.F90
     DownBit.F90
     ShaveMantissa.c
 # Fortran submodules

--- a/shared/MAPL_DateTime_Parsing.F90
+++ b/shared/MAPL_DateTime_Parsing.F90
@@ -1,0 +1,707 @@
+! MAPL Date/Time Parsing
+!
+! This module implements general parsing of strings representing dates and times
+! Zero-padded strings must be zero padded to their full width, unless
+! otherwise specified.
+! In the following:
+! ? is either a zero-width character or a delimiter like '-' or ':'
+!
+! Date
+!      YYYY
+! Years are represented by 4 numerical characters (Y).
+! The range is: '0000' to '9999' representing the years 1 BCE ('0000') to
+! 9999 CE ('9999').
+!
+! These date formats are supported.
+!      YYYY?MM?DD or YYYYMMDD
+!      YYYY?MM (but not YYYYMM)
+! YYYY is the year as specified above.
+! MM is the zero-padded month from '01' (January) to '12' (December).
+! DD is the zero-padded day of the month from '01' (1) to '31' (31).
+! The range of allowed DD strings varies according to the actual
+! calendar, though the first day is always '01'.
+!
+! Time
+! This module supports fractional seconds. (currently only milliseconds)
+!      hh?mm?ss.sss	or	Thhmmss.sss
+!      hh?mm?ss	or	Thhmmss
+!      hh?mm	or	Thhmm
+!      hh
+! hh is the zero-padded hour (24 hour system).
+! mm is the zero-padded minute. 
+! ss is the zero-padded second.
+! sss is the fractional second. It represents an arbitrary number of digits (currrently limited to 3).
+!
+! Fully-formed time with time zone. Local time not-supported
+!      <time>Z
+
+!wdb fixme need to enforce private (see commented out private statements and add to other type/variables
+#include "MAPL_Exceptions.h"
+#include "MAPL_ErrLog.h"
+module MAPL_DateTime_Parsing
+   use MAPL_KeywordEnforcerMod
+   use MAPL_ExceptionHandling
+   implicit none
+
+!   private 
+   public :: date_fields
+   public :: time_fields
+   public :: convert_to_ISO8601DateTime
+   public :: MAX_LEN
+
+   interface operator(.divides.)
+      module procedure :: divides
+   end interface
+
+   interface operator(.in.)
+      module procedure :: is_in_closed_interval
+   end interface
+
+   interface operator(.between.)
+      module procedure :: is_in_open_interval
+   end interface 
+
+   ! Error handling
+   integer, parameter :: INVALID = -1
+
+   ! parameters for processing date, time, and datetime strings
+   character(len=10), parameter :: DIGIT_CHARACTERS = '0123456789'
+
+   ! Timezone offset for Timezone Z !wdb keep for now
+   integer, parameter :: Z = 0
+
+   integer, parameter :: MAX_LEN = 1024
+
+   ! Derived type for communicating date fields internally
+   type :: date_fields
+      integer :: year_
+      integer :: month_
+      integer :: day_
+      logical :: is_valid_ = .FALSE.
+   contains
+      procedure, public, pass(this) :: year => get_year_field
+      procedure, public, pass(this) :: month => get_month_field
+      procedure, public, pass(this) :: day => get_day_field
+      procedure, public, pass(this) :: is_valid => are_valid_date_fields
+   end type date_fields
+
+   interface date_fields
+      module procedure :: construct_date_fields_default
+      module procedure :: construct_date_fields_string
+      module procedure :: construct_date_fields_null
+   end interface date_fields
+
+   ! Derived type for communicating time fields internally
+   type :: time_fields
+      integer :: hour_
+      integer :: minute_
+      integer :: second_
+      integer :: millisecond_
+      integer :: timezone_offset_
+      logical :: is_valid_ = .FALSE.
+   contains
+      procedure, public, pass(this) :: hour => get_hour_field
+      procedure, public, pass(this) :: minute => get_minute_field
+      procedure, public, pass(this) :: second => get_second_field
+      procedure, public, pass(this) :: millisecond => get_millisecond_field
+      procedure, public, pass(this) :: timezone_offset => get_timezone_offset_field
+      procedure, public, pass(this) :: is_valid => are_valid_time_fields
+   end type time_fields
+
+   interface time_fields
+      module procedure :: construct_time_fields_default
+      module procedure :: construct_time_fields_string
+      module procedure :: construct_time_fields_null
+   end interface time_fields
+
+contains
+
+! NUMBER HANDLING PROCEDURES
+
+   ! Return true if factor divides dividend evenly, false otherwise
+   pure logical function divides(factor, dividend)
+      integer, intent(in) :: factor
+      integer, intent(in) :: dividend
+      ! mod returns the remainder of dividend/factor, and if it is 0, factor divides dividend evenly
+      if(factor /= 0) then ! To avoid divide by 0
+          divides = mod(dividend, factor)==0
+      else
+          divides = .FALSE.
+      endif
+   end function divides
+
+   pure logical function is_in_closed_interval(n, clint)
+      integer, intent(in) :: n
+      integer, intent(in) :: clint(2)
+      is_in_closed_interval = .not. ((n < clint(1)) .or. (n > clint(2)))
+   end function is_in_closed_interval
+
+   pure logical function is_in_open_interval(n, opint)
+      integer, intent(in) :: n
+      integer, intent(in) :: opint(2)
+      is_in_open_interval = (n > opint(1)) .and. (n < opint(2))
+   end function is_in_open_interval
+
+   ! Check if c is a digit character
+   elemental pure logical function is_digit(c)
+      character, intent(in) :: c
+      is_digit = scan(c, DIGIT_CHARACTERS) > 0
+   end function is_digit
+
+   ! Check if n is an integer >= 0
+   pure logical function is_whole_number(n)
+      integer, intent(in) :: n
+      is_whole_number = .not. (n < 0)
+   end function is_whole_number
+
+   ! Convert c from digit character to integer
+   pure integer function get_integer_digit(c)
+      character, intent(in) :: c
+      get_integer_digit = index(DIGIT_CHARACTERS, c) - 1
+   end function get_integer_digit
+
+   ! Convert index i character from s to integer
+   pure integer function get_integer_digit_from_string(s, i)
+      character(len=*), intent(in) :: s
+      integer, intent(in) :: i
+
+      if((i>0) .and. (i<len(s)+1)) then
+         get_integer_digit_from_string = get_integer_digit(s(i:i))
+      else
+         get_integer_digit_from_string = INVALID
+      end if
+   end function get_integer_digit_from_string
+
+   ! Convert string to whole number
+   pure integer function read_whole_number(string)
+      character(len=*), intent(in) :: string
+      read_whole_number = read_whole_number_indexed(string, 1, len(string))
+   end function read_whole_number
+
+   ! Convert string(istart: istop) to whole number
+   pure integer function read_whole_number_indexed(string, istart, istop)
+      character(len=*), intent(in) :: string
+      integer, intent(in) :: istart
+      integer, intent(in) :: istop
+      integer, parameter :: BASE=10
+      integer :: n
+      integer :: i
+      integer :: place_value
+      integer :: digit_value
+
+      read_whole_number_indexed = INVALID
+
+      ! Check indices
+      if((istart < 1) .or. (istart > istop) .or. (istop > len(string))) return
+
+      ! Convert characters from string, last to first, to integers,
+      ! multiplies by place value, and adds
+      place_value = 1
+      n = 0
+      do i= istop, istart, -1
+         digit_value = get_integer_digit_from_string(string, i)
+         if(is_whole_number(digit_value)) then
+            n = n + digit_value * place_value
+            place_value = place_value * BASE
+         else
+            n = INVALID
+            exit
+         end if
+      end do
+      read_whole_number_indexed = n
+   end function read_whole_number_indexed
+
+! END NUMBER HANDLING PROCEDURES
+
+! LOW-LEVEL STRING PROCESSING PROCEDURES
+
+   ! Strip delimiter from string
+   !wdb todo should this be more than 1 character
+   pure function undelimit(string, delimiter) result(undelimited)
+      character(len=*), intent(in) :: string
+      character,  intent(in) :: delimiter
+      character(len=len(string)) :: undelimited
+      integer :: i
+      integer :: j
+      
+      undelimited = string
+      if(len_trim(delimiter) <= 0) return
+
+      undelimited = ''
+      j = 0
+      do i=1,len(string)
+        if(string(i:i) == delimiter) cycle
+        j = j + 1
+        undelimited(j:j) = string(i:i)
+      end do
+   end function undelimit
+
+   pure function undelimit_all(string) result(undelimited)
+      character(len=*), intent(in) :: string
+      character(len=len_trim(string)) :: undelimited
+      character(len=len_trim(string)) :: ljustified
+      character :: ch
+      integer :: trimmed_len
+      integer :: i, pos
+
+      ljustified = adjustl(string)
+      trimmed_len = len_trim(ljustified)
+      undelimited = ''
+      pos = 0
+
+      do i= 1, trimmed_len
+         ch = ljustified(i:i)
+         if(is_digit(ch)) then
+            pos = pos + 1
+            undelimited(pos:pos) = ch
+         end if
+      end do
+
+   end function undelimit_all
+
+! END LOW-LEVEL STRING PROCESSING PROCEDURES
+
+
+! LOW-LEVEL DATE & TIME PROCESSING PROCEDURES
+
+   ! Return true if y is a leap year, false otherwise
+   pure logical function is_leap_year(y)
+      integer, intent(in) :: y
+      ! Leap years are years divisible by 400 or (years divisible by 4 and not divisible by 100)
+      is_leap_year = (400 .divides. y) .or. ((4 .divides. y) .and. .not. (100 .divides. y))
+   end function is_leap_year
+
+   ! Return the last day numbers of each month based on the year
+   pure function get_month_ends(y) result(month_ends)
+      integer, intent(in) :: y
+      integer, parameter :: NUM_MONTHS = 12
+      integer, dimension(NUM_MONTHS) :: month_ends
+      ! last day numbers of months for leap years
+      integer, dimension(NUM_MONTHS) :: MONTH_END_LEAP
+      ! last day numbers of months for regular years
+      integer, dimension(NUM_MONTHS) :: MONTH_END
+      MONTH_END = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+      MONTH_END_LEAP = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+      if(is_leap_year(y)) then
+         month_ends = MONTH_END_LEAP
+      else
+         month_ends = MONTH_END
+      endif
+   end function get_month_ends
+
+   ! Return the last day number of month m in year y
+   pure integer function get_month_end(y, m)
+      integer, intent(in) :: y
+      integer, intent(in) :: m
+      integer, dimension(:), allocatable :: month_ends
+
+      month_ends = get_month_ends(y)
+      get_month_end = month_ends(m)
+
+   end function get_month_end
+
+   ! Verify that y is a valid year
+   pure logical function is_valid_year(y)
+      integer, intent(in) :: y
+
+      is_valid_year = y .in. [0, 9999]
+   end function is_valid_year
+
+   ! Verify that m is a valid month number
+   pure logical function is_valid_month(m)
+      integer, intent(in) :: m
+      is_valid_month = m .in. [1, 12]
+   end function is_valid_month
+
+   ! Verify that day d in in month m of year y
+   pure logical function is_valid_day(y, m, d)
+      integer, intent(in) :: y
+      integer, intent(in) :: m
+      integer, intent(in) :: d
+      is_valid_day = d .in.  [1, get_month_end(y, m)]
+   end function is_valid_day
+
+   ! Verify that hour is a valid hour
+   pure logical function is_valid_hour(hour)
+      integer, intent(in) :: hour
+      is_valid_hour = hour .in. [0, 23]
+   end function is_valid_hour
+
+   ! Verify that minute is a valid minute
+   pure logical function is_valid_minute(minute)
+      integer, intent(in) :: minute
+      is_valid_minute = minute .in. [0, 59]
+   end function is_valid_minute
+
+   ! Verify that second is a valid second
+   pure logical function is_valid_second(second)
+      integer, intent(in) :: second
+      is_valid_second = second .in. [0, 60]
+   end function is_valid_second
+
+   ! Verify that millisecond is a valid millisecond values
+   pure logical function is_valid_millisecond(millisecond)
+      integer, intent(in) :: millisecond
+      is_valid_millisecond = millisecond .in. [0, 999]
+   end function is_valid_millisecond
+
+   ! Verify that the timezone offset is valid
+   ! Not strict. Just looks for a 'reasonable' offset (+/- 1440 minutes = 24 * 60 minutes)
+   pure logical function is_valid_timezone_offset(timezone_offset)
+      integer, parameter :: MAX_OFFSET = 1440
+      integer, intent(in) :: timezone_offset
+      is_valid_timezone_offset = timezone_offset .in. [-MAX_OFFSET, MAX_OFFSET]
+   end function is_valid_timezone_offset
+
+! END LOW-LEVEL DATE & TIME PROCESSING PROCEDURES
+
+
+! DATE & TIME VERIFICATION
+
+   ! Verify all the date fields are valid
+   pure logical function is_valid_date(date)
+      type(date_fields), intent(in) :: date
+
+      is_valid_date = is_valid_year(date%year()) .and. &
+         is_valid_month(date%month()) .and. &
+         is_valid_day(date%year(), date%month(), date%day())
+
+   end function is_valid_date
+
+   ! Verify all the time fields are valid
+   pure logical function is_valid_time(time)
+      type(time_fields), intent(in) :: time
+
+      is_valid_time = is_valid_hour(time%hour()) .and. &
+         is_valid_minute(time%minute()) .and. &
+         is_valid_second(time%second()) .and. &
+         is_valid_millisecond(time%millisecond()) .and. &
+         is_valid_timezone_offset(time%timezone_offset())
+
+   end function is_valid_time
+
+! END DATE & TIME VERIFICATION
+
+
+! STRING PARSERS
+
+   ! parse string representing a timezone offset (absolute value)
+   ! return integer offset in minutes, or on error return negative number
+   pure function parse_timezone_offset(offset, field_width) result(tzo)
+      character(len=*), intent(in) :: offset
+      integer, intent(in) :: field_width
+      integer :: tzo
+      integer, parameter :: MINUTES_PER_HOUR = 60
+      integer :: offset_length
+      integer :: minutes
+      integer :: hours
+
+      offset_length = len_trim(offset)
+
+      if(offset_length == field_width) then
+         ! Offset with hours only
+         hours = read_whole_number(offset)
+         tzo = hours*MINUTES_PER_HOUR
+      elseif (offset_length == 2*field_width) then
+         ! Offset with hours and minutes
+         hours = read_whole_number(offset(1:field_width))
+         minutes = read_whole_number(offset(field_width+1:len(offset)))
+         if(is_whole_number(hours) .and. is_whole_number(minutes)) then
+            tzo = hours*MINUTES_PER_HOUR + minutes
+         else
+            tzo = INVALID
+         end if
+      else
+         tzo = INVALID
+      end if
+
+   end function parse_timezone_offset
+
+   ! Parse ISO 8601 Date string into date fields, check if valid date
+   ! and set is_valid_ flag
+   pure function parse_date(datestring, delimiter) result(fields)
+      character(len=*), intent(in) :: datestring
+      character, intent(in) :: delimiter
+      type(date_fields) :: fields
+      integer, parameter :: LENGTH = 8
+      integer, parameter :: YEAR_POSITION = 1
+      integer, parameter :: MONTH_POSITION = 5
+      integer, parameter :: DAY_POSITION = 7
+      integer :: year, month, day
+      character(len=LENGTH) :: undelimited
+
+      ! initialize fields to empty (is_valid_ .FALSE.)
+      fields = date_fields()
+
+      ! Eliminate delimiters so that there is one parsing block
+      undelimited=undelimit(datestring, DELIMITER)
+
+      if(len(undelimited) /= LENGTH) return
+
+      year = read_whole_number(undelimited(YEAR_POSITION:MONTH_POSITION-1))
+      month = read_whole_number(undelimited(MONTH_POSITION:DAY_POSITION-1))
+      day = read_whole_number(undelimited(DAY_POSITION:LENGTH))
+      fields = date_fields(year, month, day)
+
+   end function parse_date
+
+   ! Parse ISO 8601 Time string into time fields, check if valid time
+   ! and set is_valid_ flag
+   pure function parse_time(timestring, delimiter) result(fields)
+      character(len=*), intent(in) :: timestring
+      character, optional, intent(in) :: delimiter
+      type(time_fields) :: fields
+
+      character(len=:), allocatable :: timestring_
+      integer, parameter :: LENGTH = 6
+      character, parameter :: DECIMAL_POINT = '.'
+      integer, parameter :: FIELDWIDTH = 2
+      integer, parameter :: MS_WIDTH = 3
+      integer :: pos
+      character(len=:), allocatable :: undelimited
+      character :: c
+      character(len=LENGTH) :: offset
+      integer :: offset_minutes
+      integer :: undelimited_length
+      integer :: signum
+      integer :: hour
+      integer :: minute
+      integer :: second
+      integer :: millisecond
+      integer :: timezone_offset
+
+      fields = time_fields()
+      
+      timestring_ = trim(timestring)
+
+      ! Get timezone
+      ! Find timezone portion
+      pos = scan(timestring_, '-Z+')
+
+      if(.not. pos > 0) return
+
+      c = timestring_(pos:pos)
+
+      ! Check first character of timezone portion
+      select case(c)
+         case('Z')
+            signum = 0
+         case('-')
+            signum = -1
+         case('+')
+            signum = +1
+         case default
+            return
+      end select
+
+      ! Set timezone offset
+      if(signum == 0) then
+         if(pos /= len(timestring_)) return
+         timezone_offset = Z
+      else
+         offset = timestring_(pos+1:len(timestring_))
+         offset = undelimit(offset, delimiter)
+         offset_minutes = parse_timezone_offset(offset, FIELDWIDTH)
+         if(.not. is_whole_number(offset_minutes)) return
+         timezone_offset = signum * offset_minutes
+      end if
+
+      ! Select portion starting at fields%hour and ending before timezone
+      undelimited = adjustl(timestring_(1:pos-1))
+
+      ! Remove delimiter and decimal point
+      undelimited = undelimit(undelimited, delimiter)
+      undelimited=trim(undelimit(undelimited, DECIMAL_POINT))
+      undelimited_length = len(undelimited)
+
+      ! Check length of undelimited string with or without milliseconds
+      select case(undelimited_length)
+         case(LENGTH)
+            millisecond = 0
+         case(LENGTH+MS_WIDTH)
+            millisecond = read_whole_number(undelimited(7:9))
+         case default
+            return
+      end select
+
+      ! Read time fields      
+      hour = read_whole_number(undelimited(1:2))
+      minute = read_whole_number(undelimited(3:4))
+      second = read_whole_number(undelimited(5:6))
+
+      fields = time_fields(hour, minute, second, millisecond, timezone_offset)
+
+   end function parse_time
+! END STRING PARSERS
+
+
+! CONSTRUCTORS
+
+   pure function construct_date_fields_default(year, month, day) result(fields)
+      integer, intent(in) :: year
+      integer, intent(in) :: month
+      integer, intent(in) :: day
+      type(date_fields) :: fields
+      fields%year_ = year
+      fields%month_ = month
+      fields%day_ = day
+      fields%is_valid_ = is_valid_date(fields)
+   end function construct_date_fields_default
+
+   pure function construct_date_fields_string(date_string, delimiter) result(fields)
+      character(len=*), intent(in) :: date_string
+      character(len=*), intent(in) :: delimiter
+      type(date_fields) :: fields
+      fields = parse_date(date_string, delimiter)
+   end function construct_date_fields_string
+
+   pure function construct_date_fields_null() result(fields)
+      type(date_fields) :: fields
+      fields%is_valid_ = .FALSE.
+   end function construct_date_fields_null
+
+   pure function construct_time_fields_default(hour, minute, second, millisecond, &
+      timezone_offset) result(fields)
+      integer, intent(in) :: hour
+      integer, intent(in) :: minute
+      integer, intent(in) :: second
+      integer, intent(in) :: millisecond
+      integer, intent(in) :: timezone_offset
+      type(time_fields) :: fields
+      fields%hour_ = hour
+      fields%minute_ = minute
+      fields%second_ = second
+      fields%millisecond_ = millisecond
+      fields%timezone_offset_ = timezone_offset
+      fields%is_valid_ = is_valid_time(fields)
+   end function construct_time_fields_default
+
+   pure function construct_time_fields_string(time_string, delimiter) result(fields)
+      character(len=*), intent(in) :: time_string
+      character(len=*), intent(in) :: delimiter
+      type(time_fields) :: fields
+      fields = parse_time(time_string, delimiter)
+   end function construct_time_fields_string
+
+   pure function construct_time_fields_null() result(fields)
+      type(time_fields) :: fields
+      fields%is_valid_ = .FALSE.
+   end function construct_time_fields_null
+
+! END CONSTRUCTORS
+
+
+! TYPE-BOUND METHODS
+
+   pure integer function get_year_field(this)
+      class(date_fields), intent(in) :: this
+      get_year_field = this%year_
+   end function get_year_field
+
+   pure integer function get_month_field(this)
+      class(date_fields), intent(in) :: this
+      get_month_field = this%month_
+   end function get_month_field
+
+   pure integer function get_day_field(this)
+      class(date_fields), intent(in) :: this
+      get_day_field = this%day_
+   end function get_day_field
+
+   pure logical function are_valid_date_fields(this)
+      class(date_fields), intent(in) :: this
+      are_valid_date_fields = this%is_valid_
+   end function are_valid_date_fields
+
+   pure integer function get_hour_field(this)
+      class(time_fields), intent(in) :: this
+      get_hour_field = this%hour_
+   end function get_hour_field
+
+   pure integer function get_minute_field(this)
+      class(time_fields), intent(in) :: this
+      get_minute_field = this%minute_
+   end function get_minute_field
+
+   pure integer function get_second_field(this)
+      class(time_fields), intent(in) :: this
+      get_second_field = this%second_
+   end function get_second_field
+
+   pure integer function get_millisecond_field(this)
+      class(time_fields), intent(in) :: this
+      get_millisecond_field = this%millisecond_
+   end function get_millisecond_field
+
+   pure integer function get_timezone_offset_field(this)
+      class(time_fields), intent(in) :: this
+      get_timezone_offset_field = this%timezone_offset_
+   end function get_timezone_offset_field
+
+   pure logical function are_valid_time_fields(this)
+      class(time_fields), intent(in) :: this
+      are_valid_time_fields = this%is_valid_
+   end function are_valid_time_fields
+
+   subroutine convert_to_ISO8601DateTime(datetime_string, iso_string, rc)
+      character(len=*), intent(in) :: datetime_string
+      character(len=:), allocatable, intent(out) :: iso_string
+      integer, optional, intent(out) :: rc
+      integer, parameter :: YY = 1
+      integer, parameter :: MM = 2
+      integer, parameter :: DD = 3
+      integer, parameter :: HH = 4
+      integer, parameter :: M = 5
+      integer, parameter :: S = 6
+      integer, parameter :: N(2, S) = reshape([1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], [2, S])
+      integer, parameter :: MIN_LEN = 14
+      character(len=*), parameter :: ISO_DD = '-'
+      character(len=*), parameter :: ISO_TD = ':'
+      character(len=*), parameter :: ISO_DTD = 'T'
+      character(len=*), parameter :: ISO_POINT = '.'
+      character(len=len(datetime_string)) :: undelimited
+      character(len=:), allocatable :: intermediate
+      integer :: undelimited_length
+      
+      iso_string = datetime_string
+      undelimited = adjustl(undelimit_all(datetime_string))
+      undelimited_length=len_trim(undelimited)
+      _ASSERT(undelimited_length >= MIN_LEN, 'datetime_string is too short: ' // trim(undelimited))
+
+      intermediate = undelimited(N(1,YY):N(2,YY)) // ISO_DD // &
+                     undelimited(N(1,MM):N(2,MM)) // ISO_DD // &
+                     undelimited(N(1,DD):N(2,DD)) // ISO_DTD // &
+                     undelimited(N(1,HH):N(2,HH)) // ISO_TD // &
+                     undelimited(N(1,M):N(2,M)) // ISO_TD // &
+                     undelimited(N(1,S):N(2,S))
+      if(undelimited_length > MIN_LEN) intermediate = intermediate // ISO_POINT // undelimited(MIN_LEN+1:undelimited_length)
+      
+      iso_string = intermediate
+
+      _RETURN(_SUCCESS)
+
+   end subroutine convert_to_ISO8601DateTime 
+
+   function is_valid_datestring(datestring, string_format) result(tval)
+      character(len=*), intent(in) :: datestring
+      character(len=*), intent(in) :: string_format
+      logical :: tval
+      integer :: i
+
+      tval = .false.
+
+      if(len(datestring) /= len(string_format)) return
+
+      do i = 1, len_trim(string_format)
+         if(is_digit(string_format(i:i))) then
+            if(.not. is_digit(datestring(i:i))) return
+         else
+            if(datestring(i:i) /= string_format(i:i)) return
+         end if
+      end do
+
+      tval = .true.
+
+   end function is_valid_datestring
+end module MAPL_DateTime_Parsing

--- a/shared/tests/CMakeLists.txt
+++ b/shared/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set (test_srcs
     test_DSO_Utilities.pf
     test_FileSystemUtilities.pf
 #    test_MAPL_ISO8601_DateTime.pf
+    test_MAPL_DateTime_Parsing.pf
   )
 
 

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -1,0 +1,610 @@
+#include "MAPL_Exceptions.h"
+
+! Test suite
+! Not complete
+! Some portions are commented out because corresponding procedures to be
+! tested are not working completely.
+module test_MAPL_DateTime_Parsing
+      use MAPL_ExceptionHandling
+      use MAPL_DateTime_Parsing 
+      use pfunit
+      implicit none
+
+      character(len=*), parameter :: DATE_DELIMITER = '-'
+      character(len=*), parameter :: TIME_DELIMITER = ':'
+      integer, dimension(12), parameter :: ENDS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+      integer, dimension(size(ENDS)), parameter :: ENDS_LEAP = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+      integer, parameter :: SUCCESS = _SUCCESS
+      integer, parameter :: FAILURE = _FAILURE
+
+contains
+
+   @test
+   subroutine test_divides()
+      @assertTrue(divides(7, 21))
+      @assertFalse(divides(7, 22))
+      @assertTrue(7 .divides. 21)
+      @assertFalse(7 .divides. 22)
+   end subroutine test_divides
+
+   @test
+   subroutine test_between_op()
+      integer, parameter :: lower = 36
+      integer, parameter :: upper = 48
+      integer, parameter :: delta = 6
+      @assertTrue((lower + delta) .between. [lower, upper])
+      @assertFalse(lower .between. [lower, upper])
+      @assertFalse((lower - 1) .between. [lower, upper])
+      @assertFalse(upper .between. [lower, upper])
+      @assertFalse((upper + 1) .between. [lower, upper])
+   end subroutine test_between_op
+
+   @test
+   subroutine test_in_op()
+      integer, parameter :: lower = 36
+      integer, parameter :: upper = 48
+      integer, parameter :: delta = 6
+      @assertTrue((lower + delta) .between. [lower, upper])
+      @assertFalse(lower .between. [lower, upper])
+      @assertFalse((lower - 1) .between. [lower, upper])
+      @assertFalse(upper .between. [lower, upper])
+      @assertFalse((upper + 1) .between. [lower, upper])
+   end subroutine test_in_op
+
+   @test
+   subroutine test_is_digit()
+      integer :: i = -1
+      integer, parameter :: imin = 0
+      integer, parameter :: imax = 127
+      integer, parameter :: i1 = iachar('0') - 1
+      integer, parameter :: i2 = iachar('9') + 1
+      integer, parameter :: acodes(*) = [(i, i = imin, i1), (i, i = i2, imax)]
+      integer :: i0 = iachar('0')
+
+      do i = 0, 9
+         @assertTrue(is_digit(achar(i0+i)))
+      end do
+
+      do i = 1, size(acodes)
+         @assertFalse(is_digit(achar(acodes(i))))
+      end do
+
+   end subroutine test_is_digit
+
+   @test
+   subroutine test_is_whole_number()
+      integer :: n
+
+      do n= 0, 9
+         @assertTrue(is_whole_number(n))
+      end do
+
+      do n= 1, 9
+         @assertFalse(is_whole_number(-n))
+      end do
+
+   end subroutine test_is_whole_number
+
+   @test
+   subroutine test_get_integer_digit()
+      integer :: n
+      integer, parameter :: NONDIGIT = -1
+      integer, parameter :: ASCII_MIN = 0
+      integer, parameter :: ASCII_MAX = 127
+      integer, parameter :: ASCII_LT0 = iachar('0') - 1
+      integer, parameter :: ASCII_GT9 = iachar('9') + 1
+      character(len=10), parameter :: digit = '0123456789'
+      character :: c
+
+      do n = 1, len(digit)
+         @assertEqual(n-1, get_integer_digit(digit(n:n)))
+      end do
+
+      do n = ASCII_MIN, ASCII_LT0
+         c = achar(n)
+         @assertEqual(NONDIGIT, get_integer_digit(c))
+      end do
+
+      do n = ASCII_GT9, ASCII_MAX
+         c = achar(n)
+         @assertEqual(NONDIGIT, get_integer_digit(c))
+      end do
+   end subroutine test_get_integer_digit
+
+   @test
+   subroutine test_get_integer_digit_from_string
+      integer :: i
+      integer, parameter :: NONDIGIT = -1
+      character(len=5), parameter :: digit = '19150'
+      integer, dimension(5) :: values = [1, 9, 1, 5, 0]
+
+      @assertEqual(1, get_integer_digit_from_string('19150', 1))
+
+      do i= 1, len(digit)
+         @assertEqual(values(i), get_integer_digit_from_string(digit, i))
+      end do
+
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, 0))
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, -1))
+      @assertEqual(NONDIGIT, get_integer_digit_from_string(digit, len(digit)+1))
+   end subroutine test_get_integer_digit_from_string
+
+   @test
+   subroutine test_read_whole_number()
+      character(len=*), parameter :: NUM_STRING = '01234'
+      integer, parameter :: WHOLE_NUMBER = 1234
+      integer, parameter :: NOT_WHOLE_NUMBER = -1
+      character(len=*), parameter :: LETTERS = 'ABCDEFG'
+      character(len=*), parameter :: ALPHA_NUMERICS = '9B4D3F7'
+      character(len=*), parameter :: NEGATIVE_INTEGER = '-' // NUM_STRING
+      character(len=*), parameter :: SYMBOLS = '100%'
+      character(len=*), parameter :: FLOATING_POINT = '10.07'
+      character(len=*), parameter :: POSITIVE_INTEGER = '+' // NUM_STRING
+
+      @assertEqual(WHOLE_NUMBER, read_whole_number(NUM_STRING))
+
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(LETTERS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(ALPHA_NUMERICS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(NEGATIVE_INTEGER))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(SYMBOLS))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(FLOATING_POINT))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number(POSITIVE_INTEGER))
+   end subroutine test_read_whole_number
+
+   @test
+   subroutine test_read_whole_number_indexed()
+      character(len=11), parameter :: STRING = '12345678901'
+      character(len=15), parameter :: BAD_STRING = '18The3.1415...'
+      integer, parameter :: NOT_WHOLE_NUMBER = -1
+
+      @assertEqual(12, read_whole_number_indexed(STRING, 1, 2))
+      @assertEqual(90, read_whole_number_indexed(STRING, 9, 10))
+      @assertEqual(7, read_whole_number_indexed(STRING, 7, 7))
+      @assertEqual(1, read_whole_number_indexed(STRING, 10, 11))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 2, 1))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 1, 12))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, -1, 9))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 1, -1))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 0, 2))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(STRING, 2, 0))
+      @assertEqual(18, read_whole_number_indexed(BAD_STRING, 1, 2))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 2, 3))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 3, 5))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 5, 5))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 5, 6))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 6, 11))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 7, 7))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed(BAD_STRING, 7, 8))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed('+800', 1, 3))
+      @assertEqual(NOT_WHOLE_NUMBER, read_whole_number_indexed('-800', 1, 3))
+   end subroutine test_read_whole_number_indexed
+
+   @test
+   subroutine test_undelimit()
+      character(len=32), parameter :: UNDELIMITED_DATE = '20220720'
+      character(len=32), parameter :: DATE ='2022-07-20' 
+      character(len=32), parameter :: UNDELIMITED_TIME1 = '153437'
+      character(len=32), parameter :: TIME1 = '15:34:37'
+      character(len=32), parameter :: UNDELIMITED_TIME2 = '153437421'
+      character(len=32), parameter :: TIME2 = '15:34:37.421'
+      integer, parameter :: DATEWIDTH = len_trim(UNDELIMITED_DATE)
+      integer, parameter :: TIMEWIDTH1 = len_trim(UNDELIMITED_TIME1)
+      integer, parameter :: TIMEWIDTH2 = len_trim(UNDELIMITED_TIME2)
+
+      @assertEqual(trim(UNDELIMITED_DATE), trim(undelimit(DATE,'-')))
+      @assertEqual(DATEWIDTH, len_trim(UNDELIMITED_DATE)) 
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit(TIME1,':')))
+      @assertEqual(TIMEWIDTH1, len_trim(UNDELIMITED_TIME1))
+      @assertEqual(trim(UNDELIMITED_TIME2), trim(undelimit(undelimit(TIME2,':'),'.')))
+      @assertEqual(TIMEWIDTH2, len_trim(UNDELIMITED_TIME2))
+      @assertTrue(trim(UNDELIMITED_TIME1) /= trim(undelimit(TIME1,'.')))
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit(UNDELIMITED_TIME1,':')))
+      @assertEqual('', trim(undelimit('',':')))
+   end subroutine test_undelimit
+
+   @test
+   subroutine test_undelimit_all()
+      character(len=32), parameter :: UNDELIMITED_DATE = '20220720'
+      character(len=32), parameter :: DATE ='2022-07-20' 
+      character(len=32), parameter :: UNDELIMITED_TIME1 = '153437'
+      character(len=32), parameter :: TIME1 = '15:34:37'
+      character(len=32), parameter :: UNDELIMITED_TIME2 = '153437421'
+      character(len=32), parameter :: TIME2 = '15:34:37.421'
+      integer, parameter :: DATEWIDTH = len_trim(UNDELIMITED_DATE)
+      integer, parameter :: TIMEWIDTH1 = len_trim(UNDELIMITED_TIME1)
+      integer, parameter :: TIMEWIDTH2 = len_trim(UNDELIMITED_TIME2)
+
+      @assertEqual(trim(UNDELIMITED_DATE), trim(undelimit_all(DATE)))
+      @assertEqual(DATEWIDTH, len_trim(UNDELIMITED_DATE)) 
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit_all(TIME1)))
+      @assertEqual(TIMEWIDTH1, len_trim(UNDELIMITED_TIME1))
+      @assertEqual(trim(UNDELIMITED_TIME2), trim(undelimit_all(TIME2)))
+      @assertEqual(TIMEWIDTH2, len_trim(UNDELIMITED_TIME2))
+      @assertEqual(trim(UNDELIMITED_TIME1), trim(undelimit_all(UNDELIMITED_TIME1)))
+      @assertEqual('', trim(undelimit_all('')))
+   end subroutine test_undelimit_all
+
+   @test
+   subroutine test_is_leap_year()
+      @assertTrue(is_leap_year(2024))
+      @assertFalse(is_leap_year(2023))
+      @assertFalse(is_leap_year(2022))
+      @assertFalse(is_leap_year(2021))
+      @assertFalse(is_leap_year(2100))
+      @assertTrue(is_leap_year(2000))
+   end subroutine test_is_leap_year
+
+   @test
+   subroutine test_get_month_ends()
+      integer, dimension(size(ENDS)) :: actual
+      integer :: i = -1
+
+      actual = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+      actual = get_month_ends(2022)
+      do i = 1, size(actual)
+         @assertEqual(ENDS(i), actual(i))
+      end do
+
+      actual = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+      actual = get_month_ends(2020)
+      do i = 1, size(actual)
+         @assertEqual(ENDS_LEAP(i), actual(i))
+      end do
+   end subroutine test_get_month_ends
+
+   @test
+   subroutine test_get_month_end()
+      integer, parameter :: year = 2022
+      integer, parameter :: leap_year = 2020
+      integer :: i
+
+      do i = 1, 12
+         @assertEqual(ENDS(i), get_month_end(year, i))
+         @assertEqual(ENDS_LEAP(i), get_month_end(leap_year, i))
+      end do
+
+   end subroutine test_get_month_end
+
+   @test
+   subroutine test_is_valid_year()
+      integer :: i
+
+      @assertFalse(is_valid_year(-1))
+      @assertFalse(is_valid_year(10000))
+      do i = 0, 9999
+         @assertTrue(is_valid_year(i))
+      end do
+   end subroutine test_is_valid_year
+
+   @test
+   subroutine test_is_valid_month()
+      integer :: i
+
+      @assertFalse(is_valid_month(0))
+      @assertFalse(is_valid_month(-1))
+      @assertFalse(is_valid_month(13))
+      do i = 1, 12
+         @assertTrue(is_valid_month(i))
+      end do
+   end subroutine test_is_valid_month
+
+   @test
+   subroutine test_is_valid_day()
+      character(len=*), parameter :: FMT = '("day (",i4,", ",i2,", ",i2,")",a)'
+      character(len=*), parameter :: SHOULD = ' should be valid.'
+      character(len=*), parameter :: SHOULD_NOT = ' should not be valid.'
+      character(len=255) :: error_message
+
+      integer :: d, m, y
+      d = 30; m = 4; y = 2023
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+      d = 31
+      write(error_message, fmt=FMT) y, m, d, SHOULD_NOT
+      @assertFalse(is_valid_day(y, m, d), trim(error_message))
+      d = 29
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+      m = 2
+      write(error_message, fmt=FMT) y, m, d, SHOULD_NOT
+      @assertFalse(is_valid_day(y, m, d), trim(error_message))
+      y = 2024
+      write(error_message, fmt=FMT) y, m, d, SHOULD
+      @assertTrue(is_valid_day(y, m, d), trim(error_message))
+   end subroutine test_is_valid_day
+
+   @test
+   subroutine test_is_valid_hour()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 23
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_hour(i))
+      end do
+      @assertFalse(is_valid_hour(IMAX+1))
+      @assertFalse(is_valid_hour(IMIN-1))
+   end subroutine test_is_valid_hour
+
+   subroutine test_is_valid_minute()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 59
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_minute(i))
+      end do
+      @assertFalse(is_valid_minute(IMAX+1))
+      @assertFalse(is_valid_minute(IMIN-1))
+   end subroutine test_is_valid_minute
+
+   subroutine test_is_valid_second()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 60
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_second(i))
+      end do
+      @assertFalse(is_valid_second(IMAX+1))
+      @assertFalse(is_valid_second(IMIN-1))
+   end subroutine test_is_valid_second
+
+   @test
+   subroutine test_is_valid_millisecond()
+      integer, parameter :: IMIN = 0
+      integer, parameter :: IMAX = 999
+      integer :: i
+      do i= IMIN, IMAX
+         @assertTrue(is_valid_millisecond(i))
+      end do
+      @assertFalse(is_valid_millisecond(IMAX+1))
+      @assertFalse(is_valid_millisecond(IMIN-1))
+   end subroutine test_is_valid_millisecond
+
+   @test
+   subroutine test_is_valid_timezone_offset()
+      integer, parameter :: GOOD_TZ = 0
+      integer, parameter :: BAD_TZ = 60
+      @assertTrue(is_valid_timezone_offset(0))
+      @assertTrue(is_valid_timezone_offset(60))
+      @assertTrue(is_valid_timezone_offset(-60))
+      @assertFalse(is_valid_timezone_offset(4320))
+      @assertFalse(is_valid_timezone_offset(-1441))
+   end subroutine test_is_valid_timezone_offset
+
+   @test
+   subroutine test_is_valid_date()
+      type(date_fields) :: valid_date
+      type(date_fields) :: invalid_date
+      valid_date = date_fields(2022, 7, 7)
+      invalid_date = date_fields(2022, 6, 31)
+      @assertTrue(is_valid_date(valid_date))
+      @assertFalse(is_valid_date(invalid_date))
+   end subroutine test_is_valid_date
+
+   @test
+   subroutine test_is_valid_time()
+      type(time_fields) :: valid_time
+      type(time_fields) :: invalid_time
+      valid_time = time_fields(9, 41, 33, 456, 0)
+      invalid_time = time_fields(24, 41, 33, 456, 0)
+      @assertTrue(is_valid_time(valid_time))
+      @assertFalse(is_valid_time(invalid_time))
+   end subroutine test_is_valid_time
+
+   @test
+   subroutine test_parse_timezone_offset()
+      integer, parameter :: FIELD_WIDTH = 2
+      integer, parameter :: INVALID_OFFSET = -1
+
+      character(len=*), parameter :: HOUR_ONLY = '15'
+      character(len=*), parameter :: HOUR_MINUTE00 = '1500'
+      character(len=*), parameter :: HOUR_MINUTE = '1530'
+      integer, parameter :: OFFSET1500 = 15*60
+      integer, parameter :: OFFSET1530 = 15*60 + 30
+
+      character(len=*), parameter :: NARROW1 = '1'
+      character(len=*), parameter :: NARROW3 = '153'
+      character(len=*), parameter :: WIDE5 = '15307'
+      character(len=*), parameter :: GARBAGE = '1T3R'
+
+      character(len=*), parameter :: NEG_HOUR = '-15'
+      character(len=*), parameter :: NEG_HOURMIN00 = '-1500'
+      character(len=*), parameter :: NEG_HOURMIN = '-1530'
+      integer, parameter :: OFFSETM1500 = -1*(15*60)
+      integer, parameter :: OFFSETM1530 = -1*(15*60 + 30)
+
+      @assertEqual(OFFSET1500, parse_timezone_offset(HOUR_ONLY, FIELD_WIDTH))
+      @assertEqual(OFFSET1500, parse_timezone_offset(HOUR_MINUTE00, FIELD_WIDTH))
+      @assertEqual(OFFSET1530, parse_timezone_offset(HOUR_MINUTE, FIELD_WIDTH))
+
+      @assertTrue(parse_timezone_offset(NARROW1, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(NARROW3, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(WIDE5, FIELD_WIDTH) < 0)
+      @assertTrue(parse_timezone_offset(GARBAGE, FIELD_WIDTH) < 0)
+
+   end subroutine test_parse_timezone_offset
+
+   @test
+   subroutine test_parse_date()
+      type(date_fields) :: date
+
+      date = parse_date('2022-07-07', DATE_DELIMITER)
+      @assertTrue(date%is_valid_)
+      @assertEqual(2022, date%year_)
+      @assertEqual(7, date%month_)
+      @assertEqual(7, date%day_)
+
+      date = parse_date('20220707', DATE_DELIMITER)
+      @assertTrue(date%is_valid_)
+      @assertEqual(2022, date%year_)
+      @assertEqual(7, date%month_)
+      @assertEqual(7, date%day_)
+   end subroutine test_parse_date
+
+   @test
+   subroutine test_parse_time()
+      type(time_fields) :: time
+
+      time = parse_time('17:41:07.513Z', TIME_DELIMITER)
+      @assertTrue(time%is_valid_)
+      @assertEqual(17, time%hour_)
+      @assertEqual(41, time%minute_)
+      @assertEqual(7, time%second_)
+      @assertEqual(513, time%millisecond_)
+      @assertEqual(0, time%timezone_offset_)
+
+      time = parse_time('174107.513Z', TIME_DELIMITER)
+      @assertTrue(time%is_valid_)
+      @assertEqual(17, time%hour_)
+      @assertEqual(41, time%minute_)
+      @assertEqual(7, time%second_)
+      @assertEqual(513, time%millisecond_)
+      @assertEqual(0, time%timezone_offset_)
+
+   end subroutine test_parse_time
+
+   @test
+   subroutine test_construct_date_fields_null()
+      type(date_fields) :: df
+      df = date_fields()
+      @assertFalse(df % is_valid(), 'null df should not be valid.')
+   end subroutine test_construct_date_fields_null
+
+   @test
+   subroutine test_construct_time_fields_null()
+      type(time_fields) :: tf
+      tf = time_fields()
+      @assertFalse(tf % is_valid(), 'null tf should not be valid.')
+   end subroutine test_construct_time_fields_null
+
+   @test
+   subroutine test_get_year_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(y, df % year(), 'Wrong year')
+   end subroutine test_get_year_field
+
+   @test
+   subroutine test_get_month_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(m, df % month(), 'Wrong month')
+   end subroutine test_get_month_field
+
+   @test
+   subroutine test_get_day_field
+      type(date_fields) :: df
+      integer :: d = 23, m = 4, y = 2023
+      df = date_fields(y, m, d)
+      @assertTrue(df % is_valid(), 'Failed to initialize df')
+      @assertEqual(d, df % day(), 'Wrong month')
+   end subroutine test_get_day_field
+
+   @test
+   subroutine test_are_valid_date_fields
+      type(date_fields) :: df
+      df = date_fields(2023, 4, 25) 
+      @assertTrue(df % is_valid(), 'df should be valid.')
+      df = date_fields(2023, 4, 31)
+      @assertFalse(df % is_valid(), 'df should not be valid.')
+   end subroutine test_are_valid_date_fields
+
+   @test
+   subroutine test_get_hour_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(h, tf % hour())
+   end subroutine test_get_hour_field
+
+   @test
+   subroutine test_get_minute_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(m, tf % minute())
+   end subroutine test_get_minute_field
+
+   @test
+   subroutine test_get_second_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(s, tf % second())
+   end subroutine test_get_second_field
+
+   @test
+   subroutine test_get_millisecond_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(ms, tf % millisecond())
+   end subroutine test_get_millisecond_field
+
+   @test
+   subroutine test_get_timezone_offset_field
+      type(time_fields) :: tf
+      integer :: h = 13, m = 43, s = 37, ms = 100, tzo = 0
+      tf = time_fields(h, m, s, ms, tzo)
+      @assertTrue(tf % is_valid(), 'Failed to initialize tf')
+      @assertEqual(tzo, tf % timezone_offset())
+   end subroutine test_get_timezone_offset_field
+
+   @test
+   subroutine test_are_valid_time_fields
+      type(time_fields) :: tf
+      tf = time_fields(13, 43, 37, 100, 0)
+      @assertTrue(tf % is_valid(), 'tf should be valid.')
+      tf = time_fields(13, 63, 37, 100, 0)
+      @assertFalse(tf % is_valid(), 'tf should not be valid.')
+   end subroutine test_are_valid_time_fields
+
+   @test
+   subroutine test_convert_to_ISO8601DateTime()
+      integer, parameter :: N = MAX_LEN
+      character(len=N), parameter :: t = 'T'
+      character(len=N), parameter :: f = 'F'
+      character(len=N), parameter :: r = 'R'
+      integer, parameter :: sz(2) = [3,6]
+      integer :: i, status
+      character(len=:), allocatable :: output
+      character(len=N) :: input, expected, actual, runtest
+      character(len=N) :: STRINGS(sz(1),sz(2)) = reshape([ &
+            '2023-04-23 21:05:37     ' ,  '2023-04-23T21:05:37     ',   t, &
+            '20230423 210537         ' ,  '2023-04-23T21:05:37     ',   t, &
+            '2023-4-23 21:05:37      ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-04-23 21:5:37      ' ,  '2023-04-23T21:05:37     ',   r, &
+            '2023-04-23 21:05:37.337 ' ,  '2023-04-23T21:05:37.337 ',   t, &
+            '20230423210537337       ' ,  '2023-04-23T21:05:37.337 ',   t  ], sz)
+
+      do i = 1, size(STRINGS, 2)
+         input = trim(STRINGS(1,i))
+         expected = trim(STRINGS(2, i))
+         runtest = trim(STRINGS(3, i))
+         call convert_to_ISO8601DateTime(input, output, rc = status)
+         actual = trim(output)
+         select case(runtest)
+            case(t)
+               @assertEqual(status, 0, 'Convert failed')
+               @assertEqual(expected, trim(actual), 'Datetime strings do not match.')
+            case(f)
+               @assertEqual(status, 0, 'Convert failed')
+               @assertFalse(expected == trim(actual), 'Datetime strings do match.')
+            case(r)
+               @assertFalse(status == 0, 'Failed to catch illegal value.')
+         end select
+      end do
+
+   end subroutine test_convert_to_ISO8601DateTime
+
+end module test_MAPL_DateTime_Parsing

--- a/shared/tests/test_MAPL_DateTime_Parsing.pf
+++ b/shared/tests/test_MAPL_DateTime_Parsing.pf
@@ -571,39 +571,37 @@ contains
 
    @test
    subroutine test_convert_to_ISO8601DateTime()
-      integer, parameter :: N = MAX_LEN
-      character(len=N), parameter :: t = 'T'
-      character(len=N), parameter :: f = 'F'
-      character(len=N), parameter :: r = 'R'
-      integer, parameter :: sz(2) = [3,6]
-      integer :: i, status
+      character(len=*), parameter :: expected_A = '2023-04-23T21:05:37'
+      character(len=*), parameter :: expected_B = '2023-04-23T21:05:37.337'
       character(len=:), allocatable :: output
-      character(len=N) :: input, expected, actual, runtest
-      character(len=N) :: STRINGS(sz(1),sz(2)) = reshape([ &
-            '2023-04-23 21:05:37     ' ,  '2023-04-23T21:05:37     ',   t, &
-            '20230423 210537         ' ,  '2023-04-23T21:05:37     ',   t, &
-            '2023-4-23 21:05:37      ' ,  '2023-04-23T21:05:37     ',   r, &
-            '2023-04-23 21:5:37      ' ,  '2023-04-23T21:05:37     ',   r, &
-            '2023-04-23 21:05:37.337 ' ,  '2023-04-23T21:05:37.337 ',   t, &
-            '20230423210537337       ' ,  '2023-04-23T21:05:37.337 ',   t  ], sz)
+      character(len=MAX_LEN) :: actual
+      integer :: status
 
-      do i = 1, size(STRINGS, 2)
-         input = trim(STRINGS(1,i))
-         expected = trim(STRINGS(2, i))
-         runtest = trim(STRINGS(3, i))
-         call convert_to_ISO8601DateTime(input, output, rc = status)
-         actual = trim(output)
-         select case(runtest)
-            case(t)
-               @assertEqual(status, 0, 'Convert failed')
-               @assertEqual(expected, trim(actual), 'Datetime strings do not match.')
-            case(f)
-               @assertEqual(status, 0, 'Convert failed')
-               @assertFalse(expected == trim(actual), 'Datetime strings do match.')
-            case(r)
-               @assertFalse(status == 0, 'Failed to catch illegal value.')
-         end select
-      end do
+      call convert_to_ISO8601DateTime('2023-04-23 21:05:37', output, rc = status)
+      actual = trim(output)
+      @assertEqual(status, 0, 'Convert failed')
+      @assertEqual(expected_A, trim(actual), 'Datetime strings do not match.')
+
+      call convert_to_ISO8601DateTime('20230423 210537', output, rc = status)
+      actual = trim(output)
+      @assertEqual(status, 0, 'Convert failed')
+      @assertEqual(expected_A, trim(actual), 'Datetime strings do not match.')
+
+      call convert_to_ISO8601DateTime('2023-04-23 21:05:37.337', output, rc = status)
+      actual = trim(output)
+      @assertEqual(status, 0, 'Convert failed')
+      @assertEqual(expected_B, trim(actual), 'Datetime strings do not match.')
+
+      call convert_to_ISO8601DateTime('20230423210537337', output, rc = status)
+      actual = trim(output)
+      @assertEqual(status, 0, 'Convert failed')
+      @assertEqual(expected_B, trim(actual), 'Datetime strings do not match.')
+
+      call convert_to_ISO8601DateTime('2023-4-23 21:05:37', output, rc = status)
+      @assertFalse(status == 0, 'Failed to catch illegal value.')
+
+      call convert_to_ISO8601DateTime('2023-04-23 21:5:37', output, rc = status)
+      @assertFalse(status == 0, 'Failed to catch illegal value.')
 
    end subroutine test_convert_to_ISO8601DateTime
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Process NetCDF datetimes in the form of an integer span and a string, containing the time unit and start time, to an ESMF_Time (start time) and an ESMF_TimeInterval (time span), with optional output of the time unit (as a string) and the end time (ESMF_Time). The end time is the time expressed by the NetCDF integer and string.

## Motivation and Context
This feature allows better parsing of datetimes in NetCDF files.

## How Has This Been Tested?
The MAPL base and shared test suites completed successfully. This is a new feature, so it doesn't affect existing MAPL.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)