### PR TITLE
Remove ESMF_HAS_ACHAR_BUG CMake and cpp macro, update to ESMA_cmake v3.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced RC=STATUS plus `_VERIFY(RC)` in `Base_Base_implementation.F90` with just `_RC` in line with our new convention.
 - Updated CI to use Open MPI 5.0.0 for GNU
 - Enable Ninja for CI builds of MAPL
+- Removed use of `ESMF_HAS_ACHAR_BUG` CMake option and code use in `MAPL_Config.F90`. Testing has shown that with ESMF 8.6 (which is
+  now required), NAG no longer needs this workaround.
 
 ### Fixed
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -77,11 +77,6 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
    target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
 
-# Workaround for bizarre switch in ESMF
-if (ESMF_HAS_ACHAR_BUG)
-  set_source_files_properties(MAPL_Config.F90  PROPERTIES COMPILE_DEFINITIONS ESMF_HAS_ACHAR_BUG)
-endif()
-      
 if(DISABLE_GLOBAL_NAME_WARNING)
   target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${DISABLE_GLOBAL_NAME_WARNING}>)
 endif()

--- a/base/MAPL_Config.F90
+++ b/base/MAPL_Config.F90
@@ -48,13 +48,9 @@ module MAPL_ConfigMod
 
    character, parameter :: BLK = achar(32)   ! blank (space)
    character, parameter :: TAB = achar(09)   ! TAB
-#if defined(ESMF_HAS_ACHAR_BUG)
-       character, parameter :: EOL = achar(12)   ! end of line mark (cr)
-#else
-       character, parameter :: EOL = achar(10)   ! end of line mark (newline)
-#endif
-       character, parameter :: EOB = achar(00)   ! end of buffer mark (null)
-       character, parameter :: NUL = achar(00)   ! what it says
+   character, parameter :: EOL = achar(10)   ! end of line mark (newline)
+   character, parameter :: EOB = achar(00)   ! end of buffer mark (null)
+   character, parameter :: NUL = achar(00)   ! what it says
 
 contains
 
@@ -97,7 +93,7 @@ contains
 !
       subroutine MAPL_ConfigSetAttribute_real64( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: REAL64
-! 
+!
       type(ESMF_Config), intent(inout)             :: config
       real(kind=REAL64), intent(in)                :: value
       character(len=*), intent(in), optional       :: label
@@ -243,7 +239,7 @@ contains
 !
       subroutine MAPL_ConfigSetAttribute_real32( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: REAL32
-! 
+!
       type(ESMF_Config), intent(inout)             :: config
       real(kind=REAL32), intent(in)                :: value
       character(len=*), intent(in), optional       :: label
@@ -376,17 +372,17 @@ contains
    end subroutine MAPL_ConfigSetAttribute_real32
 
 !------------------------------------------------------------------------------
-!>    
+!>
 ! Set a 4-byte integer _value_ in the _config_ object.
-!     
+!
 ! The arguments are:
 !- **config**: Already created  `ESMF_Config` object.
 !- **value**: Integer value to set.
 !- **label**: Identifying attribute label.
 !- **rc**: Return code; equals `ESMF_SUCCESS` if there are no errors.
-!     
+!
 ! **Private name**: call using ESMF_ConfigSetAttribute()`.
-! 
+!
       subroutine MAPL_ConfigSetAttribute_int32( config, value, label, rc )
          use, intrinsic :: iso_fortran_env, only: INT32
 !
@@ -600,15 +596,15 @@ contains
    end subroutine MAPL_ConfigSetAttribute_reals32
 
 !------------------------------------------------------------------------------
-!>    
+!>
 ! Set a string _value_ in the _config_ object.
-!     
+!
 ! The arguments are:
 !- **config**: Already created  `ESMF_Config` object.
 !- **value**: String value to set.
 !- **label**: Identifying attribute label.
 !- **rc**: Return code; equals `ESMF_SUCCESS` if there are no errors.
-!     
+!
    subroutine MAPL_ConfigSetAttribute_string(config, value, label, rc)
       type(ESMF_Config), intent(inout)             :: config
       character(len=*), intent(in)                 :: value

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.36.0
+  tag: v3.37.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR removes the `ESMF_HAS_ACHAR_BUG` CMake option and CPP macro that was used as a workaround for a NAG + ESMF bug. Testing by @metdyn and myself shows that this is no longer needed with ESMF 8.6.0.

It also updates to [ESMA_cmake v3.37.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.37.0) which sets the `ESMF_HAS_ACHAR_BUG` to default `OFF` for now and will be removed in a later release.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Let's NAG run ExtDataDriver.x!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

NAG only seems to run the tests correctly without this, so we turn it off. If we don't run NAG, we never use this, so it doesn't affect other compilers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
