### PR TITLE
ignore iclients call when no exdata is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bypassed the I-Server reading call when there is no extdata
+
 ### Fixed
 - removed unnecessary memory allocation for tile reads. This is critical for high res runs on SCU17
 

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -1432,6 +1432,15 @@ CONTAINS
 
    call lgr%debug('ExtData Run_: READ_LOOP: Done')
 
+   if (IOBundles%size() == 0) then
+      deallocate(doUpdate)
+      deallocate(useTime)
+      if (hasRun .eqv. .false.) hasRun = .true.
+      call MAPL_TimerOff(MAPLSTATE,"-Read_Loop")
+      call MAPL_TimerOff(MAPLSTATE,"Run")
+      _RETURN(ESMF_SUCCESS)
+   endif
+
    bundle_iter = IOBundles%begin()
    do while (bundle_iter /= IoBundles%end())
       io_bundle => bundle_iter%get()


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
ignore iclients call whne there is no exdata is provided
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
