### PR TITLE
Trajectory sampler : regrid to locations in IODA files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- OSSE project: trajectory sampler (regrid to IODA locations) with file template. With ExtDataDriver.x, it can ingest G5NR (DC5760x2881-PC) then export to a single IODA output locsteam.
 ### Added
 
 - Added the ability to read string attributes of variables.   This is as opposed to "character" attributes - a distinction made by NetCDF.   Previously a small kludge had been used to allow reading string attributes, but was limited to attributes on the global var.

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -1,7 +1,7 @@
 !-------------------------------------------------------------------
-! Note:
+! Note: used for OSSE project
 !   File to be replaced by more systematic implementations.
-!   It contains ad hoc codes for time conversion and time bisect,
+!   It contains codes for time conversion and time bisect.
 !-------------------------------------------------------------------
 
 #include "MAPL_Exceptions.h"
@@ -37,7 +37,7 @@ module Plain_netCDF_Time
   interface convert_time_esmf2nc
      procedure :: time_esmf_2_nc_int
   end interface convert_time_esmf2nc
-  
+
   interface get_v2d_netcdf
      procedure ::  get_v2d_netcdf_R4
      procedure ::  get_v2d_netcdf_R8
@@ -47,7 +47,7 @@ module Plain_netCDF_Time
      procedure :: parse_timeunit_i4
      procedure :: parse_timeunit_i8
   end interface parse_timeunit
-  
+
   interface hms_2_s
      procedure :: hms_2_s
   end interface hms_2_s
@@ -68,8 +68,8 @@ contains
     integer :: ncid , dimid
     integer :: status
     character(len=ESMF_MAXSTR) :: lon_name, lat_name, time_name
-    
-    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)    
+
+    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     if (present(key_lon)) then
        lon_name=trim(key_lon)
        !    call check_nc_status(nf90_inq_dimid(ncid, "lon", dimid), _RC)
@@ -80,15 +80,15 @@ contains
     if (present(key_lat)) then
        lat_name=trim(key_lat)
        !    call check_nc_status(nf90_inq_dimid(ncid, "lat", dimid), _RC)
-       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)    
+       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)
        call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlat), _RC)
        call check_nc_status(nf90_close(ncid), _RC)
     endif
 
     if (present(key_time)) then
-       time_name=trim(key_time)    
+       time_name=trim(key_time)
        !    call check_nc_status(nf90_inq_dimid(ncid, 'time', dimid), _RC)
-       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)    
+       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)
        call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=tdim), _RC)
     endif
     call check_nc_status(nf90_close(ncid), _RC)
@@ -144,7 +144,7 @@ contains
     deallocate(str)
     iret = nf90_close(ncid)
 
-  end subroutine get_attribute_from_group  
+  end subroutine get_attribute_from_group
 
 
 
@@ -171,7 +171,7 @@ contains
     iret = nf90_close(ncid)
   end subroutine get_v2d_netcdf_R4
 
-  
+
   subroutine get_v2d_netcdf_R8(filename, name, array, Xdim, Ydim)
     use netcdf
     implicit none
@@ -326,7 +326,7 @@ contains
     !  call ESMF_CalendarDestroy(gregorianCalendar, rc=rc)
     !  if(present(rc)) rc=0
     rc=0
-    
+
   end subroutine parse_timeunit_i4
 
 
@@ -374,9 +374,9 @@ contains
     !  call ESMF_CalendarDestroy(gregorianCalendar, rc=rc)
     !  if(present(rc)) rc=0
     rc=0
-    
+
   end subroutine parse_timeunit_i8
-  
+
   subroutine ESMF_time_to_two_integer (time, itime, rc)
     type (ESMF_Time), intent(in) ::   time
     integer, intent(out) :: itime(2)
@@ -431,7 +431,7 @@ contains
 
     sec= h*3600 + m*60 + s
     if (present(rc)) rc=0
-    
+
   end subroutine hms_2_s
 
 
@@ -442,7 +442,7 @@ contains
     real(ESMF_KIND_R8), intent(in) :: x       ! pt
     integer(ESMF_KIND_I8), intent(out) :: n   !  out: bisect index
     integer(ESMF_KIND_I8), intent(in), optional :: n_LB  !  opt in : LB
-    integer(ESMF_KIND_I8), intent(in), optional :: n_UB  !  opt in : UB     
+    integer(ESMF_KIND_I8), intent(in), optional :: n_UB  !  opt in : UB
     integer, intent(out), optional :: rc
 
     integer(ESMF_KIND_I8) :: k, klo, khi, dk, LB, UB
@@ -452,7 +452,7 @@ contains
     if(present(n_LB)) LB=n_LB
     if(present(n_UB)) UB=n_UB
     klo=LB; khi=UB; dk=1
