### PR TITLE
Require ESMF 8.5.0 and 8.5.0b22 at least

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- sampling IODA file with trajectory sampler (step-1): make it run
+
 ### Added
 
+- sampling IODA file with trajectory sampler (step-1): make it run
 - Convert ExtData to use ESMF HConfig for YAML parsing rather than YaFYAML
+  - Set required ESMF version to 8.5.0
+  - Add check in CMake to make sure ESMF version is at least 8.5.0b22 if using a beta snapshot
 - Add StationSamplerMod for station sampler
 - Added ReplaceMetadata message and method to replace oserver's metadata
 - Added field utilities to perform basic numeric operations on fields

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,13 @@ if (NOT Baselibs_FOUND)
       add_library(esmf ALIAS ESMF)
     endif()
   endif ()
+else ()
+  # This is an ESMF version test when using Baselibs which doesn't use the
+  # same find_package internally in ESMA_cmake as used above (with a version
+  # number) so this lets us at least trap use of old Baselibs here.
+  if (ESMF_VERSION VERSION_LESS 8.5.0)
+    message(FATAL_ERROR "ESMF must be at least 8.5.0")
+  endif ()
 endif ()
 
 # Due to use of a feature of ESMF that came in with ESMF v8.5.0b22,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (NOT Baselibs_FOUND)
   endif()
 
   if (NOT TARGET esmf)
-    find_package(ESMF 8.4.0 MODULE REQUIRED)
+    find_package(ESMF 8.5.0 MODULE REQUIRED)
 
     # ESMF as used in MAPL requires MPI
     # NOTE: This looks odd because some versions of FindESMF.cmake out in the
@@ -156,6 +156,30 @@ if (NOT Baselibs_FOUND)
       # the latest FindESMF.cmake file from ESMF produces an ESMF target.
       add_library(esmf ALIAS ESMF)
     endif()
+  endif ()
+endif ()
+
+# Due to use of a feature of ESMF that came in with ESMF v8.5.0b22,
+# a beta version of ESMF, we need to make sure that if we are using
+# ESMF 8.5.0, that we are using at least ESMF 8.5.0b22. This is
+# a temporary fix until ESMF 8.5.0 final is released. Our criterion are:
+#  1. ESMF version is 8.5.0 (from ESMF_VERSION)
+#  2. We are using a beta snapshot of ESMF (from ESMF_BETA_RELEASE)
+#  3. The ESMF version is at least v8.5.0b22 (from ESMF_BETA_SNAPSHOT)
+
+if (ESMF_VERSION VERSION_EQUAL 8.5.0 AND ESMF_BETA_RELEASE)
+  # So now we are using a beta version of ESMF 8.5.0. We need to make sure
+  # that the version is at least 8.5.0b22. That version information
+  # is stored in ESMF_BETA_SNAPSHOT and is of the form "v8.5.0b22"
+  set (ESMF_BETA_SNAPSHOT_TARGET 22)
+  string(REGEX REPLACE "v8.5.0b([0-9]+)" "\\1" ESMF_BETA_SNAPSHOT_NUMBER ${ESMF_BETA_SNAPSHOT})
+  if (ESMF_BETA_SNAPSHOT_NUMBER LESS ESMF_BETA_SNAPSHOT_TARGET)
+    message(FATAL_ERROR
+      "ERROR! ESMF version must be at least v8.5.0b22, but you are using ${ESMF_BETA_SNAPSHOT}\n"
+      ""
+      "This is due to the use of a feature of ESMF that came in with ESMF v8.5.0b22, a beta version of ESMF.\n"
+      "This is a temporary fix until stable ESMF 8.5.0 is released.\n"
+      )
   endif ()
 endif ()
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR updates the required ESMF version to 8.5.0. Moreover, it requires that if we are using ESMF 8.5.0, we are using 8.5.0b22 which has support for hconfig (see #2218).

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Makes sure users use the right level of ESMF.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Well, if CMake runs, it works. And it seems to do so in my testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
