### PR TITLE
Fix fields utils, Issue #2530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced RC=STATUS plus `_VERIFY(RC)` in `Base_Base_implementation.F90` with just `_RC` in line with our new convention.
 - Updated CI to use Open MPI 5.0.0 for GNU
 - Enable Ninja for CI builds of MAPL
+- Fix field utils issue - tests request pe's explicitly
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced RC=STATUS plus `_VERIFY(RC)` in `Base_Base_implementation.F90` with just `_RC` in line with our new convention.
 - Updated CI to use Open MPI 5.0.0 for GNU
 - Enable Ninja for CI builds of MAPL
-- Fix field utils issue - tests request pe's explicitly
+- Fix field utils issue - add npes argument to test subroutine decorators.
 
 ### Fixed
 

--- a/field_utils/tests/Test_FieldArithmetic.pf
+++ b/field_utils/tests/Test_FieldArithmetic.pf
@@ -62,8 +62,6 @@ contains
       allocate(y4array, source=R4_ARRAY_DEFAULT)
       x = mk_r4field(R4_ARRAY_DEFAULT, 'XR4', _RC)
       y = mk_r4field(y4array, 'YR4', _RC)
-!      x = mk_r4field(R4_ARRAY_DEFAULT, 'XR4', _RC)
-!      y = mk_r4field(y4array, 'YR4', _RC)
       call ESMF_FieldGet(x , farrayPtr = x_ptr, _RC)
       call ESMF_FieldGet(y , farrayPtr = y_ptr, _RC)
 

--- a/field_utils/tests/Test_FieldArithmetic.pf
+++ b/field_utils/tests/Test_FieldArithmetic.pf
@@ -13,8 +13,13 @@ module Test_FieldArithmetic
 
    implicit none
 
+   real(kind=ESMF_KIND_R4), parameter :: ADD_R4 = 100.0
+   real(kind=ESMF_KIND_R8), parameter :: ADD_R8 = 100.0
+
 contains
 
+   ! Making the fields should be done in the tests themselves so because
+   ! of the npes argument.
    @Before
    subroutine set_up_data()
       implicit none
@@ -45,16 +50,20 @@ contains
 
    end subroutine set_up_data
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldAddR4()
       type(ESMF_Field) :: x
       type(ESMF_Field) :: y
       real(kind=ESMF_KIND_R4), pointer :: x_ptr(:,:), y_ptr(:,:)
       real(kind=ESMF_KIND_R4), allocatable :: result_array(:,:)
       integer :: status, rc
+      real(kind=ESMF_KIND_R4), allocatable :: y4array(:,:)
 
-      x = XR4
-      y = YR4
+      allocate(y4array, source=R4_ARRAY_DEFAULT)
+      x = mk_r4field(R4_ARRAY_DEFAULT, 'XR4', _RC)
+      y = mk_r4field(y4array, 'YR4', _RC)
+!      x = mk_r4field(R4_ARRAY_DEFAULT, 'XR4', _RC)
+!      y = mk_r4field(y4array, 'YR4', _RC)
       call ESMF_FieldGet(x , farrayPtr = x_ptr, _RC)
       call ESMF_FieldGet(y , farrayPtr = y_ptr, _RC)
 
@@ -64,9 +73,13 @@ contains
       result_array = 5.0
       call FieldAdd(y, x, y, _RC)
       @assertEqual(y_ptr, result_array)
+
    end subroutine test_FieldAddR4
 
-   @Test
+   ! Rather than use the fields created in setup, make the fields
+   ! in this subroutine to make sure that the npes match the
+   ! regDecomp.
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldAddR4_missing
       type(ESMF_Field) :: x
       type(ESMF_Field) :: y
@@ -87,16 +100,18 @@ contains
       @assertEqual(y_ptr, result_array)
    end subroutine test_FieldAddR4_missing
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldAddR8()
       type(ESMF_Field) :: x
       type(ESMF_Field) :: y
       real(kind=ESMF_KIND_R8), pointer :: x_ptr(:,:), y_ptr(:,:)
       real(kind=ESMF_KIND_R8), allocatable :: result_array(:,:)
       integer :: status, rc
+      real(kind=ESMF_KIND_R8), allocatable :: y8array(:,:)
 
