### PR TITLE
Fixes #2553. Detect mpiuni builds of ESMF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Convert from ABI Fixed Grid to lon/lat coordinates used in MAPL_XYGridFactory (supporting geostationary GOES-R series)
 - Modify trajectory sampler for a collection with multiple platforms: P3B (air craft) + FIREX
 - Modify swath sampler to handle two Epoch swath grids
@@ -16,8 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - parse "GOCART::CO2" from 'geovals_fields' entry in PLATFORM
 - Add call MAPL_InitializeShmem to ExtDataDriverGridComp.F90
 - Read swath data on root, call MAPL_CommsBcast [which sends data to Shmem (when Shmem initialized) or to MAPL_comm otherwise]. This approach avoids race in reading nc files [e.g. 37 files for 3 hr swath data]
-
-
 - Added memory utility, MAPL_MemReport that can be used in any code linking MAPL
 - Added capability in XY grid factory to add a mask to the grid any points are missing needed for geostationary input data
 - Added capability in the MAPL ESMF regridding wrapper to apply a destination mask if the destination grid contains a mask
@@ -41,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explictly `use` some `iso_c_binding` types previously pulled in through ESMF. This is fixed in future ESMF versions (8.7+) and so
   we anticipate this here
 - Add explicit `Fortran_MODULE_DIRECTORY` to `CMakeLists.txt` in benchmarks to avoid race condition in Ninja builds
+- Add check to make sure ESMF was not built as `mpiuni`
 
 ### Removed
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -275,7 +275,7 @@ contains
       integer :: status
       class(Logger), pointer :: lgr
       logical :: file_exists
-      type (ESMF_VM) :: VM
+      type (ESMF_VM) :: vm
       character(len=:), allocatable :: esmfComm
 
       _UNUSED_DUMMY(unusable)
@@ -295,14 +295,13 @@ contains
       ! If the file exists, we pass it into ESMF_Initialize, else, we
       ! use the one from the command line arguments
       if (file_exists) then
-         call ESMF_Initialize (configFileName='ESMF.rc', mpiCommunicator=comm, _RC)
+         call ESMF_Initialize (configFileName='ESMF.rc', mpiCommunicator=comm, vm=vm, _RC)
       else
-         call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, _RC)
+         call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, vm=vm, _RC)
       end if
 
       ! We check to see if ESMF_COMM was built as mpiuni which is not allowed for MAPL
-      call ESMF_VmGetCurrent(VM, _RC)
-      call ESMF_VmGet(VM, esmfComm = esmfComm, _RC)
+      call ESMF_VmGet(vm, esmfComm = esmfComm, _RC)
       _ASSERT( esmfComm /= 'mpiuni', 'ESMF_COMM=mpiuni is not allowed for MAPL')
 
       ! Note per ESMF this is a temporary routine as eventually MOAB will

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -275,6 +275,8 @@ contains
       integer :: status
       class(Logger), pointer :: lgr
       logical :: file_exists
+      type (ESMF_VM) :: VM
+      character(len=:), allocatable :: esmfComm
 
       _UNUSED_DUMMY(unusable)
 
@@ -297,6 +299,11 @@ contains
       else
          call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, _RC)
       end if
+
+      ! We check to see if ESMF_COMM was built as mpiuni which is not allowed for MAPL
+      call ESMF_VmGetCurrent(VM, _RC)
+      call ESMF_VmGet(VM, esmfComm = esmfComm, _RC)
+      _ASSERT( esmfComm /= 'mpiuni', 'ESMF_COMM=mpiuni is not allowed for MAPL')
 
       ! Note per ESMF this is a temporary routine as eventually MOAB will
       ! be the only mesh generator. But until then, this allows us to


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds a check in Cap after `ESMF_Initialize` to see if ESMF was built as `mpiuni` which is not supported by MAPL (we require "real" MPI). Thanks to @oehmke, `ESMF_VmGet` can tell us the comm.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #2553 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

It was found that a GCHP issue could have been quickly diagnosed if this assertion was in MAPL. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Currently testing to make sure GEOSgcm runs. It should, but good to be safe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
