### PR TITLE
Explicitly use iso_c_binding types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Explictly `use` some `iso_c_binding` types previously pulled in through ESMF. This is fixed in future ESMF versions (8.7+) and so
+  we anticipate this here
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explictly `use` some `iso_c_binding` types previously pulled in through ESMF. This is fixed in future ESMF versions (8.7+) and so
   we anticipate this here
+- Add explicit `Fortran_MODULE_DIRECTORY` to `CMakeLists.txt` in benchmarks to avoid race condition in Ninja builds
 
 ### Removed
 

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -25,6 +25,7 @@ module Plain_netCDF_Time
   !   use MAPL_CommsMod
   use, intrinsic :: iso_fortran_env, only: REAL32
   use, intrinsic :: iso_fortran_env, only: REAL64
+  use, intrinsic :: iso_c_binding, only: C_INT
   implicit none
   public
 
@@ -451,7 +452,7 @@ contains
     if(present(n_LB)) LB=max(LB, n_LB)
     if(present(n_UB)) UB=min(UB, n_UB)
     klo=LB; khi=UB; dk=1
-    
+
     if ( xa(LB ) > xa(UB) )  then
        klo= UB
        khi= LB
@@ -673,7 +674,7 @@ contains
     RETURN
   end function matches
 
-  
+
   subroutine split_string_by_space (string_in, length_mx, &
        mxseg, nseg, str_piece, jstatus)
     integer,           intent (in) :: length_mx

--- a/benchmarks/io/checkpoint_simulator/CMakeLists.txt
+++ b/benchmarks/io/checkpoint_simulator/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(exe checkpoint_simulator.x)
+set(MODULE_DIRECTORY ${esma_include}/benchmarks/io/checkpoint_simulator)
 
 ecbuild_add_executable (
   TARGET ${exe}
-  SOURCES checkpoint_simulator.F90 
+  SOURCES checkpoint_simulator.F90
   DEFINITIONS USE_MPI)
 
 target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse esmf )
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+set_target_properties (${exe} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/benchmarks/io/combo/CMakeLists.txt
+++ b/benchmarks/io/combo/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(exe combo.x)
+set(MODULE_DIRECTORY ${esma_include}/benchmarks/io/combo)
 
 ecbuild_add_executable (
   TARGET ${exe}
@@ -7,6 +8,7 @@ ecbuild_add_executable (
 
 target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+set_target_properties (${exe} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/benchmarks/io/gatherv/CMakeLists.txt
+++ b/benchmarks/io/gatherv/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MODULE_DIRECTORY ${esma_include}/benchmarks/io/gatherv)
+
 ecbuild_add_executable (
   TARGET gatherv.x
   SOURCES GathervKernel.F90 GathervSpec.F90 driver.F90
@@ -5,6 +7,7 @@ ecbuild_add_executable (
 
 target_link_libraries (gatherv.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
 target_include_directories (gatherv.x PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+set_target_properties (gatherv.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/benchmarks/io/raw_bw/CMakeLists.txt
+++ b/benchmarks/io/raw_bw/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MODULE_DIRECTORY ${esma_include}/benchmarks/io/raw_bw)
+
 ecbuild_add_executable (
   TARGET raw_bw.x
   SOURCES BW_Benchmark.F90 BW_BenchmarkSpec.F90 driver.F90
@@ -5,6 +7,7 @@ ecbuild_add_executable (
 
 target_link_libraries (raw_bw.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
 target_include_directories (raw_bw.x PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+set_target_properties (raw_bw.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/field_utils/FieldPointerUtilities.F90
+++ b/field_utils/FieldPointerUtilities.F90
@@ -3,7 +3,7 @@
 module MAPL_FieldPointerUtilities
    use ESMF
    use MAPL_ExceptionHandling
-   use, intrinsic :: iso_c_binding, only: c_ptr, c_f_pointer
+   use, intrinsic :: iso_c_binding, only: c_ptr, c_f_pointer, c_loc
    implicit none
    private
 
@@ -483,14 +483,14 @@ contains
       integer, dimension(:), allocatable :: count_x, count_y
       integer :: status
       logical :: normal_conformable
-      
+
       conformable = .false.
       ! this should really used the geom and ungridded dims
       ! for now we will do this until we have a geom agnostic stuff worked out...
       ! the ideal algorithm would be if geom == geom and input does not have ungridded
       ! and thing we are copying to does, then we are "conformable"
       normal_conformable = FIeldsAreConformable(x,y,_RC)
-      
+
       if (normal_conformable) then
          conformable = .true.
          _RETURN(_SUCCESS)
@@ -842,7 +842,7 @@ contains
         else
            _FAIL("Unsupported rank")
         end if
-     else 
+     else
         _FAIL("Unsupported type")
      end if
      _RETURN(_SUCCESS)
@@ -871,7 +871,7 @@ contains
 
      integer :: status, i
      logical :: isPresent
-     
+
      allocate(undef_values(size(fields)))
      do i =1,size(fields)
         call ESMF_AttributeGet(fields(i),name="missing_value",isPresent=isPresent,_RC)
@@ -888,7 +888,7 @@ contains
 
      integer :: status, i
      logical :: isPresent
-     
+
      allocate(undef_values(size(fields)))
      do i =1,size(fields)
         call ESMF_AttributeGet(fields(i),name="missing_value",isPresent=isPresent,_RC)


### PR DESCRIPTION

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds two explicit `use` of two `iso_c_binding` types that currently are brought in (inadvertently) via `use ESMF`. This has been fixed in ESMF upstream (`develop` at least), so this fix is in anticipation of ESMF 8.7 testing.

This was found in test attempts at fixing https://github.com/esmf-org/esmf/issues/209 by trying some ESMF hacks.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The first time someone tries building MAPL with ESMF 8.7 snapshots, things won't compile. Now they will.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

MAPL built. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
