### PR TITLE
Add ESSENTIAL label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
           repo: MAPL
           mepodevelop: false
           run_unit_tests: true
-          ctest_options: "-LE 'PERFORMANCE|EXTDATA1G_BIG_TESTS|EXTDATA2G_BIG_TESTS' --output-on-failure"
+          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
           persist_workspace: true # Needed for MAPL tutorials
 
       # Builds MAPL in a "default" way - GNU
@@ -65,7 +65,7 @@ workflows:
           repo: MAPL
           mepodevelop: false
           run_unit_tests: true
-          ctest_options: "-E bundleio -LE 'PERFORMANCE|EXTDATA1G_BIG_TESTS|EXTDATA2G_BIG_TESTS' --output-on-failure"
+          ctest_options: "-E bundleio -L 'ESSENTIAL' --output-on-failure"
           persist_workspace: true # Needed for MAPL tutorials
 
       # Builds MAPL like UFS does (no FLAP and pFlogger, static)
@@ -83,7 +83,7 @@ workflows:
           remove_pflogger: true
           extra_cmake_options: "-DBUILD_WITH_FLAP=OFF -DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF -DUSE_EXTDATA2G=OFF -DBUILD_SHARED_MAPL=OFF"
           run_unit_tests: true
-          ctest_options: "-LE 'PERFORMANCE|EXTDATA1G_BIG_TESTS|EXTDATA2G_BIG_TESTS' --output-on-failure"
+          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
 
       # Run MAPL Tutorials
       - ci/run_mapl_tutorial:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The MAPL\_ESMFRegridder manage now does compute the transpose by default
 - Bypassed the I-Server reading call when there is no extdata
+- Created new `ESSENTIAL` ctest label for tests that must pass for a release
+  - These are "simple" quick tests that don't require a lot of resources
+  - With ESMA_cmake v3.43.0, `make tests` will only run tests with the `ESSENTIAL` label. To run all tests, use `make tests-all`
 - Update `components.yaml`
-  - ESMA_cmake v3.42.0
+  - ESMA_cmake v3.43.0
     - Updates to MPI detection
     - Enable `-quiet` flag for NAG
+    - `make tests` now only runs tests with the `ESSENTIAL` label. To run all tests, use `make tests-all`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add mask sampler for geostationary satellite (GEOS-R series)
 - Add geostation name into NC for station sampler
 - Add mapping between the IODA loc_index and trajectory NC output loc_index
-- Add allocate(X, _STAT) to sampler codes
+- Add `allocate(X, _STAT)` to sampler codes
 - Skip destroy_regen_grid when list(n)%end_alarm is active (the last time step in sampler)
 - Add extract_unquoted_item(STR1) to fix a bug in geoval_xname(mx_ngeoval) in trajectory sampler
 - Add `if (compute_transpose)` to sub. destroy_route_handle to avoid destroying a nonexisting route handle
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Updates to MPI detection
     - Enable `-quiet` flag for NAG
     - `make tests` now only runs tests with the `ESSENTIAL` label. To run all tests, use `make tests-all`
+    - `BUILT_ON_SLES15` set to `FALSE` on NCCS if not built on SLES15
+  - ESMA_env v4.25.1
+    - Baselibs 7.17.1
+      - Fixes for NAG
+      - Use GCC 11.4 as Intel backing compiler at NCCS SLES15
 
 ### Fixed
 

--- a/Tests/ExtData_Testing_Framework/CMakeLists.txt
+++ b/Tests/ExtData_Testing_Framework/CMakeLists.txt
@@ -17,9 +17,9 @@ foreach(TEST_CASE ${TEST_CASES_1G})
   endif()
   add_test(
      NAME "ExtData1G_${TEST_CASE}"
-     COMMAND ${CMAKE_COMMAND} 
-       -DTEST_CASE=${TEST_CASE} 
-       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE} 
+     COMMAND ${CMAKE_COMMAND}
+       -DTEST_CASE=${TEST_CASE}
+       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
        -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
        -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
        -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
@@ -28,6 +28,7 @@ foreach(TEST_CASE ${TEST_CASES_1G})
        )
   if (${num_procs} LESS ${cutoff})
      set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SMALL_TESTS")
