### PR TITLE
Trajectory sampler to ingest multiple IODA files via one route handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- OSSE project: trajectory sampler (regrid to IODA file locations), capable of ingesting multiple files
 ### Added
 
 - Added the ability to read string attributes of variables.   This is as opposed to "character" attributes - a distinction made by NetCDF.   Previously a small kludge had been used to allow reading string attributes, but was limited to attributes on the global var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- OSSE project: trajectory sampler (regrid to IODA file locations), capable of ingesting multiple files
+
 ### Added
 
 - Added the ability to read string attributes of variables.   This is as opposed to "character" attributes - a distinction made by NetCDF.   Previously a small kludge had been used to allow reading string attributes, but was limited to attributes on the global var.
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `_HERE`: Returns the current file and line number
   - `_RETURN_IF(cond)`: Returns if the condition is true
   - `_RETURN_UNLESS(cond)`: Returns if the condition is false
+- OSSE project: trajectory sampler (regrid to IODA file locations), capable of ingesting multiple files and regridding via one route-handle
 
 ### Changed
 

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -1,20 +1,27 @@
+!-------------------------------------------------------------------
+! Note: use for OSSE project
+!   File to be replaced by more systematic implementations.
+!   It contains codes for time conversion and bisect.
+!-------------------------------------------------------------------
+
 #include "MAPL_Exceptions.h"
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
 !
 !>
-!### MODULE: `MAPL_plain_netCDF_Time`
+!### MODULE: `Plain_netCDF_Time`
 !
 ! Author: GMAO SI-Team
 !
-module MAPL_plain_netCDF_Time
+module Plain_netCDF_Time
   use MAPL_KeywordEnforcerMod
   use MAPL_ExceptionHandling
   use MAPL_ShmemMod
   use mapl_ErrorHandlingMod
   use MAPL_Constants
   use ESMF
+  use pfio_NetCDF_Supplement
   !   use MAPL_CommsMod
   use, intrinsic :: iso_fortran_env, only: REAL32
   use, intrinsic :: iso_fortran_env, only: REAL64
@@ -31,17 +38,6 @@ module MAPL_plain_netCDF_Time
      procedure :: time_esmf_2_nc_int
   end interface convert_time_esmf2nc
 
-!C  interface get_ncfile_dimension
-!     procedure :: get_ncfile_dimension
-!     procedure :: get_ncfile_dimension_I8     
-!C  end interface get_ncfile_dimension
-!
-!C  interface get_v1d_netcdf
-!     procedure :: get_v1d_netcdf_R8
-!     procedure :: get_v1d_netcdf_R8_I8
-!C  end interface get_v1d_netcdf
-
-  
   interface get_v2d_netcdf
      procedure ::  get_v2d_netcdf_R4
      procedure ::  get_v2d_netcdf_R8
@@ -51,7 +47,7 @@ module MAPL_plain_netCDF_Time
      procedure :: parse_timeunit_i4
      procedure :: parse_timeunit_i8
   end interface parse_timeunit
-  
+
   interface hms_2_s
      procedure :: hms_2_s
   end interface hms_2_s
@@ -72,8 +68,8 @@ contains
     integer :: ncid , dimid
     integer :: status
     character(len=ESMF_MAXSTR) :: lon_name, lat_name, time_name
-    
-    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)    
+
+    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     if (present(key_lon)) then
        lon_name=trim(key_lon)
        !    call check_nc_status(nf90_inq_dimid(ncid, "lon", dimid), _RC)
@@ -84,15 +80,15 @@ contains
     if (present(key_lat)) then
        lat_name=trim(key_lat)
        !    call check_nc_status(nf90_inq_dimid(ncid, "lat", dimid), _RC)
-       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)    
+       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)
        call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlat), _RC)
        call check_nc_status(nf90_close(ncid), _RC)
     endif
 
     if (present(key_time)) then
-       time_name=trim(key_time)    
+       time_name=trim(key_time)
        !    call check_nc_status(nf90_inq_dimid(ncid, 'time', dimid), _RC)
-       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)    
+       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)
        call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=tdim), _RC)
     endif
     call check_nc_status(nf90_close(ncid), _RC)
@@ -101,46 +97,56 @@ contains
     !write(6,*) "get_ncfile_dimension:  nlat, nlon, tdim = ", nlat, nlon, tdim
   end subroutine get_ncfile_dimension
 
-!
-!  subroutine get_ncfile_dimension_I8(filename, nlon, nlat, tdim, key_lon, key_lat, key_time, rc)
-!    use netcdf
-!    implicit none
-!    character(len=*), intent(in) :: filename
-!    integer*8, optional,intent(out) :: nlat, nlon, tdim
-!    character(len=*), optional, intent(in)  :: key_lon, key_lat, key_time
-!    integer, optional, intent(out) :: rc
-!    integer :: ncid , dimid
-!    integer :: status
-!    character(len=ESMF_MAXSTR) :: lon_name, lat_name, time_name
-!    
-!    call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)    
-!    if (present(key_lon)) then
-!       lon_name=trim(key_lon)
-!       !    call check_nc_status(nf90_inq_dimid(ncid, "lon", dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(lon_name), dimid), _RC)
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlon), _RC)
-!    endif
-!
-!    if (present(key_lat)) then
-!       lat_name=trim(key_lat)
-!       !    call check_nc_status(nf90_inq_dimid(ncid, "lat", dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(lat_name), dimid), _RC)    
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=nlat), _RC)
-!       call check_nc_status(nf90_close(ncid), _RC)
-!    endif
-!
-!    if (present(key_time)) then
-!       time_name=trim(key_time)    
-!       !    call check_nc_status(nf90_inq_dimid(ncid, 'time', dimid), _RC)
-!       call check_nc_status(nf90_inq_dimid(ncid, trim(time_name), dimid), _RC)    
-!       call check_nc_status(nf90_inquire_dimension(ncid, dimid, len=tdim), _RC)
-!    endif
-!    call check_nc_status(nf90_close(ncid), _RC)
-!
-!    !- debug summary
-!    !write(6,*) "get_ncfile_dimension:  nlat, nlon, tdim = ", nlat, nlon, tdim
-!  end subroutine get_ncfile_dimension_I8
-!  
+
+  subroutine get_attribute_from_group(filename, group_name, var_name, attr_name, attr)
+    use netcdf
+    use pfio_NetCDF_Supplement
+    implicit none
+    character(len=*), intent(in) :: filename, group_name, var_name, attr_name
+    character(len=*), intent(INOUT) :: attr
+    integer :: ncid, varid, ncid2
+    integer :: rc, status, iret
+    integer :: len, i, j, k
+    integer :: xtype
+    character(len=:), allocatable :: str
+    integer :: number
+    integer :: attnum, nAttributes
+    character(len=NF90_MAX_NAME) :: attr_name2
+    integer(kind=C_INT) :: c_ncid, c_varid
+    character(len=100) :: str2
+
+    call check_nc_status ( nf90_open      (fileName, NF90_NOWRITE, ncid2), rc )
+    call check_nc_status ( nf90_inq_ncid  (ncid2, group_name, ncid),  rc )
+    call check_nc_status ( nf90_inq_varid (ncid,  var_name,  varid), rc )
+    call check_nc_status ( nf90_inquire_attribute(ncid, varid, attr_name, xtype, len=len), rc )
+    c_ncid= ncid
+    c_varid= varid
+    !! print*, 'f: xtype, len=', xtype, len
+    select case (xtype)
+    case(NF90_STRING)
+       status = pfio_get_att_string(c_ncid, c_varid, attr_name, str)
+       _VERIFY(status)
+    case (NF90_CHAR)
+       allocate(character(len=len) :: str)
+       status = nf90_get_att(ncid, varid, trim(attr_name), str)
+    case default
+       _FAIL('code works only with string attribute')
+    end select
+    i=index(str, 'since')
+    ! get rid of T in 1970-01-01T00:00:0
+    str2=str(i+6:i+24)
+    j=index(str2, 'T')
+    if (j>1) then
+       k=len_trim(str2)
+       str2=str2(1:j-1)//' '//str2(j+1:k)
+    endif
+    attr = str(1:i+5)//trim(str2)
+    deallocate(str)
+    iret = nf90_close(ncid)
+
+  end subroutine get_attribute_from_group
+
+
 
   subroutine get_v2d_netcdf_R4(filename, name, array, Xdim, Ydim)
     use netcdf
@@ -165,7 +171,7 @@ contains
     iret = nf90_close(ncid)
   end subroutine get_v2d_netcdf_R4
 
-  
+
   subroutine get_v2d_netcdf_R8(filename, name, array, Xdim, Ydim)
     use netcdf
     implicit none
@@ -210,27 +216,6 @@ contains
     iret = nf90_close(ncid)
   end subroutine get_v1d_netcdf_R8
 
-
-!  subroutine get_v1d_netcdf_R8_I8(filename, name, array, Xdim, group_name)
-!    use netcdf
-!    implicit none
-!    character(len=*), intent(in) :: name, filename
-!    character(len=*), optional, intent(in) :: group_name
-!    integer*8, intent(in) :: Xdim
-!    real*8, dimension(Xdim), intent(out) :: array
-!    integer :: ncid, varid, ncid2
-!    integer :: rc, status, iret
-!
-!    call check_nc_status (  nf90_open      (trim(fileName), NF90_NOWRITE, ncid), _RC )
-!    if (present(group_name)) then
-!       ncid2= ncid
-!       call check_nc_status ( nf90_inq_ncid ( ncid2, group_name, ncid),  _RC )
-!    end if
-!    call check_nc_status (  nf90_inq_varid (ncid,  name,  varid), _RC )
-!    call check_nc_status (  nf90_get_var   (ncid, varid,  array), _RC )
-!    iret = nf90_close(ncid)
-!  end subroutine get_v1d_netcdf_R8_I8
-  
 
   subroutine check_nc_status(status, rc)
     use netcdf
@@ -284,7 +269,7 @@ contains
     n=0
     call parse_timeunit (tunit, n, time0, dt, rc)
     dt = time - time0
-    !
+    ! -- To-be-deleted: this is a bug
     ! assume unit is second
     !
     call ESMF_TimeIntervalGet(dt, s_i8=n)
@@ -341,7 +326,7 @@ contains
     !  call ESMF_CalendarDestroy(gregorianCalendar, rc=rc)
     !  if(present(rc)) rc=0
     rc=0
-    
+
   end subroutine parse_timeunit_i4
 
 
@@ -389,9 +374,9 @@ contains
     !  call ESMF_CalendarDestroy(gregorianCalendar, rc=rc)
     !  if(present(rc)) rc=0
     rc=0
-    
+
   end subroutine parse_timeunit_i8
-  
+
   subroutine ESMF_time_to_two_integer (time, itime, rc)
     type (ESMF_Time), intent(in) ::   time
     integer, intent(out) :: itime(2)
@@ -446,7 +431,7 @@ contains
 
     sec= h*3600 + m*60 + s
     if (present(rc)) rc=0
-    
+
   end subroutine hms_2_s
 
 
@@ -457,7 +442,7 @@ contains
     real(ESMF_KIND_R8), intent(in) :: x       ! pt
     integer(ESMF_KIND_I8), intent(out) :: n   !  out: bisect index
     integer(ESMF_KIND_I8), intent(in), optional :: n_LB  !  opt in : LB
-    integer(ESMF_KIND_I8), intent(in), optional :: n_UB  !  opt in : UB     
+    integer(ESMF_KIND_I8), intent(in), optional :: n_UB  !  opt in : UB
     integer, intent(out), optional :: rc
 
     integer(ESMF_KIND_I8) :: k, klo, khi, dk, LB, UB
@@ -467,7 +452,7 @@ contains
     if(present(n_LB)) LB=n_LB
     if(present(n_UB)) UB=n_UB
     klo=LB; khi=UB; dk=1
-    
+
     ! write(6,*) 'init klo, khi', klo, khi
     if ( xa(LB ) > xa(UB) )  then
        klo= UB
@@ -480,7 +465,7 @@ contains
     !     x         x                       x
     !
     !        Y(n)  <  x  <=  Y(n+1)
-    
+
     rc=-1
     if ( x <= xa(klo) ) then
        !write(6,*) 'xa(klo), xa(khi), x', xa(klo), xa(khi), x
@@ -507,20 +492,20 @@ contains
           return
        endif
     enddo
-    
+
   end subroutine bisect_find_LB_R8_I8
-    
+
 
   subroutine convert_twostring_2_esmfinterval (symd, shms, interval, rc)
     character(len=*) :: symd
     character(len=*) :: shms
     type (ESMF_TimeInterval), intent(out) :: interval
     integer, optional, intent(out) :: rc
-    integer :: status    
+    integer :: status
     character(len=20) :: s1, s2
     integer :: y, m, d, hh, mm, ss
 
-    
+
     s1=trim(symd)
     read(s1, '(3i2)') y, m, d
     s2=trim(shms)
@@ -535,4 +520,4 @@ contains
     if (present(rc)) rc=0
   end subroutine convert_twostring_2_esmfinterval
 
