### PR TITLE
Merge R21C into develop: Compress lats and lons in CS output if deflate requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix inconsistency in History output so that multi-dimensional coordinate variables are also compressed if requested in the collection
 - Minor workaround to enable NAG 7.2.01 to compile.  (Reproducer submitted to NAG.)
 - Fixed bug with split restart files
 - Removed unnecessary memory allocation for tile reads. This is critical for high res runs on SCU17

--- a/griddedio/GriddedIO.F90
+++ b/griddedio/GriddedIO.F90
@@ -128,6 +128,7 @@ module MAPL_GriddedIOMod
         integer :: metadataVarsSize
         type(StringStringMapIterator) :: s_iter
         character(len=:), pointer :: attr_name, attr_val
+        class(Variable), pointer :: coord_var
         integer :: status
 
         if ( allocated (this%metadata) ) deallocate(this%metadata)
@@ -164,6 +165,14 @@ module MAPL_GriddedIOMod
         factory => get_factory(this%output_grid,rc=status)
         _VERIFY(status)
         call factory%append_metadata(this%metadata)
+        coord_var => this%metadata%get_variable('lons')
+        if (associated(coord_var)) call coord_var%set_deflation(this%deflateLevel)
+        coord_var => this%metadata%get_variable('lats')
+        if (associated(coord_var)) call coord_var%set_deflation(this%deflateLevel)
+        coord_var => this%metadata%get_variable('corner_lons')
+        if (associated(coord_var)) call coord_var%set_deflation(this%deflateLevel)
+        coord_var => this%metadata%get_variable('corner_lats')
+        if (associated(coord_var)) call coord_var%set_deflation(this%deflateLevel)
 
 
         if (present(vdata)) then

--- a/pfio/Variable.F90
+++ b/pfio/Variable.F90
@@ -48,6 +48,7 @@ module pFIO_VariableMod
 
       procedure :: get_chunksizes
       procedure :: get_deflation
+      procedure :: set_deflation
       procedure :: get_quantize_algorithm
       procedure :: get_quantize_level
       procedure :: is_attribute_present
@@ -291,6 +292,12 @@ contains
 
       deflateLevel=this%deflation
    end function get_deflation
+
+   subroutine set_deflation(this,deflate_level)
+      class (Variable), target, intent(inout) :: this
+      integer, intent(in) :: deflate_level
+      this%deflation = deflate_level
+   end subroutine
 
    function get_quantize_algorithm(this) result(quantizeAlgorithm)
       class (Variable), target, intent(In) :: this


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #2683

If the variables in a collection are compressed, compress the coordinate variables too, just silly not too...

NOTE: This is zero-diff in regards to the state, but it will change a binary comparison of netcdf history output.

This is an attempt to merge from `R21C` into `develop`

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested this change with a run of GEOSgcm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
