### PR TITLE
Feature/bmauer/fixes #2149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ability to run ExtDataDriver.x on a MAPL "tile" grid
 - Add ability to introduce a time-step delay in ExtDataDriver.x to simulate the timestep latency of a real model
 - Added a MAPL\_Sleep function, equivalent to some vendor supplied but non-standard sleep function
 - sampling IODA file with trajectory sampler (step-1): make it run

--- a/Tests/VarspecDescription.F90
+++ b/Tests/VarspecDescription.F90
@@ -57,6 +57,8 @@ contains
          VarspecDescr%dims = MAPL_DimsHorzOnly
       else if (trim(tmpstring) == 'xyz') then
          VarspecDescr%dims = MAPL_DimsHorzVert
+      else if (trim(tmpstring) == 'tileonly') then
+         VarspecDescr%dims = MAPL_DimsTileOnly
       end if
       tmpstring = svec%at(5)
       if (trim(tmpstring) == 'none') then

--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -58,7 +58,6 @@ module MAPL_Base
   public MAPL_StateAdd
   public MAPL_FieldBundleAdd
   public MAPL_FieldBundleGet
-  public MAPL_FieldDestroy
   public MAPL_FieldBundleDestroy
   public MAPL_GetHorzIJIndex
   public MAPL_GetGlobalHorzIJIndex
@@ -641,12 +640,6 @@ module MAPL_Base
        integer, optional,                intent(  OUT) :: RC
      end subroutine MAPL_FieldAttSetI4
      ! ========================================
-
-     module subroutine MAPL_FieldDestroy(Field,RC)
-       use ESMF, only: ESMF_Field
-       type(ESMF_Field),          intent(INOUT) :: Field
-       integer, optional,         intent(OUT  ) :: RC
-     end subroutine MAPL_FieldDestroy
 
      module subroutine MAPL_FieldBundleDestroy(Bundle,RC)
        use ESMF, only: ESMF_FieldBundle

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -24,6 +24,7 @@ submodule (MAPL_Base) Base_Implementation
   ! !USES:
   !
   use ESMF
+  use MAPL_Geom
   use MAPL_Constants
   use MAPL_RangeMod
   use MAPL_SphericalGeometry
@@ -2644,60 +2645,6 @@ contains
   end subroutine MAPL_FieldAttSetI4
   ! ========================================
 
-  module subroutine MAPL_FieldDestroy(Field,RC)
-    type(ESMF_Field),          intent(INOUT) :: Field
-    integer, optional,         intent(OUT  ) :: RC
-
-    character(len=ESMF_MAXSTR), parameter :: IAm="MAPL_FieldDestroy"
-    integer                               :: STATUS
-
-    real(kind=ESMF_KIND_R4), pointer      :: VAR_1D(:), VAR_2D(:,:), VAR_3D(:,:,:)
-    real(kind=ESMF_KIND_R8), pointer      :: VR8_1D(:), VR8_2D(:,:), VR8_3D(:,:,:) 
-    integer                      :: rank
-    type(ESMF_TypeKind_Flag)     :: tk
-
-    call ESMF_FieldGet(Field,typekind=tk,dimCount=rank,rc=status)
-    _VERIFY(STATUS)
-    if (tk == ESMF_TYPEKIND_R4 .and. rank == 1) then
-       call ESMF_FieldGet(Field,0,VAR_1d,rc=status)
-       _VERIFY(STATUS)
-       deallocate(Var_1d,stat=status)
-       _VERIFY(STATUS)
-    else if (tk == ESMF_TYPEKIND_R8 .and. rank == 1) then
-       call ESMF_FieldGet(Field,0,VR8_1d,rc=status)
-       _VERIFY(STATUS)
-       deallocate(VR8_1d,stat=status)
-       _VERIFY(STATUS)
-    else if (tk == ESMF_TYPEKIND_R4 .and. rank == 2) then
-       call ESMF_FieldGet(Field,0,VAR_2d,rc=status)
-       _VERIFY(STATUS)
-       deallocate(Var_2d,stat=status)
-       _VERIFY(STATUS)
-    else if (tk == ESMF_TYPEKIND_R8 .and. rank == 2) then
-       call ESMF_FieldGet(Field,0,VR8_2d,rc=status)
-       _VERIFY(STATUS)
-       deallocate(VR8_2d,stat=status)
-       _VERIFY(STATUS)
-    else if (tk == ESMF_TYPEKIND_R4 .and. rank == 3) then
-       call ESMF_FieldGet(Field,0,VAR_3D,rc=status)
-       _VERIFY(STATUS)
-       deallocate(Var_3d,stat=status)
-       _VERIFY(STATUS)
-    else if (tk == ESMF_TYPEKIND_R8 .and. rank == 3) then
-       call ESMF_FieldGet(Field,0,VR8_3D,rc=status)
-       _VERIFY(STATUS)
-       deallocate(VR8_3d,stat=status)
-       _VERIFY(STATUS)
-    else
-       _FAIL( 'unsupported typekind+rank')
-    end if
-    call ESMF_FieldDestroy(Field,rc=status)
-    _VERIFY(STATUS)
-
-    _RETURN(ESMF_SUCCESS)
-
-  end subroutine MAPL_FieldDestroy
-
   module subroutine MAPL_FieldBundleDestroy(Bundle,RC)
     type(ESMF_FieldBundle),    intent(INOUT) :: Bundle
     integer, optional,         intent(OUT  ) :: RC
