### PR TITLE
Prepare for 2.43.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- added 0-size message to o-server root processes
-
 ### Removed
 
 ### Deprecated
+
+## [2.43.1] - 2024-01-29
+
+### Fixed
+
+- Added 0-size message to o-server root processes (fixes #2557)
 
 ## [2.43.0] - 2023-12-21
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.43.0
+  VERSION 2.43.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
This updates the CMake and Changelog for a 2.43.1 release. I'll power it in since this doesn't really need CI running on it.