-end module MAPL_Plain_NetCDF_Time
+end module Plain_NetCDF_Time

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -101,7 +101,6 @@ module MAPL_HistoryCollectionMod
      character(len=ESMF_MAXSTR)         :: output_grid_label
      type(GriddedIOItemVector)          :: items
      character(len=ESMF_MAXSTR)         :: currentFile
-     character(len=ESMF_MAXPATHLEN)     :: obsFile
      character(len=ESMF_MAXPATHLEN)     :: stationIdFile
      logical                            :: splitField
      logical                            :: regex

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -361,7 +361,7 @@ contains
     integer                                   :: useRegex
     integer                                   :: unitr, unitw
     integer                                   :: tm,resolution(2)
-    logical                                   :: match, contLine
+    logical                                   :: match, contLine, con3
     character(len=2048)                       :: line
     type(ESMF_Config)                         :: cfg
     character(len=ESMF_MAXSTR)                :: HIST_CF
@@ -398,6 +398,9 @@ contains
     integer              :: chnksz
     logical :: table_end
     logical :: old_fields_style
+
+!   variables for counting table
+    integer :: nline, ncol
 
     type(HistoryCollection) :: collection
     character(len=ESMF_MAXSTR) :: cFileOrder
@@ -664,7 +667,8 @@ contains
 
          match = .false.
          contLine = .false.
-
+         con3 = .false.
+            
          do while (.true.)
             read(unitr, '(A)', end=1234) line
             j = index( adjustl(line), trim(adjustl(string)) )
