### PR TITLE
Feature/mapl3 port to ifort 2021.10.0

### DIFF
--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -68,6 +68,14 @@ target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 target_link_libraries (${this} PUBLIC MAPL.field_utils esmf NetCDF::NetCDF_Fortran)
 
+# Workaround for ifort 2010.10.0 Explicit deep copy in some containers
+# result in odd error in GEOM_Manager.  This is not sufficient on its
+# own, and some constructors had to be converted to
+# subroutines. (ComponentSpecParser.F90)
+  target_compile_definitions(${this} PRIVATE "__gftl_map_use_default_assignment")
+  target_compile_definitions(${this} PRIVATE "__gftl_set_use_default_assignment")
+
+
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()

--- a/generic3g/OuterMetaComponent_setservices_smod.F90
+++ b/generic3g/OuterMetaComponent_setservices_smod.F90
@@ -41,7 +41,8 @@ contains
       geom_mgr => get_geom_manager()
       _ASSERT(associated(geom_mgr), 'uh oh - cannot acces global geom_manager.')
 
-      this%component_spec = parse_component_spec(this%hconfig, _RC)
+      call parse_component_spec(this%component_spec, this%hconfig, _RC)
+!#      this%component_spec = parse_component_spec(this%hconfig, _RC)
       call process_user_gridcomp(this, _RC)
       call process_children(this, _RC)
 

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -151,6 +151,7 @@ contains
       call this%set_created()
 
       _RETURN(ESMF_SUCCESS)
+      _UNUSED_DUMMY(dependency_specs)
    end subroutine create
 
    subroutine MAPL_FieldEmptySet(field, geom, rc)
@@ -291,6 +292,7 @@ contains
             
    end subroutine allocate
 
+   ! TODO: This probably belongs in a base class.
    function get_dependencies(this, rc) result(dependencies)
       type(ActualPtVector) :: dependencies
       class(FieldSpec), intent(in) :: this
@@ -299,6 +301,7 @@ contains
       dependencies = ActualPtVector()
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function get_dependencies
 
    subroutine connect_to(this, src_spec, actual_pt, rc)
@@ -394,7 +397,6 @@ contains
 
       type(ESMF_Field) :: alias
       integer :: status
-      type(ESMF_FieldStatus_Flag) :: fstatus
       type(ESMF_State) :: state, substate
       character(:), allocatable :: short_name
 
@@ -437,14 +439,12 @@ contains
       class(AbstractStateItemSpec), intent(in) :: src_spec
       integer, optional, intent(out) :: rc
 
-      integer :: status
-
       cost = 0
       select type (src_spec)
       type is (FieldSpec)
          cost = cost + get_cost(this%geom, src_spec%geom)
          cost = cost + get_cost(this%typekind, src_spec%typekind)
-!#         cost = cost + get_cost(this%units, src_spec%units)
+!#  !#         cost = cost + get_cost(this%units, src_spec%units)
       class default
          _FAIL('Cannot extend to this StateItemSpec subclass.')
       end select
@@ -459,11 +459,11 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-
+      type(StateItemSpecptr) :: list(0)
       find_mismatch: select type (dst_spec)
       type is (FieldSpec)
          allocate(extension, source=this%make_extension_safely(dst_spec))
-         call extension%create([StateItemSpecPtr::], _RC)
+         call extension%create(list, _RC)
       class default
          extension=this
          _FAIL('Unsupported subclass.')
@@ -477,14 +477,12 @@ contains
       class(FieldSpec), intent(in) :: this
       type(FieldSpec), intent(in) :: src_spec
 
-      logical :: found
-
       extension = this
       if (update_item(extension%geom, src_spec%geom)) return
       if (update_item(extension%typekind, src_spec%typekind)) then
          return
       end if
-!#      if (update_item(extension%units, src_spec%units)) return
+   !#      if (update_item(extension%units, src_spec%units)) return
 
     end function make_extension_safely
 
@@ -495,8 +493,6 @@ contains
       class(FieldSpec), intent(in) :: this
       class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
-
-      integer :: status
 
       action = NullAction() ! default
 
