### PR TITLE
Handmerge develop into MAPL 3 2024-Jan-18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,8 @@ orbs:
   ci: geos-esm/circleci-tools@2
 
 workflows:
-  build-and-test:
+  build-and-test-MAPL:
     jobs:
-
       # Builds MAPL in a "default" way - Intel
       - ci/build:
           name: build-and-test-MAPL-on-<< matrix.compiler >>-using-<< matrix.cmake_generator >>
@@ -86,6 +85,29 @@ workflows:
           run_unit_tests: true
           ctest_options: "-LE 'PERFORMANCE|EXTDATA1G_BIG_TESTS|EXTDATA2G_BIG_TESTS' --output-on-failure"
 
+      # Run MAPL Tutorials
+      - ci/run_mapl_tutorial:
+          name: run-<< matrix.tutorial_name >>-Tutorial-with-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              #compiler: [gfortran, ifort]
+              compiler: [ifort]
+              tutorial_name:
+                - hello_world
+                - parent_no_children
+                - parent_one_child_import_via_extdata
+                - parent_one_child_no_imports
+                - parent_two_siblings_connect_import_export
+          # We will only run the tutorials with GNU make. No need to double up
+          # as Ninja is a build test only
+          requires:
+            - build-and-test-MAPL-on-<< matrix.compiler >>-using-Unix Makefiles
+          baselibs_version: *baselibs_version
+
+  build-and-run-GEOSgcm:
+    jobs:
       # Build GEOSgcm -- ifort
       - ci/build:
           name: build-GEOSgcm-on-<< matrix.compiler >>
@@ -118,38 +140,6 @@ workflows:
           checkout_mapl_branch: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra, retained for one day
 
-      # Build GEOSldas on ifort
-      - ci/build:
-          name: build-GEOSldas-on-<< matrix.compiler >>
-          context:
-            - docker-hub-creds
-          matrix:
-            parameters:
-              compiler: [ifort]
-          baselibs_version: *baselibs_version
-          repo: GEOSldas
-          mepodevelop: false
-          checkout_fixture: true
-          fixture_branch: release/MAPL-v3
-          checkout_mapl3_release_branch: true
-          checkout_mapl_branch: true
-
-      # Build GEOSldas on gfortran
-      - ci/build:
-          name: build-GEOSldas-on-<< matrix.compiler >>
-          context:
-            - docker-hub-creds
-          matrix:
-            parameters:
-              compiler: [gfortran]
-          baselibs_version: *baselibs_version
-          repo: GEOSldas
-          mepodevelop: false
-          checkout_fixture: true
-          fixture_branch: release/MAPL-v3
-          checkout_mapl3_release_branch: true
-          checkout_mapl_branch: true
-
       # Run GCM (1 hour, no ExtData)
       - ci/run_gcm:
           name: run-GCM-on-<< matrix.compiler >>
@@ -180,26 +170,38 @@ workflows:
           gcm_ocean_type: MOM6
           change_layout: false
 
-      # Run MAPL Tutorials
-      - ci/run_mapl_tutorial:
-          name: run-<< matrix.tutorial_name >>-Tutorial-with-<< matrix.compiler >>
+  build-GEOSldas:
+    jobs:
+      # Build GEOSldas on ifort
+      - ci/build:
+          name: build-GEOSldas-on-<< matrix.compiler >>
           context:
             - docker-hub-creds
           matrix:
             parameters:
-              #compiler: [gfortran, ifort]
               compiler: [ifort]
-              tutorial_name:
-                - hello_world
-                - parent_no_children
-                - parent_one_child_import_via_extdata
-                - parent_one_child_no_imports
-                - parent_two_siblings_connect_import_export
-          # We will only run the tutorials with GNU make. No need to double up
-          # as Ninja is a build test only
-          requires:
-            - build-and-test-MAPL-on-<< matrix.compiler >>-using-Unix Makefiles
           baselibs_version: *baselibs_version
+          repo: GEOSldas
+          mepodevelop: false
+          checkout_fixture: true
+          fixture_branch: release/MAPL-v3
+          checkout_mapl3_release_branch: true
+          checkout_mapl_branch: true
+
+      # Build GEOSldas on gfortran
+      - ci/build:
+          name: build-GEOSldas-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran]
+          baselibs_version: *baselibs_version
+          repo: GEOSldas
+          mepodevelop: false
+          fixture_branch: release/MAPL-v3
+          checkout_mapl3_release_branch: true
+          checkout_mapl_branch: true
 
   build-GEOSadas:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ workflows:
           baselibs_version: *baselibs_version
           repo: GEOSldas
           mepodevelop: false
+          checkout_fixture: true
           fixture_branch: release/MAPL-v3
           checkout_mapl3_release_branch: true
           checkout_mapl_branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable Ninja for CI builds of MAPL
 - Removed use of `ESMF_HAS_ACHAR_BUG` CMake option and code use in `MAPL_Config.F90`. Testing has shown that with ESMF 8.6 (which is
   now required), NAG no longer needs this workaround.
+- Refactor the CircleCI workflows for more flexibility
 
 ### Fixed
 


### PR DESCRIPTION
Supersedes #2541 

This is hand merge of `develop` into `release/MAPL-v3` in order to make sure the CI works.