### PR TITLE
Remove commented code with ESMF_Attribute

### DIFF
--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -198,13 +198,6 @@ MODULE ExtDataUtRoot_GridCompMod
          call MAPL_GridCreate(GC, _RC)
          call ESMF_GridCompGet(GC, grid=grid, _RC)
          call set_locstream(_RC)
-         !allocate(ak(lm+1),stat=status)
-         !allocate(bk(lm+1),stat=status)
-         !call set_eta(lm,ls,ptop,pint,ak,bk)
-         !call ESMF_AttributeSet(grid,name='GridAK', itemCount=LM+1, &
-               !valuelist=ak,_RC)
-         !call ESMF_AttributeSet(grid,name='GridBK', itemCount=LM+1, &
-               !valuelist=bk,_RC)
 
          call MAPL_GenericInitialize ( GC, IMPORT, EXPORT, clock, _RC)
          call ForceAllocation(Export,_RC)

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -313,9 +313,9 @@ CONTAINS
    type(ESMF_GridComp), intent(inout) :: GC      !! Grid Component
    type(ESMF_State), intent(inout)    :: IMPORT  !! Import State
    type(ESMF_State), intent(inout)    :: EXPORT  !! Export State
-   integer, intent(out)               :: rc      !! Error return code:    
-                                                 !!  0 - all is well    
-                                                 !!  1 -    
+   integer, intent(out)               :: rc      !! Error return code:
+                                                 !!  0 - all is well
+                                                 !!  1 -
 !
 !-------------------------------------------------------------------------
 
@@ -1196,9 +1196,9 @@ CONTAINS
    type(ESMF_GridComp), intent(inout)  :: GC     !! Grid Component
    type(ESMF_State), intent(inout) :: IMPORT     !! Import State
    type(ESMF_State), intent(inout) :: EXPORT     !! Export State
-   integer, intent(out) ::  rc                   !! Error return code:    
-                                                 !!  0 - all is well    
-                                                 !!  1 -    
+   integer, intent(out) ::  rc                   !! Error return code:
+                                                 !!  0 - all is well
+                                                 !!  1 -
 !
 !-------------------------------------------------------------------------
 
@@ -1600,9 +1600,9 @@ CONTAINS
    type(ESMF_GridComp), intent(inout)  :: GC     !! Grid Component
    type(ESMF_State), intent(inout) :: IMPORT     !! Import State
    type(ESMF_State), intent(inout) :: EXPORT     !! Export State
-   integer, intent(out) ::  rc                   !! Error return code:    
-                                                 !!  0 - all is well    
-                                                 !!  1 -    
+   integer, intent(out) ::  rc                   !! Error return code:
+                                                 !!  0 - all is well
+                                                 !!  1 -
 !
 !-------------------------------------------------------------------------
 
@@ -3760,14 +3760,14 @@ CONTAINS
 ! extracts integers from a character-delimited string, for example, "-1,45,256,7,10".  In the context
 ! of Chem_Util, this is provided for determining the numerically indexed regions over which an
 ! emission might be applied.
-!           
+!
 ! In multiple passes, the string is parsed for the delimiter, and the characters up to, but not
 ! including the delimiter are taken as consecutive digits of an integer.  A negative sign ("-") is
 ! allowed.  After the first pass, each integer and its trailing delimiter are lopped of the head of
 ! the (local copy of the) string, and the process is started over.
 !
 ! The default delimiter is a comma (",").
-!           
+!
 ! "Unfilled" iValues are zero.
 !
 ! Return codes:
@@ -3776,7 +3776,7 @@ CONTAINS
 !
 ! @bug
 !-The routine works under the following assumptions:
-!- A non-zero return code does not stop execution. 
+!- A non-zero return code does not stop execution.
 !- Allowed numerals are: 0,1,2,3,4,5,6,7,8,9.
 !- A delimiter must be separated from another delimiter by at least one numeral.
 !- The delimiter cannot be a numeral or a negative sign.
@@ -3789,9 +3789,9 @@ CONTAINS
 ! Examples of strings that will work:
 !```
 !  "1"
-!  "-1"  
+!  "-1"
 !  "-1,2004,-3"
-!  "1+-2+3" 
+!  "1+-2+3"
 !  "-1A100A5"
 !```
 !
@@ -4453,15 +4453,6 @@ CONTAINS
          _VERIFY(STATUS)
          call MAPL_FieldBundleAdd(pbundle,Field2,rc=status)
          _VERIFY(STATUS)
-
-         !block
-            !character(len=ESMF_MAXSTR) :: vectorlist(2)
-            !vectorlist(1) = item%fcomp1
-            !vectorlist(2) = item%fcomp2
-            !call ESMF_AttributeSet(pbundle,name="VectorList:", itemCount=2, &
-                 !valuelist = vectorlist, rc=status)
-            !_VERIFY(STATUS)
-         !end block
 
       else
 


### PR DESCRIPTION
This is a insanely trivial PR. It removes some commented out ESMF_Attribute calls. I'm doing this because I often grep for that when doing MAPL3 merges to make sure MAPL3 is using ESMF_Info. And at the moment:
```
❯ rg esmf_att
gridcomps/ExtData/ExtDataGridCompMod.F90
4469:            !call ESMF_AttributeSet(pbundle,name="VectorList:", itemCount=2, &

Tests/ExtDataRoot_GridComp.F90
204:         !call ESMF_AttributeSet(grid,name='GridAK', itemCount=LM+1, &
206:         !call ESMF_AttributeSet(grid,name='GridBK', itemCount=LM+1, &

CHANGELOG.md
28:- Replace ESMF_Attribute calls with ESMF_Info calls in MAPL_FieldCopyAttribute
36:- Changed all ESMF_AttributeGet and ESMF_AttributeSet to ESMF_InfoGet and ESMF_InfoSet respectively as old calls will be deprecated soon.
```
it finds these two (the CHANGELOG is inevitable).

If I can remove them in `develop`, when I merge up to MAPL3, they will be gone!

I've spoken with @bena-nasa and he seems okay removing these as they are commented code.