@@ -515,10 +511,10 @@ contains
             _RETURN(_SUCCESS)
          end if
          
-!#         if (this%units /= dst_spec%units) then
-!#            action = ChangeUnitsAction(this%payload, dst_spec%payload)
-!#            _RETURN(_SUCCESS)
-!#         end if
+  !#         if (this%units /= dst_spec%units) then
+  !#            action = ChangeUnitsAction(this%payload, dst_spec%payload)
+  !#            _RETURN(_SUCCESS)
+  !#         end if
          
       class default
          action = NullAction()
@@ -531,14 +527,11 @@ contains
    logical function match_geom(a, b) result(match)
       type(ESMF_Geom), allocatable, intent(in) :: a, b
 
-      integer :: status
-
       match = .false.
 
       if (allocated(a) .and. allocated(b)) then
          match = MAPL_SameGeom(a, b)
       end if
-
 
    end function match_geom
 

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -136,13 +136,14 @@ contains
 
          integer :: status
          class(AbstractStateItemSpec), pointer :: spec
+         type(StateItemSpecPtr) :: empty(0)
 
          _ASSERT(this%can_connect_to(src_spec), 'illegal connection')
          _ASSERT(this%matched_items%count(actual_pt) == 0, 'duplicate connection pt')
          
          call this%matched_items%insert(actual_pt, this%reference_spec)
          spec => this%matched_items%of(actual_pt)
-!#         call spec%create([StateItemSpecPtr::], _RC)
+         call spec%create(empty, _RC)
          call spec%connect_to(src_spec, actual_pt, _RC)
 
          _RETURN(ESMF_SUCCESS)

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -2,6 +2,7 @@
 
 module mapl3g_WildcardSpec
    use mapl3g_AbstractStateItemSpec
+   use mapl3g_InvalidSpec
    use mapl3g_ActualPtStateItemSpecMap
    use mapl3g_ActualConnectionPt
    use mapl3g_MultiState
@@ -61,11 +62,11 @@ contains
       type(StateItemSpecPtr), intent(in) :: dependency_specs(:)
       integer, optional, intent(out) :: rc
 
