### PR TITLE
WIP: Convert sends to ssends

### DIFF
--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -1463,7 +1463,7 @@ contains
             deallocate(buf)
          enddo
       else
-         call mpi_send(q,im*jm,MPI_FLOAT,peid0,mypet,MPI_COMM_WORLD,status)
+         call MPI_Ssend(q,im*jm,MPI_FLOAT,peid0,mypet,MPI_COMM_WORLD,status)
          _VERIFY(status)
       end if
 
@@ -1482,7 +1482,7 @@ contains
 ! send mean back to other ranks
          do n=1,nx-1
             peid = peid0+n
-            call mpi_send(qz,jm,MPI_FLOAT,peid,peid0,MPI_COMM_WORLD,status)
+            call MPI_Ssend(qz,jm,MPI_FLOAT,peid,peid0,MPI_COMM_WORLD,status)
             _VERIFY(status)
          enddo
       else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change the verification of the grid in MAPL_GetGlobalHorzIJIndex to avoid collective call
+- Changed all `MPI_Send` and `MPI_Isend` to `MPI_Ssend` and `MPI_Issend`
 
 ### Fixed
 
@@ -1548,7 +1549,7 @@ new interface with conventional ordering has been introduced.
 ### Changed
 
 - Change to non-blocking send and receive from frontend to beckend in the class MultiGroupServer
-- Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
+- Change one sided mpi_put to MPI_Ssend and receive pair in the class MultiGroupServer
 - Change command line interface to --npes_backend_pernode to avoid confusion
 - Remove self-defined-in-file MAPL macros
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1549,7 +1549,7 @@ new interface with conventional ordering has been introduced.
 ### Changed
 
 - Change to non-blocking send and receive from frontend to beckend in the class MultiGroupServer
-- Change one sided mpi_put to MPI_Ssend and receive pair in the class MultiGroupServer
+- Change one sided mpi_put to mpi_send and receive pair in the class MultiGroupServer
 - Change command line interface to --npes_backend_pernode to avoid confusion
 - Remove self-defined-in-file MAPL macros
 

--- a/base/MAPL_CFIO.F90
+++ b/base/MAPL_CFIO.F90
@@ -2247,7 +2247,7 @@ contains
          _VERIFY(STATUS)
       end if
 
