### PR TITLE
Fixes #2244. Add print of regrid method to history init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added print of regrid method during History initialization
 - Add ability to introduce a time-step delay in ExtDataDriver.x to simulate the timestep latency of a real model
 - Added a MAPL\_Sleep function, equivalent to some vendor supplied but non-standard sleep function
 - sampling IODA file with trajectory sampler (step-1): make it run

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2440,6 +2440,7 @@ ENDDO PARSER
          print *, '    End_Date: ',       list(n)%end_date
          print *, '    End_Time: ',       list(n)%end_time
          endif
+         print *, ' Regrid Mthd: ',       regrid_method_int_to_string(list(n)%regrid_method)
 
          block
             integer :: im_world, jm_world,dims(3)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a print of the regrid method to the history initialization prints:

```
 Initializing Output Stream: geosgcm_prog
 ---------------------------
       Format: CFIO
         Mode: instantaneous
       Slices:          483
      Deflate:            1
    Frequency:        60000
     Ref_Date:     20000414
     Ref_Time:            0
     Duration:        60000
  Regrid Mthd: bilinear
  Output RSLV:           96          49
    XY-offset:            0   (DcPc: Dateline Center, Pole Center)
      Fields: PHIS SLP U V T PS H OMEGA QV QI QL RH O3 PLE
...
```

I added that `Regrid Mthd` line. The weird wording is because I wanted to keep the colons lined up. 😄 

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #2244 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Might as well print out what type of regridding is being used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran GEOS. Didn't crash, zero-diff, and the print appeared.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