@@ -2720,7 +2667,7 @@ contains
        do I = 1, FIELDCOUNT
           call ESMF_FieldBundleGet(BUNDLE, I, FIELD, RC=STATUS)
           _VERIFY(STATUS)
-          call MAPL_FieldDestroy(FIELD, RC=status)
+          call FieldDestroy(FIELD, RC=status)
           _VERIFY(STATUS)
        end do
     end if

--- a/base/MAPL_NewArthParser.F90
+++ b/base/MAPL_NewArthParser.F90
@@ -132,7 +132,8 @@ CONTAINS
      integer :: status
 
      do i=1,comp%StackSize
-        call ESMF_FieldDestroy(comp%stack(i),noGarbage=.true.,_RC)
+        !call ESMF_FieldDestroy(comp%stack(i),noGarbage=.true.,_RC)
+        call FieldDestroy(comp%stack(i),_RC)
      end do
      deallocate(comp%stack)
      deallocate(comp%ByteCode)

--- a/geom/FieldPointerUtilities.F90
+++ b/geom/FieldPointerUtilities.F90
@@ -19,6 +19,7 @@ module MAPL_FieldPointerUtilities
    public :: FieldsAreBroadcastConformable
    public :: FieldsAreSameTypeKind
    public :: FieldCopy
+   public :: FieldDestroy
    public :: FieldCopyBroadcast
 
    interface GetFieldsUndef
@@ -74,6 +75,10 @@ module MAPL_FieldPointerUtilities
    interface FieldCopyBroadcast
       procedure copy_broadcast
    end interface FieldCopyBroadcast
+
+   interface FieldDestroy
+      procedure destroy
+   end interface
 contains
 
 
@@ -373,21 +378,56 @@ contains
       character(len=ESMF_MAXSTR) :: name
       integer :: status
       integer :: field_rank, grid_rank,ungrid_size
+      type(ESMF_Index_Flag) :: index_flag
+      real(kind=ESMF_KIND_R4), pointer      :: VR4_1D(:), VR4_2D(:,:), VR4_3D(:,:,:), VR4_4D(:,:,:,:)
+      real(kind=ESMF_KIND_R8), pointer      :: VR8_1D(:), VR8_2D(:,:), VR8_3D(:,:,:), VR8_4D(:,:,:,:)
+      integer, allocatable :: lc(:)
 
       call ESMF_FieldGet(x,grid=grid,rank=field_rank,_RC)
-      call ESMF_GridGet(grid,dimCount=grid_rank,_RC)
+      lc = get_local_element_count(x,_RC)
+      call ESMF_GridGet(grid,dimCount=grid_rank,indexFlag=index_flag,_RC)
       ungrid_size = field_rank-grid_rank
       allocate(gridToFieldMap(grid_rank))
       allocate(ungriddedLBound(ungrid_size),ungriddedUBound(ungrid_size))
       call ESMF_FieldGet(x, typekind=tk, name = name, &
          staggerloc=staggerloc, gridToFieldMap=gridToFieldMap, &
-         ungriddedLBound=ungriddedLBound, ungriddedUBound=ungriddedUBound, _RC)
+         ungriddedLBound=ungriddedLBound, ungriddedUBound=ungriddedUBound,  _RC)
 
       name = trim(name) // CLONE_TAG
 
