### PR TITLE
Feature/bmauer/extdatadriver delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add ability to introduce a time-step delay in ExtDataDriver.x to simulate the timestep latency of a real model
+- Added a MAPL\_Sleep function, equivalent to some vendor supplied but non-standard sleep function
 - sampling IODA file with trajectory sampler (step-1): make it run
 - Convert ExtData to use ESMF HConfig for YAML parsing rather than YaFYAML
   - Set required ESMF version to 8.5.0

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -164,11 +164,10 @@ MODULE ExtDataUtRoot_GridCompMod
          synth => synthWrap%ptr
          call ESMF_ClockGet(Clock,currTime=currTime,_RC)
 
+         synth%delay = -1
          call ESMF_ConfigFindLabel(cf,label='delay:',isPresent=isPresent,_RC)
          if (isPresent) then
             call ESMF_ConfigGetAttribute(cf,label='delay:',value=synth%delay,_RC)
-         else
-            synth%delay = -1
          end if
 
          call ESMF_ConfigGetDim(cf,nrows,ncolumn,label="FILL_DEF::",rc=status)

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -39,7 +39,7 @@ MODULE ExtDataUtRoot_GridCompMod
          type(StringStringMap) :: fillDefs
          character(len=ESMF_MAXSTR) :: runMode
          type(timeVar) :: tFunc
-         integer :: delay
+         integer :: delay ! in milliseconds
       end type SyntheticFieldSupport
 
       type :: SyntheticFieldSupportWrapper

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -39,7 +39,7 @@ MODULE ExtDataUtRoot_GridCompMod
          type(StringStringMap) :: fillDefs
          character(len=ESMF_MAXSTR) :: runMode
          type(timeVar) :: tFunc
-         integer :: delay ! in milliseconds
+         real :: delay ! in seconds
       end type SyntheticFieldSupport
 
       type :: SyntheticFieldSupportWrapper
@@ -164,7 +164,7 @@ MODULE ExtDataUtRoot_GridCompMod
          synth => synthWrap%ptr
          call ESMF_ClockGet(Clock,currTime=currTime,_RC)
 
-         synth%delay = -1
+         synth%delay = -1.0
          call ESMF_ConfigFindLabel(cf,label='delay:',isPresent=isPresent,_RC)
          if (isPresent) then
             call ESMF_ConfigGetAttribute(cf,label='delay:',value=synth%delay,_RC)
@@ -240,7 +240,7 @@ MODULE ExtDataUtRoot_GridCompMod
          call ESMF_UserCompGetInternalState(gc,wrap_name,synthWrap,status)
          _VERIFY(status)
          synth => synthWrap%ptr
-         if (synth%delay > -1) then
+         if (synth%delay > -1.0) then
             call MAPL_Sleep(synth%delay)
          end if
          call ESMF_GridCompGet(GC,grid=grid,_RC)

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -28,6 +28,7 @@ set (srcs
     MAPL_DateTime_Parsing.F90
     DownBit.F90
     ShaveMantissa.c
+    MAPL_Sleep.F90
 # Fortran submodules
     Interp/Interp.F90 Interp/Interp_implementation.F90
     Shmem/Shmem.F90   Shmem/Shmem_implementation.F90

--- a/shared/MAPL_Sleep.F90
+++ b/shared/MAPL_Sleep.F90
@@ -1,0 +1,44 @@
+module MAPL_SleepMod
+
+implicit none
+private
+
+public MAPL_Sleep
+
+contains
+
+! wait time in milliseconds
+subroutine MAPL_Sleep(wait_time)
+integer, intent(in) :: wait_time
+
+integer :: t(8)
+
+integer :: current_time, previous_time, start_of_day
+integer :: total_accumulation, temp_accumulation, previous_days_accumulated
+
+call date_and_time(values=t)
+
+current_time = (t(5)*3600+t(6)*60+t(7))*1000+t(8)
+start_of_day = current_time
+previous_time = 0
+previous_days_accumulated = 0
+total_accumulation = 0
+
+do
+
+   call date_and_time(values=t)
+   current_time = (t(5)*3600+t(6)*60+t(7))*1000+t(8)
+   temp_accumulation = current_time - start_of_day
+   if (current_time < previous_time) then
+      start_of_day = 0
+      previous_days_accumulated = previous_days_accumulated + previous_time
+      temp_accumulation = current_time - start_of_day
+   end if
+   total_accumulation = temp_accumulation + previous_days_accumulated
+   previous_time = temp_accumulation
+   if ( total_accumulation > wait_time ) exit
+
+enddo
+
+end subroutine
+end module MAPL_SleepMod

--- a/shared/MAPL_Sleep.F90
+++ b/shared/MAPL_Sleep.F90
@@ -1,5 +1,6 @@
 module MAPL_SleepMod
 
+use, intrinsic :: iso_fortran_env, only: REAL64,INT64
 implicit none
 private
 
@@ -7,36 +8,22 @@ public MAPL_Sleep
 
 contains
 
-! wait time in milliseconds
+! wait time in seconds
 subroutine MAPL_Sleep(wait_time)
-integer, intent(in) :: wait_time
+real, intent(in) :: wait_time
 
-integer :: t(8)
+integer(kind=INT64) :: s1,s2,count_max,count_rate,delta
+real(kind=REAL64) :: seconds_elapsed
 
-integer :: current_time, previous_time, start_of_day
-integer :: total_accumulation, temp_accumulation, previous_days_accumulated
+call system_clock(count=s1,count_rate=count_rate,count_max=count_max)
 
-call date_and_time(values=t)
+do 
 
-current_time = (t(5)*3600+t(6)*60+t(7))*1000+t(8)
-start_of_day = current_time
-previous_time = 0
-previous_days_accumulated = 0
-total_accumulation = 0
-
-do
-
-   call date_and_time(values=t)
-   current_time = (t(5)*3600+t(6)*60+t(7))*1000+t(8)
-   temp_accumulation = current_time - start_of_day
-   if (current_time < previous_time) then
-      start_of_day = 0
-      previous_days_accumulated = previous_days_accumulated + previous_time
-      temp_accumulation = current_time - start_of_day
-   end if
-   total_accumulation = temp_accumulation + previous_days_accumulated
-   previous_time = temp_accumulation
-   if ( total_accumulation > wait_time ) exit
+   call system_clock(count=s2)
+   delta = s2-s1
+   if (delta < 0) delta= s2 + (count_max - mod(s1,count_max))
+   seconds_elapsed = dble(delta)/dble(count_rate)
+   if (seconds_elapsed > wait_time) exit
 
 enddo
 

--- a/shared/MaplShared.F90
+++ b/shared/MaplShared.F90
@@ -21,5 +21,6 @@ module MaplShared
    use mapl_CommGroupDescriptionMod
    use mapl_AbstractCommSplitterMod
    use mapl_DownbitMod
+   use mapl_sleepMod
    
 end module MaplShared


### PR DESCRIPTION
@tclune, thoughts on this, naming, style, etc...

Implemented a simple "mapl_sleep" function so as to avoid using the vendor "sleep", it takes a single integer argument in milliseconds (happy to change seconds etc...) and does what the name says, for that number of milliseconds. The extra bits are just in case this is called and crosses midnight.

Could not really thing of anything to add to this, not like there's any sort of error checking I can even think of to do here or even how one could add some sort of unit test for this since it is not as if there's something this returns one can check...

I did play overriding the intrinsic date_and_time so I could convince myself that indeed this would work when the system crosses midnight.

Wanted this so I could add the ability in ExtDataDriver.x to introduce a tilmestep latency for testing purposes and not use "sleep" given it is non-standard, which I also did in this branch

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
