### PR TITLE
Demonstrated ExtData scenario

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,21 +176,21 @@ endif ()
 #  2. We are using a beta snapshot of ESMF (from ESMF_BETA_RELEASE)
 #  3. The ESMF version is at least v8.5.0b22 (from ESMF_BETA_SNAPSHOT)
 
-if (ESMF_VERSION VERSION_EQUAL 8.5.0 AND ESMF_BETA_RELEASE)
-  # So now we are using a beta version of ESMF 8.5.0. We need to make sure
-  # that the version is at least 8.5.0b22. That version information
-  # is stored in ESMF_BETA_SNAPSHOT and is of the form "v8.5.0b22"
-  set (ESMF_BETA_SNAPSHOT_TARGET 22)
-  string(REGEX REPLACE "v8.5.0b([0-9]+)" "\\1" ESMF_BETA_SNAPSHOT_NUMBER ${ESMF_BETA_SNAPSHOT})
-  if (ESMF_BETA_SNAPSHOT_NUMBER LESS ESMF_BETA_SNAPSHOT_TARGET)
-    message(FATAL_ERROR
-      "ERROR! ESMF version must be at least v8.5.0b22, but you are using ${ESMF_BETA_SNAPSHOT}\n"
-      ""
-      "This is due to the use of a feature of ESMF that came in with ESMF v8.5.0b22, a beta version of ESMF.\n"
-      "This is a temporary fix until stable ESMF 8.5.0 is released.\n"
-      )
-  endif ()
-endif ()
+# if (ESMF_VERSION VERSION_EQUAL 8.5.0 AND ESMF_BETA_RELEASE)
+#   # So now we are using a beta version of ESMF 8.5.0. We need to make sure
+#   # that the version is at least 8.5.0b22. That version information
+#   # is stored in ESMF_BETA_SNAPSHOT and is of the form "v8.5.0b22"
+#   set (ESMF_BETA_SNAPSHOT_TARGET 22)
+#   string(REGEX REPLACE "v8.5.0b([0-9]+)" "\\1" ESMF_BETA_SNAPSHOT_NUMBER ${ESMF_BETA_SNAPSHOT})
+#   if (ESMF_BETA_SNAPSHOT_NUMBER LESS ESMF_BETA_SNAPSHOT_TARGET)
+#     message(FATAL_ERROR
+#       "ERROR! ESMF version must be at least v8.5.0b22, but you are using ${ESMF_BETA_SNAPSHOT}\n"
+#       ""
+#       "This is due to the use of a feature of ESMF that came in with ESMF v8.5.0b22, a beta version of ESMF.\n"
+#       "This is a temporary fix until stable ESMF 8.5.0 is released.\n"
+#       )
+#   endif ()
+# endif ()
 
 # We wish to add extra flags when compiling as Debug. We should only
 # do this if we are using esma_cmake since the flags are defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,21 +176,21 @@ endif ()
 #  2. We are using a beta snapshot of ESMF (from ESMF_BETA_RELEASE)
 #  3. The ESMF version is at least v8.5.0b22 (from ESMF_BETA_SNAPSHOT)
 
