### PR TITLE
Fix test.

### DIFF
--- a/geom_mgr/tests/Test_GeomManager.pf
+++ b/geom_mgr/tests/Test_GeomManager.pf
@@ -59,7 +59,7 @@ contains
       @assert_that(status, is(0))
 
       geom_manager = GeomManager()
-      spec = geom_manager%make_geom_spec(hconfig, rc=status)
+      allocate(spec, source=geom_manager%make_geom_spec(hconfig, rc=status))
       @assert_that(status, is(0))
 
       mapl_geom_a => geom_manager%get_mapl_geom(spec, rc=status)


### PR DESCRIPTION
Workarounds for gfortran-13

Some tests still fail because we need a portable way to set path for udunits xml.