### PR TITLE
work around #2703 and release pfio memory as early as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release the pfio memory as early as possible
 - Replace local HorzIJIndex sear with the GlobalHorzIJindex search
 - Change grd_is_ok function to avoid collective call
 - Allow fields with ungridded dimension and bundles to be created in ExtDataDriver.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<<<<<<< HEAD
 - Release the pfio memory as early as possible
 - Add glob function in sampler code, supporting wild character, e.g., filename template = `amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4`
 - Checked resource for o-server. It quits if the numer requested is inconsistent with being used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Use GCC 11.4 as Intel backing compiler at NCCS SLES15
 
 ### Fixed
-- Change to IntArry's pointer to store data to avoid Intel Ifort's bug
+- Change to IntArray's pointer to store data to avoid Intel Ifort bug
 - Fix inconsistency in History output so that multi-dimensional coordinate variables are also compressed if requested in the collection
 - Minor workaround to enable NAG 7.2.01 to compile.  (Reproducer submitted to NAG.)
 - Fixed bug with split restart files

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -2900,6 +2900,7 @@ contains
                 print*, "Error: It could be "
                 print*, "  1)Grid is NOT gnomonic_ed;"
                 print*, "  2)lats lons from MAPL_GridGetCorners are NOT accurate (single precision from ESMF)"
+                print*, "  3)This is a stretched grid which is not yet supported"
                 OK = .false.
                 return
              endif

--- a/pfio/ForwardDataAndMessage.F90
+++ b/pfio/ForwardDataAndMessage.F90
@@ -116,7 +116,7 @@ contains
         call this%msg_vec%erase(iter)
         iter = this%msg_vec%begin()
      enddo
-
+      _RETURN(_SUCCESS)
    end subroutine
 
 end module pFIO_ForwardDataAndMessageMod

--- a/pfio/ForwardDataAndMessage.F90
+++ b/pfio/ForwardDataAndMessage.F90
@@ -26,6 +26,7 @@ module pFIO_ForwardDataAndMessageMod
       procedure :: add_data_message
       procedure :: serialize
       procedure :: deserialize
+      procedure :: destroy
    end type ForwardDataAndMessage
 
    interface ForwardDataAndMessage
@@ -102,6 +103,20 @@ contains
       endif
 
       _RETURN(_SUCCESS)
+   end subroutine
+
+   subroutine destroy(this, rc)
+      class (ForwardDataAndMessage), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      type (MessageVectorIterator) :: iter
+
+      if (allocated(this%idata)) deallocate(this%idata)
+      iter = this%msg_vec%begin()
+      do while (iter /= this%msg_vec%end())
+        call this%msg_vec%erase(iter)
+        iter = this%msg_vec%begin()
+     enddo
+
    end subroutine
 
 end module pFIO_ForwardDataAndMessageMod

--- a/pfio/IntArray.F90
+++ b/pfio/IntArray.F90
@@ -26,6 +26,7 @@ module pFIO_IntArrayMod
 
    public :: IntArray
    type :: IntArray
+      private
       integer, pointer :: values(:)
    contains
       procedure :: get_values

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -418,7 +418,7 @@ contains
         endif
 
         call Mpi_Bcast( back_local_rank, 1, MPI_INTEGER, 0, this%front_comm, ierror)
-
+        if (allocated(this%buffers(back_local_rank+1)%buffer)) call MPI_Wait(this%buffers(back_local_rank+1)%request, MPI_STAT, ierror)
         call f_d_ms(collection_counter)%serialize(this%buffers(back_local_rank+1)%buffer)
         call f_d_ms(collection_counter)%destroy(_RC)
         msg_size= size(this%buffers(back_local_rank+1)%buffer)
@@ -426,8 +426,6 @@ contains
              this%back_ranks(back_local_rank+1), this%server_comm, ierror)
         call Mpi_Isend(this%buffers(back_local_rank+1)%buffer, msg_size, MPI_INTEGER, this%back_ranks(back_local_rank+1), &
             this%back_ranks(back_local_rank+1), this%server_comm, this%buffers(back_local_rank+1)%request,ierror)
-        call MPI_Wait(this%buffers(back_local_rank+1)%request, MPI_STAT, ierror)
-        deallocate(this%buffers(back_local_rank+1)%buffer)
         if (associated(ioserver_profiler)) call ioserver_profiler%stop("collection_"//i_to_string(collection_id))
      enddo
      if (associated(ioserver_profiler)) call ioserver_profiler%stop("forward_data")

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -811,6 +811,7 @@ contains
          enddo ! nfront
 
          call FileMetadata_deserialize(buffer_fmd, fmd)
+         deallocate (buffer_fmd)
 
          call thread_ptr%hist_collections%push_back(HistoryCollection(fmd))
 
@@ -832,16 +833,12 @@ contains
             call msg_iter%next()
             call array_ptr%destroy(_RC)
             call vars_map%erase(var_iter)
-         enddo
-         msg_iter = msg_map%begin()
-         do while (msg_iter /= msg_map%end())
-           call msg_map%erase(msg_iter)
-           msg_iter = msg_map%begin()
+            call msg_map%erase(msg_iter)
+            msg_iter = msg_map%begin()
          enddo
 
          call thread_ptr%clear_hist_collections()
          call thread_ptr%hist_collections%clear()
-         deallocate (buffer_fmd)
 
          time = file_timer%get_total()
          file_size = file_size*4./1024./1024. ! 4-byte integer, unit is converted to MB

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -833,6 +833,9 @@ contains
             call msg_iter%next()
             call array_ptr%destroy(_RC)
             call vars_map%erase(var_iter)
+         enddo
+         msg_iter = msg_map%begin()
+         do while (msg_iter /= msg_map%end())
             call msg_map%erase(msg_iter)
             msg_iter = msg_map%begin()
          enddo


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Save data to a integer array pointer to work around #2703 . This PR also releases the pfio memory as early as possible
## Related Issue

