### PR TITLE
fixes #2753

### DIFF
--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -705,6 +705,7 @@ contains
       integer :: status
       type(ESMF_Info) :: ungridded_dims_info
       type(ESMF_Info) :: vertical_dim_info
+      type(ESMF_Info) :: vertical_geom_info
 
       type(ESMF_Info) :: field_info
 
@@ -715,9 +716,22 @@ contains
       call ESMF_InfoDestroy(ungridded_dims_info, _RC)
 
       vertical_dim_info = this%vertical_dim%make_info(_RC)
-
-      call ESMF_InfoSet(field_info, key='MAPL/vertical', value=vertical_dim_info, _RC)
+      call ESMF_InfoSet(field_info, key='MAPL/vertical_dim', value=vertical_dim_info, _RC)
       call ESMF_InfoDestroy(vertical_dim_info, _RC)
+
+      vertical_geom_info = this%vertical_geom%make_info(_RC)
+      call ESMF_InfoSet(field_info, key='MAPL/vertical_geom', value=vertical_geom_info, _RC)
+      call ESMF_InfoDestroy(vertical_geom_info, _RC)
+
+      if (allocated(this%units)) then
+         call ESMF_InfoSet(field_info, key='MAPL/units', value=this%units, _RC)
+      end if
+      if (allocated(this%long_name)) then
+         call ESMF_InfoSet(field_info, key='MAPL/long_name', value=this%long_name, _RC)
+      end if
+      if (allocated(this%standard_name)) then
+         call ESMF_InfoSet(field_info, key='MAPL/standard_name', value=this%standard_name, _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine set_info

--- a/generic3g/tests/Test_FieldInfo.pf
+++ b/generic3g/tests/Test_FieldInfo.pf
@@ -23,6 +23,8 @@ contains
       integer :: status
       logical :: found
       real, allocatable :: coords(:)
+      character(len=:), allocatable :: temp_string
+      integer :: temp_int
       
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom = ESMF_GeomCreate(grid, _RC)
@@ -33,18 +35,24 @@ contains
 
       spec = FieldSpec(geom, vertical_geom, VERTICAL_DIM_CENTER, &
            ESMF_TYPEKIND_R4, ungridded_dims_spec, &
-           '', '', 'unknown')
+           't', 'p', 'unknown')
 
       f = ESMF_FieldCreate(geom, ESMF_TYPEKIND_R4, ungriddedLbound=[1,1], ungriddedUbound=[2,3], _RC)
       call spec%set_info(f, _RC)
 
       call ESMF_InfoGetFromHost(f, info, _RC)
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical', _RC)
+      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_dim', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical/vloc', _RC)
+      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_dim/vloc', _RC)
       @assert_that(found, is(true()))
 
+      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_geom', _RC)
+      @assert_that(found, is(true()))
+      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_geom/num_levels', _RC)
+      @assert_that(found, is(true()))
+      call ESMF_InfoGet(info, 'MAPL/vertical_geom/num_levels',temp_int , _RC)
+      @assert_that(temp_int, equal_to(4))
 
       found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims', _RC)
       @assert_that(found, is(true()))
@@ -71,6 +79,20 @@ contains
       call ESMF_InfoGetAlloc(info, 'MAPL/ungridded_dims/dim_2/coordinates', coords, _RC)
       @assert_that(coords, equal_to([1.,2.,3.]))
 
+      found = ESMF_InfoIsPresent(info, key='MAPL/standard_name', _RC)
+      @assert_that(found, is(true()))
+      call ESMF_InfoGetCharAlloc(info, 'MAPL/standard_name', temp_string, _RC)
+      @assert_that(temp_string, equal_to("t"))
+
+      found = ESMF_InfoIsPresent(info, key='MAPL/long_name', _RC)
+      @assert_that(found, is(true()))
+      call ESMF_InfoGetCharAlloc(info, 'MAPL/long_name', temp_string, _RC)
+      @assert_that(temp_string, equal_to("p"))
+
+      found = ESMF_InfoIsPresent(info, key='MAPL/units', _RC)
+      @assert_that(found, is(true()))
+      call ESMF_InfoGetCharAlloc(info, 'MAPL/units', temp_string, _RC)
+      @assert_that(temp_string, equal_to("unknown"))
 
    end subroutine test_field_set_info
 end module Test_FieldInfo


### PR DESCRIPTION
Fixes #2753 

This adds all available information to the ESMF_Info object attached to fields when they are created.
I updated the units tests.
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

