### PR TITLE
Fixes for fargparse use in CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecate the use of FLAP for command line parsing in favor of fArgParse. FLAP support will be removed in MAPL 3
-  - Set option `BUILD_WITH_FLAP` to default `OFF`
 
 ## [2.39.4] - 2023-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Created cubed-sphere grid factory with files split by face
 - Removed unneeded and confusing default in History Grid Comp (see #2081)
+- Fixes in CMake for fArgParse transition
 
 ### Removed
 
 ### Deprecated
 
 - Deprecate the use of FLAP for command line parsing in favor of fArgParse. FLAP support will be removed in MAPL 3
+  - Set option `BUILD_WITH_FLAP` to default `OFF`
 
 ## [2.39.4] - 2023-06-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if (BUILD_WITH_PFLOGGER)
   endif()
 endif()
 
-option(BUILD_WITH_FLAP "Use FLAP for command line processing" ON)
+option(BUILD_WITH_FLAP "Use FLAP for command line processing" OFF)
 if (BUILD_WITH_FLAP)
   find_package(FLAP REQUIRED)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if (BUILD_WITH_PFLOGGER)
   endif()
 endif()
 
-option(BUILD_WITH_FLAP "Use FLAP for command line processing" OFF)
+option(BUILD_WITH_FLAP "Use FLAP for command line processing" ON)
 if (BUILD_WITH_FLAP)
   find_package(FLAP REQUIRED)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ add_subdirectory (base)
 add_subdirectory (MAPL)
 add_subdirectory (gridcomps)
 add_subdirectory (griddedio)
-if (BUILD_WITH_FLAP)
+if (BUILD_WITH_FARGPARSE)
    add_subdirectory (tutorial)
 endif()
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -8,10 +8,10 @@ set (srcs
     VarspecDescription.F90
     )
 
-if (BUILD_WITH_FLAP)
+if (BUILD_WITH_FARGPARSE)
 
   ecbuild_add_executable (TARGET ExtDataDriver.x SOURCES ${srcs})
-  target_link_libraries (ExtDataDriver.x PRIVATE MAPL FLAP::FLAP esmf)
+  target_link_libraries (ExtDataDriver.x PRIVATE MAPL FARGPARSE::fargparse esmf)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
   if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
     target_link_libraries(ExtDataDriver.x PRIVATE OpenMP::OpenMP_Fortran)
@@ -21,17 +21,12 @@ if (BUILD_WITH_FLAP)
   add_subdirectory(ExtData_Testing_Framework EXCLUDE_FROM_ALL)
 
   ecbuild_add_executable (TARGET pfio_MAPL_demo.x SOURCES pfio_MAPL_demo.F90)
-  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FLAP::FLAP esmf)
+  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse esmf)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
   if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
     target_link_libraries(pfio_MAPL_demo.x PRIVATE OpenMP::OpenMP_Fortran)
   endif ()
   set_target_properties(pfio_MAPL_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-
-endif ()
-
-if (BUILD_WITH_FARGPARSE)
-
   ecbuild_add_executable (TARGET MAPL_demo_fargparse.x SOURCES MAPL_demo_fargparse.F90)
   target_link_libraries (MAPL_demo_fargparse.x PRIVATE MAPL FARGPARSE::fargparse esmf)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -28,9 +28,5 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-if (BUILD_WITH_FLAP)
-  target_compile_definitions (${this} PRIVATE USE_FLAP)
-endif()
-
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Testing with spack-as-Baselibs found that ExtData tests were not being built. The reason was that I set `-DBUILD_WITH_FLAP=NO` but we were still controlling those tests with that option...even though they don't use FLAP anymore!

I guess it was only the miracle of CMake that things built and ran (something dependency depended on fArgParse so MAPL did).

Previously, I tried setting the `BUILD_WITH_FLAP` option to default to `OFF` but this can't happen yet. Both the LDAS (see https://github.com/GEOS-ESM/GEOSldas/pull/669) and the ADAS will need to move to fargparse. This isn't hard, but I don't want to deal with it for now. Soon.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes bad CMake.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I'll try and set up a GEOSgcm run but the CI should be a good arbiter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
