### PR TITLE
Fix a bug so that MultigroupServer does not allow a file written by m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Relaxed restriction in the tripolar grid factory so that grids can be made even when the decomposition deos not evenly divide the grid dimension so that the factory can be used in utilities where the core count makes such a condition impossible to satisfiy
 
 ### Fixed
+
+- Fix a bug so that MultigroupServer does not allow a file written by multiple processes at the same time.
 - Fix a bug in time\_ave\_util.x so that it can work with files with no veritcal coordinate
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.39.5] - 2023-07-10
 
 ### Fixed
+
 - Fixed logic in generating the names of the split fields. If the alias field in the History.rc has separators (;), each substring is used to name the resulting fields. If there are no separators, this will be the exact name of the first split field
 
 ## [2.39.4] - 2023-06-23

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.39.6
+  VERSION 2.39.7
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -117,7 +117,7 @@ if (BUILD_WITH_PFLOGGER)
 endif ()
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL_SHARED::gftl-shared PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran)
+target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -46,6 +46,7 @@ module pFIO_MultiGroupServerMod
    use pFIO_AbstractRequestHandleMod
    use pFIO_FileMetadataMod
    use pFIO_IntegerMessageMapMod
+   use gFTL2_StringSet, StringSetIterator =>SetIterator
    use mpi
    use pFlogger, only: logging, Logger
 
@@ -86,6 +87,8 @@ module pFIO_MultiGroupServerMod
    interface MultiGroupServer
       module procedure new_MultiGroupServer
    end interface MultiGroupServer
+
+   integer, parameter :: FNAME_LEN = 512
 
 contains
 
@@ -335,6 +338,7 @@ contains
      type (HistoryCollection), pointer :: hist_collection
      integer, pointer :: i_ptr(:)
      class (AbstractRequestHandle), pointer :: handle
+     character(len=FNAME_LEN) :: FileName
 
      if (associated(ioserver_profiler)) call ioserver_profiler%start("receive_data")
      client_num = this%threads%size()
@@ -395,6 +399,15 @@ contains
         if (this%I_am_front_root) then
            collection_id = collection_ids%at(collection_counter)
            call Mpi_Send(collection_id, 1, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_comm, ierror)
+           msg =>f_d_ms(collection_counter)%msg_vec%at(1) ! just pick first one. All messages should have the same filename
+           select type (q=>msg)
+           class is (AbstractCollectiveDataMessage)
+              Filename = q%file_name
+              call Mpi_Send(FileName, FNAME_LEN, MPI_CHARACTER, this%back_ranks(1), this%back_ranks(1), this%server_comm, ierror)
+           class default
+              _FAIL( "yet to implemented")
+           end select
+
            ! here thread_ptr can point to any thread
            hist_collection => thread_ptr%hist_collections%at(collection_id)
            call hist_collection%fmd%serialize(buffer)
@@ -438,6 +451,7 @@ contains
      integer, parameter :: stag = 6782
 
      integer :: status
+     type (StringSet) :: FilesBeingWritten
 
      allocate(this%serverthread_done_msgs(1))
      this%serverthread_done_msgs(:) = .false.
@@ -462,6 +476,7 @@ contains
        integer :: i, no_job, local_rank, node_rank, nth_writer
        integer :: terminate, idle_writer, ierr
        integer :: MPI_STAT(MPI_STATUS_SIZE)
+       character(len=FNAME_LEN)         :: FileName
 
        nwriter_per_node = this%nwriter/this%Node_Num
        allocate(num_idlePEs(0:this%Node_Num-1))
@@ -482,8 +497,12 @@ contains
               this%front_ranks(1), this%back_ranks(1), this%server_comm, &
               MPI_STAT, ierr)
          if (collection_id == -1) exit
+
+         call MPI_recv( FileName, FNAME_LEN , MPI_CHARACTER, &
+              this%front_ranks(1), this%back_ranks(1), this%server_comm, &
+              MPI_STAT, ierr)
          ! 2) get an idle processor and notify front root
-         call dispatch_work(collection_id, idleRank, num_idlePEs, rc=status)
+         call dispatch_work(collection_id, idleRank, num_idlePEs, FileName, rc=status)
          _VERIFY(status)
        enddo ! while .true.
 
@@ -498,16 +517,19 @@ contains
        _RETURN(_SUCCESS)
      end subroutine start_back_captain
 
