### PR TITLE
Handmerge develop into release/MAPL-v3 2024-Feb-07

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -24,7 +24,7 @@ install(
   DESTINATION bin/forcing_converter)
 
 ecbuild_add_executable (TARGET Regrid_Util.x SOURCES Regrid_Util.F90)
-target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran esmf)
+target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
 target_include_directories (Regrid_Util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
@@ -32,7 +32,7 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
 endif ()
 
 ecbuild_add_executable (TARGET time_ave_util.x SOURCES time_ave_util.F90)
-target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran esmf)
+target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
 target_include_directories (time_ave_util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
@@ -40,7 +40,7 @@ if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
 endif ()
 
 ecbuild_add_executable (TARGET Comp_Testing_Driver.x SOURCES Comp_Testing_Driver.F90)
-target_link_libraries (Comp_Testing_Driver.x PRIVATE MAPL MPI::MPI_Fortran esmf)
+target_link_libraries (Comp_Testing_Driver.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
 target_include_directories (Comp_Testing_Driver.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now required), NAG no longer needs this workaround.
 - Refactor the CircleCI workflows for more flexibility
 - Fix field utils issue - add npes argument to test subroutine decorators.
+- Change MAPL CMake to use `ESMF::ESMF` target instead of `esmf` or `ESMF` as the imported target name
+  - Updated `FindESMF.cmake` to match that of ESMF `develop` as of commit `da8f410`. This will be in ESMF 8.6.1+
+  - Requires ESMA_cmake 3.40.0 or later as this adds the `ESMF::ESMF` target ALIAS for Baselibs and non-Baselibs builds
 - Changed `CMakePresets.json`
   - Updated to version 7 and required CMake 3.27.0 (the minimum version that supports CMakePresets.json v7)
   - Changed build style on NCCS machines to by default put build and install directories in a user-specified directory so as not to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,20 +147,21 @@ if (NOT Baselibs_FOUND)
      add_definitions(-DH5_HAVE_PARALLEL)
   endif()
 
-  if (NOT TARGET esmf)
+  if (NOT TARGET ESMF::ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
 
     # ESMF as used in MAPL requires MPI
     # NOTE: This looks odd because some versions of FindESMF.cmake out in the
     #       world provide an "esmf" target while others provide "ESMF". So we
     #       need this ugliness to support both.
-    if (TARGET esmf)
-      target_link_libraries(esmf INTERFACE MPI::MPI_Fortran)
+    if (TARGET ESMF::ESMF)
+      target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
     else()
-      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+      target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
       # MAPL and GEOS use lowercase target due to historical reasons but
       # the latest FindESMF.cmake file from ESMF produces an ESMF target.
-      add_library(esmf ALIAS ESMF)
+      add_library(ESMF::ESMF ALIAS ESMF)
+      add_library(ESMF::ESMF ALIAS esmf)
     endif()
   endif ()
 else ()

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -4,7 +4,7 @@ esma_set_this()
 esma_add_library (${this}
   SRCS MAPL.F90 mapl3g.F90
   DEPENDENCIES MAPL.base MAPL.generic MAPL.generic3g MAPL.cap3g MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps MAPL.orbit MAPL.griddedio MAPL.field_utils ${EXTDATA_TARGET}
-               esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
+               ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
                $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
   TYPE ${MAPL_LIBRARY_TYPE}
   )
@@ -14,5 +14,5 @@ target_compile_definitions (${this} PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WIT
 target_include_directories (${this} PUBLIC
           $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
-ecbuild_add_executable(TARGET GEOS.x SOURCES GEOS.F90 DEPENDS MAPL.generic3g MAPL.cap3g esmf)
+ecbuild_add_executable(TARGET GEOS.x SOURCES GEOS.F90 DEPENDS MAPL.generic3g MAPL.cap3g ESMF::ESMF)
 target_link_libraries(GEOS.x PRIVATE ${this})

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 
 esma_add_library (${lib}
   SRCS ${srcs}
-  DEPENDENCIES esmf NetCDF::NetCDF_Fortran
+  DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
   TYPE ${LIBRARY_TYPE}
   )
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 if (BUILD_WITH_FARGPARSE)
 
   ecbuild_add_executable (TARGET ExtDataDriver.x SOURCES ${srcs})
-  target_link_libraries (ExtDataDriver.x PRIVATE MAPL FARGPARSE::fargparse esmf)
+  target_link_libraries (ExtDataDriver.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
   if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
     target_link_libraries(ExtDataDriver.x PRIVATE OpenMP::OpenMP_Fortran)
@@ -28,14 +28,14 @@ if (BUILD_WITH_FARGPARSE)
   add_subdirectory(ExtData_Testing_Framework EXCLUDE_FROM_ALL)
 
   ecbuild_add_executable (TARGET pfio_MAPL_demo.x SOURCES pfio_MAPL_demo.F90)
-  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse esmf)
+  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
   if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
     target_link_libraries(pfio_MAPL_demo.x PRIVATE OpenMP::OpenMP_Fortran)
   endif ()
   set_target_properties(pfio_MAPL_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
   ecbuild_add_executable (TARGET MAPL_demo_fargparse.x SOURCES MAPL_demo_fargparse.F90)
-  target_link_libraries (MAPL_demo_fargparse.x PRIVATE MAPL FARGPARSE::fargparse esmf)
+  target_link_libraries (MAPL_demo_fargparse.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF)
   # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
   if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
     target_link_libraries(MAPL_demo_fargparse.x PRIVATE OpenMP::OpenMP_Fortran)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -69,7 +69,7 @@ esma_add_library(
   ${this} SRCS ${srcs}
   DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 MAPL.field_utils PFLOGGER::pflogger
                GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
-               esmf NetCDF::NetCDF_Fortran MPI::MPI_Fortran
+               ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE ${MAPL_LIBRARY_TYPE})
 
 # We don't want to disable good NAG debugging flags everywhere, but we still need to do it for
@@ -97,7 +97,7 @@ foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
   target_link_libraries(${this} PUBLIC "-Xlinker -rpath -Xlinker ${dir}")
 endforeach()
 
-ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS esmf MAPL.shared)
+ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS ESMF::ESMF MAPL.shared)
 target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ set (SRCS
 #  MAPL_Initialize.F90
 #  )
 #target_link_libraries (base_extras MAPL.shared MAPL.pfunit
-#                                   esmf NetCDF::NetCDF_Fortran)
+#                                   ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 add_pfunit_ctest(MAPL.base.tests
                 TEST_SOURCES ${TEST_SRCS}

--- a/benchmarks/esmf/CMakeLists.txt
+++ b/benchmarks/esmf/CMakeLists.txt
@@ -4,7 +4,7 @@ ecbuild_add_executable (
   TARGET ${exe}
   SOURCES gc_run.F90)
 
-target_link_libraries(${exe} PRIVATE MAPL.shared esmf)
+target_link_libraries(${exe} PRIVATE MAPL.shared ESMF::ESMF)
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/benchmarks/io/checkpoint_simulator/CMakeLists.txt
+++ b/benchmarks/io/checkpoint_simulator/CMakeLists.txt
@@ -6,7 +6,7 @@ ecbuild_add_executable (
   SOURCES checkpoint_simulator.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse esmf )
+target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse ESMF::ESMF )
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${exe} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -109,6 +109,11 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
+  # Add target alias to facilitate unambiguous linking
+  if(NOT TARGET ESMF::ESMF)
+    add_library(ESMF::ESMF ALIAS ESMF)
+  endif()
+
   # Add ESMF include directories
   set(ESMF_INCLUDE_DIRECTORIES "")
   separate_arguments(_ESMF_F90COMPILEPATHS UNIX_COMMAND ${ESMF_F90COMPILEPATHS})

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.37.0
+  tag: v3.40.0
   develop: develop
 
 ecbuild:

--- a/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
 
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 

--- a/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
@@ -7,7 +7,7 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()
-target_link_libraries(${this} PRIVATE esmf)
+target_link_libraries(${this} PRIVATE ESMF::ESMF)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/field_utils/CMakeLists.txt
+++ b/field_utils/CMakeLists.txt
@@ -34,7 +34,7 @@ esma_add_library(${this}
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC esmf)
+target_link_libraries (${this} PUBLIC ESMF::ESMF)
 
 if (PFUNIT_FOUND)
   # Turning off until test with GNU can be fixed

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -69,7 +69,7 @@ esma_add_library(${this}
   )
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC esmf NetCDF::NetCDF_Fortran)
+target_link_libraries (${this} PUBLIC ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -68,7 +68,7 @@ add_subdirectory(couplers)
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC udunits2f MAPL.field_utils esmf NetCDF::NetCDF_Fortran)
+target_link_libraries (${this} PUBLIC udunits2f MAPL.field_utils ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/geom_mgr/CMakeLists.txt
+++ b/geom_mgr/CMakeLists.txt
@@ -3,7 +3,7 @@ esma_set_this (OVERRIDE MAPL.geom_mgr)
 set(srcs
   geom_mgr.F90 # package
   GeomUtilities.F90
-  
+
   GeomSpec.F90
   NullGeomSpec.F90
   MaplGeom.F90
@@ -25,7 +25,7 @@ set(srcs
   latlon/LatLonGeomSpec_smod.F90
   latlon/LatLonGeomFactory.F90
   latlon/LatLonGeomFactory_smod.F90
-  
+
   GeomManager.F90
   GeomManager_smod.F90
 
@@ -46,7 +46,7 @@ esma_add_library(${this}
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC esmf)
+target_link_libraries (${this} PUBLIC ESMF::ESMF)
 
  if (PFUNIT_FOUND)
    add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -23,7 +23,7 @@ if (DUSTY)
                 PROPERTY COMPILE_FLAGS ${DUSTY})
 endif ()
 
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran
                                $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
                                $<$<BOOL:${BUILD_WITH_FARGPARSE}>:FARGPARSE::fargparse>)

--- a/gridcomps/ExtData/CMakeLists.txt
+++ b/gridcomps/ExtData/CMakeLists.txt
@@ -8,7 +8,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.pfio
         MAPL.griddedio MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/gridcomps/ExtData2G/CMakeLists.txt
+++ b/gridcomps/ExtData2G/CMakeLists.txt
@@ -24,7 +24,7 @@ set (srcs
 
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.generic MAPL.griddedio TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -11,7 +11,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.profiler MAPL.griddedio
                                                     TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/gridcomps/Orbit/CMakeLists.txt
+++ b/gridcomps/Orbit/CMakeLists.txt
@@ -5,7 +5,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -12,7 +12,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio
          MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared esmf NetCDF::NetCDF_Fortran
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/pfunit/CMakeLists.txt
+++ b/pfunit/CMakeLists.txt
@@ -10,5 +10,5 @@ set (srcs
 
 esma_add_library (${this} EXCLUDE_FROM_ALL SRCS ${srcs} NOINSTALL TYPE ${MAPL_LIBRARY_TYPE})
 
-target_link_libraries (${this} MAPL.shared MAPL.field_utils PFUNIT::pfunit esmf NetCDF::NetCDF_Fortran)
+target_link_libraries (${this} MAPL.shared MAPL.field_utils PFUNIT::pfunit ESMF::ESMF NetCDF::NetCDF_Fortran)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/regridder_mgr/CMakeLists.txt
+++ b/regridder_mgr/CMakeLists.txt
@@ -13,12 +13,12 @@ set(srcs
   RegridderParam.F90
   RegridderSpec.F90
   RegridderSpecVector.F90
-  
+
   Regridder.F90
   RegridderVector.F90
   NullRegridder.F90
   EsmfRegridder.F90
-  
+
   RegridderFactory.F90
   EsmfRegridderFactory.F90
   RegridderFactoryVector.F90
@@ -35,7 +35,7 @@ esma_add_library(${this}
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC esmf)
+target_link_libraries (${this} PUBLIC ESMF::ESMF)
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Supersedes #2581 

This is a handmerge of `develop` into `release/MAPL-v3`. I'm doing it this way as I want to make sure all the CI is happy.