-    
+
     ! write(6,*) 'init klo, khi', klo, khi
     if ( xa(LB ) > xa(UB) )  then
        klo= UB
@@ -465,7 +465,7 @@ contains
     !     x         x                       x
     !
     !        Y(n)  <  x  <=  Y(n+1)
-    
+
     rc=-1
     if ( x <= xa(klo) ) then
        !write(6,*) 'xa(klo), xa(khi), x', xa(klo), xa(khi), x
@@ -492,20 +492,20 @@ contains
           return
        endif
     enddo
-    
+
   end subroutine bisect_find_LB_R8_I8
-    
+
 
   subroutine convert_twostring_2_esmfinterval (symd, shms, interval, rc)
     character(len=*) :: symd
     character(len=*) :: shms
     type (ESMF_TimeInterval), intent(out) :: interval
     integer, optional, intent(out) :: rc
-    integer :: status    
+    integer :: status
     character(len=20) :: s1, s2
     integer :: y, m, d, hh, mm, ss
 
-    
+
     s1=trim(symd)
     read(s1, '(3i2)') y, m, d
     s2=trim(shms)

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -1,20 +1,27 @@
+!-------------------------------------------------------------------
+! Note:
+!   File to be replaced by more systematic implementations.
+!   It contains ad hoc codes for time conversion and time bisect,
+!-------------------------------------------------------------------
+
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
 !
 !>
-!### MODULE: `MAPL_plain_netCDF_Time`
+!### MODULE: `Plain_netCDF_Time`
 !
 ! Author: GMAO SI-Team
 !
-module MAPL_plain_netCDF_Time
+module Plain_netCDF_Time
   use MAPL_KeywordEnforcerMod
   use MAPL_ExceptionHandling
   use MAPL_ShmemMod
   use mapl_ErrorHandlingMod
   use MAPL_Constants
   use ESMF
+  use pfio_NetCDF_Supplement
   !   use MAPL_CommsMod
   use, intrinsic :: iso_fortran_env, only: REAL32
   use, intrinsic :: iso_fortran_env, only: REAL64
@@ -30,17 +37,6 @@ module MAPL_plain_netCDF_Time
   interface convert_time_esmf2nc
      procedure :: time_esmf_2_nc_int
   end interface convert_time_esmf2nc
-
-!C  interface get_ncfile_dimension
-!     procedure :: get_ncfile_dimension
-!     procedure :: get_ncfile_dimension_I8     
-!C  end interface get_ncfile_dimension
-!
-!C  interface get_v1d_netcdf
-!     procedure :: get_v1d_netcdf_R8
-!     procedure :: get_v1d_netcdf_R8_I8
-!C  end interface get_v1d_netcdf
-
   
   interface get_v2d_netcdf
      procedure ::  get_v2d_netcdf_R4
@@ -101,46 +97,56 @@ contains
     !write(6,*) "get_ncfile_dimension:  nlat, nlon, tdim = ", nlat, nlon, tdim
   end subroutine get_ncfile_dimension
 