+     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
   else()
      set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_BIG_TESTS")
   endif()
@@ -37,7 +38,7 @@ endforeach()
 file(STRINGS "test_cases/extdata_2g_cases.txt" TEST_CASES_2G)
 
 foreach(TEST_CASE ${TEST_CASES_2G})
-     
+
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc)
      file(READ ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc num_procs)
   else()
@@ -45,9 +46,9 @@ foreach(TEST_CASE ${TEST_CASES_2G})
   endif()
   add_test(
      NAME "ExtData2G_${TEST_CASE}"
-     COMMAND ${CMAKE_COMMAND} 
-       -DTEST_CASE=${TEST_CASE} 
-       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE} 
+     COMMAND ${CMAKE_COMMAND}
+       -DTEST_CASE=${TEST_CASE}
+       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
        -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
        -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
        -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
@@ -56,6 +57,7 @@ foreach(TEST_CASE ${TEST_CASES_2G})
      )
   if (${num_procs} LESS ${cutoff})
      set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_SMALL_TESTS")
+     set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
   else()
      set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_BIG_TESTS")
   endif()

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_pfunit_ctest(MAPL.base.tests
                 MAX_PES 8
                 )
 set_target_properties(MAPL.base.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.base.tests PROPERTIES LABELS "ESSENTIAL")
 
 add_dependencies(build-tests MAPL.base.tests)
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.24.0
+  tag: v4.25.1
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.43.0
+  tag: v3.44.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.42.0
+  tag: v3.43.0
   develop: develop
 
 ecbuild:

--- a/field_utils/tests/CMakeLists.txt
+++ b/field_utils/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_pfunit_ctest(MAPL.field_utils.tests
                 MAX_PES 4
                 )
 set_target_properties(MAPL.field_utils.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.field_utils.tests PROPERTIES LABELS "ESSENTIAL")
 
 if (APPLE)
   set(LD_PATH "DYLD_LIBRARY_PATH")

--- a/generic/tests/CMakeLists.txt
+++ b/generic/tests/CMakeLists.txt
@@ -15,5 +15,6 @@ add_pfunit_ctest(MAPL.generic.tests
                 MAX_PES 1
                 )
 set_target_properties(MAPL.generic.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.generic.tests PROPERTIES LABELS "ESSENTIAL")
 
 add_dependencies(build-tests MAPL.generic.tests)

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_pfunit_ctest(MAPL.pfio.tests
                 MAX_PES 8
                 )
 set_target_properties(MAPL.pfio.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.pfio.tests PROPERTIES LABELS "ESSENTIAL")
 
 include_directories(
    ${CMAKE_CURRENT_SOURCE_DIR}

--- a/profiler/tests/CMakeLists.txt
+++ b/profiler/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_pfunit_ctest (
   MAX_PES 8
   )
 set_target_properties(MAPL.profiler.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-  
+set_tests_properties(MAPL.profiler.tests PROPERTIES LABELS "ESSENTIAL")
+
 add_dependencies (build-tests MAPL.profiler.tests)
 

--- a/shared/tests/CMakeLists.txt
+++ b/shared/tests/CMakeLists.txt
@@ -16,5 +16,6 @@ add_pfunit_ctest(MAPL.shared.tests
                 LINK_LIBRARIES MAPL.shared
                 )
 set_target_properties(MAPL.shared.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.shared.tests PROPERTIES LABELS "ESSENTIAL")
 
 add_dependencies(build-tests MAPL.shared.tests)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds an `ESSENTIAL` label to many tests in MAPL. These are the "small" tests as it were. So it avoids the:

* `PERFORMANCE`
* `EXTDATA1G_BIG_TESTS`
* `EXTDATA2G_BIG_TESTS`

tests. This change along with [ESMA_cmake v3.43.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.43.0) (which this PR also updates to), means that when a user does `make tests` only the `ESSENTIAL` tests are run.

To run all the tests do `make tests-all`

Also, update to ESMA_env v4.25.1 to match GEOSgcm

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Makes testing MAPL on smaller machines a bit easier.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It worked on discover. `make tests` doesn't run all the tests now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
