### PR TITLE
Fix wrong type of RETURN

### DIFF
--- a/base/MAPL_MemUtils.F90
+++ b/base/MAPL_MemUtils.F90
@@ -781,7 +781,7 @@ subroutine MAPL_MemReport(comm,file_name,line,decorator,rc)
     character(len=:), allocatable :: extra_message
 
 #ifdef sysDarwin
-    RETURN_(ESMF_SUCCESS)
+    _RETURN(ESMF_SUCCESS)
 #endif
     call MPI_Barrier(comm,status)
     if (present(decorator)) then


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This converts a `RETURN_` to `_RETURN` in MAPL_MemUtils.F90. @tclune found this issue when running on a Mac, which is not in our usual CI.

`RETURN_` requires an `Iam` but `_RETURN` does not. Instead of adding an `Iam`, we convert to underscore-first.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
