### PR TITLE
ExtDataDriver.x updates for benchmarking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added field utilities to perform basic numeric operations on fields
+- Added new fill option and run mode for ExtDataDriver.x
 
 ### Changed
 

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -45,6 +45,7 @@ MODULE ExtDataUtRoot_GridCompMod
       end type SyntheticFieldSupportWrapper
 
       character(len=*), parameter :: runModeGenerateExports = "GenerateExports"
+      character(len=*), parameter :: runModeGenerateImports = "GenerateImports"
       character(len=*), parameter :: runModeCompareImports = "CompareImports"
       character(len=*), parameter :: runModeFillExportFromImport = "FillExportsFromImports"
       character(len=*), parameter :: runModeFillImport = "FillImport"
@@ -114,6 +115,13 @@ MODULE ExtDataUtRoot_GridCompMod
                units = 'na', &
                dims = MAPL_DimsHorzOnly, &
                vlocation = MAPL_VLocationNone, _RC)
+         call MAPL_AddInternalSpec(GC,&
+               short_name='rand', &
+               long_name='random number' , &
+               units = 'na', &
+               dims = MAPL_DimsHorzOnly, &
+               vlocation = MAPL_VLocationNone, _RC)
+
 
          call MAPL_GenericSetServices ( GC, _RC)
 
@@ -240,6 +248,10 @@ MODULE ExtDataUtRoot_GridCompMod
          case(RunModeGenerateExports)
 
             call FillState(internal,export,currTime,grid,synth,_RC) 
+
+         case(RunModeGenerateImports)
+
+            call FillState(internal,import,currTime,grid,synth,_RC) 
 
          case(runModecompareImports)
             call FillState(internal,export,currTime,grid,synth,_RC)
@@ -478,11 +490,12 @@ MODULE ExtDataUtRoot_GridCompMod
       real, pointer                       :: Exptr2(:,:) => null()
       integer :: itemcount
       character(len=ESMF_MAXSTR), allocatable :: outNameList(:)
-      type(ESMF_Field) :: expf,farray(6)
+      type(ESMF_Field) :: expf,farray(7)
       type(ESMF_State) :: pstate
       character(len=:), pointer :: fexpr
-      integer :: i1,in,j1,jn,ldims(3),i,j
-      real(kind=ESMF_KIND_R8) :: doy,time_delta
+      integer :: i1,in,j1,jn,ldims(3),i,j,seed_size,mypet
+      integer, allocatable :: seeds(:)
+      type(ESMF_VM) :: vm
 
       call MAPL_GridGet(grid,localcellcountperdim=ldims,_RC)
       call MAPL_Grid_Interior(grid,i1,in,j1,jn)
@@ -490,6 +503,9 @@ MODULE ExtDataUtRoot_GridCompMod
       allocate(outNameList(itemCount),stat=status)
       _VERIFY(status)
       call ESMF_StateGet(outState,itemNameList=outNameList,_RC)
+
+      call MAPL_GetPointer(inState,exPtr2,'time',_RC)
+      exPtr2=synth%tFunc%evaluate_time(Time,_RC)
 
       call MAPL_GetPointer(inState,exPtr2,'i_index',_RC)
       do j = 1,ldims(2)
@@ -504,16 +520,25 @@ MODULE ExtDataUtRoot_GridCompMod
          enddo
       enddo
 
+      call MAPL_GetPointer(inState,exPtr2,'doy',_RC)
+      exPtr2 = compute_doy(time,_RC)
+
+      call MAPL_GetPointer(inState,exPtr2,'rand',_RC)
+      call random_seed(size=seed_size)
+      allocate(seeds(seed_size))
+      call ESMF_VMGetCurrent(vm,_RC)
+      call ESMF_VMGet(vm,localPet=mypet,_RC)
+      seeds = mypet
+      call random_seed(put=seeds)
+      call random_number(exPtr2)
+
       call ESMF_StateGet(inState,'time',farray(1),_RC)
-      time_delta = synth%tFunc%evaluate_time(Time,_RC)
-      call FieldSet(farray(1), time_delta,_RC)
       call ESMF_StateGet(inState,'lons',farray(2),_RC)
       call ESMF_StateGet(inState,'lats',farray(3),_RC)
       call ESMF_StateGet(inState,'i_index',farray(4),_RC)
       call ESMF_StateGet(inState,'j_index',farray(5),_RC)
       call ESMF_StateGet(inState,'doy',farray(6),_RC)
-      doy = compute_doy(time,_RC)
-      call FieldSet(farray(6), doy,_RC)
+      call ESMF_StateGet(inState,'rand',farray(7),_RC)
       pstate = ESMF_StateCreate(_RC)
       call ESMF_StateAdd(pstate,farray,_RC)
 


### PR DESCRIPTION
Just a few minor tweaks for using ExtDataDriver.x for benchmarking IO.

- I added a new run option so that one could fill the imports from the "menu" just like exports if you wanted to simply test benchmarking a checkpoint and turn off extdata
- I added new fill option. Since most of the options are filling with a constant, non-spatial varying data, that would lead to unrealistically good compression. I've added to the menu to fill fields with a random number.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
