### PR TITLE
Update Ford for gFTL v1.11

### DIFF
--- a/docs/Ford/docs-with-remote-esmf.md
+++ b/docs/Ford/docs-with-remote-esmf.md
@@ -7,8 +7,8 @@ coloured_edges: true
 graph_maxdepth: 4
 graph_maxnodes: 32
 include: ../../include/
-         ../../gFTL/install/GFTL-1.10/include/v1
-         ../../gFTL/install/GFTL-1.10/include/v2
+         ../../gFTL/install/GFTL-1.11/include/v1
+         ../../gFTL/install/GFTL-1.11/include/v2
 exclude: **/EsmfRegridder.F90
          **/FieldBLAS_IntrinsicFunctions.F90
          **/GeomManager.F90

--- a/docs/Ford/docs-with-remote-esmf.public_private_protected.md
+++ b/docs/Ford/docs-with-remote-esmf.public_private_protected.md
@@ -8,8 +8,8 @@ coloured_edges: true
 graph_maxdepth: 4
 graph_maxnodes: 32
 include: ../../include/
-         ../../gFTL/install/GFTL-1.10/include/v1
-         ../../gFTL/install/GFTL-1.10/include/v2
+         ../../gFTL/install/GFTL-1.11/include/v1
+         ../../gFTL/install/GFTL-1.11/include/v2
 exclude: **/EsmfRegridder.F90
          **/FieldBLAS_IntrinsicFunctions.F90
          **/GeomManager.F90


### PR DESCRIPTION
The Ford docs broke because they had a hard coded gFTL v1.10 since that was the version for a long time. Well, gFTL `main` is now v1.11 so we need to update the control files.