-!
-!  subroutine get_ncfile_dimension_I8(filename, nlon, nlat, tdim, key_lon, key_lat, key_time, rc)
-!    use netcdf
-!    implicit none
-!    character(len=*), intent(in) :: filename
-!    integer*8, optional,intent(out) :: nlat, nlon, tdim
-!    character(len=*), optional, intent(in)  :: key_lon, key_lat, key_time
-!    integer, optional, intent(out) :: rc
-!    integer :: ncid , dimid
-!    integer :: status
-!    character(len=ESMF_MAXSTR) :: lon_name, lat_name, time_name
-!    
-!    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)    
-!    if (present(key_lon)) then
-!       lon_name=trim(key_lon)
-!       !    call check_nc_status(nf90_inq_dimid(ncid, "lon", dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(lon_name), dimid), _RC)
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlon), _RC)
-!    endif
-!
-!    if (present(key_lat)) then
-!       lat_name=trim(key_lat)
-!       !    call check_nc_status(nf90_inq_dimid(ncid, "lat", dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)    
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlat), _RC)
-!       call check_nc_status(nf90_close(ncid), _RC)
-!    endif
-!
-!    if (present(key_time)) then
-!       time_name=trim(key_time)    
-!       !    call check_nc_status(nf90_inq_dimid(ncid, 'time', dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)    
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=tdim), _RC)
-!    endif
-!    call check_nc_status(nf90_close(ncid), _RC)
-!
-!    !- debug summary
-!    !write(6,*) "get_ncfile_dimension:  nlat, nlon, tdim = ", nlat, nlon, tdim
-!  end subroutine get_ncfile_dimension_I8
-!  
+
+  subroutine get_attribute_from_group(filename, group_name, var_name, attr_name, attr)
+    use netcdf
+    use pfio_NetCDF_Supplement
+    implicit none
+    character(len=*), intent(in) :: filename, group_name, var_name, attr_name
+    character(len=*), intent(INOUT) :: attr
+    integer :: ncid, varid, ncid2
+    integer :: rc, status, iret
+    integer :: len, i, j, k
+    integer :: xtype
+    character(len=:), allocatable :: str
+    integer :: number
+    integer :: attnum, nAttributes
+    character(len=NF90_MAX_NAME) :: attr_name2
+    integer(kind=C_INT) :: c_ncid, c_varid
+    character(len=100) :: str2
+
+    call check_nc_status ( nf90_open      (fileName, NF90_NOWRITE, ncid2), rc )
+    call check_nc_status ( nf90_inq_ncid  (ncid2, group_name, ncid),  rc )
+    call check_nc_status ( nf90_inq_varid (ncid,  var_name,  varid), rc )
+    call check_nc_status ( nf90_inquire_attribute(ncid, varid, attr_name, xtype, len=len), rc )
+    c_ncid= ncid
+    c_varid= varid
+    !! print*, 'f: xtype, len=', xtype, len
+    select case (xtype)
+    case(NF90_STRING)
+       status = pfio_get_att_string(c_ncid, c_varid, attr_name, str)
+       _VERIFY(status)
+    case (NF90_CHAR)
+       allocate(character(len=len) :: str)
+       status = nf90_get_att(ncid, varid, trim(attr_name), str)
+    case default
+       _FAIL('code works only with string attribute')
+    end select
+    i=index(str, 'since')
+    ! get rid of T in 1970-01-01T00:00:0
+    str2=str(i+6:i+24)
+    j=index(str2, 'T')
+    if (j>1) then
+       k=len_trim(str2)
+       str2=str2(1:j-1)//' '//str2(j+1:k)
+    endif
+    attr = str(1:i+5)//trim(str2)
+    deallocate(str)
+    iret = nf90_close(ncid)
+
+  end subroutine get_attribute_from_group  
+
+
 
   subroutine get_v2d_netcdf_R4(filename, name, array, Xdim, Ydim)
     use netcdf
@@ -211,27 +217,6 @@ contains
   end subroutine get_v1d_netcdf_R8
 
 
-!  subroutine get_v1d_netcdf_R8_I8(filename, name, array, Xdim, group_name)
-!    use netcdf
-!    implicit none
-!    character(len=*), intent(in) :: name, filename
-!    character(len=*), optional, intent(in) :: group_name
-!    integer*8, intent(in) :: Xdim
-!    real*8, dimension(Xdim), intent(out) :: array
-!    integer :: ncid, varid, ncid2
-!    integer :: rc, status, iret
-!
-!    call check_nc_status (  nf90_open      (trim(fileName), NF90_NOWRITE, ncid), _RC )
-!    if (present(group_name)) then
-!       ncid2= ncid
-!       call check_nc_status ( nf90_inq_ncid ( ncid2, group_name, ncid),  _RC )
-!    end if
-!    call check_nc_status (  nf90_inq_varid (ncid,  name,  varid), _RC )
-!    call check_nc_status (  nf90_get_var   (ncid, varid,  array), _RC )
-!    iret = nf90_close(ncid)
-!  end subroutine get_v1d_netcdf_R8_I8
-  
-
   subroutine check_nc_status(status, rc)
     use netcdf
     implicit none
@@ -284,7 +269,7 @@ contains
     n=0
     call parse_timeunit (tunit, n, time0, dt, rc)
     dt = time - time0
-    !
+    ! -- To-be-deleted: this is a bug
     ! assume unit is second
     !
     call ESMF_TimeIntervalGet(dt, s_i8=n)
@@ -535,4 +520,4 @@ contains
     if (present(rc)) rc=0
   end subroutine convert_twostring_2_esmfinterval
 
-end module MAPL_Plain_NetCDF_Time
+end module Plain_NetCDF_Time

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -3436,7 +3436,6 @@ ENDDO PARSER
          lgr => logging%get_logger('HISTORY.sampler')
          if (list(n)%timeseries_output) then
             if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
-               call list(n)%trajectory%close_file_handle(_RC)
                call list(n)%trajectory%create_file_handle(filename(n),_RC)
                list(n)%currentFile = filename(n)
                list(n)%unit = -1
@@ -3596,8 +3595,7 @@ ENDDO PARSER
          call list(n)%trajectory%regrid_accumulate(_RC)
          if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
             call list(n)%trajectory%append_file(current_time,_RC)
-            !!bug
-            !!the barrier did not work
+            call list(n)%trajectory%close_file_handle(_RC)
             call ESMF_GridCompGet(gc, vm=vm, _RC)
             call ESMF_VMGetCurrent(vm, _RC)
             call ESMF_VMbarrier(vm, _RC)