-# if (ESMF_VERSION VERSION_EQUAL 8.5.0 AND ESMF_BETA_RELEASE)
-#   # So now we are using a beta version of ESMF 8.5.0. We need to make sure
-#   # that the version is at least 8.5.0b22. That version information
-#   # is stored in ESMF_BETA_SNAPSHOT and is of the form "v8.5.0b22"
-#   set (ESMF_BETA_SNAPSHOT_TARGET 22)
-#   string(REGEX REPLACE "v8.5.0b([0-9]+)" "\\1" ESMF_BETA_SNAPSHOT_NUMBER ${ESMF_BETA_SNAPSHOT})
-#   if (ESMF_BETA_SNAPSHOT_NUMBER LESS ESMF_BETA_SNAPSHOT_TARGET)
-#     message(FATAL_ERROR
-#       "ERROR! ESMF version must be at least v8.5.0b22, but you are using ${ESMF_BETA_SNAPSHOT}\n"
-#       ""
-#       "This is due to the use of a feature of ESMF that came in with ESMF v8.5.0b22, a beta version of ESMF.\n"
-#       "This is a temporary fix until stable ESMF 8.5.0 is released.\n"
-#       )
-#   endif ()
-# endif ()
+ if (ESMF_VERSION VERSION_EQUAL 8.5.0 AND ESMF_BETA_RELEASE)
+   # So now we are using a beta version of ESMF 8.5.0. We need to make sure
+   # that the version is at least 8.5.0b22. That version information
+   # is stored in ESMF_BETA_SNAPSHOT and is of the form "v8.5.0b22"
+   set (ESMF_BETA_SNAPSHOT_TARGET 22)
+   string(REGEX REPLACE "v8.5.0b([0-9]+)" "\\1" ESMF_BETA_SNAPSHOT_NUMBER ${ESMF_BETA_SNAPSHOT})
+   if (ESMF_BETA_SNAPSHOT_NUMBER LESS ESMF_BETA_SNAPSHOT_TARGET)
+     message(FATAL_ERROR
+       "ERROR! ESMF version must be at least v8.5.0b22, but you are using ${ESMF_BETA_SNAPSHOT}\n"
+       ""
+       "This is due to the use of a feature of ESMF that came in with ESMF v8.5.0b22, a beta version of ESMF.\n"
+       "This is a temporary fix until stable ESMF 8.5.0 is released.\n"
+       )
+   endif ()
+ endif ()
 
 # We wish to add extra flags when compiling as Debug. We should only
 # do this if we are using esma_cmake since the flags are defined

--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -104,6 +104,7 @@ contains
          type(ESMF_StateItem_Flag), allocatable :: itemtype
 
          type(StringVector), allocatable :: service_items
+         integer :: status
 
          b = ESMF_HConfigIterBegin(config) 
          e = ESMF_HConfigIterEnd(config) 
@@ -182,6 +183,7 @@ contains
       end subroutine val_to_float
 
       subroutine to_typekind(typekind, attributes, rc)
+         use :: mapl3g_ESMF_Utilities, only: ESMF_TYPEKIND_MIRROR
          type(ESMF_TypeKind_Flag) :: typekind
          type(ESMF_HConfig), intent(in) :: attributes
          integer, optional, intent(out) :: rc
@@ -204,8 +206,10 @@ contains
             typekind = ESMF_TYPEKIND_I4
          case ('I8')
             typekind = ESMF_TYPEKIND_I8
+         case ('mirror')
+            typekind = ESMF_TYPEKIND_MIRROR
          case default