-     subroutine dispatch_work(collection_id, idleRank, num_idlePEs, rc)
+     subroutine dispatch_work(collection_id, idleRank, num_idlePEs, FileName, rc)
        integer, intent(in) :: collection_id
        integer, intent(inout) :: idleRank(0:,0:)
        integer, intent(inout) :: num_idlePEs(0:)
+       character(*), intent(in) :: FileName
        integer, optional, intent(out) :: rc
 
        integer :: MPI_STAT(MPI_STATUS_SIZE)
        integer :: local_rank, idle_writer, nth_writer, node_rank
        integer :: i, ierr, nwriter_per_node
        logical :: flag
+       character(len=FNAME_LEN) :: FileDone
+       type (StringSetIterator) :: iter
 
        ! 2.1)  try to retrieve idle writers
        !       keep looping (waiting) until there are idle processors
@@ -526,10 +548,21 @@ contains
                num_idlePEs(node_rank) = num_idlePEs(node_rank) + 1
                nth_writer = mod(local_rank, nwriter_per_node)
                idleRank(node_rank, nth_writer) = local_rank
+
+               call MPI_recv(FileDone, FNAME_LEN, MPI_CHARACTER, &
+                             local_rank, stag+1, this%back_comm, &
+                             MPI_STAT, ierr)
+
+               iter = FilesBeingWritten%find(FileDone)
+               _ASSERT( iter /= FilesBeingWritten%end(), "FileDone should be in the set")
+               iter = FilesBeingWritten%erase(iter)
              endif
           enddo
           ! if there is no idle processor, get back to probe
           if (all(num_idlePEs == 0)) cycle
+          ! if this file is still being written, get back to probe  
+          iter = FilesBeingWritten%find(FileName)
+          if (iter /= FilesBeingWritten%end()) cycle 
 
           ! get the node with the most idle processors
           node_rank = maxloc(num_idlePEs, dim=1) - 1
@@ -541,7 +574,8 @@ contains
             exit
           enddo
           _ASSERT(1<= idle_writer .and. idle_writer <= this%nwriter-1, "wrong local rank of writer")
-          exit ! exit while loop after get one idle processor
+          call FilesBeingWritten%insert(FileName)
+          exit ! exit the loop after get one idle processor and the file is done
        enddo ! while,  get one idle writer
 
        ! 2.2) tell front comm which idel_worker is ready
@@ -559,6 +593,7 @@ contains
        integer :: MPI_STAT(MPI_STATUS_SIZE)
        integer :: node_rank, local_rank, nth_writer
        integer :: ierr, no_job, nwriter_per_node, idle_writer
+       character(len=FNAME_LEN) :: FileDone
 
        no_job = -1
        nwriter_per_node = size(idleRank, 2)
@@ -573,6 +608,9 @@ contains
              ! For busy worker, wait to receive idle_writer and the send no_job
              call MPI_recv( idle_writer, 1, MPI_INTEGER, &
                             local_rank, stag, this%back_comm, &
+                            MPI_STAT, ierr)
+             call MPI_recv( FileDone, FNAME_LEN, MPI_CHARACTER, &
+                            local_rank, stag+1, this%back_comm, &
                             MPI_STAT, ierr)
              _ASSERT(local_rank == idle_writer, "local_rank and idle_writer should match")
              call MPI_send(no_job, 1, MPI_INTEGER, local_rank, local_rank, this%back_comm, ierr)
@@ -612,6 +650,7 @@ contains
        type(AdvancedMeter) :: file_timer
        real(kind=REAL64) :: time
        character(len=:), allocatable :: filename
+       character(len=FNAME_LEN) :: FileDone
        real(kind=REAL64) :: file_size, speed
 
        class(Logger), pointer :: lgr
@@ -828,7 +867,10 @@ contains
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
          ! telling captain it is idle by sending its own rank
          !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
          call MPI_send(back_local_rank, 1, MPI_INTEGER, 0, stag, this%back_comm , ierr)
+         FileDone = Filename
+         call MPI_send(FileDone, FNAME_LEN, MPI_CHARACTER, 0, stag+1, this%back_comm , ierr)
        enddo
        _RETURN(_SUCCESS)
      end subroutine start_back_writers


### PR DESCRIPTION
…ultiple processes at the same time

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
The names of files being written are saved. Every time before sending an empty rpocess, it checks the file name first. If it is still being written, it would wait to avoid writing a file in multiple processors.
## Description
<!--- Describe your changes in detail -->
This PR replaces the PR #2230 
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