@@ -3866,9 +3864,9 @@ ENDDO PARSER
             call MAPL_GridGet(pgrid,globalCellCountPerDim=dims,_RC)
             IM = dims(1)
             JM = dims(2)
-            DLON   =  360._REAL64/float(IM)
+            DLON   =  360._REAL64/IM
             if (JM /= 1) then
-               DLAT   =  180._REAL64/float(JM-1)
+               DLAT   =  180._REAL64/(JM-1)
             else
                DLAT   =  1.0
             end if

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -59,6 +59,7 @@
   use gFTL_StringStringMap
   !use ESMF_CFIOMOD
   use pflogger, only: Logger, logging
+  use mpi
 
   implicit none
   private
@@ -141,8 +142,6 @@
   integer, parameter :: MAPL_T2G2G = 3
 
   public HISTORY_ExchangeListWrap
-
-  include "mpif.h"
 
 contains
 
@@ -3401,7 +3400,7 @@ ENDDO PARSER
 !         write(6,'(10a)') 'trim(INTSTATE%expid)', trim(INTSTATE%expid)
 !         write(6,'(2x,a,10i20)') 'nymd, nhms', nymd, nhms
 
-         
+
          call fill_grads_template ( filename(n), fntmpl, &
               experiment_id=trim(INTSTATE%expid), &
               nymd=nymd, nhms=nhms, _RC ) ! here is where we get the actual filename of file we will write
@@ -3410,7 +3409,7 @@ ENDDO PARSER
 !         write(6,'(a)') 'filename(n), fntmpl=', trim(filename(n)), trim(fntmpl)
 !         write(6,'(10a)') 'trim(INTSTATE%expid)', trim(INTSTATE%expid)
 !         write(6,'(2x,a,10i20)') 'nymd, nhms', nymd, nhms
-         
+
 
          if(list(n)%monthly .and. list(n)%partial) then
             filename(n)=trim(filename(n)) // '-partial'
@@ -3598,7 +3597,7 @@ ENDDO PARSER
          if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
             call list(n)%trajectory%append_file(current_time,_RC)
             !!bug
-            !!the barrier did not work when destroy crashes
+            !!the barrier did not work
             call ESMF_GridCompGet(gc, vm=vm, _RC)
             call ESMF_VMGetCurrent(vm, _RC)
             call ESMF_VMbarrier(vm, _RC)

--- a/gridcomps/History/MAPL_HistoryTrajectoryMod.F90
+++ b/gridcomps/History/MAPL_HistoryTrajectoryMod.F90
@@ -62,7 +62,7 @@ module HistoryTrajectoryMod
      type(ESMF_TimeInterval)        :: obsfile_interval
      integer                        :: obsfile_Ts_index     ! for epoch
      integer                        :: obsfile_Te_index     
-     logical                        :: obsfile_is_available
+     logical                        :: is_valid
 
    contains
      procedure :: initialize
@@ -152,6 +152,7 @@ module HistoryTrajectoryMod
      end subroutine time_real_to_ESMF
 
      module subroutine create_grid(this, rc)
+       !!use pflogger, only: Logger, logging
        class(HistoryTrajectory), intent(inout) :: this
        integer, optional, intent(out)          :: rc
     end subroutine create_grid

--- a/gridcomps/History/MAPL_HistoryTrajectoryMod.F90
+++ b/gridcomps/History/MAPL_HistoryTrajectoryMod.F90
@@ -21,13 +21,13 @@ module HistoryTrajectoryMod
      type(ESMF_Time), allocatable :: times(:)
      real(kind=REAL64), allocatable :: times_R8(:)
      real(kind=REAL64), allocatable :: lons(:)
-     real(kind=REAL64), allocatable :: lats(:)     
+     real(kind=REAL64), allocatable :: lats(:)
      type(ESMF_FieldBundle) :: bundle
      type(ESMF_FieldBundle) :: output_bundle
      type(ESMF_FieldBundle) :: acc_bundle
      type(ESMF_Field)       :: fieldA
      type(ESMF_Field)       :: fieldB
-     
+
      type(GriddedIOitemVector) :: items
      type(FileMetadata) :: metadata
      type(VerticalData) :: vdata
@@ -61,7 +61,7 @@ module HistoryTrajectoryMod
      type(ESMF_Time)                :: obsfile_end_time
      type(ESMF_TimeInterval)        :: obsfile_interval
      integer                        :: obsfile_Ts_index     ! for epoch
-     integer                        :: obsfile_Te_index     
+     integer                        :: obsfile_Te_index
      logical                        :: is_valid
 
    contains
@@ -81,7 +81,7 @@ module HistoryTrajectoryMod
      procedure :: get_x_subset
      procedure :: get_obsfile_Tbracket_from_epoch
      procedure :: get_filename_from_template_use_index
-     
+
   end type HistoryTrajectory
 
   interface HistoryTrajectory