-            _FAIL('Unsupported typekind')
+            _FAIL('Unsupported typekind: <'//typekind_str//'>')
          end select
 
          _RETURN(_SUCCESS)

--- a/generic3g/ESMF_Utilities.F90
+++ b/generic3g/ESMF_Utilities.F90
@@ -8,6 +8,9 @@ module mapl3g_ESMF_Utilities
 
    public :: write(formatted)
    public :: get_substate
+   public :: ESMF_TYPEKIND_MIRROR
+
+   type(ESMF_TypeKind_Flag), parameter :: ESMF_TYPEKIND_MIRROR = ESMF_TypeKind_Flag(200)
 
    interface write(formatted)
       procedure write_state

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -251,7 +251,7 @@ contains
 
       integer :: status
       type(ChildComponent), pointer :: child_ptr
-      
+
       child_ptr => this%children%at(child_name, rc=status)
       _ASSERT(associated(child_ptr), 'Child not found: <'//child_name//'>.')
 
@@ -600,6 +600,7 @@ contains
       character(*), parameter :: PHASE_NAME = 'GENERIC::INIT_POST_ADVERTISE'
       type(MultiState) :: outer_states
 
+      call exec_user_init_phase(this, clock, PHASE_NAME, _RC)
       call this%registry%add_to_states(this%user_states, mode='user', _RC)
       this%state_extensions = this%registry%get_extensions()
       

--- a/generic3g/OuterMetaComponent_setservices_smod.F90
+++ b/generic3g/OuterMetaComponent_setservices_smod.F90
@@ -144,7 +144,6 @@ contains
 
          if (ESMF_HConfigIsDefined(child_spec,keyString='config_file')) then
             config_file = ESMF_HConfigAsString(child_spec,keyString='config_file',_RC)
-!!$            _HERE, 'config file? ', config_file
             new_config = ESMF_HConfigCreate(filename=config_file,_RC)
             generic_config = GenericConfig(yaml_cfg=new_config)
          end if

--- a/generic3g/connection/MatchConnection.F90
+++ b/generic3g/connection/MatchConnection.F90
@@ -47,7 +47,7 @@ contains
 
    end function new_MatchConnection
 
-  function get_source(this) result(source)
+   function get_source(this) result(source)
       type(ConnectionPt) :: source
       class(MatchConnection), intent(in) :: this
       source = this%source
@@ -87,6 +87,8 @@ contains
 
       do i = 1, dst_v_pts%size()
          dst_pattern => dst_v_pts%of(i)
+         src_pattern = VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
+              '^'//dst_pattern%get_esmf_name()//'$', comp_name=dst_pattern%get_comp_name())
          dst_specs = dst_registry%get_actual_pt_SpecPtrs(dst_pattern, _RC)
 
          src_pattern = VirtualConnectionPt(ESMF_STATEINTENT_EXPORT, &
@@ -106,9 +108,9 @@ contains
 
          end do
       end do
-      
+
       _RETURN(_SUCCESS)
    end subroutine connect
 
 
- end module mapl3g_MatchConnection
+end module mapl3g_MatchConnection

--- a/generic3g/connection/VirtualConnectionPt.F90
+++ b/generic3g/connection/VirtualConnectionPt.F90
@@ -64,7 +64,9 @@ contains
 
       v_pt%state_intent = state_intent
       v_pt%short_name = short_name
-      if (present(comp_name)) v_pt%comp_name = comp_name
+      if (present(comp_name)) then
+         if (comp_name /= '') v_pt%comp_name = comp_name
+      end if
 
       _UNUSED_DUMMY(unusable)
     end function new_VirtualPt_basic
@@ -224,7 +226,7 @@ contains
       matches = (this%get_state_intent() == item%get_state_intent())
       if (.not. matches) return
 
-      call regcomp(regex,this%get_full_name(),flags='xmi')
+      call regcomp(regex,'^'//this%get_full_name()//'$',flags='xmi')
       matches = regexec(regex,item%get_full_name())
 
    end function matches

--- a/generic3g/registry/HierarchicalRegistry.F90
+++ b/generic3g/registry/HierarchicalRegistry.F90
@@ -827,14 +827,16 @@ contains
       type(VirtualConnectionPt), pointer :: v_pt
       type(ActualPtVec_MapIterator) :: iter
       
-      associate (e => this%virtual_pts%end())
-        iter = this%virtual_pts%begin()
+      associate (e => this%virtual_pts%ftn_end())
+        iter = this%virtual_pts%ftn_begin()
         do while (iter /= e)
+           call iter%next()
            v_pt => iter%first()
 
-           if (pattern%matches(v_pt)) call matches%push_back(v_pt)
-           
-           call iter%next()
+           if (pattern%matches(v_pt)) then
+              call matches%push_back(v_pt)
+           end if
+
         end do
       end associate
 

--- a/generic3g/specs/AbstractStateItemSpec.F90
+++ b/generic3g/specs/AbstractStateItemSpec.F90
@@ -92,11 +92,11 @@ module mapl3g_AbstractStateItemSpec
          integer, optional, intent(out) :: rc
       end function I_get_dependencies
 
-      function I_make_extension(this, src_spec, rc) result(extension)
+      function I_make_extension(this, dst_spec, rc) result(extension)
          import AbstractStateItemSpec
          class(AbstractStateItemSpec), allocatable :: extension
          class(AbstractStateItemSpec), intent(in) :: this
-         class(AbstractStateItemSpec), intent(in) :: src_spec
+         class(AbstractStateItemSpec), intent(in) :: dst_spec
          integer, optional, intent(out) :: rc
       end function I_make_extension
          

--- a/generic3g/specs/InvalidSpec.F90
+++ b/generic3g/specs/InvalidSpec.F90
@@ -142,10 +142,10 @@ contains
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
 
-   function make_extension(this, src_spec, rc) result(extension)
+   function make_extension(this, dst_spec, rc) result(extension)
       class(AbstractStateItemSpec), allocatable :: extension
       class(InvalidSpec), intent(in) :: this
-      class(AbstractStateItemSpec), intent(in) :: src_spec
+      class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -211,10 +211,10 @@ contains
       _RETURN(_SUCCESS)
    end function make_action
 
-   function make_extension(this, src_spec, rc) result(extension)
+   function make_extension(this, dst_spec, rc) result(extension)
       class(AbstractStateItemSpec), allocatable :: extension
       class(ServiceSpec), intent(in) :: this
-      class(AbstractStateItemSpec), intent(in) :: src_spec
+      class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
       _RETURN(_SUCCESS)
    end function make_extension

--- a/generic3g/specs/StateSpec.F90
+++ b/generic3g/specs/StateSpec.F90
@@ -180,10 +180,10 @@ contains
    end subroutine add_to_bundle
    
 
-   function make_extension(this, src_spec, rc) result(extension)
+   function make_extension(this, dst_spec, rc) result(extension)
       class(AbstractStateItemSpec), allocatable :: extension
       class(StateSpec), intent(in) :: this
-      class(AbstractStateItemSpec), intent(in) :: src_spec
+      class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
       _RETURN(_SUCCESS)
    end function make_extension

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -183,10 +183,10 @@ contains
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
 
-   function make_extension(this, src_spec, rc) result(extension)
+   function make_extension(this, dst_spec, rc) result(extension)
       class(AbstractStateItemSpec), allocatable :: extension
       class(WildcardSpec), intent(in) :: this
-      class(AbstractStateItemSpec), intent(in) :: src_spec
+      class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
 
       _FAIL('wildcard cannot be extended - only used for imports')

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -5,9 +5,10 @@ add_library(scratchpad SHARED scratchpad.F90)
 add_subdirectory(gridcomps)
 
 set (test_srcs
-  Test_VirtualConnectionPt.pf
-  
 #  Test_AddVarSpec.pf
+
+  Test_VirtualConnectionPt.pf
+ 
   Test_SimpleLeafGridComp.pf
   Test_SimpleParentGridComp.pf
   Test_Traverse.pf
@@ -19,7 +20,6 @@ set (test_srcs
   Test_ConnectionPt.pf
   Test_FieldDictionary.pf
   Test_GenericInitialize.pf
-
   Test_HierarchicalRegistry.pf
 
   Test_Scenarios.pf

--- a/generic3g/tests/MockItemSpec.F90
+++ b/generic3g/tests/MockItemSpec.F90
@@ -196,17 +196,17 @@ contains
       _RETURN(_SUCCESS)
    end subroutine mock_run
 
-   function make_extension(this, src_spec, rc) result(extension)
+   function make_extension(this, dst_spec, rc) result(extension)
       class(AbstractStateItemSpec), allocatable :: extension
       class(MockItemSpec), intent(in) :: this
-      class(AbstractStateItemSpec), intent(in) :: src_spec
+      class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
 
       integer :: status
 
-      select type(src_spec)
+      select type(dst_spec)
       type is (MockItemSpec)
-         extension = this%make_extension_typesafe(src_spec, rc)
+         extension = this%make_extension_typesafe(dst_spec, rc)
       class default
          _FAIL('incompatible spec')
       end select

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -128,6 +128,7 @@ contains
               ScenarioDescription('scenario_reexport_twice', 'grandparent.yaml', check_name, check_stateitem), &
               ScenarioDescription('history_1',               'cap.yaml',         check_name, check_stateitem), &
               ScenarioDescription('history_wildcard',        'cap.yaml',         check_name, check_stateitem), &
+              ScenarioDescription('extdata_1',               'cap.yaml',         check_name, check_stateitem), &
               ScenarioDescription('precision_extension',     'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('3d_specs',                'parent.yaml',      check_name, check_stateitem), & 
               ScenarioDescription('ungridded_dims',          'parent.yaml',      check_name, check_stateitem),  &
@@ -325,9 +326,9 @@ contains
       msg = description
       expected_itemtype = get_expected_itemtype(expectations, _RC)
 
-      
+
       itemtype=get_itemtype(state, short_name, _RC)
-      @assert_that(expected_itemtype == itemtype, is(true()))
+      @assert_that(short_name, expected_itemtype == itemtype, is(true()))
 
       rc = 0
 

--- a/generic3g/tests/gridcomps/CMakeLists.txt
+++ b/generic3g/tests/gridcomps/CMakeLists.txt
@@ -1,12 +1,18 @@
 esma_set_this ()
 
 add_library(simple_leaf_gridcomp SHARED SimpleLeafGridComp.F90)
-target_link_libraries(simple_leaf_gridcomp MAPL.generic3g scratchpad)
-target_include_directories(simple_leaf_gridcomp PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_link_libraries(simple_leaf_gridcomp scratchpad)
 
 add_library(simple_parent_gridcomp SHARED SimpleParentGridComp.F90)
-target_link_libraries(simple_parent_gridcomp MAPL.generic3g scratchpad)
-target_include_directories(simple_parent_gridcomp PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_link_libraries(simple_parent_gridcomp scratchpad)
+
+add_library(proto_extdata_gc SHARED ProtoExtDataGC.F90)
+
+set (comps simple_parent_gridcomp simple_leaf_gridcomp proto_extdata_gc)
+foreach (comp ${comps})
+  target_link_libraries(${comp} MAPL.generic3g)
+  target_include_directories(${comp} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+endforeach()  
 
 #add_library(parameterized_gridcomp SHARED ParameterizedGridComp.F90)
 #target_link_libraries(parameterized_gridcomp MAPL.generic3g scratchpad)
@@ -14,4 +20,4 @@ target_include_directories(simple_parent_gridcomp PRIVATE ${CMAKE_CURRENT_BINARY
 
 # These targets are not part of all, nor do the tests directly depend upon them (by design).
 # So, we need to ensure that build-tests builds them.
-add_dependencies(build-tests simple_leaf_gridcomp simple_parent_gridcomp) # parameterized_gridcomp)
+add_dependencies(build-tests ${comps}) # parameterized_gridcomp)

--- a/generic3g/tests/gridcomps/ProtoExtDataGC.F90
+++ b/generic3g/tests/gridcomps/ProtoExtDataGC.F90
@@ -1,0 +1,126 @@
+#include "MAPL_ErrLog.h"
+
+! See external setservices() procedure at end of file
+
+
+module ProtoExtDataGC
+   use mapl_ErrorHandling
+   use mapl3g_OuterMetaComponent
+   use mapl3g_GenericConfig
+   use mapl3g_Generic
+   use mapl3g_UserSetServices
+   use mapl3g_HierarchicalRegistry
+   use mapl3g_VirtualConnectionPt
+   use mapl3g_ActualConnectionPt
+   use mapl3g_ConnectionPt
+   use mapl3g_SimpleConnection
+   use mapl3g_AbstractStateItemSpec
+   use esmf
+   implicit none
+   private
+
+   public :: setservices
+   
+contains
+
+   subroutine setservices(gc, rc)
+      use mapl3g_Generic, only: MAPL_GridCompSetEntryPoint
+      type(ESMF_GridComp) :: gc
+      integer, intent(out) :: rc
+
+      integer :: status
+
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_RUN, run, _RC)
+      call MAPL_GridCompSetEntryPoint(gc, ESMF_METHOD_INITIALIZE, init_post_advertise, phase_name='GENERIC::INIT_POST_ADVERTISE', _RC)
+
+      _RETURN(ESMF_SUCCESS)
+   end subroutine setservices
+
+   
+   subroutine init_post_advertise(gc, importState, exportState, clock, rc)
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
+
+      type(OuterMetaComponent), pointer :: outer_meta
+      integer :: status
+      type(VirtualConnectionPt) :: export_v_pt, import_v_pt
+      type(ActualConnectionPt) :: a_pt
+      type(ConnectionPt) :: s_pt, d_pt
+      type(SimpleConnection) :: conn
+      type(HierarchicalRegistry), pointer :: registry
+      class(AbstractStateItemSpec), pointer :: export_spec
+      class(AbstractStateItemSpec), pointer :: import_spec
+
+      outer_meta => get_outer_meta_from_inner_gc(gc, _RC)
+      registry => outer_meta%get_registry()
+
+      _HERE,'hardwired for now - use config eventually'
+      export_v_pt = VirtualConnectionPt(ESMF_STATEINTENT_EXPORT, 'E1')
+      import_v_pt = VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, 'E1')
+      a_pt = ActualConnectionPt(export_v_pt)
+      export_spec => registry%get_item_spec(a_pt, _RC)
+
+      allocate(import_spec, source=export_spec)
+!!$      import_spec = export_spec
+      ! Need new payload ... (but maybe not as it will get tossed at connect() anyway.)
+      call import_spec%create([StateItemSpecPtr::], _RC)
+      call registry%add_item_spec(import_v_pt, import_spec)
+
+      ! And now connect
+      export_v_pt = VirtualConnectionPt(ESMF_STATEINTENT_EXPORT, 'E1')
+      s_pt = ConnectionPt('collection_1', export_v_pt)
+      d_pt = ConnectionPt('<self>', import_v_pt)
+      conn = SimpleConnection(source=s_pt, destination=d_pt)
+
+      call registry%add_connection(conn, _RC)
+
+      _RETURN(ESMF_SUCCESS)
+   end subroutine init_post_advertise
+
+
+   subroutine run(gc, importState, exportState, clock, rc)
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
+
+      type(OuterMetaComponent), pointer :: outer_meta
+      integer :: status
+
+      outer_meta => get_outer_meta_from_inner_gc(gc, _RC)
+      call outer_meta%run_children(clock, _RC)
+      
+      _RETURN(ESMF_SUCCESS)
+   end subroutine run
+   
+   subroutine init(gc, importState, exportState, clock, rc)
+      type(ESMF_GridComp) :: gc
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
+
+      
+      _RETURN(ESMF_SUCCESS)
+   end subroutine init
+
+end module ProtoExtDataGC
+
+subroutine setServices(gc, rc)
+   use esmf, only: ESMF_GridComp
+   use esmf, only: ESMF_SUCCESS
+   use mapl_ErrorHandling
+   use ProtoExtDataGC, only: inner_setservices => setservices
+   type(ESMF_GridComp) :: gc
+   integer, intent(out) :: rc
+
+   integer :: status
+
+   call inner_setservices(gc, _RC)
+
+   _RETURN(ESMF_SUCCESS)
+end subroutine setServices

--- a/generic3g/tests/scenarios/extdata_1/cap.yaml
+++ b/generic3g/tests/scenarios/extdata_1/cap.yaml
@@ -1,0 +1,15 @@
+children:
+  - name: extdata
+    dso:  libproto_extdata_gc
+    config_file: scenarios/extdata_1/extdata.yaml
+  - name: root
+    dso:  libsimple_parent_gridcomp
+    config_file: scenarios/extdata_1/root.yaml
+
+states: {}
+
+
+connections:
+  - all_unsatisfied: true
+    src_comp: extdata
+    dst_comp: root

--- a/generic3g/tests/scenarios/extdata_1/collection_1.yaml
+++ b/generic3g/tests/scenarios/extdata_1/collection_1.yaml
@@ -1,0 +1,7 @@
+
+states:
+  export:
+     E1:
+       standard_name: 'T1'
+       units: none
+       typekind: R8

--- a/generic3g/tests/scenarios/extdata_1/expectations.yaml
+++ b/generic3g/tests/scenarios/extdata_1/expectations.yaml
@@ -1,0 +1,33 @@
+# For each component:
+#   - provide a path to the outer/user componen in the hierarchy
+#   - list the fields expected in each import/export/internal states
+#   - annotate whether field is "complete"
+
+- component: root/<user>
+  import:
+    E1: {status: complete, typekind: R4}
+
+- component: root
+  import:
+    E1: {status: complete, typekind: R4}
+
+- component: extdata/collection_1/<user>
+  export:
+    E1: {status: complete, typekind: R8}
+
+- component: extdata/collection_1
+  export:
+    E1: {status: complete, typekind: R8}
+    E1(0): {status: complete, typekind: R4}
+
+- component: extdata/<user>
+  export:
+    E1: {status: complete, typekind: R4}
+  import:
+    E1: {status: complete, typekind: R4}
+
+- component: extdata
+#  export:
+#    "collection_1/E1": {status: complete, typekind: R8}
+#    "collection_1/E1(0)": {status: complete, typekind: R4}
+

--- a/generic3g/tests/scenarios/extdata_1/extdata.yaml
+++ b/generic3g/tests/scenarios/extdata_1/extdata.yaml
@@ -1,0 +1,11 @@
+states:
+  export:
+     E1:
+       standard_name: 'T1'
+       units: none
+       typekind: mirror
+
+children:
+  - name: collection_1
+    dso:  libsimple_leaf_gridcomp
+    config_file: scenarios/extdata_1/collection_1.yaml

--- a/generic3g/tests/scenarios/extdata_1/root.yaml
+++ b/generic3g/tests/scenarios/extdata_1/root.yaml
@@ -1,0 +1,7 @@
+
+states:
+  import:
+     E1:
+       standard_name: 'T1'
+       units: 'none'
+       typekind: R4

--- a/generic3g/tests/scenarios/history_wildcard/collection_1.yaml
+++ b/generic3g/tests/scenarios/history_wildcard/collection_1.yaml
@@ -1,6 +1,6 @@
 states:
   import:
-    ^A/E_A.*$:
+    A/E_A.*:
       standard_name: 'huh1'
       units: 'x'
       class: wildcard


### PR DESCRIPTION
The `post_advertise` phase is used to do "late" connections.  This is demonstrated with precision extensions in a prototype of a real
extdata component.   The real scenario would involve the Collection
component exporting IntervalSpecs that are connected to ExtData
_after_ the usual connections are complete.

As part of this exercise, "mirroring" was introduced in FieldSpec, but only for Precision matching for now.

A small fix was introduced into handling of wildcard patterns. Previously MatchALl was too aggressive for matching source specs because "^" and "$" were not used to force the pattern to span the entire string rather than match strings that had matching substrings. E.g.,  a dst pattern of "E1" should not match a src virtual pt named "connection/E1".

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
