### PR TITLE
Fixed a memory leak affecting regional masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-- fixed memory leak affecting reginal masking. Temporary ESMF field was created but never destroyed
+- fixed memory leak affecting regional masking. Temporary ESMF field was created but never destroyed
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- fixed memory leak affecting reginal masking. Temporary ESMF field was created but never destroyed
 
 ### Removed
 

--- a/gridcomps/ExtData2G/ExtDataMasking.F90
+++ b/gridcomps/ExtData2G/ExtDataMasking.F90
@@ -186,6 +186,7 @@ module MAPL_ExtDataMask
           enddo
        end if
        deallocate( mask)
+       call ESMF_FieldDestroy(temp_field, noGarbage=.true., _RC)
 
       _RETURN(_SUCCESS)
    end subroutine evaluate_region_mask
@@ -256,6 +257,7 @@ module MAPL_ExtDataMask
              where(limitS <= lats .and. lats <=limitN) var3d(:,:,i) = rvar3d(:,:,i)
           enddo
        end if
+       call ESMF_FieldDestroy(temp_field, noGarbage=.true., _RC)
 
       _RETURN(_SUCCESS)
    end subroutine evaluate_zone_mask
@@ -424,6 +426,7 @@ module MAPL_ExtDataMask
           end if
           deallocate(temp2d)
        end if
+       call ESMF_FieldDestroy(temp_field, noGarbage=.true., _RC)
 
        _RETURN(_SUCCESS)
   end subroutine evaluate_box_mask


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
 Fixes memory leak afection regional masking

## Description
<!--- Describe your changes in detail -->
Several temporary ESMF fields were created but never destroyed. This PR adds the missing "ESMF_FieldDestroy

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
