### PR TITLE
Workarounds for gfortran 13.2

### DIFF
--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -443,8 +443,9 @@ contains
       num_specs = ESMF_HConfigGetSize(conn_specs, _RC)
       do i = 1, num_specs
          conn_spec = ESMF_HConfigCreateAt(conn_specs, index=i, _RC)
-         conn = parse_connection(conn_spec, _RC)
+         allocate(conn, source=parse_connection(conn_spec, rc=status)); _VERIFY(status)
          call connections%push_back(conn)
+         deallocate(conn)
       enddo 
 
       _RETURN(_SUCCESS)

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -522,7 +522,8 @@ contains
 
          _ASSERT(var_spec%itemtype /= MAPL_STATEITEM_UNKNOWN, 'Invalid type id in variable spec <'//var_spec%short_name//'>.')
 
-         item_spec = var_spec%make_ItemSpec(geom, vertical_geom, registry, _RC)
+!#         item_spec = var_spec%make_ItemSpec(geom, vertical_geom, registry, _RC)
+         allocate(item_spec, source=var_spec%make_ItemSpec(geom, vertical_geom, registry, rc=status)); _VERIFY(status)
          call item_spec%create(_RC)
          
          virtual_pt = var_spec%make_virtualPt()

--- a/generic3g/tests/Test_SimpleLeafGridComp.pf
+++ b/generic3g/tests/Test_SimpleLeafGridComp.pf
@@ -1,3 +1,4 @@
+#include "MAPL_TestErr.h"
 module Test_SimpleLeafGridComp
    use mapl3g_Generic
    use mapl3g_GenericPhases

--- a/generic3g/tests/Test_SimpleParentGridComp.pf
+++ b/generic3g/tests/Test_SimpleParentGridComp.pf
@@ -1,3 +1,4 @@
+#include "MAPL_TestErr.h"
 module Test_SimpleParentGridComp
    use mapl3g_GenericPhases
    use mapl3g_Generic
@@ -19,11 +20,6 @@ module Test_SimpleParentGridComp
    type(MultiState) :: parent_outer_states
 
 contains
-
-   ! This macro should only be used as safety for "unexpected" exceptions.
-#define _VERIFY(status) if(status /= 0) then; rc=status;print*,'ERROR AT: ',__FILE__,__LINE__, status; return; endif
-#define _RC rc=status); _VERIFY(status
-#define _HERE print*,__FILE__,__LINE__
 
    subroutine setup(outer_gc, states, rc)
       type(ESMF_GridComp), intent(inout) :: outer_gc

--- a/geom_mgr/tests/Test_GeomManager.pf
+++ b/geom_mgr/tests/Test_GeomManager.pf
@@ -1,3 +1,4 @@
+#include "MAPL_TestErr.h"
 module Test_GeomManager
    use pfunit
    use mapl3g_geom_mgr
@@ -105,7 +106,7 @@ contains
            rc=status)
       @assert_that(status, is(0))
       geom_manager = GeomManager()
-      spec = geom_manager%make_geom_spec(hconfig, rc=status)
+      allocate(spec, source=geom_manager%make_geom_spec(hconfig, rc=status))
       @assert_that(status, is(0))
       call ESMF_HConfigDestroy(hconfig, rc=status)
       @assert_that(status, is(0))
@@ -122,7 +123,8 @@ contains
       hconfig = ESMF_HConfigCreate(content="{schema: latlon, im_world: 10, jm_world: 13, pole: PC, dateline: DC, nx: 1, ny: 1}", &
            rc=status)
       @assert_that(status, is(0))
-      spec = geom_manager%make_geom_spec(hconfig, rc=status)
+      deallocate(spec)
+      allocate(spec, source=geom_manager%make_geom_spec(hconfig, rc=status))
       @assert_that(status, is(0))
       call ESMF_HConfigDestroy(hconfig, rc=status)
       @assert_that(status, is(0))

--- a/geom_mgr/tests/Test_LatLonGeomFactory.pf
+++ b/geom_mgr/tests/Test_LatLonGeomFactory.pf
@@ -22,7 +22,7 @@ contains
       hconfig = ESMF_HConfigCreate(content="{im_world: 12, jm_world: 13, pole: PC, dateline: DC, nx: 1, ny: 1}", rc=status)
       @assert_that(status, is(0))
 
-      geom_spec = factory%make_spec(hconfig, rc=status)
+      allocate(geom_spec, source=factory%make_spec(hconfig, rc=status))
       @assert_that(status, is(0))
 
       geom = factory%make_geom(geom_spec, rc=status)


### PR DESCRIPTION
Eliminated a few polymorphic assignments.  Sigh.  2008 is 16 years old now.

Ran unit tests  with gfortran 13 and nag on OS X laptop.