@@ -104,7 +104,7 @@ module HistoryTrajectoryMod
        type(TimeData), intent(inout)           :: timeInfo
        type(VerticalData), optional, intent(inout) :: vdata
        logical, optional, intent(inout)        :: recycle_track
-       integer, optional, intent(out)          :: rc       
+       integer, optional, intent(out)          :: rc
      end subroutine initialize
 
      module subroutine  create_metadata_variable(this,vname,rc)
@@ -143,7 +143,7 @@ module HistoryTrajectoryMod
 
      module subroutine sort_three_arrays_by_time(U,V,T,rc)
        real(ESMF_KIND_R8) :: U(:), V(:), T(:)
-       integer, optional, intent(out)          :: rc       
+       integer, optional, intent(out)          :: rc
      end subroutine sort_three_arrays_by_time
 
      module subroutine time_real_to_ESMF (this,rc)
@@ -152,7 +152,6 @@ module HistoryTrajectoryMod
      end subroutine time_real_to_ESMF
 
      module subroutine create_grid(this, rc)
-       !!use pflogger, only: Logger, logging
        class(HistoryTrajectory), intent(inout) :: this
        integer, optional, intent(out)          :: rc
     end subroutine create_grid
@@ -180,14 +179,14 @@ module HistoryTrajectoryMod
        type(ESMF_Time), intent(in)             :: currTime
        integer, optional, intent(out)          :: rc
      end subroutine get_obsfile_Tbracket_from_epoch
-     
+
      module function get_filename_from_template (time, file_template, rc) result(filename)
        type(ESMF_Time), intent(in)             :: time
        character(len=*), intent(in)            :: file_template
-       character(len=ESMF_MAXSTR)              :: filename              
+       character(len=ESMF_MAXSTR)              :: filename
        integer, optional, intent(out)          :: rc
      end function get_filename_from_template
- 
+
      module function get_filename_from_template_use_index (this, f_index, rc) result(filename)
        class(HistoryTrajectory), intent(inout) :: this
 !       character(len=*), intent(in)            :: file_template

--- a/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
+++ b/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
@@ -43,7 +43,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          integer                    :: itime(2), nymd, nhms
          character(len=ESMF_MAXSTR) :: STR1
          character(len=ESMF_MAXSTR) :: symd, shms
-         integer                    :: i, j, k         
+         integer                    :: i, j, k
 
          ! __ s1. parse variables; set alarm
          ! __ s2. retrieve obs_file; set default for obs_begin, end, is_valid
@@ -102,9 +102,9 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                write(6,105) 'obs_file_end provided:', trim(STR1)
             end if
          end if
-         
+
          call ESMF_ConfigGetAttribute(config, value=STR1, default="", &
-              label=trim(string) // 'obs_file_interval:', _RC)         
+              label=trim(string) // 'obs_file_interval:', _RC)
          _ASSERT(STR1/='', 'fatal error: obs_file_interval not provided in RC file')
          if (mapl_am_I_root()) write(6,105) 'obs_file_interval:', trim(STR1)
          if (mapl_am_I_root()) write(6,106) 'Epoch (second)   :', second
@@ -123,11 +123,11 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          ! when obs is valid, traj sampler is valid
          !
          traj%is_valid = .true.
-         
+
          _RETURN(_SUCCESS)
 
 105      format (1x,a,2x,a)
-106      format (1x,a,2x,i8)         
+106      format (1x,a,2x,i8)
        end procedure
 
 
@@ -144,7 +144,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
          this%bundle=bundle
          this%items=items
-         
+
          if (present(vdata)) then
             this%vdata=vdata
          else
@@ -165,7 +165,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          endif
          call this%create_grid(_RC)
          call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
-         this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)         
+         this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)
          this%output_bundle = this%create_new_bundle(_RC)
          this%acc_bundle    = this%create_new_bundle(_RC)
          this%time_info = timeInfo
@@ -261,7 +261,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
         integer :: rank,lb(1),ub(1)
         real(kind=REAL32), pointer :: p_acc_3d(:,:),p_acc_2d(:)
         integer :: status
-        
+
         new_bundle = ESMF_FieldBundleCreate(_RC)
         iter = this%items%begin()
         do while (iter /= this%items%end())
@@ -319,7 +319,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
           if (.NOT. this%is_valid) then
              _RETURN(ESMF_SUCCESS)
           endif
-           
+
           if (trim(this%file_name) /= '') then
              if (mapl_am_i_root()) then
                 call this%file_handle%close(_RC)
@@ -335,7 +335,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(ESMF_RouteHandle) :: RH
 
          type(ESMF_Field) :: src_field, dst_field
-         type(ESMF_Field) :: acc_field         
+         type(ESMF_Field) :: acc_field
          type(ESMF_Field) :: acc_field_2d_rt, acc_field_3d_rt
          !!real(kind=REAL32), allocatable :: p_new_lev(:,:,:)
          !!real(kind=REAL32), pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
