### PR TITLE
Fixed issue with ordering of childern setservices

### DIFF
--- a/MAPL/GEOS.F90
+++ b/MAPL/GEOS.F90
@@ -5,6 +5,7 @@ program geos
    use mapl3g
    use mapl_ErrorHandling
    use esmf
+   use pflogger, only: pflogger_initialize => initialize
    implicit none
 
    integer :: status
@@ -12,6 +13,7 @@ program geos
    type(ESMF_HConfig) :: hconfig
 
    call ESMF_Initialize(configFileNameFromArgNum=1, configKey=['esmf'], config=config, _RC)
+   call pflogger_initialize()
    call ESMF_ConfigGet(config, hconfig=hconfig, _RC)
    call run_geos(hconfig, _RC)
    call ESMF_Finalize(_RC)

--- a/generic3g/GenericGridComp.F90
+++ b/generic3g/GenericGridComp.F90
@@ -41,6 +41,7 @@ contains
       type(OuterMetaComponent), pointer :: outer_meta
 
       outer_meta => get_outer_meta(gridcomp, _RC)
+      call outer_meta%setServices(_RC)
       call set_entry_points(gridcomp, _RC)
 
       _RETURN(ESMF_SUCCESS)
@@ -113,15 +114,14 @@ contains
       user_clock = ESMF_ClockCreate(clock, _RC)
       user_gc_driver = GriddedComponentDriver(user_gridcomp, user_clock, MultiState())
 #ifndef __GFORTRAN__
-      outer_meta = OuterMetaComponent(gridcomp, user_gc_driver, config)
+      outer_meta = OuterMetaComponent(gridcomp, user_gc_driver, set_services, config)
 #else
       ! GFortran 12 & 13 cannot directly assign to outer_meta.  But
       ! the assignment works for an object without the POINTER
       ! attribute.  An internal procedure is a workaround, but
       ! ... ridiculous.
-      call ridiculous(outer_meta, OuterMetaComponent(gridcomp, user_gc_driver, config))
+      call ridiculous(outer_meta, OuterMetaComponent(gridcomp, user_gc_driver, set_services, config))
 #endif
-      call outer_meta%setservices(set_services, _RC)
       call outer_meta%init_meta(_RC)
 
 

--- a/generic3g/OuterMetaComponent_smod.F90
+++ b/generic3g/OuterMetaComponent_smod.F90
@@ -29,9 +29,8 @@ contains
    ! reverse when step (3) is moved to a new generic initialization phase.
    !=========================================================================
    
-   recursive module subroutine SetServices_(this, user_setservices, rc)
+   recursive module subroutine SetServices_(this, rc)
       use mapl3g_GenericGridComp, only: generic_setservices => setservices
-      class(AbstractUserSetServices), intent(in) :: user_setservices
       class(OuterMetaComponent), intent(inout) :: this
       integer, intent(out) :: rc
 
@@ -41,8 +40,9 @@ contains
       this%component_spec = parse_component_spec(this%hconfig, _RC)
       user_gridcomp = this%user_gc_driver%get_gridcomp()
       call attach_inner_meta(user_gridcomp, this%self_gridcomp, _RC)
+      call this%user_setservices%run(user_gridcomp, _RC)
       call add_children(this, _RC)
-      call user_setservices%run(user_gridcomp, _RC)
+      call run_children_setservices(this, _RC)
 
       _RETURN(ESMF_SUCCESS)
 
@@ -120,7 +120,6 @@ contains
       clock = this%user_gc_driver%get_clock()
       child_clock = ESMF_ClockCreate(clock, _RC)
       child_gc = create_grid_comp(child_name, setservices, hconfig, clock, _RC)
-      call ESMF_GridCompSetServices(child_gc, generic_setservices, _RC)
 
       child_gc_driver = GriddedComponentDriver(child_gc, child_clock, MultiState())
 

--- a/generic3g/tests/Test_RunChild.pf
+++ b/generic3g/tests/Test_RunChild.pf
@@ -1,3 +1,5 @@
+#include "MAPL_TestErr.h"
+
 module Test_RunChild
    use mapl3g_GenericGridComp
    use mapl3g_Generic


### PR DESCRIPTION


## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Not really a bug, and not really a new feature.

Previously children setservices would run during AddChild() which was a bit confusing in some contexts.  Fixing that exposed a few other minor issues that are fixed here too.

## Related Issue

