### PR TITLE
Fix non-Baselibs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@
 CMakeUserPresets.json
 
 # Ignore possible symlinked build and install directories
-build-*
-install-*
+build*/
+install*/
 
 *.swp
 *.swo

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,12 @@
 CMakeUserPresets.json
 
 # Ignore possible symlinked build and install directories
-build*/
-install*/
+# Note: we can't use a / at the end because they might be
+# symlink to a directory
+build*
+install*
+
+# If you build with spack libraries, you can get spack log files
 spack*.log
 
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ CMakeUserPresets.json
 # Ignore possible symlinked build and install directories
 build*/
 install*/
+spack*.log
 
 *.swp
 *.swo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.44.1] - 2024-02-12
+
+### Fixed
+
+- Fixed non-Baselibs build using `ESMF::ESMF` target
+
 ## [2.44.0] - 2024-02-08
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,11 @@ if (NOT Baselibs_FOUND)
   if (NOT TARGET ESMF::ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
 
-    target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
     # MAPL and GEOS use lowercase target due to historical reasons but
     # the latest FindESMF.cmake file from ESMF produces an ESMF target.
+    add_library(esmf ALIAS ESMF::ESMF)
     add_library(ESMF ALIAS ESMF::ESMF)
-    add_library(ESMF ALIAS esmf)
   endif ()
 else ()
   # This is an ESMF version test when using Baselibs which doesn't use the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,7 @@ if (NOT Baselibs_FOUND)
 
   if (NOT TARGET ESMF::ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
-
     target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
-    # MAPL and GEOS use lowercase target due to historical reasons but
-    # the latest FindESMF.cmake file from ESMF produces an ESMF target.
-    add_library(esmf ALIAS ESMF::ESMF)
   endif ()
 else ()
   # This is an ESMF version test when using Baselibs which doesn't use the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,19 +150,11 @@ if (NOT Baselibs_FOUND)
   if (NOT TARGET ESMF::ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
 
-    # ESMF as used in MAPL requires MPI
-    # NOTE: This looks odd because some versions of FindESMF.cmake out in the
-    #       world provide an "esmf" target while others provide "ESMF". So we
-    #       need this ugliness to support both.
-    if (TARGET ESMF)
-      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
-    else()
-      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
-      # MAPL and GEOS use lowercase target due to historical reasons but
-      # the latest FindESMF.cmake file from ESMF produces an ESMF target.
-      add_library(ESMF ALIAS ESMF::ESMF)
-      add_library(ESMF ALIAS esmf)
-    endif()
+    target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+    # MAPL and GEOS use lowercase target due to historical reasons but
+    # the latest FindESMF.cmake file from ESMF produces an ESMF target.
+    add_library(ESMF ALIAS ESMF::ESMF)
+    add_library(ESMF ALIAS esmf)
   endif ()
 else ()
   # This is an ESMF version test when using Baselibs which doesn't use the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.44.0
+  VERSION 2.44.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui
@@ -147,21 +147,21 @@ if (NOT Baselibs_FOUND)
      add_definitions(-DH5_HAVE_PARALLEL)
   endif()
 
-  if (NOT TARGET ESMF::ESMF)
+  if (NOT TARGET ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
 
     # ESMF as used in MAPL requires MPI
     # NOTE: This looks odd because some versions of FindESMF.cmake out in the
     #       world provide an "esmf" target while others provide "ESMF". So we
     #       need this ugliness to support both.
-    if (TARGET ESMF::ESMF)
-      target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
+    if (TARGET ESMF)
+      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
     else()
-      target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
+      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
       # MAPL and GEOS use lowercase target due to historical reasons but
       # the latest FindESMF.cmake file from ESMF produces an ESMF target.
-      add_library(ESMF::ESMF ALIAS ESMF)
-      add_library(ESMF::ESMF ALIAS esmf)
+      add_library(ESMF ALIAS ESMF::ESMF)
+      add_library(ESMF ALIAS esmf)
     endif()
   endif ()
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if (NOT Baselibs_FOUND)
      add_definitions(-DH5_HAVE_PARALLEL)
   endif()
 
-  if (NOT TARGET ESMF)
+  if (NOT TARGET ESMF::ESMF)
     find_package(ESMF 8.6.0 MODULE REQUIRED)
 
     # ESMF as used in MAPL requires MPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,6 @@ if (NOT Baselibs_FOUND)
     # MAPL and GEOS use lowercase target due to historical reasons but
     # the latest FindESMF.cmake file from ESMF produces an ESMF target.
     add_library(esmf ALIAS ESMF::ESMF)
-    add_library(ESMF ALIAS ESMF::ESMF)
   endif ()
 else ()
   # This is an ESMF version test when using Baselibs which doesn't use the

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -109,7 +109,7 @@ if(EXISTS ${ESMFMKFILE})
     endif()
   endif()
 
-  # Add target alias to facilitate unambiguous linking
+  # Add ESMF as an alias to ESMF::ESMF for backward compatibility
   if(NOT TARGET ESMF)
     add_library(ESMF ALIAS ESMF::ESMF)
   endif()

--- a/cmake/FindESMF.cmake
+++ b/cmake/FindESMF.cmake
@@ -96,22 +96,22 @@ if(EXISTS ${ESMFMKFILE})
       message(WARNING "Static ESMF library (libesmf.a) not found in \
                        ${ESMF_LIBSDIR}. Try setting USE_ESMF_STATIC_LIBS=OFF")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF STATIC IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF STATIC IMPORTED)
     endif()
   else()
     find_library(ESMF_LIBRARY_LOCATION NAMES esmf PATHS ${ESMF_LIBSDIR} NO_DEFAULT_PATH)
     if(ESMF_LIBRARY_LOCATION MATCHES "ESMF_LIBRARY_LOCATION-NOTFOUND")
       message(WARNING "ESMF library not found in ${ESMF_LIBSDIR}.")
     endif()
-    if(NOT TARGET ESMF)
-      add_library(ESMF UNKNOWN IMPORTED)
+    if(NOT TARGET ESMF::ESMF)
+      add_library(ESMF::ESMF UNKNOWN IMPORTED)
     endif()
   endif()
 
   # Add target alias to facilitate unambiguous linking
-  if(NOT TARGET ESMF::ESMF)
-    add_library(ESMF::ESMF ALIAS ESMF)
+  if(NOT TARGET ESMF)
+    add_library(ESMF ALIAS ESMF::ESMF)
   endif()
 
   # Add ESMF include directories
@@ -135,7 +135,7 @@ if(EXISTS ${ESMFMKFILE})
                       ESMF_F90COMPILEPATHS
         VERSION_VAR ESMF_VERSION)
 
-  set_target_properties(ESMF PROPERTIES
+  set_target_properties(ESMF::ESMF PROPERTIES
         IMPORTED_LOCATION "${ESMF_LIBRARY_LOCATION}"
         INTERFACE_INCLUDE_DIRECTORIES "${ESMF_INCLUDE_DIRECTORIES}"
         INTERFACE_LINK_LIBRARIES "${ESMF_INTERFACE_LINK_LIBRARIES}")


### PR DESCRIPTION
# NOTE NOTE NOTE

Note to @mathomp4: Because this needs an update to ESMF 8.6.1 to work, this will *not* be a hotfix and all this will need to go against develop. But I'm leaving the PR here so I don't lose anything until ready.

---

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As found by @AlexanderRichert-NOAA in https://github.com/spack/spack/pull/42619 I was a bit too heavy-handed with the sed and changed too many things to `ESMF::ESMF`. As such, I broke the Spack build of MAPL 2.44

This should be the right fix, though testing is underway. I can say I can build MAPL using spack libraries. I'm trying `spack install mapl` now.

Related: https://github.com/GEOS-ESM/ESMA_cmake/pull/354

I'm still trying to figure out the right stuff in ESMA_cmake to get this to work. I think I broke...something.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixes the spack build of MAPL!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing now. As this is a pure CMake bug, if it builds, it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