-      x = XR8
-      y = YR8
+      allocate(y8array, source=R8_ARRAY_DEFAULT)
+      x = mk_r8field(R8_ARRAY_DEFAULT, 'XR8', _RC)
+      y = mk_r8field(y8array, 'YR8', _RC)
       call ESMF_FieldGet(x , farrayPtr = x_ptr, _RC)
       call ESMF_FieldGet(y , farrayPtr = y_ptr, _RC)
 
@@ -108,7 +123,7 @@ contains
       @assertEqual(y_ptr, result_array)
    end subroutine test_FieldAddR8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldPowR4()
       type(ESMF_Field) :: x
       real(kind=ESMF_KIND_R4), pointer :: x_ptr(:,:)
@@ -127,7 +142,7 @@ contains
       @assertEqual(x_ptr, result_array)
    end subroutine test_FieldPowR4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldPowR8()
       type(ESMF_Field) :: x
       real(kind=ESMF_KIND_R8), pointer :: x_ptr(:,:)
@@ -146,7 +161,7 @@ contains
       @assertEqual(x_ptr, result_array)
    end subroutine test_FieldPowR8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldSinR4()
       type(ESMF_Field) :: x
       real(kind=ESMF_KIND_R4), pointer :: x_ptr(:,:)
@@ -163,7 +178,7 @@ contains
       @assertEqual(x_ptr, result_array)
    end subroutine test_FieldSinR4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldNegR4()
       type(ESMF_Field) :: x
       real(kind=ESMF_KIND_R4), pointer :: x_ptr(:,:)

--- a/field_utils/tests/Test_FieldBLAS.pf
+++ b/field_utils/tests/Test_FieldBLAS.pf
@@ -43,7 +43,7 @@ contains
 
    end subroutine set_up_data
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldCOPY subroutine (REAL32)
    subroutine test_FieldCOPY_R4()
       type(ESMF_Field) :: x
@@ -61,7 +61,7 @@ contains
 
    end subroutine test_FieldCOPY_R4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldCOPY subroutine (REAL64)
    subroutine test_FieldCOPY_R8()
       type(ESMF_Field) :: x
@@ -79,7 +79,7 @@ contains
 
    end subroutine test_FieldCOPY_R8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldCOPY subroutine (REAL32 -> REAL64)
    subroutine test_FieldCOPY_R4R8()
       type(ESMF_Field) :: x
@@ -97,7 +97,7 @@ contains
 
    end subroutine test_FieldCOPY_R4R8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldCOPY subroutine (REAL64 -> REAL32)
    subroutine test_FieldCOPY_R8R4()
       type(ESMF_Field) :: x
@@ -117,7 +117,7 @@ contains
 
    end subroutine test_FieldCOPY_R8R4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldSCAL subroutine (REAL32)
    subroutine test_FieldSCAL_R4()
       real(kind=ESMF_KIND_R4), parameter :: a = 2.0
@@ -135,7 +135,7 @@ contains
 
    end subroutine test_FieldSCAL_R4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Basic test of FieldSCAL subroutine (REAL64)
    subroutine test_FieldSCAL_R8()
       real(kind=ESMF_KIND_R8), parameter :: a = 2.0
@@ -153,7 +153,7 @@ contains
 
    end subroutine test_FieldSCAL_R8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    !
    subroutine test_FieldAXPY_R4()
       real(kind=ESMF_KIND_R4), parameter :: a = 2.0
@@ -178,7 +178,7 @@ contains
 
    end subroutine test_FieldAXPY_R4
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    !
    subroutine test_FieldAXPY_R8()
       real(kind=ESMF_KIND_R8), parameter :: a = 2.0
@@ -203,7 +203,7 @@ contains
 
    end subroutine test_FieldAXPY_R8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldGetLocalElementCount()
       type(ESMF_Field) :: x
       integer :: rank
@@ -221,7 +221,7 @@ contains
 
    end subroutine test_FieldGetLocalElementCount
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
     !
    subroutine test_FieldGetLocalSize()
       type(ESMF_Field) :: x
@@ -242,7 +242,7 @@ contains
 
    end subroutine test_FieldGetLocalSize
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    ! Test getting the c_ptr for a field
    !wdb fixme  Should test more extensively for different ranks
    !wdb fixme  Should test for ESMF_KIND_I4 and ESMF_KIND_I8
