### PR TITLE
fix integer divides in config.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `READ_RESTART_BY_FACE` has been fixed and now can read restarts from full CS grids as well as restarts that have been separated by face via `WRITE_RESTART_BY_FACE`.    The current implementation requires that both `num_readers` and `num_writers` must be multiple of 6.
+- 'config.py' has been fixed. python3 requires // for integer divides.
+
 ### Removed
 
 ### Deprecated

--- a/Python/MAPL/config.py
+++ b/Python/MAPL/config.py
@@ -244,14 +244,14 @@ def strTemplate(templ,expid=None,nymd=None,nhms=None,
 
     if nymd is not None:
         nymd = int(nymd)
-        yy = nymd/10000
-        mm = (nymd - yy*10000)/100
+        yy = nymd//10000
+        mm = (nymd - yy*10000)//100
         dd = nymd - (10000*yy + 100*mm )
 
     if nhms is not None:
         nhms = int(nhms)
-        h = nhms/10000
-        m = (nhms - h * 10000)/100
+        h = nhms//10000
+        m = (nhms - h * 10000)//100
         s = nhms - (10000*h + 100*m)
 
     if expid is not None:


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
python 3 requires '//' for integer divides.  fixed these in config.py. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
bad outputs from strTemplate. Address #2127 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested through python3 calls.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