@@ -364,7 +364,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             rc=0
             return
          endif
-         
+
          if (mapl_am_i_root()) then
             _ASSERT (nx /= 0, 'wrong, we should never have zero obs here!')
             call this%file_handle%put_var(this%var_name_time, real(this%times_R8), &
@@ -404,12 +404,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                else if (rank==2) then
                   call ESMF_FieldGet( acc_field, localDE=0, farrayPtr=p_acc_3d, _RC)
                   call ESMF_FieldGet( acc_field_3d_rt, localDE=0, farrayPtr=p_acc_rt_3d, _RC)
-                  
+
                   dst_field=ESMF_FieldCreate(this%LS_rt,typekind=ESMF_TYPEKIND_R4, &
                        gridToFieldMap=[2],ungriddedLBound=[1],ungriddedUBound=[lm],_RC)
                   src_field=ESMF_FieldCreate(this%LS_ds,typekind=ESMF_TYPEKIND_R4, &
                        gridToFieldMap=[2],ungriddedLBound=[1],ungriddedUBound=[lm],_RC)
-                  
+
                   call ESMF_FieldGet(src_field,localDE=0,farrayPtr=p_src,_RC)
                   call ESMF_FieldGet(dst_field,localDE=0,farrayPtr=p_dst,_RC)
 
@@ -436,8 +436,8 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_FieldDestroy(acc_field_3d_rt, noGarbage=.true., _RC)
          call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
 
-         !!print*, 'end append_file, nobs_epoch=', nx         
-         
+         !!print*, 'end append_file, nobs_epoch=', nx
+
          _RETURN(_SUCCESS)
 
        end procedure append_file
@@ -506,7 +506,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          integer :: i, len
          integer :: int_time
          integer :: status
-         
+
          datetime_units = this%datetime_units
          len = size (this%times_R8)
          do i=1, len
@@ -527,14 +527,14 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(FileMetadataUtils) :: metadata_utils
          type(FileMetadata) :: fmd
          !!integer(ESMF_KIND_I8) :: num_times
-         integer(ESMF_KIND_I4) :: num_times         
+         integer(ESMF_KIND_I4) :: num_times
          integer :: ncid, ncid0
          integer :: dimid(10),  dimlen(10)
          integer :: len
-         integer :: len_full         
+         integer :: len_full
          integer :: status
          type(Logger), pointer :: lgr
-         
+
          character(len=ESMF_MAXSTR) :: grp_name
          character(len=ESMF_MAXSTR) :: dim_name(10)
          character(len=ESMF_MAXSTR) :: var_name_lon
@@ -549,7 +549,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
          real(kind=REAL64), allocatable :: lons_full(:), lats_full(:)
          real(kind=REAL64), allocatable :: times_R8_full(:)
-         real(kind=REAL64), allocatable :: XA(:)         
+         real(kind=REAL64), allocatable :: XA(:)
 
          integer(ESMF_KIND_I4), pointer :: ptAI(:), ptBI(:)
          real(ESMF_KIND_R8), pointer :: ptAT(:), ptBT(:)
@@ -561,7 +561,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(ESMF_Field) :: src_fld, dst_fld
          type(ESMF_Field) :: src_fld2, dst_fld2
          type(ESMF_Grid) :: grid
-         
+
          type(ESMF_VM) :: vm
          integer :: mypet, petcount
 
@@ -584,7 +584,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          lgr => logging%get_logger('HISTORY.sampler')
 
          call ESMF_VMGetGlobal(vm,_RC)
-         call ESMF_VMGet(vm, localPet=mypet, petCount=petCount, _RC)         
+         call ESMF_VMGet(vm, localPet=mypet, petCount=petCount, _RC)
 
          if (this%nc_index == '') then
             filename=trim(this%obsFile)
@@ -601,7 +601,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                call formatter%get_var("latitude",this%lats,_RC)
             end if
             call metadata_utils%get_time_info(timeVector=this%times,_RC)
-         else         
+         else
             i=index(this%nc_longitude, '/')
             _ASSERT (i>0, 'group name not found')
             grp_name = this%nc_longitude(1:i-1)
@@ -609,7 +609,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             this%var_name_lon = this%nc_longitude(i+1:)
             this%var_name_time= this%nc_time(i+1:)
 
-            
+
             ! __ loop obsfile_index for epoch
             !    get max len, allocate array, concatenate , get_var
             !
@@ -624,7 +624,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                rc=0
                return
             end if
-            
+
 
             ! __ this is all fid_e >= L case : file exist at this time
             !    read in dim
@@ -637,17 +637,17 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   filename = this%get_filename_from_template_use_index(j, _RC)
                   call lgr%debug('%a %a', 'input filename: ', trim(filename))
                   !!call get_ncfile_dimension_I8(filename, tdim=num_times, key_time=this%nc_index, _RC)
-                  call get_ncfile_dimension(filename, tdim=num_times, key_time=this%nc_index, _RC)               
+                  call get_ncfile_dimension(filename, tdim=num_times, key_time=this%nc_index, _RC)
                   len = len + num_times
                   j=j+1
-               enddo            
+               enddo
                len_full = len
                allocate(lons_full(len),lats_full(len),_STAT)
                allocate(times_R8_full(len),_STAT)
                call lgr%debug('%a %i12', 'nobs from input file:', len_full)
-               
+
                j = max (fid_s, L)
-               len = 0 
+               len = 0
                do while (j<=fid_e)
                   filename = this%get_filename_from_template_use_index(j, _RC)
                   call get_ncfile_dimension(trim(filename), tdim=num_times, key_time=this%nc_index, _RC)
@@ -676,12 +676,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                enddo
             end if
 
-            
+
             !__ epoch grid on root
-            !   
+            !
             !
             if (mapl_am_I_root()) then
-               call sort_three_arrays_by_time(lons_full, lats_full, times_R8_full, _RC)               
+               call sort_three_arrays_by_time(lons_full, lats_full, times_R8_full, _RC)
                call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
                timeset(1) = current_time
                timeset(2) = current_time + this%epoch_frequency
@@ -699,7 +699,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                endif
                call lgr%debug ('%a %f20.1 %f20.1', 'jx0, jx1', jx0, jx1)
                call lgr%debug ('%a %i20 %i20', 'jt1, jt2', jt1, jt2)
-               
+
                ! (x1, x2]  design in bisect
                if (jt1==0) then
                   this%epoch_index(1)= 1
@@ -717,7 +717,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                this%nobs_epoch = nx
                allocate(this%lons(nx),this%lats(nx),_STAT)
                allocate(this%times_R8(nx),_STAT)
-               
+
                j=this%epoch_index(1)
                do i=1, nx
                   this%lons(i) = lons_full(j)
@@ -736,14 +736,14 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                this%epoch_index(1:2)=0
                this%nobs_epoch = 0
                nx=0
-               arr(1)=nx               
+               arr(1)=nx
             endif
-            
+
             call ESMF_VMAllFullReduce(vm, sendData=arr, recvData=nx_sum, &
                  count=1, reduceflag=ESMF_REDUCE_SUM, rc=rc)
-            this%nobs_epoch_sum = nx_sum            
+            this%nobs_epoch_sum = nx_sum
             if (mapl_am_I_root()) write(6,*) 'nobs in Epoch    :', nx_sum
-            
+
             this%locstream_factory = LocStreamFactory(this%lons,this%lats,_RC)
             this%LS_rt = this%locstream_factory%create_locstream(_RC)
             call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
@@ -758,12 +758,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                ptAT(:) = this%times_R8(:)
             end if
             this%obsTime= -1.d0
-            
+
             call ESMF_FieldRedistStore (this%fieldA, this%fieldB, RH, _RC)
             call ESMF_FieldRedist      (this%fieldA, this%fieldB, RH, _RC)
 
-            !!write(6,'(2x,a,i5,2x,10E20.11)')  'pet=', mypet, this%obsTime(1:10)            
-            
+            !!write(6,'(2x,a,i5,2x,10E20.11)')  'pet=', mypet, this%obsTime(1:10)
+
             call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
             call ESMF_FieldDestroy(this%fieldA,nogarbage=.true.,_RC)
             ! defer destroy fieldB at regen_grid step
@@ -801,7 +801,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            if (.NOT. this%is_valid) then
               _RETURN(ESMF_SUCCESS)
            endif
-           
+
            ! __ s1.  get x_subset for each model time step interval on each pet
            call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
            call ESMF_ClockGet(this%clock,timeStep=dur, _RC )
@@ -872,12 +872,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          module procedure get_x_subset
            type   (ESMF_Time)    :: T1,  T2
            real   (ESMF_KIND_R8) :: rT1, rT2
-           
+
            integer(ESMF_KIND_I8) :: i1,  i2
            integer(ESMF_KIND_I8) :: jt1, jt2, lb, ub
            integer               :: jlo, jhi
            integer               :: status
-           
+
            T1= interval(1)
            T2= interval(2)
 
@@ -891,7 +891,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
              call time_esmf_2_nc_int (T1, this%datetime_units, i1, _RC)
              call time_esmf_2_nc_int (T2, this%datetime_units, i2, _RC)
              rT1=real(i1, kind=ESMF_KIND_R8)
-             rT2=real(i2, kind=ESMF_KIND_R8) 
+             rT2=real(i2, kind=ESMF_KIND_R8)
              jlo = 1
              jhi= size(this%obstime)
              if (jhi==0) then
@@ -901,7 +901,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
              !!write(6,*) 'jlo, jhi in obstime', jlo, jhi
              !!write(6,'(2x,a,2i15)') 'time/sec: i1, i2', i1, i2
-             !!write(6,'(2x,a,2f22.11)') 'obstime(1:n) in get_x_subset' 
+             !!write(6,'(2x,a,2f22.11)') 'obstime(1:n) in get_x_subset'
              !!write(6,'(2x,5E22.11)') this%obstime(jlo), this%obstime((jhi+jhi)/2), this%obstime(jhi)
 
              !
@@ -948,13 +948,13 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                    x_subset(2) = jt2
                 endif
              endif
-             
+
              !! print*, 'x_subset(1:2)', x_subset(1:2)
 
            _RETURN(_SUCCESS)
          end procedure get_x_subset
 
-         
+
          module procedure destroy_rh_regen_LS
            integer :: status
 
@@ -997,7 +997,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            call ESMF_ClockGet ( this%clock, CurrTime=currTime, _RC )
            if (currTime > this%obsfile_end_time) then
               this%is_valid = .false.
-              _RETURN(ESMF_SUCCESS)              
+              _RETURN(ESMF_SUCCESS)
            end if
 
            ! __ s3. regenerate LS, RH, bundles
@@ -1010,7 +1010,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
            ! __ s4. Epoch reset
            this%epoch_index(1:2)=0
-           
+
 
            _RETURN(ESMF_SUCCESS)
 
@@ -1035,7 +1035,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            real(ESMF_KIND_R8) :: s1, s2
            integer :: n1, n2
            integer :: K
-           
+
          ! get obs file index:  n1, n2
          ! get obs file content:
          !   given  traj%obsfile_Template
@@ -1047,8 +1047,8 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          !          nfile, filename(nfile) : time_esmf(nfile)
 
            T1 = this%obsfile_start_time
-           Tn = this%obsfile_end_time           
-           
+           Tn = this%obsfile_end_time
+
            cT1 = currTime
            dT1 = currTime - T1
            dT2 = currTime + this%epoch_frequency - T1
@@ -1070,12 +1070,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            !!!write(6,*) 'ck: due to epoch,  integer multiple of obsfile_interval', n1, n2
 
            this%obsfile_Ts_index = n1
-           if ( dT2_s - n2*dT0_s < 1 ) then 
+           if ( dT2_s - n2*dT0_s < 1 ) then
               this%obsfile_Te_index = n2 - 1
            else
               this%obsfile_Te_index = n2
            end if
-              
+
 
            !! -- prone to error
            !!dT3 = Tn - T1
@@ -1086,8 +1086,8 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            !!else
            !!   this%obsfile_is_available = .false.
            !!end if
-           
-           _RETURN(ESMF_SUCCESS)           
+
+           _RETURN(ESMF_SUCCESS)
          end procedure get_obsfile_Tbracket_from_epoch
 
 
@@ -1102,7 +1102,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             nymd = itime(1)
             nhms = itime(2)
             call fill_grads_template ( filename, file_template, &
-                 experiment_id='', nymd=nymd, nhms=nhms, _RC ) 
+                 experiment_id='', nymd=nymd, nhms=nhms, _RC )
            print*, 'ck: this%obsFile_T=', trim(filename)
            _RETURN(ESMF_SUCCESS)
          end procedure