@@ -260,7 +260,7 @@ contains
 
    end subroutine test_FieldGetCptr
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    !wdb fixme  Probably should test for non-conformable fields
    subroutine test_FieldsAreConformableR4()
       type(ESMF_Field) :: x, y
@@ -276,7 +276,7 @@ contains
    end subroutine test_FieldsAreConformableR4
 
    !wdb fixme  Probably should test for non-conformable fields
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldsAreConformableR8()
       type(ESMF_Field) :: x, y
       integer :: status, rc
@@ -290,7 +290,7 @@ contains
 
    end subroutine test_FieldsAreConformableR8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    !
    subroutine test_FieldsAreSameTypeKind()
       type(ESMF_Field) :: x, y
@@ -318,7 +318,7 @@ contains
    end subroutine test_FieldsAreSameTypeKind
 
 !wdb fixme Enable assertEqual
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldConvertPrec_R4R8()
       integer, parameter :: NROWS = 4
       integer, parameter :: NCOLS = NROWS
@@ -344,7 +344,7 @@ contains
 
    end subroutine test_FieldConvertPrec_R4R8
 
-   @Test
+   @Test(npes=product(REG_DECOMP_DEFAULT))
    subroutine test_FieldClone3D()
       type(ESMF_Field) :: x, y
       integer :: status, rc
@@ -406,7 +406,7 @@ contains
    end subroutine test_almost_equal_array
 
 end module Test_FieldBLAS
-!   @Test
+!   @Test(npes=product(REG_DECOMP_DEFAULT))
 !   !
 !   subroutine test_FieldGEMV_R4()
 !      real(kind=ESMF_KIND_R4), parameter :: alpha = 3.0
@@ -446,7 +446,7 @@ end module Test_FieldBLAS
 !
 !   end subroutine test_FieldGEMV_R4
 
-!   @Test
+!   @Test(npes=product(REG_DECOMP_DEFAULT))
 !   !
 !   subroutine test_FieldSpread()
 !   end subroutine test_FieldSpread

--- a/field_utils/tests/field_utils_setup.F90
+++ b/field_utils/tests/field_utils_setup.F90
@@ -183,4 +183,50 @@ contains
 
    end subroutine initialize_array_R8
 
+   function mk_r4field(r4array, field_name, rc) result(r4field)
+      type(ESMF_Field) :: r4field
+      real(kind=ESMF_KIND_R4), intent(in) :: r4array(:,:)
+      character(len=*), intent(in) :: field_name
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      r4field = mk_field(r4array, regDecomp=REG_DECOMP_DEFAULT, minIndex=MIN_INDEX_DEFAULT, &
+         maxIndex=MAX_INDEX_DEFAULT, indexflag=INDEX_FLAG_DEFAULT, name = field_name, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end function mk_r4field
+
+   function mk_r8field(r8array, field_name, rc) result(r8field)
+      type(ESMF_Field) :: r8field
+      real(kind=ESMF_KIND_R8), intent(in) :: r8array(:,:)
+      character(len=*), intent(in) :: field_name
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      r8field = mk_field(r8array, regDecomp=REG_DECOMP_DEFAULT, minIndex=MIN_INDEX_DEFAULT, &
+         maxIndex=MAX_INDEX_DEFAULT, indexflag=INDEX_FLAG_DEFAULT, name = field_name, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end function mk_r8field
+
+   function mk_r4ungrid_field(field_name, lbound, ubound, rc) result(r4field)
+      type(ESMF_Field) :: r4field
+      character(len=*), intent(in) :: field_name
+      integer, intent(in) :: lbound
+      integer, intent(in) :: ubound
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      r4field = mk_field_r4_ungrid(regDecomp=REG_DECOMP_DEFAULT, minIndex=MIN_INDEX_DEFAULT, maxIndex=MAX_INDEX_DEFAULT, &
+         indexflag=INDEX_FLAG_DEFAULT, name = field_name, ungriddedLBound=[lbound],ungriddedUBound=[ubound],_RC)
+
+      _RETURN(_SUCCESS)
+
+   end function mk_r4ungrid_field
+
 end module field_utils_setup


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This feature PR adds the npes to the `@Test` decorators. It also moves creation of some fields to the test subroutines so that the field creation is consistent with the regDecomp argument.
## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2530

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
npes were not being passed into the test subroutines.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the MAPL tests in question

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
