### PR TITLE
Add remove attribute procedure to FileMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added procedures to remove an attribute from a FileMetadata object and from a Variable object in PFIO
 - Add per-collection timer output for History
 - Add python utilities to split and recombine restarts
 - Add a new "SPLIT\_CHECKPOINT:" option that has replaced the write-by-face option. This will write a file per writer wit the base checkpoint name being a control file that tells how many files were written to. On reading if this control file is provided as the restart file name, it will automatically trigger reading the individual files

--- a/pfio/FileMetadata.F90
+++ b/pfio/FileMetadata.F90
@@ -44,6 +44,7 @@ module pFIO_FileMetadataMod
       procedure :: add_attribute_1d
       procedure :: get_attribute
       procedure :: has_attribute
+      procedure :: remove_attribute
 
       procedure :: get_variable
       procedure :: get_coordinate_variable
@@ -87,7 +88,7 @@ contains
      type (StringVector), optional, intent(in) :: order
 
 
- 
+
      fmd%dimensions = StringIntegerMap()
      if (present(dimensions)) fmd%dimensions = dimensions
 
@@ -234,6 +235,14 @@ contains
       has_attribute = this%global_var%is_attribute_present(attr_name)
 
    end function has_attribute
+
+   subroutine remove_attribute(this, attr_name)
+      class (FileMetadata), target, intent(inout) :: this
+      character(len=*), intent(in) :: attr_name
+
+      call this%global_var%remove_attribute(attr_name)
+
+   end subroutine
 
 
    function get_attributes(this, rc ) result(attributes)

--- a/pfio/Variable.F90
+++ b/pfio/Variable.F90
@@ -43,6 +43,7 @@ module pFIO_VariableMod
       generic :: add_attribute => add_attribute_1d
       procedure :: add_attribute_0d
       procedure :: add_attribute_1d
+      procedure :: remove_attribute
       procedure :: add_const_value
 
       procedure :: get_chunksizes
@@ -182,6 +183,17 @@ contains
 
    end function get_attributes
 
+   subroutine remove_attribute(this,attr_name,rc)
+      class (Variable), target, intent(inout) :: this
+      character(len=*), intent(in) :: attr_name
+      integer, optional, intent(out) :: rc
+      type(StringAttributeMapIterator) :: iter
+      integer :: status
+
+      iter = this%attributes%find(attr_name)
+      call this%attributes%erase(iter)
+      _RETURN(_SUCCESS)
+   end subroutine
 
    subroutine add_attribute_0d(this, attr_name, attr_value, rc)
       class (Variable), target, intent(inout) :: this


### PR DESCRIPTION
In the interp_restart code, to produce the output file I "cheat". Basically load the input file and produce a fileMetadata object from it. I then copy this to a new fileMetadata object and change the dimensions in object. Then I can use this to produce the new file.

The problem is that if the input is stretched but the output is not, @wmputman found that the stretching parameters were getting into the output file in his new updated inpterp_restarts.x version that can handle both and input and/or output stretched grid. So I needed a procedure to remove them if needed before writing.

<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GEOSgcm (if non-trivial)
- [X] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [X] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