@@ -672,14 +676,18 @@ contains
             if (match) then
                j = index(line, trim(string)//'fields:')
                contLine = (j > 0)
+               k = index(line, trim(string)//'obs_files:')
+               con3 = (k > 0)               
             end if
-            if (match .or. contLine) then
+            if (match .or. contLine .or. con3) then
                write(unitw,'(A)') trim(line)
             end if
             if (contLine) then
                if (adjustl(line) == '::') contLine = .false.
             end if
-
+            if (con3) then
+               if (adjustl(line) == '::') con3 = .false.               
+            endif
          end do
 
 1234     continue
@@ -872,9 +880,12 @@ contains
             label=trim(string) // 'station_id_file:', _RC)
 
 ! Get an optional file containing a 1-D track for the output
-       call ESMF_ConfigGetAttribute(cfg, value=list(n)%obsFile, default="", &
-                                    label=trim(string) // 'obs_file:', _RC)
-       if (trim(list(n)%obsFile) /= '') list(n)%timeseries_output = .true.
+       call ESMF_ConfigGetDim(cfg, nline, ncol,  label=trim(string)//'obs_files:', rc=rc)  ! here donot check rc on purpose
+       if (rc==0) then
+          if (nline > 0) then
+             list(n)%timeseries_output = .true.             
+          endif
+       endif
        call ESMF_ConfigGetAttribute(cfg, value=list(n)%recycle_track, default=.false., &
                                     label=trim(string) // 'recycle_track:', _RC)
 
@@ -3435,8 +3446,6 @@ ENDDO PARSER
          lgr => logging%get_logger('HISTORY.sampler')
          if (list(n)%timeseries_output) then
             if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
-               if (mapl_am_i_root()) write(6,*)"Sampling to new file: ",trim(filename(n))
-               call list(n)%trajectory%close_file_handle(_RC)
                call list(n)%trajectory%create_file_handle(filename(n),_RC)
                list(n)%currentFile = filename(n)
                list(n)%unit = -1
@@ -3596,6 +3605,7 @@ ENDDO PARSER
          call list(n)%trajectory%regrid_accumulate(_RC)
          if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
             call list(n)%trajectory%append_file(current_time,_RC)
+            call list(n)%trajectory%close_file_handle(_RC)
             call list(n)%trajectory%destroy_rh_regen_LS (_RC)
          end if
       end if
@@ -3861,11 +3871,11 @@ ENDDO PARSER
             call MAPL_GridGet(pgrid,globalCellCountPerDim=dims,_RC)
             IM = dims(1)
             JM = dims(2)
-            DLON   =  360._REAL64/real(IM)
+            DLON   =  360._REAL64/IM
             if (JM /= 1) then
-               DLAT   =  180._REAL64/real(JM-1)
+               DLAT   =  180._REAL64/(JM-1)
             else
-               DLAT   =  1.0
+               DLAT   =  1._REAL64
             end if
             LONBEG = -180._REAL64
             LATBEG =  -90._REAL64

--- a/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
+++ b/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
@@ -1,7 +1,6 @@
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
-
 submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
   use ESMF
   use MAPL_ErrorHandlingMod
@@ -19,7 +18,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
   use MAPL_SortMod
   use MAPL_NetCDF
   use MAPL_StringTemplate
-  use MAPL_plain_netCDF_Time
+  use Plain_netCDF_Time
   use MAPL_ISO8601_DateTime_ESMF
   use, intrinsic :: iso_fortran_env, only: REAL32
   use, intrinsic :: iso_fortran_env, only: REAL64
@@ -28,35 +27,25 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
    contains
 
      module procedure HistoryTrajectory_from_config
+         use pflogger, only         :  Logger, logging
          character(len=ESMF_MAXSTR) :: filename
          character(len=ESMF_MAXSTR) :: grp_name
          character(len=ESMF_MAXSTR) :: dim_name(10)
          character(len=ESMF_MAXSTR) :: var_name_lon
          character(len=ESMF_MAXSTR) :: var_name_lat
          character(len=ESMF_MAXSTR) :: var_name_time
-         type(ESMF_TimeInterval)    :: epoch_frequency
          type(ESMF_Time)            :: currTime
+         type(ESMF_TimeInterval)    :: epoch_frequency
+         type(ESMF_TimeInterval)    :: obs_time_span
          integer                    :: time_integer, second
-         integer                    :: ncid, grpid, ncid0
          integer                    :: len, status
          integer                    :: itime(2), nymd, nhms
          character(len=ESMF_MAXSTR) :: STR1
-         character(len=ESMF_MAXSTR) :: symd, shms         
-         integer                    :: i, j, k         
-         ! __ parse variables, set alarm
-         !
-         !!call ESMF_ConfigGetAttribute(config, value=traj%obsFile, default="", &
-         !!     label=trim(string) // 'obs_file:', _RC)
-
-         
-         call ESMF_ConfigGetAttribute(config, value=traj%nc_index, default="", &
-              label=trim(string) // 'nc_Index:', _RC)
-         call ESMF_ConfigGetAttribute(config, value=traj%nc_time, default="", &
-              label=trim(string) // 'nc_Time:', _RC)
-         call ESMF_ConfigGetAttribute(config, value=traj%nc_longitude, default="", &
-              label=trim(string) // 'nc_Longitude:', _RC)
-         call ESMF_ConfigGetAttribute(config, value=traj%nc_latitude, default="", &
-              label=trim(string) // 'nc_Latitude:', _RC)
+         character(len=ESMF_MAXSTR) :: symd, shms
+         integer                    :: nline, ncol
+         logical                    :: tend
+         integer                    :: i, j, k
+         type(Logger), pointer :: lgr
 
          traj%clock=clock
          call ESMF_ClockGet ( clock, CurrTime=currTime, _RC )
@@ -65,27 +54,80 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call hms_2_s (time_integer, second, _RC)
          call ESMF_TimeIntervalSet(epoch_frequency, s=second, _RC)
          traj%Epoch = time_integer
+         traj%RingTime = currTime
          traj%epoch_frequency = epoch_frequency
-         traj%RingTime  = currTime
          traj%alarm = ESMF_AlarmCreate( clock=clock, RingInterval=epoch_frequency, &
               RingTime=traj%RingTime, sticky=.false., _RC )
 
-         call ESMF_ConfigGetAttribute(config, value=traj%obsfile_template, default="", &
-              label=trim(string) // 'obs_file:', _RC)
+         call ESMF_ConfigGetAttribute(config, value=traj%nc_index, default="", &
+              label=trim(string) // 'nc_Index:', _RC)
+         call ESMF_ConfigGetAttribute(config, value=traj%nc_time, default="", &
+              label=trim(string) // 'nc_Time:', _RC)
+         call ESMF_ConfigGetAttribute(config, value=traj%nc_longitude, default="", &
+              label=trim(string) // 'nc_Longitude:', _RC)
+         call ESMF_ConfigGetAttribute(config, value=traj%nc_latitude, default="", &
+              label=trim(string) // 'nc_Latitude:', _RC)
+         call ESMF_ConfigGetDim(config, nline, ncol, label=trim(string)//'obs_files:', rc=rc)
+         _ASSERT(rc==0 .AND. nline > 0, 'obs_files not found')
+         traj%nobs_type = nline
+         allocate (traj%obs(nline))
+         do k=1, nline
+            allocate (traj%obs(k)%metadata)
+            if (mapl_am_i_root()) then
+               allocate (traj%obs(k)%file_handle)
+            end if
+         end do
+         call ESMF_ConfigFindLabel( config, trim(string)//'obs_files:', rc=rc)
+         lgr => logging%get_logger('HISTORY.sampler')
+         call lgr%debug('%a %i8', 'nobs_type=', nline)
+
+         do i=1, nline
+            call ESMF_ConfigNextLine( config, tableEnd=tend, rc=rc)
+            call ESMF_ConfigGetAttribute( config, traj%obs(i)%input_template, rc=rc)
+            call lgr%debug('%a %i4 %a  %a', 'obs(', i, ') input_template =', &
+                 trim(traj%obs(i)%input_template))
+            j=index(traj%obs(i)%input_template , '%')
+            k=index(traj%obs(i)%input_template , '/', back=.true.)
+            _ASSERT(j>0, '% is not found,  template is wrong')
+            traj%obs(i)%name = traj%obs(i)%input_template(k+1:j-1)
+         enddo
+
          call ESMF_ConfigGetAttribute(config, value=STR1, default="", &
               label=trim(string) // 'obs_file_begin:', _RC)
-         if (mapl_am_I_root()) write(6,*) 'obs_file_begin:', trim(STR1)
-         call ESMF_TimeSet(traj%obsfile_start_time, STR1, _RC)
+         if (trim(STR1)=='') then
+            traj%obsfile_start_time = currTime
+            call ESMF_TimeGet(currTime, timestring=STR1, _RC)
+            if (mapl_am_I_root()) then
+               write(6,105) 'obs_file_begin missing, default = currTime :', trim(STR1)
+            endif
+         else
+            call ESMF_TimeSet(traj%obsfile_start_time, STR1, _RC)
+            if (mapl_am_I_root()) then
+               write(6,105) 'obs_file_begin provided: ', trim(STR1)
+            end if
+         end if
 
          call ESMF_ConfigGetAttribute(config, value=STR1, default="", &
               label=trim(string) // 'obs_file_end:', _RC)
-         if (mapl_am_I_root()) write(6,*) 'obs_file_end:', trim(STR1)
-         call ESMF_TimeSet(traj%obsfile_end_time, STR1, _RC)         
+         if (trim(STR1)=='') then
+            call ESMF_TimeIntervalSet(obs_time_span, d=14, _RC)
+            traj%obsfile_end_time = traj%obsfile_start_time + obs_time_span
+            call ESMF_TimeGet(traj%obsfile_end_time, timestring=STR1, _RC)
+            if (mapl_am_I_root()) then
+               write(6,105) 'obs_file_end   missing, default = begin+14D:', trim(STR1)
+            endif
+         else
+            call ESMF_TimeSet(traj%obsfile_end_time, STR1, _RC)
+            if (mapl_am_I_root()) then
+               write(6,105) 'obs_file_end provided:', trim(STR1)
+            end if
+         end if
 
          call ESMF_ConfigGetAttribute(config, value=STR1, default="", &
-              label=trim(string) // 'obs_file_interval:', _RC)         
-         if (mapl_am_I_root()) write(6,*) 'obs_file_interval:', trim(STR1)
-
+              label=trim(string) // 'obs_file_interval:', _RC)
+         _ASSERT(STR1/='', 'fatal error: obs_file_interval not provided in RC file')
+         if (mapl_am_I_root()) write(6,105) 'obs_file_interval:', trim(STR1)
+         if (mapl_am_I_root()) write(6,106) 'Epoch (second)   :', second
 
          i= index( trim(STR1), ' ' )
          if (i>0) then
@@ -95,10 +137,13 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             symd=''
             shms=trim(STR1)
          endif
-         call convert_twostring_2_esmfinterval (symd, shms,  traj%obsfile_interval, _RC)         
+         call convert_twostring_2_esmfinterval (symd, shms,  traj%obsfile_interval, _RC)
+         traj%is_valid = .true.
 
          _RETURN(_SUCCESS)
 
+105      format (1x,a,2x,a)
+106      format (1x,a,2x,i8)
        end procedure
 
 
@@ -109,53 +154,59 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(GriddedIOitemVectorIterator) :: iter
          type(GriddedIOitem), pointer :: item
          type(ESMF_Time)            :: currTime
-         ! __ s.1   create LS grid, RH, output/acc bundle
-         ! __ s.2   metadata
-         ! __ s.3   misc
+         integer :: k
 
          this%bundle=bundle
          this%items=items
-         this%epoch_index(1:2)=0
-
          if (present(vdata)) then
             this%vdata=vdata
          else
             this%vdata=VerticalData(_RC)
          end if
-         call this%vdata%append_vertical_metadata(this%metadata,this%bundle,_RC)
+         do k=1, this%nobs_type
+            call this%vdata%append_vertical_metadata(this%obs(k)%metadata,this%bundle,_RC)
+         end do
          this%do_vertical_regrid = (this%vdata%regrid_type /= VERTICAL_METHOD_NONE)
          if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%bundle,_RC)
 
-         call ESMF_ClockGet ( this%clock, CurrTime=currTime, _RC )
-         call this%get_obsfile_Tbracket_from_epoch(currTime, _RC) 
+         call ESMF_ClockGet (this%clock, CurrTime=currTime, _RC)
+         call this%get_obsfile_Tbracket_from_epoch(currTime, _RC)
+         if (this%obsfile_Te_index < 0) then
+            if (mapl_am_I_root()) then
+               write(6,*) "model start time is earlier than obsfile_start_time"
+               write(6,*) "solution: adjust obsfile_start_time and Epoch in rc file"
+            end if
+            _FAIL("obs file not found at init time")
+         endif
          call this%create_grid(_RC)
+
          call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
-         this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)         
+         this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)
          this%output_bundle = this%create_new_bundle(_RC)
          this%acc_bundle    = this%create_new_bundle(_RC)
-         
-         
          this%time_info = timeInfo
 
-         call this%metadata%add_dimension('time', this%nobs_epoch)
-         if (this%time_info%integer_time) then
-            v = Variable(type=PFIO_INT32,dimensions='time')
-         else
-            v = Variable(type=PFIO_REAL32,dimensions='time')
-         end if
-         call v%add_attribute('units', this%datetime_units)
-         call v%add_attribute('long_name', this%nc_time)
-         call this%metadata%add_variable(this%var_name_time,v)
+         do k=1, this%nobs_type
+            call this%obs(k)%metadata%add_dimension(this%nc_index, this%obs(k)%nobs_epoch)
+            if (this%time_info%integer_time) then
+               v = Variable(type=PFIO_INT32,dimensions=this%nc_index)
+            else
+               v = Variable(type=PFIO_REAL32,dimensions=this%nc_index)
+            end if
+            call v%add_attribute('units', this%datetime_units)
+            call v%add_attribute('long_name', 'dateTime')
+            call this%obs(k)%metadata%add_variable(this%var_name_time,v)
 
-         v = variable(type=PFIO_REAL64,dimensions="time")
-         call v%add_attribute('units','degrees_east')
-         call v%add_attribute('long_name','longitude')
-         call this%metadata%add_variable(this%var_name_lon,v)
+            v = variable(type=PFIO_REAL64,dimensions=this%nc_index)
+            call v%add_attribute('units','degrees_east')
+            call v%add_attribute('long_name','longitude')
+            call this%obs(k)%metadata%add_variable(this%var_name_lon,v)
 
-         v = variable(type=PFIO_REAL64,dimensions="time")
-         call v%add_attribute('units','degrees_east')
-         call v%add_attribute('long_name','latitude')
-         call this%metadata%add_variable(this%var_name_lat,v)
+            v = variable(type=PFIO_REAL64,dimensions=this%nc_index)
+            call v%add_attribute('units','degrees_north')
+            call v%add_attribute('long_name','latitude')
+            call this%obs(k)%metadata%add_variable(this%var_name_lat,v)
+         end do
 
          iter = this%items%begin()
          do while (iter /= this%items%end())
@@ -169,8 +220,6 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             call iter%next()
          enddo
 
-         this%file_name = ''
-
          this%recycle_track=.false.
          if (present(recycle_track)) then
             this%recycle_track=recycle_track
@@ -178,10 +227,87 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          if (this%recycle_track) then
             call this%reset_times_to_current_day(_RC)
          end if
+
          _RETURN(_SUCCESS)
 
-      end procedure
+       end procedure initialize
 
+
+       module procedure reinitialize
+         integer :: status,nobs
+         type(ESMF_Grid) :: grid
+         type(variable) :: v
+         type(GriddedIOitemVectorIterator) :: iter
+         type(GriddedIOitem), pointer :: item
+         type(ESMF_Time)            :: currTime
+         integer :: k
+
+         do k=1, this%nobs_type
+            allocate (this%obs(k)%metadata)
+            if (mapl_am_i_root()) then
+               allocate (this%obs(k)%file_handle)
+            end if
+         end do
+         
+         do k=1, this%nobs_type
+            call this%vdata%append_vertical_metadata(this%obs(k)%metadata,this%bundle,_RC)
+         end do
+         this%do_vertical_regrid = (this%vdata%regrid_type /= VERTICAL_METHOD_NONE)
+         if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%bundle,_RC)
+
+         call ESMF_ClockGet (this%clock, CurrTime=currTime, _RC)
+         call this%get_obsfile_Tbracket_from_epoch(currTime, _RC)
+         if (this%obsfile_Te_index < 0) then
+            if (mapl_am_I_root()) then
+               write(6,*) "model start time is earlier than obsfile_start_time"
+               write(6,*) "solution: adjust obsfile_start_time and Epoch in rc file"
+            end if
+            _FAIL("obs file not found at init time")
+         endif
+         call this%create_grid(_RC)
+
+         call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
+         this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)
+         this%output_bundle = this%create_new_bundle(_RC)
+         this%acc_bundle    = this%create_new_bundle(_RC)
+
+         do k=1, this%nobs_type
+            call this%obs(k)%metadata%add_dimension(this%nc_index, this%obs(k)%nobs_epoch)
+            if (this%time_info%integer_time) then
+               v = Variable(type=PFIO_INT32,dimensions=this%nc_index)
+            else
+               v = Variable(type=PFIO_REAL32,dimensions=this%nc_index)
+            end if
+            call v%add_attribute('units', this%datetime_units)
+            call v%add_attribute('long_name', 'dateTime')
+            call this%obs(k)%metadata%add_variable(this%var_name_time,v)
+
+            v = variable(type=PFIO_REAL64,dimensions=this%nc_index)
+            call v%add_attribute('units','degrees_east')
+            call v%add_attribute('long_name','longitude')
+            call this%obs(k)%metadata%add_variable(this%var_name_lon,v)
+
+            v = variable(type=PFIO_REAL64,dimensions=this%nc_index)
+            call v%add_attribute('units','degrees_north')
+            call v%add_attribute('long_name','latitude')
+            call this%obs(k)%metadata%add_variable(this%var_name_lat,v)
+         end do
+
+         iter = this%items%begin()
+         do while (iter /= this%items%end())
+            item => iter%get()
+            if (item%itemType == ItemTypeScalar) then
+               call this%create_variable(item%xname,_RC)
+            else if (item%itemType == ItemTypeVector) then
+               call this%create_variable(item%xname,_RC)
+               call this%create_variable(item%yname,_RC)
+            end if
+            call iter%next()
+         enddo
+         _RETURN(_SUCCESS)
+
+       end procedure reinitialize
+       
 
       module procedure create_metadata_variable
         type(ESMF_Field) :: field
@@ -189,6 +315,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
         logical :: is_present
         integer :: field_rank, status
         character(len=ESMF_MAXSTR) :: var_name,long_name,units,vdims
+        integer :: k
 
         call ESMF_FieldBundleGet(this%bundle,vname,field=field,_RC)
         call ESMF_FieldGet(field,name=var_name,rank=field_rank,_RC)
@@ -205,9 +332,9 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
            units = 'unknown'
         endif
         if (field_rank==2) then
-           vdims = "time"
+           vdims = this%nc_index
         else if (field_rank==3) then
-           vdims = "time,lev"
+           vdims = trim(this%nc_index)//",lev"
         end if
         v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
         call v%add_attribute('units',trim(units))
@@ -215,8 +342,11 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
         call v%add_attribute('missing_value',MAPL_UNDEF)
         call v%add_attribute('_FillValue',MAPL_UNDEF)
         call v%add_attribute('valid_range',(/-MAPL_UNDEF,MAPL_UNDEF/))
-        call this%metadata%add_variable(trim(var_name),v,_RC)
 
+        do k = 1, this%nobs_type
+           call this%obs(k)%metadata%add_variable(trim(var_name),v,_RC)
+        enddo
+        
          _RETURN(_SUCCESS)
       end procedure create_metadata_variable
 
@@ -228,7 +358,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
         integer :: rank,lb(1),ub(1)
         real(kind=REAL32), pointer :: p_acc_3d(:,:),p_acc_2d(:)
         integer :: status
-        
+
         new_bundle = ESMF_FieldBundleCreate(_RC)
         iter = this%items%begin()
         do while (iter /= this%items%end())
@@ -262,29 +392,328 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
       module procedure create_file_handle
          type(variable) :: v
          integer :: status
+         integer :: k
+         character(len=ESMF_MAXSTR) :: filename
+         
+         if (.NOT. this%is_valid) then
+            _RETURN(ESMF_SUCCESS)
+         endif
 
-         this%file_name = trim(filename)
-         ! __ update metadata
-         call this%metadata%modify_dimension('time', this%nobs_epoch)
+         do k=1, this%nobs_type            
+            call this%obs(k)%metadata%modify_dimension(this%nc_index, this%obs(k)%nobs_epoch)
+         enddo
          if (mapl_am_I_root()) then
-            call this%file_handle%create(trim(filename),_RC)
-            call this%file_handle%write(this%metadata,_RC)
+            do k=1, this%nobs_type
+               if (this%obs(k)%nobs_epoch > 0) then
+                  filename=trim(this%obs(k)%name)//trim(filename_suffix)
+                  call this%obs(k)%file_handle%create(trim(filename),_RC)
+                  call this%obs(k)%file_handle%write(this%obs(k)%metadata,_RC)
+                  write(6,*) "Sampling to new file : ",trim(filename)
+               end if
+            enddo
          end if
-
+            
         _RETURN(_SUCCESS)
       end procedure create_file_handle
 
 
        module procedure close_file_handle
           integer :: status
+          integer :: k
 
-          if (trim(this%file_name) /= '') then
-             if (mapl_am_i_root()) then
-                call this%file_handle%close(_RC)
-             end if
-          end if
+          if (.NOT. this%is_valid) then
+             _RETURN(ESMF_SUCCESS)
+          endif
+
+         if (mapl_am_I_root()) then
+            do k=1, this%nobs_type
+               if (this%obs(k)%nobs_epoch > 0) then
+                  call this%obs(k)%file_handle%close(_RC)
+               end if
+            end do
+         end if
           _RETURN(_SUCCESS)
        end procedure close_file_handle
+
+
+        module procedure create_grid
+        use pflogger, only: Logger, logging
+         character(len=ESMF_MAXSTR) :: filename
+         type(NetCDF4_FileFormatter) :: formatter
+         type(FileMetadataUtils) :: metadata_utils
+         type(FileMetadata) :: fmd
+         integer(ESMF_KIND_I4) :: num_times
+         integer :: dimid(10),  dimlen(10)
+         integer :: len
+         integer :: len_full
+         integer :: status
+         type(Logger), pointer :: lgr
+
+         character(len=ESMF_MAXSTR) :: grp_name
+         character(len=ESMF_MAXSTR) :: dim_name(10)
+         character(len=ESMF_MAXSTR) :: var_name_lon
+         character(len=ESMF_MAXSTR) :: var_name_lat
+         character(len=ESMF_MAXSTR) :: var_name_time
+         character(len=ESMF_MAXSTR) :: attr_name
+         character(len=ESMF_MAXSTR) :: attr
+         character(len=ESMF_MAXSTR) :: timeunits_file
+
+         type(ESMF_Config) :: config_grid
+         character(len=ESMF_MAXSTR) :: time_string
+
+         real(kind=REAL64), allocatable :: lons_full(:), lats_full(:)
+         real(kind=REAL64), allocatable :: times_R8_full(:)
+         integer,           allocatable :: obstype_id_full(:)
+         real(kind=REAL64), allocatable :: XA(:)
+
+         real(ESMF_KIND_R8), pointer :: ptAT(:)
+         type(ESMF_routehandle) :: RH
+         type(ESMF_Time) :: timeset(2)
+         type(ESMF_Time) :: current_time
+         type(ESMF_Time) :: time0, time1, time2
+         type(ESMF_TimeInterval) :: interval
+         type(ESMF_Grid) :: grid
+
+         type(ESMF_VM) :: vm
+         integer :: mypet, petcount
+
+         integer :: i, j, k, L
+         integer :: fid_s, fid_e
+         integer(kind=ESMF_KIND_I8) :: j0, j1
+         integer(kind=ESMF_KIND_I8) :: jt1, jt2
+         integer(kind=ESMF_KIND_I8) :: nstart, nend
+         real(kind=ESMF_KIND_R8) :: jx0, jx1
+         integer :: nx, nx_sum
+         integer :: arr(1)
+         integer :: sec
+         integer :: int_time
+         character(len=:), allocatable :: tunit
+         integer (ESMF_KIND_I8) :: n_second
+         integer, allocatable :: ix(:) !  counter for each obs(k)%nobs_epoch
+         integer :: nx2
+
+
+         this%datetime_units = "seconds since 1970-01-01 00:00:00"
+         lgr => logging%get_logger('HISTORY.sampler')
+
+         call ESMF_VMGetGlobal(vm,_RC)
+         call ESMF_VMGet(vm, localPet=mypet, petCount=petCount, _RC)
+
+         if (this%nc_index == '') then
+            !
+            !-- non IODA case
+            !
+            _FAIL('non-IODA format is not implemented here')
+            !! sorry Ben, cannot make everything work
+            !!filename=trim(this%obsFile)
+            !!!!         print*, 'obs file name=', trim(filename)
+            !!call formatter%open(trim(filename),pFIO_READ,_RC)
+            !!fmd = formatter%read(_RC)
+            !!call metadata_utils%create(fmd,trim(filename))
+            !!num_times = metadata_utils%get_dimension("time",_RC)
+            !!allocate(this%lons(num_times),this%lats(num_times),_STAT)
+            !!if (metadata_utils%is_var_present("longitude")) then
+            !!   call formatter%get_var("longitude",this%lons,_RC)
+            !!end if
+            !!if (metadata_utils%is_var_present("latitude")) then
+            !!   call formatter%get_var("latitude",this%lats,_RC)
+            !!end if
+            !!call metadata_utils%get_time_info(timeVector=this%times,_RC)
+         else
+            !
+            !-- IODA case
+            !            
+            i=index(this%nc_longitude, '/')
+            _ASSERT (i>0, 'group name not found')
+            grp_name = this%nc_longitude(1:i-1)
+            this%var_name_lat = this%nc_latitude(i+1:)
+            this%var_name_lon = this%nc_longitude(i+1:)
+            this%var_name_time= this%nc_time(i+1:)
+
+            L=0
+            fid_s=this%obsfile_Ts_index
+            fid_e=this%obsfile_Te_index
+            if(fid_e < L) then
+               allocate(this%lons(0),this%lats(0),_STAT)
+               allocate(this%times_R8(0),_STAT)
+               allocate(this%obstype_id(0),_STAT)               
+               this%epoch_index(1:2)=0
+               this%nobs_epoch = 0
+               rc=0
+               return
+            end if
+
+            if (mapl_am_I_root()) then
+               len = 0
+               do k=1, this%nobs_type
+                  j = max (fid_s, L)
+                  do while (j<=fid_e)
+                     filename = this%get_filename_from_template_use_index(j, this%obs(k)%input_template,  _RC)
+                     call lgr%debug('%a %a', 'input filename: ', trim(filename))
+                     call get_ncfile_dimension(filename, tdim=num_times, key_time=this%nc_index, _RC)
+                     len = len + num_times
+                     j=j+1
+                  enddo
+               enddo
+               len_full = len
+               allocate(lons_full(len),lats_full(len),_STAT)
+               allocate(times_R8_full(len),_STAT)
+               allocate(obstype_id_full(len),_STAT)
+               call lgr%debug('%a %i12', 'nobs from input file:', len_full)
+
+               len = 0
+               do k=1, this%nobs_type
+                  j = max (fid_s, L)
+                  do while (j<=fid_e)
+                     filename = this%get_filename_from_template_use_index(j, this%obs(k)%input_template, _RC)
+                     call get_ncfile_dimension(trim(filename), tdim=num_times, key_time=this%nc_index, _RC)
+                     call get_v1d_netcdf_R8 (filename, this%var_name_lon,  lons_full(len+1:), num_times, group_name=grp_name)
+                     call get_v1d_netcdf_R8 (filename, this%var_name_lat,  lats_full(len+1:), num_times, group_name=grp_name)
+                     call get_v1d_netcdf_R8 (filename, this%var_name_time, times_R8_full(len+1:), num_times, group_name=grp_name)
+                     call get_attribute_from_group (filename, grp_name, this%var_name_time, "units", timeunits_file)
+                     obstype_id_full(len+1:len+num_times) = k
+                     call lgr%debug('%a %f25.12, %f25.12', 'times_R8_full(1:200:100)', &
+                          times_R8_full(1), times_R8_full(200))
+
+                     len = len + num_times
+                     j=j+1
+                  enddo
+               enddo
+            end if
+
+
+            if (mapl_am_I_root()) then
+               call sort_multi_arrays_by_time(lons_full, lats_full, times_R8_full, obstype_id_full, _RC)
+               call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
+               timeset(1) = current_time
+               timeset(2) = current_time + this%epoch_frequency
+               call time_esmf_2_nc_int (timeset(1), this%datetime_units, j0, _RC)
+               call hms_2_s (this%Epoch, sec, _RC)
+               j1 = j0 + int(sec, kind=ESMF_KIND_I8)
+               jx0 = real ( j0, kind=ESMF_KIND_R8)
+               jx1 = real ( j1, kind=ESMF_KIND_R8)
+
+               nstart=1; nend=size(times_R8_full)
+               call bisect( times_R8_full, jx0, jt1, n_LB=int(nstart, ESMF_KIND_I8), n_UB=int(nend, ESMF_KIND_I8), rc=rc)
+               call bisect( times_R8_full, jx1, jt2, n_LB=int(nstart, ESMF_KIND_I8), n_UB=int(nend, ESMF_KIND_I8), rc=rc)
+               if (jt1==jt2) then
+                  _FAIL('Epoch Time is too small, empty swath grid is generated, increase Epoch')
+               endif
+               call lgr%debug ('%a %f20.1 %f20.1', 'jx0, jx1', jx0, jx1)
+               call lgr%debug ('%a %i20 %i20', 'jt1, jt2', jt1, jt2)
+
+               ! (x1, x2]  design in bisect
+               if (jt1==0) then
+                  this%epoch_index(1)= 1
+               else
+                  this%epoch_index(1)= jt1
+               endif
+               _ASSERT(jt2<=len, 'bisect index for this%epoch_index(2) failed')
+               if (jt2==0) then
+                  this%epoch_index(2)= 1
+               else
+                  this%epoch_index(2)= jt2
+               endif
+
+               nx= this%epoch_index(2) - this%epoch_index(1) + 1
+               this%nobs_epoch = nx
+               allocate(this%lons(nx),this%lats(nx),_STAT)
+               allocate(this%times_R8(nx),_STAT)
+               allocate(this%obstype_id(nx),_STAT)               
+
+               j=this%epoch_index(1)
+               do i=1, nx
+                  this%lons(i) = lons_full(j)
+                  this%lats(i) = lats_full(j)
+                  this%times_R8(i) = times_R8_full(j)
+                  this%obstype_id(i) = obstype_id_full(j)
+                  j=j+1
+               enddo
+               arr(1)=nx
+
+               do k=1, this%nobs_type
+                  this%obs(k)%nobs_epoch = 0
+               enddo
+               do j = this%epoch_index(1), this%epoch_index(2)
+                  k = obstype_id_full(j)
+                  this%obs(k)%nobs_epoch = this%obs(k)%nobs_epoch + 1
+               enddo
+
+               do k=1, this%nobs_type
+                  nx2 = this%obs(k)%nobs_epoch
+                  allocate (this%obs(k)%lons(nx2))
+                  allocate (this%obs(k)%lats(nx2))
+                  allocate (this%obs(k)%times_R8(nx2))
+               enddo
+
+               allocate(ix(this%nobs_type))
+               ix(:)=0
+               j=this%epoch_index(1)
+               do i=1, nx
+                  k = obstype_id_full(j)
+                  ix(k) = ix(k) + 1
+                  this%obs(k)%lons(ix(k)) = lons_full(j)
+                  this%obs(k)%lats(ix(k)) = lats_full(j)
+                  this%obs(k)%times_R8(ix(k)) = times_R8_full(j)
+                  !if (mod(k,10**8)==1) then
+                  !   write(6,*) 'this%obs(k)%times_R8(ix(k))', this%obs(k)%times_R8(ix(k))
+                  !endif
+                  j=j+1
+               enddo
+               deallocate(ix)
+               deallocate(lons_full, lats_full, times_R8_full, obstype_id_full)
+
+               call lgr%debug('%a %i12 %i12 %i12', &
+                    'epoch_index(1:2), nx', this%epoch_index(1), &
+                    this%epoch_index(2), this%nobs_epoch)
+               do k=1, this%nobs_type
+                  call lgr%debug('%a %i4 %a %i12', &
+                       'obs(', k, ')%nobs_epoch', this%obs(k)%nobs_epoch )
+               enddo               
+
+            else
+               allocate(this%lons(0),this%lats(0),_STAT)
+               allocate(this%times_R8(0),_STAT)
+               allocate(this%obstype_id(0),_STAT)
+               this%epoch_index(1:2)=0
+               this%nobs_epoch = 0
+               nx=0
+               arr(1)=nx
+            endif
+
+            call ESMF_VMAllFullReduce(vm, sendData=arr, recvData=nx_sum, &
+                 count=1, reduceflag=ESMF_REDUCE_SUM, rc=rc)
+            this%nobs_epoch_sum = nx_sum
+            if (mapl_am_I_root()) write(6,*) 'nobs in Epoch    :', nx_sum
+
+            this%locstream_factory = LocStreamFactory(this%lons,this%lats,_RC)
+            this%LS_rt = this%locstream_factory%create_locstream(_RC)
+            call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
+            this%LS_ds = this%locstream_factory%create_locstream(grid=grid,_RC)
+
+            this%fieldA = ESMF_FieldCreate (this%LS_rt, name='A_time', typekind=ESMF_TYPEKIND_R8, _RC)
+            this%fieldB = ESMF_FieldCreate (this%LS_ds, name='B_time', typekind=ESMF_TYPEKIND_R8, _RC)
+
+            call ESMF_FieldGet( this%fieldA, localDE=0, farrayPtr=ptAT)
+            call ESMF_FieldGet( this%fieldB, localDE=0, farrayPtr=this%obsTime)
+            if (mypet == 0) then
+               ptAT(:) = this%times_R8(:)
+            end if
+            this%obsTime= -1.d0
+
+            call ESMF_FieldRedistStore (this%fieldA, this%fieldB, RH, _RC)
+            call ESMF_FieldRedist      (this%fieldA, this%fieldB, RH, _RC)
+
+            !!write(6,'(2x,a,i5,2x,10E20.11)')  'pet=', mypet, this%obsTime(1:10)
+
+            call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
+            call ESMF_FieldDestroy(this%fieldA,nogarbage=.true.,_RC)
+            ! defer destroy fieldB at regen_grid step
+            !
+         end if
+         _RETURN(_SUCCESS)
+       end procedure create_grid
+
 
 
       module procedure append_file
@@ -293,13 +722,11 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(ESMF_RouteHandle) :: RH
 
          type(ESMF_Field) :: src_field, dst_field
-         type(ESMF_Field) :: acc_field         
+         type(ESMF_Field) :: acc_field
          type(ESMF_Field) :: acc_field_2d_rt, acc_field_3d_rt
-         real(kind=REAL32), allocatable :: p_new_lev(:,:,:)
-         real(kind=REAL32), pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
-         real(kind=REAL32), pointer :: p_dst_3d(:,:),p_dst_2d(:)
          real(kind=REAL32), pointer :: p_acc_3d(:,:),p_acc_2d(:)
          real(kind=REAL32), pointer :: p_acc_rt_3d(:,:),p_acc_rt_2d(:)
+         real(kind=REAL32), pointer :: p_src(:,:),p_dst(:,:)
          real(kind=ESMF_KIND_R8), allocatable :: rtimes(:)
 
          integer :: is, ie, nx
@@ -307,26 +734,33 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          integer :: lm
          integer :: rank
          integer :: status
+         integer :: j, k
+         integer, allocatable :: ix(:)
 
-         nx=this%nobs_epoch
-         is=1
-         ie=nx
-         print*, 'begin append_file, nobs_epoch=', nx
-
+         if (.NOT. this%is_valid) then
+            _RETURN(ESMF_SUCCESS)
+         endif
+         
          if (this%nobs_epoch_sum==0) then
             rc=0
             return
          endif
-         
-         if (mapl_am_i_root()) then
-            _ASSERT (nx /= 0, 'wrong, we should never have zero obs here!')
-            call this%file_handle%put_var(this%var_name_time, real(this%times_R8), &
-                 start=[is], count=[nx], _RC)
-            call this%file_handle%put_var(this%var_name_lon, this%lons, &
-                 start=[is], count=[nx], _RC)
-            call this%file_handle%put_var(this%var_name_lat, this%lats, &
-                 start=[is], count=[nx], _RC)
-         end if
+            
+         is=1
+         do k = 1, this%nobs_type
+            !-- limit  nx < 2**32 (integer*4)
+            nx=this%obs(k)%nobs_epoch
+            if (nx >0) then
+               if (mapl_am_i_root()) then
+                  call this%obs(k)%file_handle%put_var(this%var_name_time, real(this%obs(k)%times_R8), &
+                       start=[is], count=[nx], _RC)
+                  call this%obs(k)%file_handle%put_var(this%var_name_lon, this%obs(k)%lons, &
+                       start=[is], count=[nx], _RC)
+                  call this%obs(k)%file_handle%put_var(this%var_name_lat, this%obs(k)%lats, &
+                       start=[is], count=[nx], _RC)
+               end if
+            end if
+         enddo
 
          ! get RH from 2d field
          src_field = ESMF_FieldCreate(this%LS_ds,typekind=ESMF_TYPEKIND_R4,gridToFieldMap=[1],_RC)
@@ -340,6 +774,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          acc_field_2d_rt = ESMF_FieldCreate (this%LS_rt, name='field_2d_rt', typekind=ESMF_TYPEKIND_R4, _RC)
          acc_field_3d_rt = ESMF_FieldCreate (this%LS_rt, name='field_3d_rt', typekind=ESMF_TYPEKIND_R4, &
               gridToFieldMap=[1],ungriddedLBound=[1],ungriddedUBound=[lm],_RC)
+
          iter = this%items%begin()
          do while (iter /= this%items%end())
             item => iter%get()
@@ -351,18 +786,90 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   call ESMF_FieldGet( acc_field_2d_rt, localDE=0, farrayPtr=p_acc_rt_2d, _RC)
                   call ESMF_FieldRedist( acc_field,  acc_field_2d_rt, RH, _RC)
                   if (mapl_am_i_root()) then
-                     call this%file_handle%put_var(trim(item%xname),p_acc_rt_2d(1:nx),&
-                          start=[is],count=[nx])
+                     !
+                     !-- pack fields to obs(k)%p2d and put_var
+                     !
+                     is=1
+                     ie=this%epoch_index(2)-this%epoch_index(1)+1
+                     do k=1, this%nobs_type
+                        nx = this%obs(k)%nobs_epoch
+                        allocate (this%obs(k)%p2d(nx))
+                     enddo
+                     
+                     allocate(ix(this%nobs_type))
+                     ix(:)=0
+                     do j=is, ie
+                        k = this%obstype_id(j)
+                        ix(k) = ix(k) + 1
+                        this%obs(k)%p2d(ix(k)) = p_acc_rt_2d(j)
+                     enddo
+
+                     do k=1, this%nobs_type
+                        if (ix(k) /= this%obs(k)%nobs_epoch) then
+                           print*, 'obs_', k, ' : ix(k) /= this%obs(k)%nobs_epoch'
+                           print*, 'obs_', k, ' : this%obs(k)%nobs_epoch, ix(k) =', this%obs(k)%nobs_epoch, ix(k)
+                           _FAIL('test ix(k) failed')
+                        endif
+                     enddo
+                     deallocate(ix)
+                     do k=1, this%nobs_type
+                        is = 1
+                        nx = this%obs(k)%nobs_epoch
+                        if (nx>0) then
+                           call this%obs(k)%file_handle%put_var(trim(item%xname), this%obs(k)%p2d(1:nx), &
+                                start=[is],count=[nx])
+                        endif
+                     enddo
                   end if
                else if (rank==2) then
                   call ESMF_FieldGet( acc_field, localDE=0, farrayPtr=p_acc_3d, _RC)
                   call ESMF_FieldGet( acc_field_3d_rt, localDE=0, farrayPtr=p_acc_rt_3d, _RC)
-                  call ESMF_FieldRedist( acc_field,  acc_field_3d_rt, RH, _RC)
+
+                  dst_field=ESMF_FieldCreate(this%LS_rt,typekind=ESMF_TYPEKIND_R4, &
+                       gridToFieldMap=[2],ungriddedLBound=[1],ungriddedUBound=[lm],_RC)
+                  src_field=ESMF_FieldCreate(this%LS_ds,typekind=ESMF_TYPEKIND_R4, &
+                       gridToFieldMap=[2],ungriddedLBound=[1],ungriddedUBound=[lm],_RC)
+
+                  call ESMF_FieldGet(src_field,localDE=0,farrayPtr=p_src,_RC)
+                  call ESMF_FieldGet(dst_field,localDE=0,farrayPtr=p_dst,_RC)
+
+                  p_src= reshape(p_acc_3d,shape(p_src), order=[2,1])
+                  call ESMF_FieldRegrid(src_field,dst_field,RH,_RC)
+                  p_acc_rt_3d=reshape(p_dst, shape(p_acc_rt_3d), order=[2,1])
+
+                  call ESMF_FieldDestroy(dst_field,noGarbage=.true.,_RC)
+                  call ESMF_FieldDestroy(src_field,noGarbage=.true.,_RC)
+
                   if (mapl_am_i_root()) then
+                     !
+                     !-- pack fields to obs(k)%p3d and put_var
+                     !
+                     is=1
+                     ie=this%epoch_index(2)-this%epoch_index(1)+1
+                     do k=1, this%nobs_type
+                        nx = this%obs(k)%nobs_epoch
+                        allocate (this%obs(k)%p3d(nx, size(p_acc_rt_3d,2)))
+                     enddo
+                     allocate(ix(this%nobs_type))
+                     ix(:)=0
+                     do j=is, ie
+                        k = this%obstype_id(j)
+                        ix(k) = ix(k) + 1
+                        this%obs(k)%p3d(ix(k),:) = p_acc_rt_3d(j,:)
+                     enddo
+                     deallocate(ix)
+                     do k=1, this%nobs_type
+                        is = 1
+                        nx = this%obs(k)%nobs_epoch
+                        if (nx>0) then
+                           call this%obs(k)%file_handle%put_var(trim(item%xname), this%obs(k)%p3d(:,:), &
+                                start=[is,1],count=[nx,size(p_acc_rt_3d,2)])                           
+                        endif
+                     enddo
                      !!write(6,'(10f8.2)') p_acc_rt_3d(:,:)
                      !!write(6,*) 'here in append_file:  put_var 3d'
-                     call this%file_handle%put_var(trim(item%xname),p_acc_rt_3d(:,:),&
-                          start=[is,1],count=[nx,size(p_acc_3d,2)])
+                     !!call this%obs(k)%file_handle%put_var(trim(item%xname),p_acc_rt_3d(:,:),&
+                     !!     start=[is,1],count=[nx,size(p_acc_rt_3d,2)])
                   end if
                endif
             else if (item%itemType == ItemTypeVector) then
@@ -374,16 +881,345 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_FieldDestroy(acc_field_3d_rt, noGarbage=.true., _RC)
          call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
 
-         print*, 'end append_file, nobs_epoch=', nx         
-         print*, __LINE__, __FILE__
-         write(6,'(//)')
-         
          _RETURN(_SUCCESS)
-
        end procedure append_file
 
 
-      module procedure reset_times_to_current_day
+
+
+         module procedure regrid_accumulate_on_xsubset
+           integer                 :: x_subset(2)
+           type(ESMF_Time)         :: timeset(2)
+           type(ESMF_Time)         :: current_time
+           type(ESMF_TimeInterval) :: dur
+           type(GriddedIOitemVectorIterator) :: iter
+           type(GriddedIOitem), pointer :: item
+           type(ESMF_Field) :: src_field,dst_field,acc_field
+           integer :: rank
+           real(kind=REAL32), allocatable :: p_new_lev(:,:,:)
+           real(kind=REAL32), pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
+           real(kind=REAL32), pointer :: p_dst_3d(:,:),p_dst_2d(:)
+           real(kind=REAL32), pointer :: p_acc_3d(:,:),p_acc_2d(:)
+           integer :: is, ie
+           integer :: status
+           integer :: ic
+
+           type (ESMF_VM) :: vm
+           integer :: mypet, petcount
+
+           if (.NOT. this%is_valid) then
+              _RETURN(ESMF_SUCCESS)
+           endif
+
+           call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
+           call ESMF_ClockGet(this%clock,timeStep=dur, _RC )
+           timeset(1) = current_time - dur
+           timeset(2) = current_time
+           call this%get_x_subset(timeset, x_subset, _RC)
+           is=x_subset(1)
+           ie=x_subset(2)
+
+           if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
+              call this%vdata%setup_eta_to_pressure(_RC)
+           endif
+
+
+           iter = this%items%begin()
+           do while (iter /= this%items%end())
+              item => iter%get()
+              if (item%itemType == ItemTypeScalar) then
+                 call ESMF_FieldBundleGet(this%bundle,trim(item%xname),field=src_field,_RC)
+                 call ESMF_FieldBundleGet(this%output_bundle,trim(item%xname),field=dst_field,_RC)
+                 call ESMF_FieldBundleGet(this%acc_bundle,trim(item%xname),field=acc_field,_RC)
+                 call ESMF_FieldGet(src_field,rank=rank,_RC)
+                 if (rank==2) then
+                    call ESMF_FieldGet(src_field,farrayptr=p_src_2d,_RC)
+                    call ESMF_FieldGet(dst_field,farrayptr=p_dst_2d,_RC)
+                    call ESMF_FieldGet(acc_field,farrayptr=p_acc_2d,_RC)
+
+                    !! print*, 'size(src,dst,acc)', size(p_src_2d), size(p_dst_2d), size(p_acc_2d)
+                    call this%regridder%regrid(p_src_2d,p_dst_2d,_RC)
+                    if (is > 0 .AND. is <= ie ) then
+                       p_acc_2d(is:ie) = p_dst_2d(is:ie)
+                    endif
+
+                    !!if (is>0) write(6,'(a)')  'regrid_accu:  p_dst_2d'
+                    !!if (is>0) write(6,'(10f7.1)')  p_dst_2d
+
+                 else if (rank==3) then
+                    call ESMF_FieldGet(src_field,farrayptr=p_src_3d,_RC)
+                    call ESMF_FieldGet(dst_field,farrayptr=p_dst_3d,_RC)
+                    call ESMF_FieldGet(acc_field,farrayptr=p_acc_3d,_RC)
+                    if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
+                       allocate(p_new_lev(size(p_src_3d,1),size(p_src_3d,2),this%vdata%lm),_STAT)
+                       call this%vdata%regrid_eta_to_pressure(p_src_3d,p_new_lev,_RC)
+                       call this%regridder%regrid(p_new_lev,p_dst_3d,_RC)
+                       if (is > 0 .AND. is <= ie ) then
+                          p_acc_3d(is:ie,:) = p_dst_3d(is:ie,:)
+                       end if
+                    else
+                       call this%regridder%regrid(p_src_3d,p_dst_3d,_RC)
+                       if (is > 0 .AND. is <= ie ) then
+                          p_acc_3d(is:ie,:) = p_dst_3d(is:ie,:)
+                       end if
+                    end if
+                 end if
+              else if (item%itemType == ItemTypeVector) then
+                 _FAIL("ItemTypeVector not yet supported")
+              end if
+              call iter%next()
+           enddo
+
+           _RETURN(ESMF_SUCCESS)
+
+         end procedure regrid_accumulate_on_xsubset
+
+
+         module procedure destroy_rh_regen_LS
+           integer :: status
+           integer :: numVars, i, k
+           character(len=ESMF_MAXSTR), allocatable :: names(:)
+           type(ESMF_Field) :: field
+           type(ESMF_Grid)  :: grid
+           type(ESMF_Time)  :: currTime
+
+          if (.NOT. this%is_valid) then
+             _RETURN(ESMF_SUCCESS)
+          endif
+
+           call ESMF_FieldDestroy(this%fieldB,nogarbage=.true.,_RC)
+           call this%locstream_factory%destroy_locstream(this%LS_rt, _RC)
+           call this%locstream_factory%destroy_locstream(this%LS_ds, _RC)
+           call this%regridder%destroy(_RC)
+           deallocate (this%lons, this%lats, &
+                this%times_R8, this%obstype_id)
+
+           do k=1, this%nobs_type
+              deallocate (this%obs(k)%metadata)
+              if (mapl_am_i_root()) then
+                 deallocate (this%obs(k)%file_handle)
+              end if
+           end do
+
+           if (mapl_am_i_root()) then
+              do k=1, this%nobs_type
+                 deallocate (this%obs(k)%lons)
+                 deallocate (this%obs(k)%lats)
+                 deallocate (this%obs(k)%times_R8)
+                 if (allocated(this%obs(k)%p2d)) then
+                    deallocate (this%obs(k)%p2d)
+                 endif
+                 if (allocated(this%obs(k)%p3d)) then
+                    deallocate (this%obs(k)%p3d)
+                 endif
+              end do
+           end if
+           
+           call ESMF_FieldBundleGet(this%acc_bundle,fieldCount=numVars,_RC)
+           allocate(names(numVars),stat=status)
+           call ESMF_FieldBundleGet(this%acc_bundle,fieldNameList=names,_RC)
+           do i=1,numVars
+              call ESMF_FieldBundleGet(this%acc_bundle,trim(names(i)),field=field,_RC)
+              call ESMF_FieldDestroy(field,noGarbage=.true., _RC)
+           enddo
+           call ESMF_FieldBundleDestroy(this%acc_bundle,noGarbage=.true.,_RC)
+
+           call ESMF_FieldBundleGet(this%output_bundle,fieldCount=numVars,_RC)
+           allocate(names(numVars),stat=status)
+           call ESMF_FieldBundleGet(this%output_bundle,fieldNameList=names,_RC)
+           do i=1,numVars
+              call ESMF_FieldBundleGet(this%output_bundle,trim(names(i)),field=field,_RC)
+              call ESMF_FieldDestroy(field,noGarbage=.true., _RC)
+           enddo
+           call ESMF_FieldBundleDestroy(this%output_bundle,noGarbage=.true.,_RC)
+
+
+           call ESMF_ClockGet ( this%clock, CurrTime=currTime, _RC )
+           if (currTime > this%obsfile_end_time) then
+              this%is_valid = .false.
+              _RETURN(ESMF_SUCCESS)
+           end if
+
+           this%epoch_index(1:2)=0
+
+           call this%reinitialize(_RC)
+
+           _RETURN(ESMF_SUCCESS)
+
+         end procedure destroy_rh_regen_LS
+
+
+         module procedure get_x_subset
+           type   (ESMF_Time)    :: T1,  T2
+           real   (ESMF_KIND_R8) :: rT1, rT2
+
+           integer(ESMF_KIND_I8) :: i1,  i2
+           integer(ESMF_KIND_I8) :: jt1, jt2, lb, ub
+           integer               :: jlo, jhi
+           integer               :: status
+
+           T1= interval(1)
+           T2= interval(2)
+           call time_esmf_2_nc_int (T1, this%datetime_units, i1, _RC)
+           call time_esmf_2_nc_int (T2, this%datetime_units, i2, _RC)
+           rT1=real(i1, kind=ESMF_KIND_R8)
+           rT2=real(i2, kind=ESMF_KIND_R8)
+           jlo = 1
+           jhi= size(this%obstime)
+           if (jhi==0) then
+              x_subset(1:2)=0
+              _RETURN(_SUCCESS)
+           endif
+
+           lb=int(jlo, ESMF_KIND_I8)
+           ub=int(jhi, ESMF_KIND_I8)
+           call bisect( this%obstime, rT1, jt1, n_LB=lb, n_UB=ub, rc=rc)
+           call bisect( this%obstime, rT2, jt2, n_LB=lb, n_UB=ub, rc=rc)
+           x_subset(1) = jt1
+
+           if (jt1<lb) then
+              if (jt2<lb) then
+                 x_subset(1) = 0
+                 x_subset(2) = 0
+              elseif (jt2>=ub) then
+                 x_subset(1) = lb
+                 x_subset(2) = ub
+              else
+                 x_subset(1) = lb
+                 x_subset(2) = jt2
+              endif
+           elseif (jt1>=ub) then
+              x_subset(1) = 0
+              x_subset(2) = 0
+           else
+              x_subset(1) = jt1
+              if (jt2>=ub) then
+                 x_subset(2) = ub
+              else
+                 x_subset(2) = jt2
+              endif
+           endif
+           
+           _RETURN(_SUCCESS)
+         end procedure get_x_subset
+         
+
+         module procedure get_obsfile_Tbracket_from_epoch
+           implicit none
+           integer :: status
+           integer :: numVars, i
+           character(len=ESMF_MAXSTR), allocatable :: names(:)
+           type(ESMF_Field) :: field
+           type(ESMF_Grid)  :: grid
+
+           type(ESMF_Time)  :: T1, Tn
+           type(ESMF_Time)  :: cT1, cTn
+           type(ESMF_Time)  :: Ts, Te
+           type(ESMF_TimeInterval)  :: dT1, dT2, dT3, dTs, dTe
+           real(ESMF_KIND_R8) :: Tint_r8
+           real(ESMF_KIND_R8) :: Tint2_r8
+           real(ESMF_KIND_R8) :: dT0_s, dT1_s, dT2_s, dT3_s
+           real(ESMF_KIND_R8) :: s1, s2
+           integer :: n1, n2
+           integer :: K
+
+           T1 = this%obsfile_start_time
+           Tn = this%obsfile_end_time
+
+           cT1 = currTime
+           dT1 = currTime - T1
+           dT2 = currTime + this%epoch_frequency - T1
+
+           call ESMF_TimeIntervalGet(this%obsfile_interval, s_r8=dT0_s, rc=status)
+           call ESMF_TimeIntervalGet(dT1, s_r8=dT1_s, rc=status)
+           call ESMF_TimeIntervalGet(dT2, s_r8=dT2_s, rc=status)
+           n1 = floor (dT1_s / dT0_s)
+           n2 = floor (dT2_s / dT0_s)
+           s1 = n1 * dT0_s
+           s2 = n2 * dT0_s
+           call ESMF_TimeIntervalSet(dTs, s_r8=s1, rc=status)
+           call ESMF_TimeIntervalSet(dTe, s_r8=s2, rc=status)
+           Ts = T1 + dTs
+           Te = T1 + dTe
+
+           this%obsfile_Ts_index = n1
+           if ( dT2_s - n2*dT0_s < 1 ) then
+              this%obsfile_Te_index = n2 - 1
+           else
+              this%obsfile_Te_index = n2
+           end if
+
+           _RETURN(ESMF_SUCCESS)
+         end procedure get_obsfile_Tbracket_from_epoch
+
+
+         module procedure  get_filename_from_template
+            integer :: itime(2)
+            integer :: nymd, nhms
+            integer :: status
+
+            stop 'DO not use get_filename_from_template'
+            call ESMF_time_to_two_integer(time, itime, _RC)
+            print*, 'two integer time,  itime(:)', itime(1:2)
+            nymd = itime(1)
+            nhms = itime(2)
+            call fill_grads_template ( filename, file_template, &
+                 experiment_id='', nymd=nymd, nhms=nhms, _RC )
+           print*, 'ck: this%obsFile_T=', trim(filename)
+           _RETURN(ESMF_SUCCESS)
+         end procedure get_filename_from_template
+
+
+         module procedure  get_filename_from_template_use_index
+            integer :: itime(2)
+            integer :: nymd, nhms
+            integer :: status
+            real(ESMF_KIND_R8) :: dT0_s
+            real(ESMF_KIND_R8) :: s
+            type(ESMF_TimeInterval) :: dT
+            type(ESMF_Time)         :: time
+
+            call ESMF_TimeIntervalGet(this%obsfile_interval, s_r8=dT0_s, rc=status)
+            s = dT0_s * f_index
+            call ESMF_TimeIntervalSet(dT, s_r8=s, rc=status)
+            time = this%obsfile_start_time + dT
+
+            call ESMF_time_to_two_integer(time, itime, _RC)
+            nymd = itime(1)
+            nhms = itime(2)
+            call fill_grads_template ( filename, file_template, &
+                 experiment_id='', nymd=nymd, nhms=nhms, _RC )
+
+            _RETURN(ESMF_SUCCESS)
+         end procedure get_filename_from_template_use_index
+
+
+
+       module procedure time_real_to_ESMF
+         type(ESMF_TimeInterval) :: interval
+         type(ESMF_Time) :: time0
+         type(ESMF_Time) :: time1
+         character(len=:), allocatable :: tunit
+         character(len=ESMF_MAXSTR) :: datetime_units
+         integer :: i, len
+         integer :: int_time
+         integer :: status
+
+         datetime_units = this%datetime_units
+         len = size (this%times_R8)
+         do i=1, len
+            int_time = this%times_R8(i)
+            call convert_NetCDF_DateTime_to_ESMF(int_time, datetime_units, interval, time0, time1=time1, tunit=tunit, _RC)
+            this%times(i) = time1
+         enddo
+
+         _RETURN(_SUCCESS)
+       end procedure time_real_to_ESMF
+         
+         
+
+
+     module procedure reset_times_to_current_day
 
          integer :: i,status,h,m,yp,mp,dp,s,ms,us,ns
          type(ESMF_Clock) :: clock
@@ -431,604 +1267,46 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          do i=1, len
             T(i) = X(IA(i))
          enddo
-
          _RETURN(_SUCCESS)
        end procedure sort_three_arrays_by_time
 
 
+      module procedure sort_four_arrays_by_time
+        integer :: status
+        integer :: i, len
+        integer, allocatable :: IA(:)
+        integer(ESMF_KIND_I8), allocatable :: IX(:)
+        real(ESMF_KIND_R8), allocatable :: X(:)
+        integer, allocatable :: NX(:)        
 
-       module procedure time_real_to_ESMF
-         type(ESMF_TimeInterval) :: interval
-         type(ESMF_Time) :: time0
-         type(ESMF_Time) :: time1
-         character(len=:), allocatable :: tunit
-         character(len=ESMF_MAXSTR) :: datetime_units
-         integer :: i, len
-         integer :: int_time
-         integer :: status
-         
-         datetime_units = this%datetime_units
-         len = size (this%times_R8)
+        _ASSERT (size(U)==size(V), 'U,V different dimension')
+        _ASSERT (size(U)==size(T), 'U,T different dimension')
+        len = size (T)
+
+         allocate (IA(len), IX(len), X(len), NX(len))
          do i=1, len
-            int_time = this%times_R8(i)
-            call convert_NetCDF_DateTime_to_ESMF(int_time, datetime_units, interval, time0, time1=time1, tunit=tunit, _RC)
-            this%times(i) = time1
+            IX(i)=T(i)
+            IA(i)=i
          enddo
+         call MAPL_Sort(IX,IA)
 
+         X = U
+         do i=1, len
+            U(i) = X(IA(i))
+         enddo
+         X = V
+         do i=1, len
+            V(i) = X(IA(i))
+         enddo
+         X = T
+         do i=1, len
+            T(i) = X(IA(i))
+         enddo
+         NX = ID
+         do i=1, len
+            ID(i) = NX(IA(i))
+         enddo         
          _RETURN(_SUCCESS)
-       end procedure time_real_to_ESMF
+       end procedure sort_four_arrays_by_time
 
-
-
-        module procedure create_grid
-         character(len=ESMF_MAXSTR) :: filename
-         type(NetCDF4_FileFormatter) :: formatter
-         type(FileMetadataUtils) :: metadata_utils
-         type(FileMetadata) :: fmd
-         !!integer(ESMF_KIND_I8) :: num_times
-         integer(ESMF_KIND_I4) :: num_times         
-         integer :: ncid, ncid0
-         integer :: dimid(10),  dimlen(10)
-         integer :: len
-         integer :: len_full         
-         integer :: status
-         
-         character(len=ESMF_MAXSTR) :: grp_name
-         character(len=ESMF_MAXSTR) :: dim_name(10)
-         character(len=ESMF_MAXSTR) :: var_name_lon
-         character(len=ESMF_MAXSTR) :: var_name_lat
-         character(len=ESMF_MAXSTR) :: var_name_time
-
-         type(ESMF_Config) :: config_grid
-         character(len=ESMF_MAXSTR) :: time_string
-
-         real(kind=REAL64), allocatable :: lons_full(:), lats_full(:)
-         real(kind=REAL64), allocatable :: times_R8_full(:)
-         real(kind=REAL64), allocatable :: XA(:)         
-
-         integer(ESMF_KIND_I4), pointer :: ptAI(:), ptBI(:)
-         real(ESMF_KIND_R8), pointer :: ptAT(:), ptBT(:)
-         type(ESMF_routehandle) :: RH
-         type(ESMF_Time) :: timeset(2)
-         type(ESMF_Time) :: current_time
-         type(ESMF_Field) :: src_fld, dst_fld
-         type(ESMF_Field) :: src_fld2, dst_fld2
-         type(ESMF_Grid) :: grid
-         
-         type(ESMF_VM) :: vm
-         integer :: mypet, petcount
-
-         integer :: i, j, k, L
-         integer :: is, ie
-         integer(kind=ESMF_KIND_I8) :: j0, j1
-         integer(kind=ESMF_KIND_I8) :: jt1, jt2
-         integer(kind=ESMF_KIND_I8) :: nstart, nend
-         real(kind=ESMF_KIND_R8) :: jx0, jx1
-         integer :: nx, nx_sum
-         integer :: arr(1)
-         integer :: sec
-
-         ! TOBE removed: hard coded tunits
-         this%datetime_units = "seconds since 1970-01-01 00:00:00"
-
-
-         if (this%nc_index == '') then
-            filename=trim(this%obsFile)
-            !!         print*, 'obs file name=', trim(filename)
-            call formatter%open(trim(filename),pFIO_READ,_RC)
-            fmd = formatter%read(_RC)
-            call metadata_utils%create(fmd,trim(filename))
-            num_times = metadata_utils%get_dimension("time",_RC)
-            allocate(this%lons(num_times),this%lats(num_times),_STAT)
-            if (metadata_utils%is_var_present("longitude")) then
-               call formatter%get_var("longitude",this%lons,_RC)
-            end if
-            if (metadata_utils%is_var_present("latitude")) then
-               call formatter%get_var("latitude",this%lats,_RC)
-            end if
-            call metadata_utils%get_time_info(timeVector=this%times,_RC)
-         else         
-            i=index(this%nc_longitude, '/')
-            _ASSERT (i>0, 'group name not found')
-            grp_name = this%nc_longitude(1:i-1)
-            this%var_name_lat = this%nc_latitude(i+1:)
-            this%var_name_lon = this%nc_longitude(i+1:)
-            this%var_name_time= this%nc_time(i+1:)
-
-
-            ! __ loop obsfile_index for epoch
-            !    get max len, allocate array, concatenate , get_var
-            !
-            L=0
-            is=this%obsfile_Ts_index   ! from call get_obsfile_Tbracket_from_epoch
-            ie=this%obsfile_Te_index
-            if(ie < L) then
-               allocate(this%lons(0),this%lats(0),_STAT)
-               allocate(this%times_R8(0),_STAT)
-               this%epoch_index(1:2)=0
-               this%nobs_epoch = 0
-               rc=0
-               return
-            end if
-
-            ! -- this is all  ie >= L case
-            !    get bounds, get_var
-            j = max (is, L)
-            len = 0 
-            do while (j<=ie)
-               filename = this%get_filename_from_template_use_index(j, _RC)
-               !!call get_ncfile_dimension_I8(filename, tdim=num_times, key_time=this%nc_index, _RC)
-               call get_ncfile_dimension(filename, tdim=num_times, key_time=this%nc_index, _RC)               
-               len = len + num_times
-               j=j+1
-               if (mapl_am_I_root()) write(6,*) 'input filename=', trim(filename)
-            enddo            
-            len_full = len
-            write(6,*) 'len_full=', len_full
-            allocate(lons_full(len),lats_full(len),_STAT)
-            allocate(times_R8_full(len),_STAT)
-
-            j = max (is, L)
-            len = 0 
-            do while (j<=ie)
-               filename = this%get_filename_from_template_use_index(j, _RC)
-               call get_ncfile_dimension(trim(filename), tdim=num_times, key_time=this%nc_index, _RC)
-               call get_v1d_netcdf_R8 (filename, this%var_name_lon,  lons_full(len+1:), num_times, group_name=grp_name)
-               call get_v1d_netcdf_R8 (filename, this%var_name_lat,  lats_full(len+1:), num_times, group_name=grp_name)
-               call get_v1d_netcdf_R8 (filename, this%var_name_time, times_R8_full(len+1:), num_times, group_name=grp_name)
-               len = len + num_times
-               j=j+1
-            enddo
-
-            call ESMF_VMGetGlobal(vm,_RC)
-            call ESMF_VMGet(vm, localPet=mypet, petCount=petCount, _RC)
-
-
-            !__ epoch grid on root
-            !
-            if (mapl_am_I_root()) then
-               call sort_three_arrays_by_time(lons_full, lats_full, times_R8_full, _RC)               
-               call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
-               timeset(1) = current_time
-               timeset(2) = current_time + this%epoch_frequency
-               call time_esmf_2_nc_int (timeset(1), this%datetime_units, j0, _RC)
-               call hms_2_s (this%Epoch, sec, _RC)
-               j1 = j0 + sec
-               jx0 = real ( j0, kind=ESMF_KIND_R8)
-               jx1 = real ( j1, kind=ESMF_KIND_R8)
-               !!call lgr%debug ('%a %i4 %i4', 'jx0, jx1', jx0, jx1)
-               write(6,*) 'jx0, jx1', jx0, jx1
-
-               nstart=1; nend=size(times_R8_full)
-               call bisect( times_R8_full, jx0, jt1, n_LB=int(nstart, ESMF_KIND_I8), n_UB=int(nend, ESMF_KIND_I8), rc=rc)
-               call bisect( times_R8_full, jx1, jt2, n_LB=int(nstart, ESMF_KIND_I8), n_UB=int(nend, ESMF_KIND_I8), rc=rc)
-               if (jt1==jt2) then
-                  _FAIL('Epoch Time is too small, empty swath grid is generated, increase Epoch')
-               endif
-               ! (x1, x2]  design in bisect
-               if (this%epoch_index(1) == 0) then
-                  if (jt1==0) then
-                     this%epoch_index(1)= 1
-                  else
-                     this%epoch_index(1)= jt1
-                  endif
-               else
-                  this%epoch_index(1)= this%epoch_index(2)  !  previous save
-               end if
-!               if (jt2<=nend) then
-                  this%epoch_index(2)= jt2
-!               else
-!                  this%epoch_index(2)= nend
-!               endif
-
-               nx= this%epoch_index(2) - this%epoch_index(1) + 1
-               this%nobs_epoch = nx
-               allocate(this%lons(nx),this%lats(nx),_STAT)
-               allocate(this%times_R8(nx),_STAT)
-
-
-               write(6,*) 'jx0, jx1', jx0, jx1
-               write(6,*) 'full time array, nstart, nend', nstart, nend               
-               write(6,*) 'epoch_index(1:2), nx', this%epoch_index(1:2), this%nobs_epoch
-               
-               j=this%epoch_index(1)
-               do i=1, nx
-                  this%lons(i) = lons_full(j)
-                  this%lats(i) = lats_full(j)
-                  this%times_R8(i) = times_R8_full(j)
-                  j=j+1
-               enddo
-               arr(1)=nx
-            else
-               allocate(this%lons(0),this%lats(0),_STAT)
-               allocate(this%times_R8(0),_STAT)
-               this%epoch_index(1:2)=0
-               this%nobs_epoch = 0
-               nx=0
-               arr(1)=nx               
-            endif
-
-
-            call ESMF_VMAllFullReduce(vm, sendData=arr, recvData=nx_sum, &
-                 count=1, reduceflag=ESMF_REDUCE_SUM, rc=rc)
-            write(6,*) 'epoch_index(1:2), nx', this%epoch_index(1:2), this%nobs_epoch
-            write(6,*) 'nx_sum', nx_sum
-            this%nobs_epoch_sum = nx_sum
-
-            
-            this%locstream_factory = LocStreamFactory(this%lons,this%lats,_RC)
-            this%LS_rt = this%locstream_factory%create_locstream(_RC)
-            call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
-            this%LS_ds = this%locstream_factory%create_locstream(grid=grid,_RC)   ! use background grid
-
-            this%fieldA = ESMF_FieldCreate (this%LS_rt, name='A_time', typekind=ESMF_TYPEKIND_R8, _RC)
-            this%fieldB = ESMF_FieldCreate (this%LS_ds, name='B_time', typekind=ESMF_TYPEKIND_R8, _RC)
-
-            call ESMF_FieldGet( this%fieldA, localDE=0, farrayPtr=ptAT)
-            call ESMF_FieldGet( this%fieldB, localDE=0, farrayPtr=this%obsTime)
-            if (mypet == 0) then
-               ptAT(:) = this%times_R8(:)
-            end if
-            this%obsTime= -1.d0
-            
-            call ESMF_FieldRedistStore (this%fieldA, this%fieldB, RH, _RC)
-            call ESMF_FieldRedist      (this%fieldA, this%fieldB, RH, _RC)
-
-            !!write(6,'(2x,a,10E20.11)') 'obstime bf destroy'
-            !!write(6,'(2x,a,i5,2x,10E20.11)')  'pet=', mypet, this%obsTime(1:10)            
-            
-            call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
-            call ESMF_FieldDestroy(this%fieldA,nogarbage=.true.,_RC)
-            ! defer destroy fieldB at regen_grid step
-
-            !!write(6,'(2x,a,10E20.11)') 'obstime af destroy'
-            !!write(6,'(2x,a,i5,2x,10E20.11)')  'pet=', mypet, this%obsTime(1:10)
-            
-            print*, 'end create_grid'
-
-         end if
-
-         deallocate(lons_full, lats_full, times_R8_full)
-
-         
-         _RETURN(_SUCCESS)
-       end procedure create_grid
-            !! debug
-            !!write(6, '(a)')  'lons_full(1:3*num_times:num_times) and  times_R8_full'
-            !!write(6, '(10f10.1)')  lons_full(1:3*num_times:num_times/2)
-            !!write(6, '(10E25.12)')  times_R8_full(1:3*num_times:num_times/2)
-            !!write(6, '(10E25.12)')  times_R8_full(1:len:20)
-
-
-       
-
-
-         module procedure regrid_accumulate_on_xsubset
-           integer                 :: x_subset(2)
-           type(ESMF_Time)         :: timeset(2)
-           type(ESMF_Time)         :: current_time
-           type(ESMF_TimeInterval) :: dur
-           type(GriddedIOitemVectorIterator) :: iter
-           type(GriddedIOitem), pointer :: item
-           type(ESMF_Field) :: src_field,dst_field,acc_field
-           integer :: rank
-           real(kind=REAL32), allocatable :: p_new_lev(:,:,:)
-           real(kind=REAL32), pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
-           real(kind=REAL32), pointer :: p_dst_3d(:,:),p_dst_2d(:)
-           real(kind=REAL32), pointer :: p_acc_3d(:,:),p_acc_2d(:)
-           integer :: is, ie
-           integer :: status
-
-           ! __ s1.  get x_subset for each model time step interval on each pet
-           call ESMF_ClockGet(this%clock,currTime=current_time,_RC)
-           call ESMF_ClockGet(this%clock,timeStep=dur, _RC )
-           timeset(1) = current_time - dur
-           timeset(2) = current_time
-           call this%get_x_subset(timeset, x_subset, _RC)
-           is=x_subset(1)
-           ie=x_subset(2)
-           
-           if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
-              call this%vdata%setup_eta_to_pressure(_RC)
-           endif
-
-
-           ! __ s2. regrid & accumulate
-           if (is > 0 .AND. is <= ie ) then
-           iter = this%items%begin()
-           do while (iter /= this%items%end())
-              item => iter%get()
-              if (item%itemType == ItemTypeScalar) then
-                 call ESMF_FieldBundleGet(this%bundle,trim(item%xname),field=src_field,_RC)
-                 call ESMF_FieldBundleGet(this%output_bundle,trim(item%xname),field=dst_field,_RC)
-                 call ESMF_FieldBundleGet(this%acc_bundle,trim(item%xname),field=acc_field,_RC)
-                 call ESMF_FieldGet(src_field,rank=rank,_RC)
-                 if (rank==2) then
-                    call ESMF_FieldGet(src_field,farrayptr=p_src_2d,_RC)
-                    call ESMF_FieldGet(dst_field,farrayptr=p_dst_2d,_RC)
-                    call ESMF_FieldGet(acc_field,farrayptr=p_acc_2d,_RC)
-
-                    print*, 'size(src,dst,acc)', size(p_src_2d), size(p_dst_2d), size(p_acc_2d)
-                    call this%regridder%regrid(p_src_2d,p_dst_2d,_RC)
-                    p_acc_2d(is:ie) = p_dst_2d(is:ie)
-
-                    !!if (is>0) write(6,'(a)')  'regrid_accu:  p_dst_2d'
-                    !!if (is>0) write(6,'(10f7.1)')  p_dst_2d
-
-                 else if (rank==3) then
-                    call ESMF_FieldGet(src_field,farrayptr=p_src_3d,_RC)
-                    call ESMF_FieldGet(dst_field,farrayptr=p_dst_3d,_RC)
-                    call ESMF_FieldGet(acc_field,farrayptr=p_acc_3d,_RC)
-                    if (this%vdata%regrid_type==VERTICAL_METHOD_ETA2LEV) then
-                       allocate(p_new_lev(size(p_src_3d,1),size(p_src_3d,2),this%vdata%lm),_STAT)
-                       call this%vdata%regrid_eta_to_pressure(p_src_3d,p_new_lev,_RC)
-                       call this%regridder%regrid(p_new_lev,p_dst_3d,_RC)
-                       p_acc_3d(is:ie,:) = p_dst_3d(is:ie,:)
-                    else
-                       call this%regridder%regrid(p_src_3d,p_dst_3d,_RC)
-                       p_acc_3d(is:ie,:) = p_dst_3d(is:ie,:)
-                    end if
-                 end if
-              else if (item%itemType == ItemTypeVector) then
-                 _FAIL("ItemTypeVector not yet supported")
-              end if
-              call iter%next()
-           enddo
-        endif
-           _RETURN(ESMF_SUCCESS)
-
-         end procedure regrid_accumulate_on_xsubset
-
-
-         module procedure get_x_subset
-           type   (ESMF_Time)    :: T1,  T2
-           real   (ESMF_KIND_R8) :: rT1, rT2
-           
-           integer(ESMF_KIND_I8) :: i1,  i2
-           integer(ESMF_KIND_I8) :: jt1, jt2, lb, ub
-           integer               :: jlo, jhi
-           integer               :: status
-           
-           T1= interval(1)
-           T2= interval(2)
-
-           ! __ s1. find index on each PET
-           !
-           !              T1 <--> T2
-           !      --------------------------->
-           !         |                |
-           !   epoch_index(1)        (2)
-
-             call time_esmf_2_nc_int (T1, this%datetime_units, i1, _RC)
-             call time_esmf_2_nc_int (T2, this%datetime_units, i2, _RC)
-             rT1=real(i1, kind=ESMF_KIND_R8)
-             rT2=real(i2, kind=ESMF_KIND_R8) 
-             jlo = 1
-             jhi= size(this%obstime)
-             if (jhi==0) then
-                x_subset(1:2)=0
-                _RETURN(_SUCCESS)
-             endif
-
-             !!write(6,*) 'jlo, jhi in obstime', jlo, jhi
-             !!write(6,'(2x,a,2i15)') 'time/sec: i1, i2', i1, i2
-             !!write(6,'(2x,a,2f22.11)') 'obstime(1:n) in get_x_subset' 
-             !!write(6,'(2x,5E22.11)') this%obstime(jlo), this%obstime((jhi+jhi)/2), this%obstime(jhi)
-
-             !
-             ! bisect design
-             !    y(n)  < x(key) <=  y(n+1)
-             !
-             !     (x1, x2 ]
-             !   o--o-o-o-o--o--o--o--
-             !     |          |
-             !
-             !
-
-             lb=int(jlo, ESMF_KIND_I8)
-             ub=int(jhi, ESMF_KIND_I8)
-             call bisect( this%obstime, rT1, jt1, n_LB=lb, n_UB=ub, rc=rc)
-             call bisect( this%obstime, rT2, jt2, n_LB=lb, n_UB=ub, rc=rc)
-!             if (jt1<lb .OR. jt1>=ub) jt1=0   ! out of bounds
-!             if (jt2<lb .OR. jt2>=ub) jt2=0   ! out of bounds
-
-
-             x_subset(1) = jt1
-             !
-             !  correction: for inclusive end
-             !
-             if (jt1<lb) then
-                if (jt2<lb) then
-                   x_subset(1) = 0
-                   x_subset(2) = 0
-                elseif (jt2>=ub) then
-                   x_subset(1) = lb
-                   x_subset(2) = ub
-                else
-                   x_subset(1) = lb
-                   x_subset(2) = jt2
-                endif
-             elseif (jt1>=ub) then
-                x_subset(1) = 0
-                x_subset(2) = 0
-             else
-                x_subset(1) = jt1
-                if (jt2>=ub) then
-                   x_subset(2) = ub
-                else
-                   x_subset(2) = jt2
-                endif
-             endif
-             
-             print*, 'x_subset(1:2)', x_subset(1:2)
-
-           _RETURN(_SUCCESS)
-         end procedure get_x_subset
-
-         
-         module procedure destroy_rh_regen_LS
-           integer :: status
-
-           integer :: numVars, i
-           character(len=ESMF_MAXSTR), allocatable :: names(:)
-           type(ESMF_Field) :: field
-           type(ESMF_Grid)  :: grid
-           type(ESMF_Time)  :: currTime
-
-           ! __ s1. destroy RH, LS, acc_bundle / output_bundle
-           call ESMF_FieldDestroy(this%fieldB,nogarbage=.true.,_RC)
-           call this%regridder%destroy(_RC)
-           call this%locstream_factory%destroy_locstream(this%LS_rt, _RC)
-           call this%locstream_factory%destroy_locstream(this%LS_ds, _RC)
-           deallocate (this%lons, this%lats, this%times_R8)
-
-           call ESMF_FieldBundleGet(this%acc_bundle,fieldCount=numVars,_RC)
-           allocate(names(numVars),stat=status)
-           call ESMF_FieldBundleGet(this%acc_bundle,fieldNameList=names,_RC)
-           do i=1,numVars
-              call ESMF_FieldBundleGet(this%acc_bundle,trim(names(i)),field=field,_RC)
-              call ESMF_FieldDestroy(field,noGarbage=.true., _RC)
-           enddo
-           call ESMF_FieldBundleDestroy(this%acc_bundle,noGarbage=.true.,_RC)
-
-           call ESMF_FieldBundleGet(this%output_bundle,fieldCount=numVars,_RC)
-           allocate(names(numVars),stat=status)
-           call ESMF_FieldBundleGet(this%output_bundle,fieldNameList=names,_RC)
-           do i=1,numVars
-              call ESMF_FieldBundleGet(this%output_bundle,trim(names(i)),field=field,_RC)
-              call ESMF_FieldDestroy(field,noGarbage=.true., _RC)
-           enddo
-           call ESMF_FieldBundleDestroy(this%output_bundle,noGarbage=.true.,_RC)
-
-           ! __ s2. regenerate LS, RH, bundles
-           call ESMF_ClockGet ( this%clock, CurrTime=currTime, _RC )
-           call this%get_obsfile_Tbracket_from_epoch(currTime, _RC)
-           call this%create_grid(_RC)  !  setup LS_rt, LS_ds
-           call ESMF_FieldBundleGet(this%bundle,grid=grid,_RC)
-           this%regridder = LocStreamRegridder(grid,this%LS_ds,_RC)
-           this%output_bundle = this%create_new_bundle(_RC)
-           this%acc_bundle    = this%create_new_bundle(_RC)
-
-           ! __ s3. Epoch reset
-           this%epoch_index(1:2)=0
-           
-           _RETURN(ESMF_SUCCESS)
-
-         end procedure destroy_rh_regen_LS
-
-
-         module procedure get_obsfile_Tbracket_from_epoch
-           implicit none
-           integer :: status
-           integer :: numVars, i
-           character(len=ESMF_MAXSTR), allocatable :: names(:)
-           type(ESMF_Field) :: field
-           type(ESMF_Grid)  :: grid
-
-           type(ESMF_Time)  :: T1, Tn
-           type(ESMF_Time)  :: cT1, cTn
-           type(ESMF_Time)  :: Ts, Te
-           type(ESMF_TimeInterval)  :: dT1, dT2, dT3, dTs, dTe
-           real(ESMF_KIND_R8) :: Tint_r8
-           real(ESMF_KIND_R8) :: Tint2_r8
-           real(ESMF_KIND_R8) :: dT0_s, dT1_s, dT2_s, dT3_s
-           real(ESMF_KIND_R8) :: s1, s2
-           integer :: n1, n2
-           integer :: K
-           
-         ! get obs file index:  n1, n2
-         ! get obs file content:
-         !   given  traj%obsfile_Template
-         !          traj%obsfile_begin
-         !          traj%obsfile_interval
-         !          currTime
-         !          EpochTime
-         !   output:
-         !          nfile, filename(nfile) : time_esmf(nfile)
-
-           T1 = this%obsfile_start_time
-           Tn = this%obsfile_end_time           
-           
-           cT1 = currTime
-           dT1 = currTime - T1
-           dT2 = currTime + this%epoch_frequency - T1
-
-           call ESMF_TimeIntervalGet(this%obsfile_interval, s_r8=dT0_s, rc=status)
-           call ESMF_TimeIntervalGet(dT1, s_r8=dT1_s, rc=status)
-           call ESMF_TimeIntervalGet(dT2, s_r8=dT2_s, rc=status)
-           n1 = floor (dT1_s / dT0_s)
-           n2 = floor (dT2_s / dT0_s)
-           s1 = n1 * dT0_s
-           s2 = n2 * dT0_s
-           call ESMF_TimeIntervalSet(dTs, s_r8=s1, rc=status)
-           call ESMF_TimeIntervalSet(dTe, s_r8=s2, rc=status)
-           Ts = T1 + dTs
-           Te = T1 + dTe
-
-           !! debug
-           !!write(6,*) 'ck: due to epoch,  at curr_time, time bracket for files:  '
-           !!!write(6,*) 'ck: due to epoch,  integer multiple of obsfile_interval', n1, n2
-
-           this%obsfile_Ts_index = n1
-           this%obsfile_Te_index = n2
-
-           !! -- prone to error
-           !!dT3 = Tn - T1
-           !!call ESMF_TimeIntervalGet(dT3, s_r8=dT3_s, rc=status)
-           !!K   = floor (dT3_s / dT0_s)
-           !!if (n1>=0 .AND. n2<=K) then
-           !!   this%obsfile_is_available = .true.
-           !!else
-           !!   this%obsfile_is_available = .false.
-           !!end if
-           
-           _RETURN(ESMF_SUCCESS)           
-         end procedure get_obsfile_Tbracket_from_epoch
-
-
-         module procedure  get_filename_from_template
-            integer :: itime(2)
-            integer :: nymd, nhms
-            integer :: status
-
-            stop 'DO not use get_filename_from_template'
-            call ESMF_time_to_two_integer(time, itime, _RC)
-            print*, 'two integer time,  itime(:)', itime(1:2)
-            nymd = itime(1)
-            nhms = itime(2)
-            call fill_grads_template ( filename, file_template, &
-                 experiment_id='', nymd=nymd, nhms=nhms, _RC ) 
-           print*, 'ck: this%obsFile_T=', trim(filename)
-           _RETURN(ESMF_SUCCESS)
-         end procedure
-
-
-         module procedure  get_filename_from_template_use_index
-            integer :: itime(2)
-            integer :: nymd, nhms
-            integer :: status
-            real(ESMF_KIND_R8) :: dT0_s
-            real(ESMF_KIND_R8) :: s
-            type(ESMF_TimeInterval) :: dT
-            type(ESMF_Time)         :: time            
-
-            
-            call ESMF_TimeIntervalGet(this%obsfile_interval, s_r8=dT0_s, rc=status)
-            s = dT0_s * f_index
-            call ESMF_TimeIntervalSet(dT, s_r8=s, rc=status)
-            time = this%obsfile_start_time + dT
-
-            call ESMF_time_to_two_integer(time, itime, _RC)
-            !!print*, 'two integer time,  itime(:)', itime(1:2)
-            nymd = itime(1)
-            nhms = itime(2)
-            call fill_grads_template ( filename, this%obsfile_template, &
-                 experiment_id='', nymd=nymd, nhms=nhms, _RC ) 
-            !!print*, 'ck: this%obsFile_T=', trim(filename)
-
-            _RETURN(ESMF_SUCCESS)
-            
-         end procedure
-         
-         
 end submodule HistoryTrajectory_implement

--- a/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
+++ b/gridcomps/History/MAPL_HistoryTrajectoryMod_smod.F90
@@ -504,21 +504,6 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             !-- non IODA case
             !
             _FAIL('non-IODA format is not implemented here')
-            !! sorry Ben, cannot make everything work
-            !!filename=trim(this%obsFile)
-            !!!!         print*, 'obs file name=', trim(filename)
-            !!call formatter%open(trim(filename),pFIO_READ,_RC)
-            !!fmd = formatter%read(_RC)
-            !!call metadata_utils%create(fmd,trim(filename))
-            !!num_times = metadata_utils%get_dimension("time",_RC)
-            !!allocate(this%lons(num_times),this%lats(num_times),_STAT)
-            !!if (metadata_utils%is_var_present("longitude")) then
-            !!   call formatter%get_var("longitude",this%lons,_RC)
-            !!end if
-            !!if (metadata_utils%is_var_present("latitude")) then
-            !!   call formatter%get_var("latitude",this%lats,_RC)
-            !!end if
-            !!call metadata_utils%get_time_info(timeVector=this%times,_RC)
          else
             !
             !-- IODA case


### PR DESCRIPTION
## Description

The trajectory sampler code originally written by @bena-nasa to regrid to flight trajectory is extended to ingest and regrid to multiple IODA file locations.  The implementation mainly have followed https://github.com/GEOS-ESM/MAPL/issues/2144.  The listed items therein, except for the item-8: related to 3D height interpolation, have been finished in this PR. 

The important features include:
- Epoch time is tunable by user to determine output freqeuency to netCDF files
- Read in multiple IODA files from one collection and regrid with the route handle therein
- Loc stream is extended from root to distributed MPI processes based on background grids
- Written out to NC files happens at Epoch time only, while each time step the regridded region is accumulated to an intermediate bundle
- A derived type is allocated to handle each individual IODA type (filename, metadata, lon/lat/field)

The drawback is the original aircraft trajectory functionality is disabled, as the code is tuned for IODA files format. 

Note:  
  - I modified  MAPL_HistoryGridComp.F90 to read in a table inside a collection

Input:
```
VERSION: 1

  COLLECTIONS:
  geovals
  ::

  GRID_LABELS:
  ::

  geovals.template:       '%y4%m2%d2_%h2%n2z.nc4',
  geovals.format:         'CFIO',
  geovals.obs_files:     # table start from next line
      DIR/aircraft.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/airs_aqua.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsr2_gcom-w1.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsua_aqua.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsua_metop-b.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsua_n15.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsua_n18.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/amsua_n19.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/atms_n20.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/atms_npp.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/avhrr3_metop-b.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/avhrr3_n18.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/avhrr3_n19.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/cris-fsr_n20.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/cris-fsr_npp.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/gmi_gpm.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/gps.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/iasi_metop-b.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/mhs_metop-b.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/mhs_n19.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/mls55_aura.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/omi_aura.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/ompsnm_npp.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/satwind.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/scatwind.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/sfc.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/sfcship.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/sondes.%y4%m2%d2T%h2%n2%S2Z.nc4
      DIR/ssmis_f17.%y4%m2%d2T%h2%n2%S2Z.nc4
::
  geovals.obs_file_interval:  '000000 060000'    #  fixed string format:  yymmdd hhmmss
  geovals.Epoch:          060000                 #  fixed integer format:  hhmmss
  geovals.nc_Index:       Location
  geovals.nc_Time:        MetaData/dateTime
  geovals.nc_Longitude:   MetaData/longitude
  geovals.nc_Latitude:    MetaData/latitude

  geovals.regrid_method:  'BILINEAR' ,
  geovals.fields:         'var2', 'Root'
                         'var3', 'Root'
::
```

Output:   *.geovals.20190801_0300z.nc4  etc. 

## How Has This Been Tested?
Tested regridding the synthetic data from C720 to 29-IODA files spanning 12 hr time period (from 2019-07-31T21Z). Run finishes in 8 min with 6-cores. Previous experience shows when synthetic data runs can succeed through ExtDataDriver.x, the G5NR run can finish without error. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
