### PR TITLE
Read string attribute from netCDF variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Read string attribute from netCDF variable
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Read string attribute from netCDF variable
-
 ### Added
+- Added the ability to read string attributes of variables.   This is as opposed to "character" attributes - a distinction made by NetCDF.   Previously a small kludge had been used to allow reading string attributes, but was limited to attributes on the global var.
+
 
 - Trajectory sampler with Epoch time span
 - Added utility to convert binary files used by MAPL\_ReadForcing to NetCDF

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -987,10 +987,8 @@ contains
             call cf%add_attribute(trim(attr_name), str)
             deallocate(str)
          case (NF90_STRING)
-            ! W.Y. Note: pfio only supports global string attributes.
-            ! varid is not passed in. NC_GLOBAL is used inside the call
             !$omp critical
-            status = pfio_get_att_string(this%ncid, trim(attr_name), str)
+            status = pfio_get_att_string(this%ncid, varid, trim(attr_name), str)
             !$omp end critical
             _VERIFY(status)
             call cf%add_attribute(trim(attr_name), str)

--- a/pfio/NetCDF_Supplement.F90
+++ b/pfio/NetCDF_Supplement.F90
@@ -8,12 +8,13 @@ module pfio_NetCDF_Supplement
 
    public :: pfio_get_att_string
    interface
-      function c_f_pfio_get_att_string(ncid, name, string, attlen) &
+      function c_f_pfio_get_att_string(ncid, varid, name, string, attlen) &
            & result(stat) bind(C, name='pfio_get_att_string')
          use, intrinsic :: iso_c_binding
          implicit none
          integer :: stat
          integer(kind=C_INT), value, intent(in) :: ncid
+         integer(kind=C_INT), value, intent(in) :: varid
          character(kind=C_CHAR), intent(in) :: name(*)
          character(kind=C_CHAR), intent(inout) :: string(*)
          integer(kind=C_INT), intent(inout) :: attlen
@@ -22,12 +23,13 @@ module pfio_NetCDF_Supplement
 
 contains
 
-   function pfio_get_att_string(ncid, name, string) result(status)
+   function pfio_get_att_string(ncid, varid, name, string) result(status)
       integer :: status
       integer(kind=C_INT), intent(in) :: ncid
+      integer(kind=C_INT), intent(in) :: varid
       character(*), intent(in) :: name
       character(:), allocatable, intent(out) :: string
-      
+
       integer :: name_len
       integer(kind=C_INT),target :: attlen
       character(kind=C_CHAR, len=:), target, allocatable :: c_name
@@ -40,7 +42,7 @@ contains
       c_name(name_len+1:name_len+1) = C_NULL_CHAR
       tmp_str = ''
       ! This c-call would fill tmp_str with the global attribute
-      status = c_f_pfio_get_att_string(ncid, c_name, tmp_str, attlen)
+      status = c_f_pfio_get_att_string(ncid, varid, c_name, tmp_str, attlen)
       allocate(character(len=attlen) :: string)
       string = trim(tmp_str)
       deallocate(c_name)

--- a/pfio/pfio_get_att_string.c
+++ b/pfio/pfio_get_att_string.c
@@ -10,12 +10,15 @@ void pfio_check(int stat) {
   }
 }
 
-int pfio_get_att_string(int ncid, const char* name, char* value, int *attlen)
+int pfio_get_att_string(int ncid, int varid, const char* name, char* value, int *attlen)
 {
   int stat;
   size_t alen;
 
-  stat = nc_inq_attlen(ncid, NC_GLOBAL, name, &alen); pfio_check(stat);
+  /* note: C-varid starts from 0, Fortran from 1 */
+  int varid_C = varid - 1;
+
+  stat = nc_inq_attlen(ncid, varid_C, name, &alen); pfio_check(stat);
  
   if (alen > 1) {
    printf("pfio doesnot support multi-dimentional strings");
@@ -25,7 +28,7 @@ int pfio_get_att_string(int ncid, const char* name, char* value, int *attlen)
   char **string_attr = (char**)malloc( sizeof(char*));
   memset(string_attr, 0, sizeof(char*));
 
-  stat = nc_get_att_string(ncid, NC_GLOBAL, name, string_attr); pfio_check(stat);
+  stat = nc_get_att_string(ncid, varid_C, name, string_attr); pfio_check(stat);
 
   *attlen = 0;
   alen = 0;


### PR DESCRIPTION
## Description

Previously  pfio only supports global string attributes.  This PR enables reading string attribute from netCDF variable in any VARID. 


## Related Issue

To read a IODA file with the string attribute, we need access to pfio/pfio_get_att_string.c.  The current setting allows for  varied = NC_GLOBAL only.  

Turned out:
C starts the varid from zero while Fortran from 1.   A constant shift is needed when using netCDF Fortran varid to access  netCDF-C function such as nc_get_att_string.   

Input: 
```
group: MetaData 
  variables:
             int64 dateTime(Location) ;
                 string dateTime:units = "seconds since 1970-01-01T00:00:00Z" ;
```
Output:  
```
ncid2, ncid, varid (Fortran)=       65536       65546           2
 xtype=12, len=          1
varid(C) = 1
 timeunits=seconds since 1970-01-01T00:00:00Z
```

## How Has This Been Tested?
gcc compiler

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