-         call MPI_ISend(Gout, size(Gout), MPI_REAL, MCFIO%RootRank, &
+         call MPI_Issend(Gout, size(Gout), MPI_REAL, MCFIO%RootRank, &
                  trans_tag, mCFIO%comm, request,         STATUS)
             _VERIFY(STATUS)
 

--- a/base/MAPL_Comms.F90
+++ b/base/MAPL_Comms.F90
@@ -540,7 +540,7 @@ module MAPL_CommsMod
        jn = request%jn(request%mype)
        request%DstArray(i1:in,j1:jn) = local_array
     else
-       call MPI_ISend(request%Local_Array, size(Local_Array), MPI_REAL, &
+       call MPI_Issend(request%Local_Array, size(Local_Array), MPI_REAL, &
             request%root, request%tag, request%comm, request%send(0), status)
        _VERIFY(STATUS)
     end if
@@ -609,7 +609,7 @@ module MAPL_CommsMod
              else
                   request%Buff(n)%A = Global_Array(i1:in,j1:jn)
              end if
-             call MPI_ISend(request%Buff(n)%A, count, MPI_REAL, &
+             call MPI_Issend(request%Buff(n)%A, count, MPI_REAL, &
                   n, request%tag, request%comm, request%send(n),  status)
              _VERIFY(STATUS)
           end if

--- a/base/MAPL_LocStreamMod.F90
+++ b/base/MAPL_LocStreamMod.F90
@@ -2251,7 +2251,7 @@ subroutine MAPL_LocStreamTransformT2T ( OUTPUT, XFORM, INPUT, RC )
      allocate(request(NumReceivers), stat=status)
      _VERIFY(status)
      do n=1, NumReceivers
-        call MPI_ISend(input, count, MPI_REAL, &
+        call MPI_Issend(input, count, MPI_REAL, &
                        Xform%PTR%receivers(n), msg_tag, &
                        Xform%PTR%Comm, request(n), status)
         _VERIFY(status)

--- a/base/send.H
+++ b/base/send.H
@@ -37,7 +37,7 @@
     call ESMF_VMGet(vm, mpiCommunicator=COMM, rc=status)
     _VERIFY(STATUS)
 
-    call MPI_Send(DATA, count, MPITYPE_, dest, msg_tag, COMM, IERR)
+    call MPI_Ssend(DATA, count, MPITYPE_, dest, msg_tag, COMM, IERR)
     _VERIFY(IERR)
 
     _RETURN(ESMF_SUCCESS)

--- a/pfio/DirectoryService.F90
+++ b/pfio/DirectoryService.F90
@@ -241,7 +241,7 @@ contains
          call this%mutex%release()
 
          if (found) then
-            call MPI_Send(this%rank, 1, MPI_INTEGER, server_root_rank, DISCOVERY_TAG, this%comm, ierror)
+            call MPI_Ssend(this%rank, 1, MPI_INTEGER, server_root_rank, DISCOVERY_TAG, this%comm, ierror)
          else
             call MPI_Recv(server_root_rank, 1, MPI_INTEGER, MPI_ANY_SOURCE, DISCOVERY_TAG, this%comm, status, ierror)
          end if
@@ -260,8 +260,8 @@ contains
 
       call MPI_Gather(this%rank, 1, MPI_INTEGER, client_ranks, 1, MPI_INTEGER, 0, client_comm, ierror)
       if (rank_in_client == 0) then
-         call MPI_Send(client_npes, 1, MPI_INTEGER, server_root_rank, NPES_TAG, this%comm, ierror)
-         call MPI_Send(client_ranks, client_npes, MPI_INTEGER, server_root_rank, RANKS_TAG, this%comm, ierror)
+         call MPI_Ssend(client_npes, 1, MPI_INTEGER, server_root_rank, NPES_TAG, this%comm, ierror)
+         call MPI_Ssend(client_ranks, client_npes, MPI_INTEGER, server_root_rank, RANKS_TAG, this%comm, ierror)
          call MPI_Recv(server_ranks, client_npes, MPI_INTEGER, server_root_rank, 0, this%comm, status, ierror)
          call MPI_Recv(server_npes, 1, MPI_INTEGER, server_root_rank, 0, this%comm, status, ierror)
          if (present(server_size)) server_size = server_npes
@@ -351,7 +351,7 @@ contains
          call this%mutex%release()
 
          if (found) then
-            call MPI_Send(this%rank, 1, MPI_INTEGER, client_root_rank, DISCOVERY_TAG, this%comm, ierror)
+            call MPI_Ssend(this%rank, 1, MPI_INTEGER, client_root_rank, DISCOVERY_TAG, this%comm, ierror)
          else
             call MPI_Recv(client_root_rank, 1, MPI_INTEGER, MPI_ANY_SOURCE, DISCOVERY_TAG, this%comm, status, ierror)
          end if
@@ -396,8 +396,8 @@ contains
            & 0, server_comm, ierror)
 
       if (rank_in_server == 0) then
-        call MPI_Send(server_ranks, client_npes, MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
-        call MPI_Send(server_npes,   1,          MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
+        call MPI_Ssend(server_ranks, client_npes, MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
+        call MPI_Ssend(server_npes,   1,          MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
       endif
 
       if (rank_in_server /= 0) then
@@ -409,7 +409,7 @@ contains
 
       do p = 1, cnts
          client_rank = my_client_ranks(p)
-         call MPI_Send(this%rank, 1, MPI_INTEGER, client_rank, CONNECT_TAG, this%comm, ierror)
+         call MPI_Ssend(this%rank, 1, MPI_INTEGER, client_rank, CONNECT_TAG, this%comm, ierror)
          allocate(sckt, source=MpiSocket(this%comm, client_rank, this%parser))
          call server%add_connection(sckt)
          nullify(sckt)
@@ -575,7 +575,7 @@ contains
 
          do i = 1, dir%num_entries
 
-            call MPI_Send(TERMINATE, 1, MPI_INTEGER, dir%entries(i)%partner_root_rank, DISCOVERY_TAG, &
+            call MPI_Ssend(TERMINATE, 1, MPI_INTEGER, dir%entries(i)%partner_root_rank, DISCOVERY_TAG, &
                 & this%comm, ierror)
 
          enddo

--- a/pfio/MpiMutex.F90
+++ b/pfio/MpiMutex.F90
@@ -154,7 +154,7 @@ contains
         end if
 
         if (next_rank /= -1) then
-           call MPI_Send(buffer, 0, MPI_LOGICAL, next_rank, &
+           call MPI_Ssend(buffer, 0, MPI_LOGICAL, next_rank, &
                 & LOCK_TAG, this%comm, ierror)
         end if
       end block

--- a/pfio/MpiSocket.F90
+++ b/pfio/MpiSocket.F90
@@ -127,7 +127,7 @@ contains
       integer :: ierror
 
       buffer = this%parser%encode(message)
-      call MPI_Send(buffer, size(buffer), MPI_INTEGER, this%pair_remote_rank, MESSAGE_TAG, this%pair_comm, &
+      call MPI_Ssend(buffer, size(buffer), MPI_INTEGER, this%pair_remote_rank, MESSAGE_TAG, this%pair_comm, &
            & ierror)
       _RETURN(_SUCCESS)      
    end subroutine send
@@ -164,7 +164,7 @@ contains
       n_words = big_n
       call c_f_pointer(local_reference%base_address, data, shape=[n_words])
       if (n_words ==0) allocate(data(1))
-      call MPI_Isend(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
+      call MPI_Issend(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
       allocate(handle, source=MpiRequestHandle(local_reference, request))
       if (n_words ==0) deallocate(data)
       _RETURN(_SUCCESS)

--- a/pfio/MultiCommServer.F90
+++ b/pfio/MultiCommServer.F90
@@ -125,7 +125,7 @@ contains
 
          call MPI_AllGather(s_rank, 1, MPI_INTEGER, s%front_ranks, 1, MPI_INTEGER, s%front_comm, ierror)
          if (local_rank ==0 ) then
-            call MPI_Send(s%front_ranks, s_size-nwriter, MPI_INTEGER, s%back_ranks(1), 777, s%server_comm, ierror)
+            call MPI_Ssend(s%front_ranks, s_size-nwriter, MPI_INTEGER, s%back_ranks(1), 777, s%server_comm, ierror)
          endif
 
       endif
@@ -136,7 +136,7 @@ contains
          call MPI_Comm_rank(s%back_comm, local_rank, ierror)
          if (local_rank ==0 ) then
             s%I_am_back_root = .true.
-            call MPI_Send(s%back_ranks, nwriter, MPI_INTEGER, 0, 666, s%server_comm, ierror)
+            call MPI_Ssend(s%back_ranks, nwriter, MPI_INTEGER, 0, 666, s%server_comm, ierror)
          endif
 
          if (s_rank == s%back_ranks(1)) then
@@ -273,13 +273,13 @@ contains
       if (this%I_am_front_root) then
          call serialize_message_vector(thread_ptr%request_backlog,buffer)
          bsize = size(buffer)
-         call MPI_send(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
-         call MPI_send(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         call MPI_Ssend(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         call MPI_Ssend(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
 
          call HistoryCollectionVector_serialize(thread_ptr%hist_collections, buffer)
          bsize = size(buffer)
-         call MPI_send(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
-         call MPI_send(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         call MPI_Ssend(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         call MPI_Ssend(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
 
       endif
 

--- a/pfio/MultiLayerServer.F90
+++ b/pfio/MultiLayerServer.F90
@@ -125,7 +125,7 @@ contains
       ! send terminate back for synchronization
       ! if no syncrohization, the writer may be still writing while the main testing node is comparing
       if( this%rank == 0 .and. this%nwriters > 1 ) then
-        call MPI_send(terminate, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
+        call MPI_Ssend(terminate, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
         call MPI_recv(terminate, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, MPI_STAT, ierr)
       endif
 
@@ -243,18 +243,18 @@ contains
          call serialize_message_vector(forwardVec,buffer)
          bsize = size(buffer)
 
-         call MPI_send(command, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
+         call MPI_Ssend(command, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
          call MPI_recv(writer_rank, 1, MPI_INTEGER, &
                    0, pFIO_s_tag, this%Inter_Comm , &
                    MPI_STAT, ierr)
          !forward Message
-         call MPI_send(bsize,  1,     MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
-         call MPI_send(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         call MPI_Ssend(bsize,  1,     MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         call MPI_Ssend(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
          !send number of collections
          call StringAttributeMap_serialize(forwardData,buffer)
          bsize = size(buffer)
-         call MPI_send(bsize,  1, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
-         call MPI_send(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         call MPI_Ssend(bsize,  1, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         call MPI_Ssend(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
          !2) send the data
 
          _RETURN(_SUCCESS)

--- a/pfio/pfio.md
+++ b/pfio/pfio.md
@@ -114,7 +114,7 @@ PFIO follows these steps in the execution of the `MultiGroupServer` option:
 
 - The `Oserver` is divided into frontend and backend.
 - **When the frontend receive the data,  its root process asks `backend`‘s root (or head) for an idle process for each collection**. Then it broadcasts the info to the other `frontend` processes.
-- When the `frontend` processors forward (`MPI_SEND`) the data to the backend ( different collections to different `backend` processors), they get back to the clients without waiting for the actual writing.
+- When the `frontend` processors forward (`MPI_Ssend`) the data to the backend ( different collections to different `backend` processors), they get back to the clients without waiting for the actual writing.
 
 ![MultiGroup](fig_MultiGroupServerClass.png)
 

--- a/pfio/pfio_writer.F90
+++ b/pfio/pfio_writer.F90
@@ -78,22 +78,22 @@ program main
             endif
 
             ! tell server the idel_worker
-            call MPI_send(idle_worker, 1, MPI_INTEGER, server_rank, pFIO_s_tag, Inter_Comm, ierr)
+            call MPI_Ssend(idle_worker, 1, MPI_INTEGER, server_rank, pFIO_s_tag, Inter_Comm, ierr)
             busy(idle_worker) = 1
             ! tell the idle_worker which server has work
-            call MPI_send(server_rank, 1, MPI_INTEGER, idle_worker, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+            call MPI_Ssend(server_rank, 1, MPI_INTEGER, idle_worker, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
 
          else ! command /=1, notify the worker to quit and finalize
             no_job = -1
             do i = 1, n_workers -1
                if ( busy(i) == 0) then
-                  call MPI_send(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+                  call MPI_Ssend(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
                else
                   call MPI_recv( idle, 1, MPI_INTEGER, &
                        i, pFIO_w_m_tag, MPI_COMM_WORLD, &
                        MPI_STAT, ierr)
                    if (idle /= i ) stop ("idle should be i")
-                   call MPI_send(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+                   call MPI_Ssend(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
                endif  
             enddo  
             exit
@@ -167,7 +167,7 @@ program main
         deallocate(bufferd, bufferm)
  
         ! telling captain, I am the soldier that is ready to have more work
-        call MPI_send(rank, 1, MPI_INTEGER, 0, pFIO_w_m_tag, MPI_COMM_WORLD , ierr)
+        call MPI_Ssend(rank, 1, MPI_INTEGER, 0, pFIO_w_m_tag, MPI_COMM_WORLD , ierr)
 
       enddo
    endif
@@ -178,7 +178,7 @@ program main
       ! send done message to server
       ! this serves the syncronization with oserver
       command = -1
-      call MPI_send(command, 1, MPI_INTEGER, 0, pFIO_s_tag, Inter_Comm, ierr)
+      call MPI_Ssend(command, 1, MPI_INTEGER, 0, pFIO_s_tag, Inter_Comm, ierr)
    endif
      
    call MPI_Finalize(ierr)

--- a/shared/MAPL_LoadBalance.F90
+++ b/shared/MAPL_LoadBalance.F90
@@ -166,7 +166,7 @@ contains
 
           if(SEND) then ! -- SENDER
              CURSOR = CURSOR - LENGTH
-             call MPI_SEND(A(CURSOR), VLength, Vtype, PROCESSOR, PASS, COMM, STATUS)
+             call MPI_Ssend(A(CURSOR), VLength, Vtype, PROCESSOR, PASS, COMM, STATUS)
              _ASSERT(STATUS==MPI_SUCCESS,'needs informative message')
           endif
 
@@ -270,7 +270,7 @@ contains
 
           if(SEND) then ! -- SENDER
              CURSOR = CURSOR - LENGTH
-             call MPI_SEND(A(CURSOR), VLength, Vtype, PROCESSOR, PASS, COMM, STATUS)
+             call MPI_Ssend(A(CURSOR), VLength, Vtype, PROCESSOR, PASS, COMM, STATUS)
              _ASSERT(STATUS==MPI_SUCCESS,'needs informative message')
           endif
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is an odd test. While at SC23 I was reminded about all the odd sends MPI provides. So I thought, let's try ssends (aka synchronous sends). I then ran some C360 runs before and after and saw one interesting thing:

Current `develop`:
```
3721:--Finalize                                                1   132.238  16.03     0.017   0.00
3721:--Finalize                                                1   127.424  15.27     0.009   0.00
3722:--Finalize                                                1   112.208  13.75     0.006   0.00
```

Using Ssends:
```
3721:--Finalize                                                1   102.804  12.50     0.006   0.00
3721:--Finalize                                                1    99.120  11.93     0.009   0.00
3722:--Finalize                                                1    88.122  10.40     0.007   0.00
```

So...yeah. I mean, nothing else really changed, but the Finalize timer was consistently faster.

I'm wondering if one of the testers of @bena-nasa might be able to explore this? If there is one that can do checkpointing, maybe we could scale up and see if this is just an oddity of when I ran or something real?

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