@@ -1115,9 +1115,9 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             real(ESMF_KIND_R8) :: dT0_s
             real(ESMF_KIND_R8) :: s
             type(ESMF_TimeInterval) :: dT
-            type(ESMF_Time)         :: time            
+            type(ESMF_Time)         :: time
 
-            
+
             call ESMF_TimeIntervalGet(this%obsfile_interval, s_r8=dT0_s, rc=status)
             s = dT0_s * f_index
             call ESMF_TimeIntervalSet(dT, s_r8=s, rc=status)
@@ -1128,12 +1128,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             nymd = itime(1)
             nhms = itime(2)
             call fill_grads_template ( filename, this%obsfile_template, &
-                 experiment_id='', nymd=nymd, nhms=nhms, _RC ) 
+                 experiment_id='', nymd=nymd, nhms=nhms, _RC )
             !!print*, 'ck: this%obsFile_T=', trim(filename)
 
             _RETURN(ESMF_SUCCESS)
-            
+
          end procedure
-         
-         
+
+
 end submodule HistoryTrajectory_implement


### PR DESCRIPTION
## Description
Improved the trajectory sampler module in the History grid component to regrid model data to IODA lat-lon locations via locstream.  Additions include:

- code can read in file template for IODA files
- read netCDF string attribute from group
- add debug information

## How Has This Been Tested?
Tested with G5NR and IODA data on discover with 368 cores

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
