### PR TITLE
Restore MAPL Python2 import behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `components.yaml`
   - ESMA_env v4.24.0 (Baselibs 7.17.0)
 - Update CI to use circleci-tools v2
-- Changed the Python MAPL `__init__.py` file to restore behavior from pre-Python3 transition where we did `from foo import *`.
+- Changed the Python MAPL `__init__.py` file to restore behavior from pre-Python3 transition where we did `from foo import *`. Also fix up other Python2 code to Python3.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `components.yaml`
   - ESMA_env v4.24.0 (Baselibs 7.17.0)
 - Update CI to use circleci-tools v2
+- Changed the Python MAPL `__init__.py` file to restore behavior from pre-Python3 transition where we did `from foo import *`.
 
 ### Fixed
 

--- a/Python/MAPL/Date.py
+++ b/Python/MAPL/Date.py
@@ -149,7 +149,7 @@ class Date(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         #Last day of the month.
         if self.day == NumberDaysMonth(self.month, self.year):
             self.day = 1
@@ -230,7 +230,7 @@ class Date(object):
             #Convert back to date format.
             return DateFromJDNumber(temp)
         else:
-            raise TypeError, "%s is not an integer." % str(n)
+            raise TypeError("%s is not an integer." % str(n))
 
     def __sub__(self, date):
         """Returns the (signed) difference of days between the dates."""
@@ -253,7 +253,7 @@ class Date(object):
                         ret += NumberDaysYear(year)
                     return ret
         else:
-            raise TypeError, "%s is neither an integer nor a Date." % str(date)
+            raise TypeError("%s is neither an integer nor a Date." % str(date))
 
     #Adding an integer is "commutative".
     def __radd__(self, n):
@@ -283,7 +283,7 @@ class Date(object):
 def DateFromJDNumber(n):
     """Returns a date corresponding to the given Julian day number."""
     if not isinstance(n, int):
-        raise TypeError, "%s is not an integer." % str(n)
+        raise TypeError("%s is not an integer." % str(n))
 
     a = n + 32044
     b = (4*a + 3)//146097
@@ -320,21 +320,21 @@ if __name__ == "__main__":
     temp = Date()
     curr_month = temp.month
     while temp.month == curr_month:
-        print temp
-        temp.next()
+        print(temp)
+        next(temp)
 
-    print "\n"
+    print("\n")
 
     #How many days until the end of the year?
     temp = Date()
     temp.day, temp.month = 1, 1
     curr_year = temp.year
     while temp.year == curr_year:
-        print "%s is %d days away from the end of the year." % (str(temp),
-                                                                temp.DaysToEndYear())
+        print("%s is %d days away from the end of the year." % (str(temp),
+                                                                temp.DaysToEndYear()))
         temp += NumberDaysMonth(temp.month)
 
-    print "\n"
+    print("\n")
 
     #Playing with __sub__.
     temp = Date()
@@ -344,11 +344,11 @@ if __name__ == "__main__":
         temp_list.append(temp)
         temp += NumberDaysMonth(temp.month)
     for elem in temp_list:
-        print "%s differs %d days from current date: %s" % (str(elem),
+        print("%s differs %d days from current date: %s" % (str(elem),
                                                             elem - Date(),
-                                                            str(Date()))
+                                                            str(Date())))
 
-    print "\n"
+    print("\n")
 
     #Swapping arguments works?
-    print 23 + Date()
+    print(23 + Date())

--- a/Python/MAPL/__init__.py
+++ b/Python/MAPL/__init__.py
@@ -45,3 +45,11 @@ integration, and the the whole experiment is about 3 month long.
 """
 
 __version__ = "1.0.0"
+
+from .exp      import *
+from .job      import *
+from .run      import *
+from .config   import *
+from .history  import *
+from .Date     import *
+from .filelock import *

--- a/Python/MAPL/exp.py
+++ b/Python/MAPL/exp.py
@@ -35,7 +35,7 @@ class Exp(object):
         self.submit()  # resubmit itsef
 
     def submit(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
         
 
 #                   --------------
@@ -74,7 +74,7 @@ def setup(inConfigFiles=None):
     os.mkdir(tmpdir)
     os.chdir(tmpdir)
     if os.system(cmd):
-       raise IOerror, "red_ma.pl did not complete successfully"
+       raise IOerror("red_ma.pl did not complete successfully")
 
 #   Resources as specified by user
 #   ------------------------------
@@ -82,7 +82,7 @@ def setup(inConfigFiles=None):
         
 #   Setup directory tree
 #   --------------------
-    for dir in  cf.regex('Dir$').values():
+    for dir in  list(cf.regex('Dir$').values()):
         os.mkdir(dir)
 
 #   Populate Resources

--- a/Python/MAPL/history.py
+++ b/Python/MAPL/history.py
@@ -2,7 +2,7 @@
 A special class for handling history resources.
 """
 
-from config import *
+from .config import *
 
 class History(Config):
 
@@ -35,15 +35,14 @@ class History(Config):
         *.temkplate resources.
         """
         dict = self.regex('template$')
-        Tmpl = [str.replace("'","").replace(",","") for str in dict.values()]
-        Coll = [ str.split('.')[0].replace(",","")  for str in dict.keys()  ]
+        Tmpl = [str.replace("'","").replace(",","") for str in list(dict.values())]
+        Coll = [ str.split('.')[0].replace(",","")  for str in list(dict.keys())  ]
         Arch = [str.replace("'","").replace(",","") \
-                for str in self.regex('archive$').values()]
+                for str in list(self.regex('archive$').values())]
 
         if len(Tmpl) != len(Arch):
-            raise IOError,\
-            "There are %d template resources but only %d archive resources."\
-            %(len(Tmpl),len(Arch))
+            raise IOError("There are %d template resources but only %d archive resources."\
+            %(len(Tmpl),len(Arch)))
 
         header = '# PESTO resource for History Collections ' + \
                  '(automatically generated - do not edit)'

--- a/Python/MAPL/job.py
+++ b/Python/MAPL/job.py
@@ -11,8 +11,8 @@ Design remarks:
 
 """
 
-import Abstract
-from exp import Exp
+from . import Abstract
+from .exp import Exp
 
 class Job(Exp):
     
@@ -72,13 +72,13 @@ class Job(Exp):
 #                         -----------------
 
     def getResources(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
     def getRecyclables(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
     def putRecyclables(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
 
 #                         ----------------

--- a/Python/MAPL/run.py
+++ b/Python/MAPL/run.py
@@ -5,7 +5,7 @@ experiment, whichever is sooner.)
 
 """
 
-from job import Job
+from .job import Job
 
 class Run(Job):
 


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As pointed out by @amdasilva, the MAPL Python interface inadvertently lost its Python2 behavior in re `__init__.py`. This restores that by adding back the `from .foo import *` lines.

Moreover, testing by @patricia-nasa found more bugs in the MAPL python code. Essentially, a lot of it was not Python3. Now it is.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Restores our MAPL Python behavior to pre-Python3.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I'll probably ask @patricia-nasa to do some tests for me.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