-      integer :: status
-
       call this%set_created()
 
       _RETURN(ESMF_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(dependency_specs)
    end subroutine create
 
    ! No-op
@@ -73,11 +74,10 @@ contains
       class(WildcardSpec), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
-      integer :: status
-
       call this%set_created(.false.)
 
       _RETURN(ESMF_SUCCESS)
+      _UNUSED_DUMMY(this)
    end subroutine destroy
 
 
@@ -85,7 +85,6 @@ contains
       class(WildcardSpec), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
-      integer :: status
 !!$      type(ActualPtSpecPtrMapIterator) :: iter
 !!$      class(StateItemSpecPtr), pointer :: spec_ptr
 !!$
@@ -100,6 +99,7 @@ contains
 !!$      end associate
    
       _RETURN(ESMF_SUCCESS)
+      _UNUSED_DUMMY(this)
    end subroutine allocate
 
    function get_dependencies(this, rc) result(dependencies)
@@ -110,6 +110,7 @@ contains
       dependencies = ActualPtVector()
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function get_dependencies
 
    subroutine connect_to(this, src_spec, actual_pt, rc)
@@ -120,9 +121,12 @@ contains
 
       integer :: status
 
-      call with_target_attribute(this, src_spec, actual_pt, rc)
+      call with_target_attribute(this, src_spec, actual_pt, _RC)
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(src_spec)
+      _UNUSED_DUMMY(actual_pt)
    contains
       subroutine with_target_attribute(this, src_spec, actual_pt, rc)
          class(WildcardSpec), target, intent(inout) :: this
@@ -138,7 +142,7 @@ contains
          
          call this%matched_items%insert(actual_pt, this%reference_spec)
          spec => this%matched_items%of(actual_pt)
-         call spec%create([StateItemSpecPtr::], _RC)
+!#         call spec%create([StateItemSpecPtr::], _RC)
          call spec%connect_to(src_spec, actual_pt, _RC)
 
          _RETURN(ESMF_SUCCESS)
@@ -198,11 +202,11 @@ contains
       type(ESMF_FieldBundle), intent(inout) :: bundle
       integer, optional, intent(out) :: rc
 
-      integer :: status
-
       _FAIL('not implemented')
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(bundle)
    end subroutine add_to_bundle
 
    function make_extension(this, dst_spec, rc) result(extension)
@@ -211,7 +215,10 @@ contains
       class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
 
+      extension = InvalidSpec()
       _FAIL('wildcard cannot be extended - only used for imports')
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(dst_spec)
    end function make_extension
 
    function make_action(this, dst_spec, rc) result(action)
@@ -220,10 +227,10 @@ contains
       class(AbstractStateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
 
-      integer :: status
-
       action = NullAction()
       _FAIL('wildcard cannot be extended - only used for imports')
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(dst_spec)
    end function make_action
 
    integer function extension_cost(this, src_spec, rc) result(cost)
@@ -236,6 +243,8 @@ contains
       cost = this%reference_spec%extension_cost(src_spec, _RC)
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(src_spec)
    end function extension_cost
 
 end module mapl3g_WildcardSpec

--- a/generic3g/tests/Test_AddFieldSpec.pf
+++ b/generic3g/tests/Test_AddFieldSpec.pf
@@ -74,7 +74,7 @@ contains
       type(ESMF_Field) :: f
       integer :: rank
       integer :: status
-
+      type(StateItemSpecPtr) :: empty(0)
 
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', rc=status)
       call ESMF_InfoGetFromHost(grid, info, rc=status)
@@ -82,7 +82,7 @@ contains
       geom = ESMF_GeomCreate(grid, ESMF_STAGGERLOC_INVALID)
       vertical_dim_spec = VERTICAL_DIM_CENTER
       field_spec = FieldSpec(geom, vertical_geom, vertical_dim_spec, ESMF_TYPEKIND_R4, UngriddedDimsSpec(), '', '', '')
-      call field_spec%create([ StateItemSpecPtr :: ], rc=status)
+      call field_spec%create(empty, rc=status)
       call field_spec%allocate(rc=status)
 
       multi_state = MultiState(importState=ESMF_StateCreate(), exportState=ESMF_StateCreate())

--- a/generic3g/tests/Test_ComponentSpecParser.pf
+++ b/generic3g/tests/Test_ComponentSpecParser.pf
@@ -138,7 +138,8 @@ contains
 
       hconfig = ESMF_HConfigCreate(content='{}')
 
-      found = parse_children(hconfig, _RC)
+!#      found = parse_children(hconfig, _RC)
+      call parse_children(found, hconfig, _RC)
       @assert_that(found == expected, is(true()))
 
       call ESMF_HConfigDestroy(hconfig)
@@ -154,7 +155,8 @@ contains
       config = ESMF_HConfigCreate(content='children: {A: {sharedObj: libA}}')
       config_ptr => config
       call expected%insert('A', ChildSpec(user_setservices('libA', 'setservices_')))
-      found = parse_children(config_ptr, _RC)
+!#      found = parse_children(config_ptr, _RC)
+      call parse_children(found, config_ptr, _RC)
       @assert_that(found == expected, is(true()))
       
    end subroutine test_parse_ChildSpecMap_1
@@ -173,7 +175,8 @@ contains
 
       call expected%insert('A', ChildSpec(user_setservices('libA', 'setservices_')))
       call expected%insert('B', ChildSpec(user_setservices('libB', 'setservices_')))
-      found = parse_children(config_ptr, _RC)
+!#      found = parse_children(config_ptr, _RC)
+      call parse_children(found, config_ptr, _RC)
 
       @assert_that(found%of('A') == expected%of('A'), is(true()))
       @assert_that(found%of('B') == expected%of('B'), is(true()))

--- a/generic3g/tests/gridcomps/ProtoExtDataGC.F90
+++ b/generic3g/tests/gridcomps/ProtoExtDataGC.F90
@@ -57,6 +57,8 @@ contains
       type(ESMF_HConfigIter) :: iter,e,b
       character(:), allocatable :: var_name
 
+      type(StateItemSpecPtr) :: empty(0)
+
       call MAPL_Get(gc, hconfig=hconfig, registry=registry, _RC)
 
       ! We would do this quite differently in an actual ExtData implementation.
@@ -81,7 +83,7 @@ contains
                allocate(import_spec, source=export_spec)
 
                ! Need new payload ... (but maybe not as it will get tossed at connect() anyway.)
-               call import_spec%create([StateItemSpecPtr::], _RC)
+               call import_spec%create(empty, _RC)
                call registry%add_item_spec(import_v_pt, import_spec)
 
                ! And now connect

--- a/geom_mgr/CMakeLists.txt
+++ b/geom_mgr/CMakeLists.txt
@@ -36,13 +36,13 @@ set(srcs
 
   VectorBasis.F90
   VectorBasis_smod.F90
-  )
+)
 
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.pfio MAPL.base MAPL.shared MAPL.field_utils GFTL::gftl-v2
   TYPE ${MAPL_LIBRARY_TYPE}
-  )
+)
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/geom_mgr/CoordinateAxis.F90
+++ b/geom_mgr/CoordinateAxis.F90
@@ -1,7 +1,6 @@
 module mapl3g_CoordinateAxis
    use mapl_RangeMod
    use esmf, only: ESMF_KIND_R8
-   use pfio
    implicit none
    private
 
@@ -89,6 +88,7 @@ module mapl3g_CoordinateAxis
       end function is_periodic
 
       module function get_dim_name(file_metadata, units, rc) result(dim_name)
+         use pfio_FileMetadataMod, only: FileMetadata
          character(:), allocatable :: dim_name
          type(FileMetadata), target, intent(in) :: file_metadata
          character(*), intent(in) :: units
@@ -96,7 +96,7 @@ module mapl3g_CoordinateAxis
       end function get_dim_name
 
       module function get_coordinates_dim(file_metadata, dim_name, rc) result(coordinates)
-         use pfio, only: FileMetadata
+         use pfio_FileMetadataMod, only: FileMetadata
          real(kind=R8), dimension(:), allocatable :: coordinates
          type(FileMetadata), intent(in) :: file_metadata
          character(len=*), intent(in) :: dim_name

--- a/geom_mgr/CoordinateAxis_smod.F90
+++ b/geom_mgr/CoordinateAxis_smod.F90
@@ -94,6 +94,11 @@ contains
 
  
    module function get_dim_name(file_metadata, units, rc) result(dim_name)
+      use pfio_FileMetadataMod, only: FileMetadata
+      use pfio_StringVariableMapMod, only: StringVariableMap, StringVariableMapIterator, operator(/=)
+      use pfio_VariableMod, only: Variable
+      use pfio_CoordinateVariableMod, only: CoordinateVariable
+      use pfio_AttributeMod, only: Attribute
       character(:), allocatable :: dim_name
       type(FileMetadata), target, intent(in) :: file_metadata
       character(*), intent(in) :: units
@@ -147,6 +152,8 @@ contains
    end function get_dim_name
 
    module function get_coordinates_dim(file_metadata, dim_name, rc) result(coordinates)
+      use pfio_FileMetadataMod, only: FileMetadata
+      use pfio_CoordinateVariableMod, only: CoordinateVariable
       real(kind=R8), dimension(:), allocatable :: coordinates
       type(FileMetadata), intent(in) :: file_metadata
       character(len=*), intent(in) :: dim_name

--- a/geom_mgr/GeomManager_smod.F90
+++ b/geom_mgr/GeomManager_smod.F90
@@ -16,12 +16,12 @@ submodule (mapl3g_GeomManager) GeomManager_smod
 contains
    
    module function new_GeomManager() result(mgr)
-      use mapl3g_LatLonGeomFactory
+!#      use mapl3g_LatLonGeomFactory
 !#      use mapl_CubedSphereGeomFactory
       type(GeomManager) :: mgr
 
       ! Load default factories
-      type(LatLonGeomFactory) :: latlon_factory
+!#      type(LatLonGeomFactory) :: latlon_factory
 !#      type(CubedSphereGeomFactory) :: cs_factory
 !#      type(FakeCubedSphereGeomFactory) :: fake_cs_factory 
 !#      type(TripolarGeomFactory) :: tripolar_factory
@@ -39,8 +39,9 @@ contains
 !#      call mgr%factories%push_back(TrajectorySampler_factory)
 !#      call mgr%factories%push_back(SwathSampler_factory)
 
-      call mgr%add_factory(latlon_factory)
+!#      call mgr%add_factory(latlon_factory)
 
+      call mgr%initialize()
    end function new_GeomManager
 
    module subroutine initialize(this)
@@ -50,6 +51,7 @@ contains
       ! Load default factories
       type(LatLonGeomFactory) :: latlon_factory
 
+      this%mapl_geoms = IntegerMaplGeomMap()
       call this%add_factory(latlon_factory)
 
    end subroutine initialize

--- a/geom_mgr/IntegerMaplGeomMap.F90
+++ b/geom_mgr/IntegerMaplGeomMap.F90
@@ -4,11 +4,13 @@ module mapl3g_IntegerMaplGeomMap
 #define Key __INTEGER
 #define T MaplGeom
 #define Map IntegerMaplGeomMap
+#define Pair IntegerMaplGeomPair
 #define MapIterator IntegerMaplGeomMapIterator
 
 #include "map/template.inc"
 
 #undef MapIterator
+#undef Pair
 #undef Map
 #undef Key
 #undef T

--- a/geom_mgr/MaplGeom.F90
+++ b/geom_mgr/MaplGeom.F90
@@ -27,7 +27,7 @@ module mapl3g_MaplGeom
       class(GeomSpec), allocatable :: spec
       type(ESMF_Geom) :: geom
       type(FileMetadata) :: file_metadata
-      type(StringVector) :: gridded_dims ! center staggered
+     type(StringVector) :: gridded_dims ! center staggered
 
       ! Derived - lazy initialization
       type(VectorBases) :: bases

--- a/geom_mgr/latlon/LatAxis.F90
+++ b/geom_mgr/latlon/LatAxis.F90
@@ -1,6 +1,5 @@
 module mapl3g_LatAxis
    use mapl3g_CoordinateAxis
-   use pfio
    use esmf
    implicit none
    private
@@ -56,6 +55,7 @@ module mapl3g_LatAxis
       end function supports_hconfig
 
       logical module function supports_metadata(file_metadata, rc) result(supports)
+         use pfio_FileMetadataMod, only: FileMetadata
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc
       end function supports_metadata
@@ -76,6 +76,7 @@ module mapl3g_LatAxis
       end function make_LatAxis_from_hconfig
 
       module function make_LatAxis_from_metadata(file_metadata, rc) result(axis)
+         use pfio_FileMetadataMod, only: FileMetadata
          type(LatAxis) :: axis
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc

--- a/geom_mgr/latlon/LatAxis_smod.F90
+++ b/geom_mgr/latlon/LatAxis_smod.F90
@@ -51,6 +51,7 @@ contains
 
 
    logical module function supports_metadata(file_metadata, rc) result(supports)
+      use pfio_FileMetadataMod, only: FileMetadata
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc
 
@@ -94,6 +95,7 @@ contains
    end function make_LatAxis_from_hconfig
 
    module function make_lataxis_from_metadata(file_metadata, rc) result(axis)
+      use pfio_FileMetadataMod, only: FileMetadata
       type(LatAxis) :: axis
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc

--- a/geom_mgr/latlon/LatLonGeomFactory.F90
+++ b/geom_mgr/latlon/LatLonGeomFactory.F90
@@ -6,7 +6,6 @@ module mapl3g_LatLonGeomFactory
    use mapl3g_LatLonGeomSpec
    use mapl_KeywordEnforcerMod
    use gftl_StringVector
-   use pfio
    use esmf
    implicit none
    private
@@ -44,7 +43,7 @@ module mapl3g_LatLonGeomFactory
 
       module function make_geom_spec_from_metadata(this, file_metadata, rc) result(geom_spec)
          use mapl3g_GeomSpec, only: GeomSpec
-         use pfio, only: FileMetadata
+         use pFIO_FileMetadataMod, only: FileMetadata
          class(GeomSpec), allocatable :: geom_spec
          class(LatLonGeomFactory), intent(in) :: this
          type(FileMetadata), intent(in) :: file_metadata
@@ -67,7 +66,7 @@ module mapl3g_LatLonGeomFactory
       end function supports_hconfig
 
       logical module function supports_metadata(this, file_metadata, rc) result(supports)
-         use pfio, only: FileMetadata
+         use pFIO_FileMetadataMod, only: FileMetadata
          class(LatLonGeomFactory), intent(in) :: this
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc
@@ -101,12 +100,6 @@ module mapl3g_LatLonGeomFactory
       end subroutine fill_coordinates
 
 
-      module subroutine get_ranks(nx, ny, ix, iy, rc)
-         integer, intent(in) :: nx, ny
-         integer, intent(out) :: ix, iy
-         integer, optional, intent(out) :: rc
-      end subroutine get_ranks
-
       module function make_gridded_dims(this, geom_spec, rc) result(gridded_dims)
          type(StringVector) :: gridded_dims
          class(LatLonGeomFactory), intent(in) :: this
@@ -116,6 +109,7 @@ module mapl3g_LatLonGeomFactory
 
 
       module function make_file_metadata(this, geom_spec, rc) result(file_metadata)
+         use pFIO_FileMetadataMod, only: FileMetadata
          type(FileMetadata) :: file_metadata
          class(LatLonGeomFactory), intent(in) :: this
          class(GeomSpec), intent(in) :: geom_spec

--- a/geom_mgr/latlon/LatLonGeomFactory_smod.F90
+++ b/geom_mgr/latlon/LatLonGeomFactory_smod.F90
@@ -8,7 +8,6 @@ submodule (mapl3g_LatLonGeomFactory) LatLonGeomFactory_smod
    use mapl_MinMaxMod
    use mapl_ErrorHandlingMod
    use mapl_Constants
-   use pFIO
    use gFTL_StringVector
    use esmf
    implicit none
@@ -28,10 +27,12 @@ contains
       geom_spec = make_LatLonGeomSpec(hconfig, _RC)
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function make_geom_spec_from_hconfig
 
 
    module function make_geom_spec_from_metadata(this, file_metadata, rc) result(geom_spec)
+      use pFIO_FileMetadataMod, only: FileMetadata
       class(GeomSpec), allocatable :: geom_spec
       class(LatLonGeomFactory), intent(in) :: this
       type(FileMetadata), intent(in) :: file_metadata
@@ -42,7 +43,8 @@ contains
       geom_spec = make_LatLonGeomSpec(file_metadata, _RC)
 
       _RETURN(_SUCCESS)
-   end function make_geom_spec_from_metadata
+       _UNUSED_DUMMY(this)
+  end function make_geom_spec_from_metadata
 
 
    logical module function supports_spec(this, geom_spec) result(supports)
@@ -52,7 +54,7 @@ contains
       type(LatLonGeomSpec) :: reference
 
       supports = same_type_as(geom_spec, reference)
-
+      _UNUSED_DUMMY(this)
    end function supports_spec
 
    logical module function supports_hconfig(this, hconfig, rc) result(supports)
@@ -66,9 +68,11 @@ contains
       supports = spec%supports(hconfig, _RC)
       
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function supports_hconfig
 
    logical module function supports_metadata(this, file_metadata, rc) result(supports)
+      use pFIO_FileMetadataMod, only: FileMetadata
       class(LatLonGeomFactory), intent(in) :: this
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc
@@ -79,6 +83,7 @@ contains
       supports = spec%supports(file_metadata, _RC)
       
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function supports_metadata
 
 
@@ -98,6 +103,7 @@ contains
       end select
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function make_geom
 
 
@@ -236,7 +242,8 @@ contains
    end subroutine fill_coordinates
 
 
-   module subroutine get_ranks(nx, ny, ix, iy, rc)
+   ! Helper procedure
+   subroutine get_ranks(nx, ny, ix, iy, rc)
       integer, intent(in) :: nx, ny
       integer, intent(out) :: ix, iy
       integer, optional, intent(out) :: rc
@@ -248,6 +255,8 @@ contains
       call ESMF_VMGetCurrent(vm, _RC)
       call ESMF_VMGet(vm, petCount=petCount, localPet=localPet, _RC)
 
+      _ASSERT(localPet < nx*ny, 'Requested topology does not include all PEs.')
+         
       ix = mod(localPet, nx)
       iy = localPet / nx
 
@@ -270,10 +279,12 @@ contains
       end select
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function make_gridded_dims
 
 
    module function make_file_metadata(this, geom_spec, rc) result(file_metadata)
+      use pFIO_FileMetadataMod, only: FileMetadata
       type(FileMetadata) :: file_metadata
       class(LatLonGeomFactory), intent(in) :: this
       class(GeomSpec), intent(in) :: geom_spec
@@ -289,9 +300,14 @@ contains
       end select
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
    end function make_file_metadata
 
    function typesafe_make_file_metadata(geom_spec, rc) result(file_metadata)
+      use pFIO_FileMetadataMod, only: FileMetadata
+      use pFIO_VariableMod, only: Variable
+      use pFIO, only: PFIO_REAL64
+      use pFIO, only: UnlimitedEntity
       type(FileMetadata) :: file_metadata
       type(LatLonGeomSpec), intent(in) :: geom_spec
       integer, optional, intent(out) :: rc

--- a/geom_mgr/latlon/LatLonGeomSpec.F90
+++ b/geom_mgr/latlon/LatLonGeomSpec.F90
@@ -22,8 +22,8 @@ module mapl3g_LatLonGeomSpec
       procedure :: equal_to
 
       ! LatLon specific
-      procedure :: supports_hconfig
-      procedure :: supports_metadata
+      procedure :: supports_hconfig => supports_hconfig_
+      procedure :: supports_metadata => supports_metadata_
       generic :: supports => supports_hconfig, supports_metadata
 
       ! Accessors
@@ -78,7 +78,7 @@ interface
       ! as the optimal decomposition depends on the ratio of the extens along each
       ! dimension.
       module function make_LatLonGeomSpec_from_metadata(file_metadata, rc) result(spec)
-         use pfio, only: FileMetadata
+         use pFIO_FileMetadataMod, only: FileMetadata
          type(LatLonGeomSpec) :: spec
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc
@@ -127,19 +127,19 @@ interface
          class(LatLonGeomSpec), intent(in) :: spec
       end function get_decomposition
 
-      logical module function supports_hconfig(this, hconfig, rc) result(supports)
+      logical module function supports_hconfig_(this, hconfig, rc) result(supports)
          use esmf, only: ESMF_HConfig
          class(LatLonGeomSpec), intent(in) :: this
          type(ESMF_HConfig), intent(in) :: hconfig
          integer, optional, intent(out) :: rc
-      end function supports_hconfig
+      end function supports_hconfig_
 
-      logical module function supports_metadata(this, file_metadata, rc) result(supports)
-         use pfio, only: FileMetadata
+      logical module function supports_metadata_(this, file_metadata, rc) result(supports)
+         use pFIO_FileMetadataMod, only: FileMetadata
          class(LatLonGeomSpec), intent(in) :: this
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc
-      end function supports_metadata
+      end function supports_metadata_
 
    end interface
 

--- a/geom_mgr/latlon/LatLonGeomSpec_smod.F90
+++ b/geom_mgr/latlon/LatLonGeomSpec_smod.F90
@@ -4,7 +4,6 @@ submodule (mapl3g_LatLonGeomSpec) LatLonGeomSpec_smod
    use mapl3g_CoordinateAxis
    use mapl3g_GeomSpec
    use mapl3g_HConfigUtils
-   use pfio
    use MAPL_RangeMod
    use MAPLBase_Mod
    use mapl_ErrorHandling
@@ -139,6 +138,7 @@ contains
    ! as the optimal decomposition depends on the ratio of the extens along each
    ! dimension.
    module function make_LatLonGeomSpec_from_metadata(file_metadata, rc) result(spec)
+      use pFIO_FileMetadataMod, only: FileMetadata
       type(LatLonGeomSpec) :: spec
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc
@@ -191,7 +191,7 @@ contains
       decomposition = spec%decomposition
    end function get_decomposition
 
-   logical module function supports_hconfig(this, hconfig, rc) result(supports)
+   logical module function supports_hconfig_(this, hconfig, rc) result(supports)
       class(LatLonGeomSpec), intent(in) :: this
       type(ESMF_HConfig), intent(in) :: hconfig
       integer, optional, intent(out) :: rc
@@ -216,9 +216,10 @@ contains
       _RETURN_UNLESS(supports)
 
       _RETURN(_SUCCESS)
-   end function supports_hconfig
+   end function supports_hconfig_
 
-   logical module function supports_metadata(this, file_metadata, rc) result(supports)
+   logical module function supports_metadata_(this, file_metadata, rc) result(supports)
+      use pFIO_FileMetadataMod, only: FileMetadata
       class(LatLonGeomSpec), intent(in) :: this
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc
@@ -236,6 +237,6 @@ contains
       _RETURN_UNLESS(supports)
 
       _RETURN(_SUCCESS)
-   end function supports_metadata
+   end function supports_metadata_
 
 end submodule LatLonGeomSpec_smod

--- a/geom_mgr/latlon/LonAxis.F90
+++ b/geom_mgr/latlon/LonAxis.F90
@@ -1,6 +1,5 @@
 module mapl3g_LonAxis
    use mapl3g_CoordinateAxis
-   use pfio
    use esmf
    implicit none
    private
@@ -56,6 +55,7 @@ module mapl3g_LonAxis
       end function supports_hconfig
 
       module logical function supports_metadata(file_metadata, rc) result(supports)
+         use pFIO_FileMetadataMod, only: FileMetadata
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc
       end function supports_metadata
@@ -76,6 +76,7 @@ module mapl3g_LonAxis
       end function make_LonAxis_from_hconfig
 
       module function make_LonAxis_from_metadata(file_metadata, rc) result(axis)
+         use pFIO_FileMetadataMod, only: FileMetadata
          type(LonAxis) :: axis
          type(FileMetadata), intent(in) :: file_metadata
          integer, optional, intent(out) :: rc

--- a/geom_mgr/latlon/LonAxis_smod.F90
+++ b/geom_mgr/latlon/LonAxis_smod.F90
@@ -134,6 +134,7 @@ contains
    
 
    logical module function supports_metadata(file_metadata, rc) result(supports)
+      use pFIO_FileMetadataMod, only: FileMetadata
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc
 
@@ -149,6 +150,7 @@ contains
 
 
    module function make_LonAxis_from_metadata(file_metadata, rc) result(axis)
+      use pFIO_FileMetadataMod, only: FileMetadata
       type(LonAxis) :: axis
       type(FileMetadata), intent(in) :: file_metadata
       integer, optional, intent(out) :: rc

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -130,7 +130,10 @@ target_include_directories (${this} PUBLIC
 # Workaround for ifort 2010.10.0 Explicit deep copy in some pfio
 # container results in odd error in GEOM_Manager - even when pfio is
 # not being directly used.
-target_compile_options(${this} PRIVATE "-D__gftl_map_use_default_assignment")
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+  target_compile_definitions(${this} PRIVATE "__gftl_map_use_default_assignment")
+  target_compile_definitions(${this} PRIVATE "__gftl_set_use_default_assignment")
+endif()
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -125,7 +125,12 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 target_include_directories (${this} PUBLIC
-          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+  $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+
+# Workaround for ifort 2010.10.0 Explicit deep copy in some pfio
+# container results in odd error in GEOM_Manager - even when pfio is
+# not being directly used.
+target_compile_options(${this} PRIVATE "-D__gftl_map_use_default_assignment")
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 # Kludge for OSX security and DYLD_LIBRARY_PATH ...


### PR DESCRIPTION
Tested unit tests with 

- gfortran 12.3
- ifort 2021.10.0
- nag 7.1.40

on OS X.


Note that the pfio tests do not reliably pass on os x with any of these.    Not entirely reproducible from what I have seen.  Also some evidence that at least one ExtData test is not always reproducible.   These issues must be investigated as unreliable unit tests are worse than useless.