### PR TITLE
Add DEPENDS_ON and DEPENDS_ON_CHILDREN options to ACG

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -49,8 +49,12 @@ RESTART_EMIT = make_entry_emit({'OPT'  : 'MAPL_RestartOptional', 'SKIP' : 'MAPL_
         'REQ'  : 'MAPL_RestartRequired', 'BOOT' : 'MAPL_RestartBoot',
         'SKIPI': 'MAPL_RestartSkipInitial'})
 
+# emit function for logical-valued functions
+LOGICAL_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
 # emit function for Option.ADD2EXPORT
-ADD2EXPORT_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
+ADD2EXPORT_EMIT = LOGICAL_EMIT
+# emit function for OPTION.DEPENDS_ON_CHILDREN
+DEPENDS_CHILDREN_EMIT = LOGICAL_EMIT
 
 # parent class for class Option
 # defines a few methods
@@ -89,6 +93,8 @@ Option = Enum(value = 'Option', names = {
         'AVINT': ('averaging_interval',),
         'DATATYPE': ('datatype',),
         'DEFAULT': ('default',),
+        'DEPENDS_ON_CHILDREN': ('depends_on_children', DEPENDS_CHILDREN_EMIT),
+        'DEPENDS_ON': ('depends_on', string_emit),
         'FIELD_TYPE': ('field_type',),
         'FRIENDLYTO': ('friendlyto', string_emit),
         'FRIEND2': ('friendlyto', string_emit),

--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -30,6 +30,25 @@ string_emit = lambda value: ("'" + value + "'") if value else None
 array_emit = lambda value: ('[' + value + ']') if value else None
 lstripped = lambda s: s.lower().strip(' .')
 
+# emit function for character arrays
+string_array_emit = lambda value: make_string_array(value) if value else None
+
+def make_string_array(s):
+    """ Returns a string representing a Fortran character array """
+    ss = s.strip()
+    if ',' in ss:
+        ls = [s.strip() for s in s.strip().split(',')]
+    else:
+        ls = s.strip().split()
+    ls = [rm_quotes(s) for s in ls]
+    ls = [s for s in ls if s]
+    n = max(ls)
+    ss = ','.join([add_quotes(s) for s in ls])
+    return f"[character(len={n}) :: {ss}]"
+
+rm_quotes = lambda s: s.strip().strip('"\'').strip()
+add_quotes = lambda s: "'" + s + "'"
+
 mangle_name = lambda name: string_emit(name.replace("*","'//trim(comp_name)//'")) if name else None 
 make_internal_name = lambda name: name.replace('*','') if name else None
 
@@ -56,7 +75,6 @@ FALSEVALUES = {'f', 'false', 'no', 'n', 'no', 'non', 'nao'}
 TRUE_VALUE = '.true.'
 FALSE_VALUE = '.false.'
 logical_emit = lambda s: TRUE_VALUE if lstripped(s) in TRUEVALUES else FALSE_VALUE if lstripped(s) in FALSEVALUES else None
-
 # emit function for Option.ADD2EXPORT
 ADD2EXPORT_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
 
@@ -98,7 +116,7 @@ Option = Enum(value = 'Option', names = {
         'DATATYPE': ('datatype',),
         'DEFAULT': ('default',),
         'DEPENDS_ON_CHILDREN': ('depends_on_children', logical_emit),
-        'DEPENDS_ON': ('depends_on', string_emit),
+        'DEPENDS_ON': ('depends_on', string_array_emit),
         'FIELD_TYPE': ('field_type',),
         'FRIENDLYTO': ('friendlyto', string_emit),
         'FRIEND2': ('friendlyto', string_emit),

--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -28,6 +28,7 @@ identity_emit = lambda value: value
 string_emit = lambda value: ("'" + value + "'") if value else None
 # Return value in brackets
 array_emit = lambda value: ('[' + value + ']') if value else None
+lstripped = lambda s: s.lower().strip(' .')
 
 mangle_name = lambda name: string_emit(name.replace("*","'//trim(comp_name)//'")) if name else None 
 make_internal_name = lambda name: name.replace('*','') if name else None
@@ -50,9 +51,14 @@ RESTART_EMIT = make_entry_emit({'OPT'  : 'MAPL_RestartOptional', 'SKIP' : 'MAPL_
         'SKIPI': 'MAPL_RestartSkipInitial'})
 
 # emit function for logical-valued functions
-LOGICAL_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
+TRUEVALUES = {'t', 'true', 'yes', 'y', 'si', 'oui', 'sim'}
+FALSEVALUES = {'f', 'false', 'no', 'n', 'no', 'non', 'nao'}
+TRUE_VALUE = '.true.'
+FALSE_VALUE = '.false.'
+LOGICAL_EMIT = lambda s: TRUE_VALUE if lstripped(s) in TRUEVALUES else FALSE_VALUE if lstripped(s) in FALSEVALUES else None
+
 # emit function for Option.ADD2EXPORT
-ADD2EXPORT_EMIT = LOGICAL_EMIT
+ADD2EXPORT_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
 # emit function for OPTION.DEPENDS_ON_CHILDREN
 DEPENDS_CHILDREN_EMIT = LOGICAL_EMIT
 

--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -50,17 +50,15 @@ RESTART_EMIT = make_entry_emit({'OPT'  : 'MAPL_RestartOptional', 'SKIP' : 'MAPL_
         'REQ'  : 'MAPL_RestartRequired', 'BOOT' : 'MAPL_RestartBoot',
         'SKIPI': 'MAPL_RestartSkipInitial'})
 
-# emit function for logical-valued functions
+# emit function for logical-valued options
 TRUEVALUES = {'t', 'true', 'yes', 'y', 'si', 'oui', 'sim'}
 FALSEVALUES = {'f', 'false', 'no', 'n', 'no', 'non', 'nao'}
 TRUE_VALUE = '.true.'
 FALSE_VALUE = '.false.'
-LOGICAL_EMIT = lambda s: TRUE_VALUE if lstripped(s) in TRUEVALUES else FALSE_VALUE if lstripped(s) in FALSEVALUES else None
+logical_emit = lambda s: TRUE_VALUE if lstripped(s) in TRUEVALUES else FALSE_VALUE if lstripped(s) in FALSEVALUES else None
 
 # emit function for Option.ADD2EXPORT
 ADD2EXPORT_EMIT = make_entry_emit({'T': '.true.', 'F': '.false.'})
-# emit function for OPTION.DEPENDS_ON_CHILDREN
-DEPENDS_CHILDREN_EMIT = LOGICAL_EMIT
 
 # parent class for class Option
 # defines a few methods
@@ -99,7 +97,7 @@ Option = Enum(value = 'Option', names = {
         'AVINT': ('averaging_interval',),
         'DATATYPE': ('datatype',),
         'DEFAULT': ('default',),
-        'DEPENDS_ON_CHILDREN': ('depends_on_children', DEPENDS_CHILDREN_EMIT),
+        'DEPENDS_ON_CHILDREN': ('depends_on_children', logical_emit),
         'DEPENDS_ON': ('depends_on', string_emit),
         'FIELD_TYPE': ('field_type',),
         'FRIENDLYTO': ('friendlyto', string_emit),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add python utilities to split and recombine restarts
 - Add a new "SPLIT\_CHECKPOINT:" option that has replaced the write-by-face option. This will write a file per writer
 - Implemented a new algorthm to read tile files
+- Added two options, depends_on and depends_on_children, to ACG
 
 ### Changed
 


### PR DESCRIPTION
## Description
For export specs, there are `DEPENDS_ON` (string of fields) and `DEPENDS_ON_CHILDREN` (logical) options. This PR adds `DEPENDS_ON` and `DEPENDS_ON_CHILDREN` Options to **ACG**, so **ACG** can generate export specs that include these two options.

## Motivation and Context
This allows the ACG to generate export specs with the `DEPENDS_ON` and `DEPENDS_ON_CHILDREN` options.
 
## How Has This Been Tested?
Since this is a new feature, that does not affect existing functionality, I ran the ACG script with a state spec file with fields that include neither option, each option separately, and both options. The resulting Fortran include file matches the expected result, while not affecting the declaration or get_pointer include files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
