### PR TITLE
Add count substring utility to string.F90 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.39.0] - 2023-06-07
+
+### Added
+
+- subroutin count_substring to shared/String.F90
+
 ## [2.39.2] - 2023-05-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- subroutin count_substring to shared/String.F90
+- Added procedure to count substrings in a string.
+    - function `count(string, substring)` in shared/String.F90
 
 ## [2.39.2] - 2023-05-30
 

--- a/shared/String.F90
+++ b/shared/String.F90
@@ -425,7 +425,7 @@ contains
      implicit none
      integer :: ncount
      class(String), intent(in) :: this
-     character(len=*), intent(in) :: t
+     character(len=*), intent(in) :: t  ! any text
 
      integer :: i, j, k, lt
      ncount=0
@@ -433,8 +433,6 @@ contains
      lt = len(t) - 1
      do
         i=index(this%string(k:), t)
-        write(6,*) 'i=', i
-        write(6,*)  'sub string =', trim(this%string(k:))
         if (i==0) exit
         ncount = ncount + 1
         k = k+i+lt

--- a/shared/String.F90
+++ b/shared/String.F90
@@ -105,6 +105,7 @@ module MAPL_String
       procedure :: lower
       procedure :: upper
       procedure :: capitalize
+      procedure :: count_substring
 
    end type String
 
@@ -420,5 +421,26 @@ contains
 
    end function capitalize
 
+   function count_substring(this, t) result(ncount)
+     implicit none
+     integer :: ncount
+     class(String), intent(in) :: this
+     character(len=*), intent(in) :: t
+
+     integer :: i, j, k, lt
+     ncount=0
+     k=1
+     lt = len(t) - 1
+     do
+        i=index(this%string(k:), t)
+        write(6,*) 'i=', i
+        write(6,*)  'sub string =', trim(this%string(k:))
+        if (i==0) exit
+        ncount = ncount + 1
+        k = k+i+lt
+     end do
+
+   end function count_substring
+   
    
 end module MAPL_String

--- a/shared/tests/test_String.pf
+++ b/shared/tests/test_String.pf
@@ -214,4 +214,13 @@ contains
       
    end subroutine test_capitalize
 
+   @test
+   subroutine test_count_substring()
+      type(String) :: s
+
+      s = 'aaa,bbb,xxa,yya,zzb'
+      @assert_that(s%count_substring('a,') == 3, is(true()))
+      
+   end subroutine test_count_substring
+
 end module Test_String


### PR DESCRIPTION
## Description

I am adding the subroutine to count  substring inside a string.  E.g., 
string='a,b,c,aa,bb'
substring='a,'
count=2
https://github.com/GEOS-ESM/MAPL/issues/2172

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- I have added the ctest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:

