### PR TITLE
Fix a bug in subroutine destroy_route_handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `if (compute_transpose)` to sub. destroy_route_handle to avoid destroying a nonexisting route handle
 - Add option to MAPL regridding layer to write and retrieve ESMF weights.
 - Add options to History and ExtData to turn on the ability to write and read route handle weights
 - Add option to renable the transpose computation when calling make\_regridder

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -1665,6 +1665,7 @@ contains
      type(ESMF_RouteHandle) :: route_handle
      type(RegridderSpecRouteHandleMapIterator) :: iter
      integer :: status
+     logical :: compute_transpose
 
      if (kind == ESMF_TYPEKIND_R4) then
         route_handles => route_handles_r4
@@ -1684,11 +1685,14 @@ contains
      iter = route_handles%find(spec)
      call route_handles%erase(iter)
 
-     _ASSERT(transpose_route_handles%count(spec) == 1, 'Did not find this spec in route handle table.')
-     route_handle = transpose_route_handles%at(spec)
-     call ESMF_RouteHandleDestroy(route_handle, noGarbage=.true., _RC)
-     iter = transpose_route_handles%find(spec)
-     call transpose_route_handles%erase(iter)
+     compute_transpose = IAND(spec%hints,REGRID_HINT_COMPUTE_TRANSPOSE) /= 0
+     if (compute_transpose) then
+        _ASSERT(transpose_route_handles%count(spec) == 1, 'Did not find this spec in route handle table.')
+        route_handle = transpose_route_handles%at(spec)
+        call ESMF_RouteHandleDestroy(route_handle, noGarbage=.true., _RC)
+        iter = transpose_route_handles%find(spec)
+        call transpose_route_handles%erase(iter)
+     end if
 
       _RETURN(_SUCCESS)
    end subroutine destroy_route_handle


### PR DESCRIPTION
Ben helps me to fix the bug we find when destroy the CS-to-Swath route-handle for sampler codes. Otherwise, the following error message appears:

pe=00002 FAIL at line=01687    MAPL_EsmfRegridder.F90                   <Did not find this spec in route handle table.>
pe=00002 FAIL at line=01651    MAPL_EsmfRegridder.F90                   <status=1>
pe=00002 FAIL at line=00308    MAPL_EpochSwathMod.F90                   <status=1>