### PR TITLE
Add Ford CI job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,6 +13,20 @@ on:
       - ".editorconfig"
 
 jobs:
+  check-ford-docs:
+    name: Build Ford Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and Deploy Docs
+        uses: ./.github/actions/deploy-ford-docs
+        with:
+          ford-input: docs/Ford/ford-ci.md
+          doc-folder: docs/Ford/ci-doc
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   build_test_mapl:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add glob function in sampler code, supporting wild character, e.g., filename template = amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4
+- Add glob function in sampler code, supporting wild character, e.g., filename template = `amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4`
 - Checked resource for o-server. It quits if the numer requested is inconsistent with being used
 - Replace local HorzIJIndex sear with the GlobalHorzIJindex search
 - Change grd_is_ok function to avoid collective call
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new "SPLIT\_CHECKPOINT:" option that has replaced the write-by-face option. This will write a file per writer
 - Implemented a new algorthm to read tile files
 - Added two options, depends_on and depends_on_children, to ACG
+- Add CI job to test Ford build (does not publish)
 
 ### Changed
 

--- a/docs/Ford/ford-ci.md
+++ b/docs/Ford/ford-ci.md
@@ -1,0 +1,68 @@
+---
+preprocessor: cpp -traditional-cpp -E
+src_dir: ../../
+output_dir: ci-doc
+search: false
+graph: false
+coloured_edges: true
+graph_maxdepth: 4
+graph_maxnodes: 32
+include: ../../include/
+         ../../gFTL/install/GFTL-1.13/include/v1
+         ../../gFTL/install/GFTL-1.13/include/v2
+exclude: **/EsmfRegridder.F90
+         **/FieldBLAS_IntrinsicFunctions.F90
+         **/GeomManager.F90
+         **/MaplGeom.F90
+         **/Regridder.F90
+         **/StateSupplement.F90
+exclude_dir: ../../docs
+             ../../Doxygen
+             ../../ESMA_cmake
+             ../../ESMA_env
+             ../../build
+             ../../gFTL
+             ../../esmf
+             ../../pFUnit
+             ../../fArgParse
+             ../../pFlogger
+macro: USE_MPI=1
+       BUILD_WITH_PFLOGGER=1
+       BUILD_WITH_EXTDATA2G=1
+       USE_FLAP=1
+       H5_HAVE_PARALLEL=1
+       TWO_SIDED_COMM=1
+       MAPL_MODE=1
+fixed_length_limit: false
+source: true
+display: public
+         private
+         protected
+extra_mods: iso_fortran_env:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fFORTRAN_005fENV.html
+            iso_c_binding:https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html#ISO_005fC_005fBINDING
+external: remote = https://mathomp4.github.io/esmf
+project: MAPL
+project_github: https://github.com/GEOS-ESM/MAPL
+project_website: https://github.com/GEOS-ESM/MAPL
+summary: MAPL is a foundation layer of the GEOS architecture, whose original purpose is to supplement the Earth System Modeling Framework (ESMF)
+author: The MAPL Developers
+github: https://github.com/GEOS-ESM
+email: matthew.thompson@nasa.gov
+print_creation_date: true
+sort: type-alpha
+predocmark_alt: >
+predocmark: <
+docmark_alt:
+docmark: !
+md_extensions: markdown.extensions.toc
+               markdown.extensions.smarty
+extensions: f90
+            F90
+            pf
+fpp_extensions: F90
+                pf
+                F
+externalize: true
+---
+
+{!../../README.md!}


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR adds a new CI job checking to see if Ford docs are broken by a PR. This helps @JulesKouatchou and myself make sure that when we make a release on `main` the docs should work.

I was inspired by the talks at ISSC 2024 where CI + docs was a common theme. :)

NOTE: This does *NOT* do the graph and search functions of Ford as those can take a long time. So this isn't a one-to-one match with the full docs. But should only take a few minutes compared to ~15-20 minutes with the full docs.


## Related Issue

Closes #2759 