### PR TITLE
Fixes #2761 - RECURSIVE attribute needed

### DIFF
--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -253,8 +253,7 @@ contains
 
    ! In this procedure, gridcomp is actually an _outer_ gridcomp.   The intent is that
    ! an inner gridcomp will call this on its child which is a wrapped user comp.
-
-   subroutine run_child_by_name(gridcomp, child_name, unusable, phase_name, rc)
+   recursive subroutine run_child_by_name(gridcomp, child_name, unusable, phase_name, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       character(len=*), intent(in) :: child_name
       class(KeywordEnforcer), optional, intent(in) :: unusable
@@ -272,7 +271,7 @@ contains
    end subroutine run_child_by_name
 
 
-   subroutine run_children(gridcomp, unusable, phase_name, rc)
+   recursive subroutine run_children(gridcomp, unusable, phase_name, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       class(KeywordEnforcer), optional, intent(in) :: unusable
       character(len=*), intent(in) :: phase_name

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -44,11 +44,13 @@ contains
       type(ESMF_Clock) :: clock
       character(:), allocatable :: cap_name
       integer :: status, user_status
+      type(ESMF_HConfig) :: cap_gc_hconfig
 
-      cap_name = ESMF_HConfigAsString(hconfig, keystring='cap_name', _RC)
+      cap_name = ESMF_HConfigAsString(hconfig, keystring='name', _RC)
       ! TODO:  Rename to MAPL_CreateGridComp() ?
       clock = create_clock(hconfig, _RC)
-      cap_gridcomp = create_grid_comp(cap_name, user_setservices(cap_setservices), hconfig, clock, _RC)
+      cap_gc_hconfig = ESMF_HConfigCreateAt(hconfig, keystring='cap_gc', _RC)
+      cap_gridcomp = create_grid_comp(cap_name, user_setservices(cap_setservices), cap_gc_hconfig, clock, _RC)
       call ESMF_GridCompSetServices(cap_gridcomp, generic_setServices, userRC=user_status, _RC)
       _VERIFY(user_status)
 

--- a/gridcomps/cap3g/tests/basic_captest/cap.yaml
+++ b/gridcomps/cap3g/tests/basic_captest/cap.yaml
@@ -1,42 +1,41 @@
-cap_name: bob
-
-clock:
-  dt: PT1H
-  start: 1891-03-01T00:00:00
-  stop: 2999-03-02T21:00:00
-  segment_duration: PT10H
-
-num_segments: 1 # segments per batch submission
-
-run_extdata: false
-extdata_name: EXTDATA
-history_name: HIST
-root_name: GCM
-
-mapl:
-  children:
-    GCM:
-      dso: libconfigurable_leaf_gridcomp.dylib
-      setServices: setservices_
-      config_file: GCM.yaml
-    #EXTDATA:
-      #dso: libextdata_gc
-      #config_file: extdata.yaml
-    HIST:
-      dso: libMAPL.history3g.dylib
-      config_file: history.yaml
-
-# Global services
 esmf:
   logKindFlag: ESMF_LOGKIND_MULTI_ON_ERROR
 
-servers:
-  pfio:
-    num_nodes: 9
-  model:
-    num_nodes: any
+#mapl:
+#  pflogger_cfg_file: pflogger.yaml
 
-mapl:
-  pflogger_cfg_file: pflogger.yaml
+cap:
+  name: cap
 
-    
+  clock:
+    dt: PT1H
+    start: 1891-03-01T00:00:00
+    stop: 2999-03-02T21:00:00
+    segment_duration: PT10H
+
+    num_segments: 1 # segments per batch submission
+
+    servers:
+      pfio:
+        num_nodes: 9
+      model:
+        num_nodes: any
+
+  cap_gc:
+    run_extdata: false
+    extdata_name: EXTDATA
+    history_name: HIST
+    root_name: GCM
+
+    mapl:
+      children:
+        GCM:
+          dso: libconfigurable_leaf_gridcomp.dylib
+          setServices: setservices_
+          config_file: GCM.yaml
+        #EXTDATA:
+          #dso: libextdata_gc
+          #config_file: extdata.yaml
+        HIST:
+          dso: libMAPL.history3g.dylib
+          config_file: history.yaml

--- a/gridcomps/cap3g/tests/basic_captest/cap.yaml
+++ b/gridcomps/cap3g/tests/basic_captest/cap.yaml
@@ -30,11 +30,13 @@ mapl:
 esmf:
   logKindFlag: ESMF_LOGKIND_MULTI_ON_ERROR
 
-pflogger:
-  config_file: pflogger.yaml
-
 servers:
   pfio:
     num_nodes: 9
   model:
     num_nodes: any
+
+mapl:
+  pflogger_cfg_file: pflogger.yaml
+
+    

--- a/mapl3g/GEOS.F90
+++ b/mapl3g/GEOS.F90
@@ -23,7 +23,8 @@ contains
       integer, optional, intent(out) :: rc
       
       integer :: status
-      type(ESMF_HConfig) :: hconfig, mapl_hconfig
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_HConfig), allocatable :: mapl_hconfig
       logical :: has_mapl_section
 
       call ESMF_Initialize(configFilenameFromArgNum=1, configKey=['esmf'], config=config, _RC)
@@ -41,11 +42,16 @@ contains
       type(ESMF_Config), intent(inout) :: config
       integer, optional, intent(out) :: rc
 
-      type(ESMF_HConfig) :: cap_hconfig
+      type(ESMF_HConfig) :: cap_hconfig, hconfig
+      logical :: has_cap_hconfig
       integer :: status
 
-      call ESMF_ConfigGet(config, hconfig=cap_hconfig, _RC)
+      call ESMF_ConfigGet(config, hconfig=hconfig, _RC)
+      has_cap_hconfig = ESMF_HConfigIsDefined(hconfig, keystring='cap', _RC)
+      _ASSERT(has_cap_hconfig, 'No cap section found in configuration file')
+      cap_hconfig = ESMF_HConfigCreateAt(hconfig, keystring='cap', _RC)
       call MAPL_run_driver(cap_hconfig, _RC)
+      call ESMF_HConfigDestroy(cap_hconfig, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine run_geos

--- a/mapl3g/MaplFramework.F90
+++ b/mapl3g/MaplFramework.F90
@@ -110,7 +110,7 @@ contains
       integer :: status
 
 !#      call finalize_profiler(_RC)
-!#      call pflogger_finalize()
+      call logging%free()
       
       _RETURN(_SUCCESS)
    end subroutine finalize

--- a/mapl3g/MaplFramework.F90
+++ b/mapl3g/MaplFramework.F90
@@ -69,9 +69,11 @@ contains
       call ESMF_VMGet(mapl_vm, mpiCommunicator=comm_world, _RC)
 
 #ifdef BUILD_WITH_PFLOGGER
-      has_pflogger_cfg_file = ESMF_HConfigIsDefined(mapl_hconfig, keystring="pflogger_cfg_file", _RC)
-      if (has_pflogger_cfg_file) then
-         pflogger_cfg_file = ESMF_HConfigAsString(mapl_hconfig, keystring="pflogger_cfg_file", _RC)
+      if (present(mapl_hconfig)) then
+         has_pflogger_cfg_file = ESMF_HConfigIsDefined(mapl_hconfig, keystring="pflogger_cfg_file", _RC)
+         if (has_pflogger_cfg_file) then
+            pflogger_cfg_file = ESMF_HConfigAsString(mapl_hconfig, keystring="pflogger_cfg_file", _RC)
+         end if
       end if
       call initialize_pflogger(pflogger_cfg_file=pflogger_cfg_file, comm_world=comm_world, _RC)
 #endif


### PR DESCRIPTION
GFortran 13 still does not implement F2008 default RECURSIVE, so it must be added on select procedures.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

