### PR TITLE
Use glob function to allow wild character in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add glob function in sampler code, supporting wild character, e.g., filename template = amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4
 - Checked resource for o-server. It quits if the numer requested is inconsistent with being used
 - Replace local HorzIJIndex sear with the GlobalHorzIJindex search
 - Change grd_is_ok function to avoid collective call

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -47,7 +47,7 @@ set (srcs
   ESMF_CFIOPtrVectorMod.F90
   CFIOCollection.F90                    MAPL_CFIO.F90
   regex_module.F90 StringTemplate.F90 MAPL_SphericalGeometry.F90
-  regex_F.c
+  regex_F.c  MAPL_ObsUtil.c
   c_mapl_locstream_F.c  getrss.c  memuse.c
   Base/Base_Base.F90 Base/Base_Base_implementation.F90
   TimeStringConversion.F90

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -948,7 +948,6 @@ contains
     filename=""
     if (slen>0) filename(1:slen)=c_filename(1:slen)
 
-    deallocate(c_search_name)
     return
   end subroutine fglob
 

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -574,12 +574,9 @@ contains
 
     ! parse time info
     !
-    !
     allow_wild_char=.true.
     j= index(file_template, '*')
-    if (.NOT. allow_wild_char .AND. j>0) then
-       _FAIL("* is not allowed in template")
-    end if
+    _ASSERT ( j==0 .OR. allow_wild_char, "* is not allowed in template")
     call fill_grads_template ( filename, file_template, &
          experiment_id='', nymd=nymd, nhms=nhms, _RC )
     if (j==0) then
@@ -588,12 +585,8 @@ contains
     else
        ! now filename is:  file*.nc
        call fglob(filename, filename2, rc=status)
-       if (status==0) then
-          exist=.true.
-          filename=trim(filename2)
-       else
-          exist=.false.
-       end if
+       exist = (status==0)
+       if (exist) filename=trim(filename2)
     end if
 
     _RETURN(_SUCCESS)

--- a/base/MAPL_ObsUtil.c
+++ b/base/MAPL_ObsUtil.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <string.h>
+#include <glob.h>
+
+int glob_C (char*, char*, int*);
+
+int glob_C (char *pattern, char *filename, int* stringlen)
+{
+  glob_t  globlist;
+  int error = 1;
+  int failure = -1;
+  char *s;
+
+  int j = glob( pattern, GLOB_ERR, NULL, &globlist );
+  if ( j == GLOB_NOSPACE  || j == GLOB_NOMATCH )
+    return (failure);
+  if ( j == GLOB_ABORTED)
+    return (error);
+
+  int i = 0;
+  for (; globlist.gl_pathv[i] ; ++i)
+    // printf("f = %s\n", globlist.gl_pathv[i]);
+    ;
+  s = globlist.gl_pathv[--i];
+  for (i=0; *(s+i) != '\0'; i++)
+    *(filename+i) = *(s+i);
+  if (i>512) return error;
+  *stringlen = i;
+
+  return 0;
+}

--- a/base/MAPL_ObsUtil.c
+++ b/base/MAPL_ObsUtil.c
@@ -4,28 +4,29 @@
 
 int glob_C (char*, char*, int*);
 
-int glob_C (char *pattern, char *filename, int* stringlen)
+int glob_C (char *pattern, char *filename, int *stringlen)
 {
   glob_t  globlist;
   int error = 1;
   int failure = -1;
   char *s;
+  int MAXLEN = 512;  // set path length limit
 
   int j = glob( pattern, GLOB_ERR, NULL, &globlist );
-  if ( j == GLOB_NOSPACE  || j == GLOB_NOMATCH )
+  if ( j == GLOB_NOSPACE || j == GLOB_NOMATCH )
     return (failure);
   if ( j == GLOB_ABORTED)
     return (error);
 
   int i = 0;
-  for (; globlist.gl_pathv[i] ; ++i)
+  for (; globlist.gl_pathv[i] ; i++)
     // printf("f = %s\n", globlist.gl_pathv[i]);
     ;
   s = globlist.gl_pathv[--i];
   for (i=0; *(s+i) != '\0'; i++)
     *(filename+i) = *(s+i);
-  if (i>512) return error;
   *stringlen = i;
 
+  if ( i > MAXLEN ) return error;
   return 0;
 }


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

In the current sampler code (interpolation for each time interval along model run),  reading a filename with template sometimes requires us to rename the observation file name to concord with the template.  For example, 
```
template = MYD04_L2.A%y4%D3.%h2%n2.hdf
obs file = MYD04_L2.A2019262.2305.061.2019263152708.hdf
requiring user to either link the file (or rename it)
MOD04_L2.A2019212.2330.hdf -> MOD04_L2.A2019212.2330.061.2019213072220.hdf
```

This is simplified, if wild character is allowed
```
template = MYD04_L2.A%y4%D3.%h2%n2*.hdf
```
@amdasilva suggested using glob function to enable * character in template.  
This PR is a code implementation.

Example input:
```
PLATFORM.airs_aqua::
    file_name_template:  airs_aqua.%y4%m2%d2T%h2%n2*.nc4
PLATFORM.amsr2_gcom-w1::
    file_name_template: amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4
```

Sampler code output:
```
        sampler: DEBUG: non-exist: filename fid j  :          0
        sampler: DEBUG: non-exist: missing filename: /Users/yyu11/ModelData/JEDI/ioda/Y2019/M08/D01/H00_06/airs_aqua.20190731T2100*.nc4
        sampler: DEBUG: non-exist: filename fid j  :          1
        sampler: DEBUG: non-exist: missing filename: /Users/yyu11/ModelData/JEDI/ioda/Y2019/M08/D01/H00_06/airs_aqua.20190801T0300*.nc4
        sampler: DEBUG: exist: filename fid j      :          0
        sampler: DEBUG: exist: true filename       : /Users/yyu11/ModelData/JEDI/ioda/Y2019/M08/D01/H00_06/amsr2_gcom-w1.20190731T210000Z.nc4
        sampler: DEBUG: exist: filename fid j      :          1
        sampler: DEBUG: exist: true filename       : /Users/yyu11/ModelData/JEDI/ioda/Y2019/M08/D01/H00_06/amsr2_gcom-w1.20190801T030000Z.nc4
        sampler: DEBUG: nobs from input file:        12584
```

## Related Issue