-      y = ESMF_FieldCreate(grid, typekind=tk, staggerloc=staggerloc, &
-         gridToFieldMap=gridToFieldMap, ungriddedLBound=ungriddedLBound, &
-         ungriddedUBound=ungriddedUBound, name=name, _RC)
+      if (index_flag == ESMF_INDEX_USER) then
+         if (tk == ESMF_TYPEKIND_R4 .and. field_rank == 1) then
+            allocate(VR4_1d(lc(1)),_STAT)
+            y = ESMF_FieldCreate(grid,VR4_1d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R8 .and. field_rank == 1) then
+            allocate(VR8_1d(lc(1)),_STAT)
+            y = ESMF_FieldCreate(grid,VR8_1d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R4 .and. field_rank == 2) then
+            allocate(VR4_2d(lc(1),lc(2)),_STAT)
+            y = ESMF_FieldCreate(grid,VR4_2d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R8 .and. field_rank == 2) then
+            allocate(VR8_2d(lc(1),lc(2)),_STAT)
+            y = ESMF_FieldCreate(grid,VR8_2d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R4 .and. field_rank == 3) then
+            allocate(VR4_3d(lc(1),lc(2),lc(3)),_STAT)
+            y = ESMF_FieldCreate(grid,VR4_3d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R8 .and. field_rank == 3) then
+            allocate(VR8_3d(lc(1),lc(2),lc(3)),_STAT)
+            y = ESMF_FieldCreate(grid,VR8_3d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R4 .and. field_rank == 4) then
+            allocate(VR4_4d(lc(1),lc(2),lc(3),lc(4)),_STAT)
+            y = ESMF_FieldCreate(grid,VR4_4d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else if (tk == ESMF_TYPEKIND_R8 .and. field_rank == 4) then
+            allocate(VR8_4d(lc(1),lc(2),lc(3),lc(4)),_STAT)
+            y = ESMF_FieldCreate(grid,VR8_4d,gridToFieldMap=gridToFieldMap,name=name,_RC)
+         else
+            _FAIL( 'unsupported typekind+field_rank')
+         end if
+      else
+         y = ESMF_FieldCreate(grid, tk, staggerloc=staggerloc, &
+            gridToFieldMap=gridToFieldMap, ungriddedLBound=ungriddedLBound, &
+            ungriddedUBound=ungriddedUBound, name=name, _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine clone
@@ -859,4 +899,51 @@ contains
      _RETURN(_SUCCESS)
   end subroutine GetFieldsUndef_r8
 
+subroutine Destroy(Field,RC)
+    type(ESMF_Field),          intent(INOUT) :: Field
+    integer, optional,         intent(OUT  ) :: RC
+
+    integer                               :: STATUS
+
+    real(kind=ESMF_KIND_R4), pointer      :: VR4_1D(:), VR4_2D(:,:), VR4_3D(:,:,:), VR4_4D(:,:,:,:)
+    real(kind=ESMF_KIND_R8), pointer      :: VR8_1D(:), VR8_2D(:,:), VR8_3D(:,:,:), VR8_4D(:,:,:,:)
+    integer                      :: rank
+    type(ESMF_TypeKind_Flag)     :: tk
+    logical :: esmf_allocated
+
+    call ESMF_FieldGet(Field,typekind=tk,dimCount=rank,isESMFAllocated=esmf_allocated,_RC)
+    if (.not. esmf_allocated) then
+       if (tk == ESMF_TYPEKIND_R4 .and. rank == 1) then
+          call ESMF_FieldGet(Field,0,VR4_1d,_RC)
+          deallocate(VR4_1d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R8 .and. rank == 1) then
+          call ESMF_FieldGet(Field,0,VR8_1d,_RC)
+          deallocate(VR8_1d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R4 .and. rank == 2) then
+          call ESMF_FieldGet(Field,0,VR4_2d,_RC)
+          deallocate(VR4_2d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R8 .and. rank == 2) then
+          call ESMF_FieldGet(Field,0,VR8_2d,_RC)
+          deallocate(VR8_2d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R4 .and. rank == 3) then
+          call ESMF_FieldGet(Field,0,VR4_3D,_RC)
+          deallocate(VR4_3d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R8 .and. rank == 3) then
+          call ESMF_FieldGet(Field,0,VR8_3D,_RC)
+          deallocate(VR8_3d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R4 .and. rank == 4) then
+          call ESMF_FieldGet(Field,0,VR4_4D,_RC)
+          deallocate(VR4_3d,_STAT)
+       else if (tk == ESMF_TYPEKIND_R8 .and. rank == 4) then
+          call ESMF_FieldGet(Field,0,VR8_4D,_RC)
+          deallocate(VR8_3d,_STAT)
+       else
+          _FAIL( 'unsupported typekind+rank')
+       end if
+    end if
+    call ESMF_FieldDestroy(Field,noGarbage = .true., rc=status)
+    _VERIFY(STATUS)
+    _RETURN(ESMF_SUCCESS)
+
+  end subroutine Destroy
 end module


### PR DESCRIPTION
This allows ExtDataDriver.x to work on "tile" grids and create the locstream on an attached grid and then create 'tileonly' variables which is precursor to getting ExtData able to ingest tile data and retire MAPL_ReadForcing. This will allow me to develop without having to run the full model.

Unfortunately do to a bug or limitation (which has been reported to ESMF) when doing ESMF_FIeldCreate on grids with ESMF_USER_INDEX, I had to redo the "clone" function in the field operation utilities to have MAPL, rather than ESMF allocate the memory which of course of the ugly rank/type logic we wan to avoid. I'm sorry, very sorry about this but until ESMF either fixes the bug or removes the limitation this is what we must do and the way it must be, it just is.

I also updated and moved the field destroy that takes advantage of the fact ESMF now can report who allocated the memory so that I can destroy these fields no matter who allocated the memory.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
