### PR TITLE
Fix MAPL dependencies for MAPL-as-library in CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.40.4] - 2023-09-01
+
+### Fixed
+
+- Fixed handling of MAPL dependencies for when `find_package(MAPL)` is used
+
 ## [2.40.3] - 2023-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [2.40.4] - 2023-09-01
+## [2.40.4] - 2023-09-14
 
 ### Fixed
 

--- a/cmake/mapl-import.cmake.in
+++ b/cmake/mapl-import.cmake.in
@@ -1,3 +1,0 @@
-list (APPEND CMAKE_MODULE_PATH @MAPL_FULL_INSTALL_DATA_DIR@/cmake)
-include (mapl_create_stub_component)
-include (mapl_acg)

--- a/mapl-import.cmake.in
+++ b/mapl-import.cmake.in
@@ -1,5 +1,9 @@
 include(CMakeFindDependencyMacro)
 
+find_dependency(MPI COMPONENTS Fortran REQUIRED)
+find_dependency(NetCDF COMPONENTS Fortran REQUIRED)
+find_dependency(OpenMP COMPONENTS Fortran REQUIRED)
+
 set(GFTL_FOUND @GFTL_FOUND@)
 if(GFTL_FOUND)
    find_dependency(GFTL HINTS @GFTL_DIR@)

--- a/mapl-import.cmake.in
+++ b/mapl-import.cmake.in
@@ -1,0 +1,25 @@
+include(CMakeFindDependencyMacro)
+
+set(GFTL_FOUND @GFTL_FOUND@)
+if(GFTL_FOUND)
+   find_dependency(GFTL HINTS @GFTL_DIR@)
+endif()
+
+set(GFTL_SHARED_FOUND @GFTL_SHARED_FOUND@)
+if(GFTL_SHARED_FOUND)
+   find_dependency(GFTL_SHARED HINTS @GFTL_SHARED_DIR@)
+endif()
+
+set(FARGPARSE_FOUND @FARGPARSE_FOUND@)
+if(FARGPARSE_FOUND)
+   find_dependency(FARGPARSE HINTS @FARGPARSE_DIR@)
+endif()
+
+set(PFLOGGER_FOUND @PFLOGGER_FOUND@)
+if(PFLOGGER_FOUND)
+   find_dependency(PFLOGGER HINTS @PFLOGGER_DIR@)
+endif()
+
+list (APPEND CMAKE_MODULE_PATH @MAPL_FULL_INSTALL_DATA_DIR@/cmake)
+include (mapl_create_stub_component)
+include (mapl_acg)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is an attempt to fix an issue being seen by @climbfuji in using the latest MAPL in UFS. I believe the problem is that now MAPL is being built with pFlogger (and fArgparse?) support and GOCART-as-UFS builds doesn't know that those are needed. 

I tried to do some limited testing locally and I think this solves at least the CMake problems. The main thing is I can't do any building because I don't think I have the right flags set (since I'm building as `-DUFS_GOCART=ON`) and so I get:
```
/Users/mathomp4/Models/GOCART-LikeUFS/GOCART/Process_Library/MieQuery.H:156:132:

  156 |              pmom(__DIMS__,i,j)  =  __RHINTERP5__(this%pmom, irh, arh, channel, bin, i, j, rh)
      |                                                                                                                                    1
Error: Line truncated at (1) [-Werror=line-truncation]
```

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Let's users of MAPL-as-library via `find_package(MAPL)` get dependencies correct.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not much at all.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
