### PR TITLE
Fixes #2407. Fix bad history print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated CI GEOSadas build to use special branch (as stock ADAS at the moment is too far behind GEOSgcm main)
+- Fix incorrect History print during runtime
 
 ### Removed
 

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -668,7 +668,7 @@ contains
          match = .false.
          contLine = .false.
          con3 = .false.
-            
+
          do while (.true.)
             read(unitr, '(A)', end=1234) line
             j = index( adjustl(line), trim(adjustl(string)) )
@@ -677,7 +677,7 @@ contains
                j = index(line, trim(string)//'fields:')
                contLine = (j > 0)
                k = index(line, trim(string)//'obs_files:')
-               con3 = (k > 0)               
+               con3 = (k > 0)
             end if
             if (match .or. contLine .or. con3) then
                write(unitw,'(A)') trim(line)
@@ -686,7 +686,7 @@ contains
                if (adjustl(line) == '::') contLine = .false.
             end if
             if (con3) then
-               if (adjustl(line) == '::') con3 = .false.               
+               if (adjustl(line) == '::') con3 = .false.
             endif
          end do
 
@@ -883,7 +883,7 @@ contains
        call ESMF_ConfigGetDim(cfg, nline, ncol,  label=trim(string)//'obs_files:', rc=rc)  ! here donot check rc on purpose
        if (rc==0) then
           if (nline > 0) then
-             list(n)%timeseries_output = .true.             
+             list(n)%timeseries_output = .true.
           endif
        endif
        call ESMF_ConfigGetAttribute(cfg, value=list(n)%recycle_track, default=.false., &
@@ -2449,7 +2449,12 @@ ENDDO PARSER
          print *, '    End_Date: ',       list(n)%end_date
          print *, '    End_Time: ',       list(n)%end_time
          endif
-         print *, ' Regrid Mthd: ',       regrid_method_int_to_string(list(n)%regrid_method)
+         if (trim(list(n)%output_grid_label)/='') then
+            print *, ' Regrid Mthd: ',       regrid_method_int_to_string(list(n)%regrid_method)
+         else
+            print *, ' Regrid Mthd: ',       'identity'
+         end if
+
 
          block
             integer :: im_world, jm_world,dims(3)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the dumb history print bug detailed in #2407. Now we get:
```
 Initializing Output Stream: geosgcm_prog_nat
 ---------------------------
       Format: CFIO
         Mode: instantaneous
       Slices:          483
      Deflate:            1
    Frequency:        60000
     Ref_Date:     20000414
     Ref_Time:            0
     Duration:        60000
  Regrid Mthd: identity
    XY-offset:            0   (DcPc: Dateline Center, Pole Center)
```

Huzzah! A native collection says it's using the identity regridder!

And I checked that the non-native collections still print `bilinear` or whatever.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #2407 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Makes the output correct.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Did a run of GEOSgcm and it was zero-diff and the print is fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
