### PR TITLE
Fix an error in filename when wild character is introduced into template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bug fix for filename with wild character in trajectory sampler
 - Add glob function in sampler code, supporting wild character, e.g., filename template = `amsr2_gcom-w1.%y4%m2%d2T%h2%n2*.nc4`
 - Checked resource for o-server. It quits if the numer requested is inconsistent with being used
 - Replace local HorzIJIndex sear with the GlobalHorzIJindex search

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -43,7 +43,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          character(len=ESMF_MAXSTR), allocatable :: word(:)
          integer                    :: nobs, head, jvar
          logical                    :: tend
-         integer                    :: i, j, k, M
+         integer                    :: i, j, k, k2, M
          integer                    :: count, idx
          integer                    :: unitr, unitw
          type(GriddedIOitem)        :: item
@@ -235,12 +235,21 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          do i=1, traj%nobs_type
             call lgr%debug('%a %i4 %a  %a', 'obs(', i, ') input_template =', &
                  trim(traj%obs(i)%input_template))
-            j=index(traj%obs(i)%input_template , '%')
             k=index(traj%obs(i)%input_template , '/', back=.true.)
-            _ASSERT(j>0, '% is not found,  template is wrong')
-            traj%obs(i)%name = traj%obs(i)%input_template(k+1:j-1)
+            j=index(traj%obs(i)%input_template(k+1:), '%')
+            if (j>0) then
+               ! normal case:  geos_atmosphere/aircraft.%y4%m2%d2T%h2%n2%S2Z.nc4
+               traj%obs(i)%name = traj%obs(i)%input_template(k+1:k+j-1)
+            else
+               ! different case:  Y%y4/M%m2/.../this.nc or ./this
+               k2=index(traj%obs(i)%input_template(k+1:), '.')
+               if (k2>0) then
+                  traj%obs(i)%name = traj%obs(i)%input_template(k+1:k+k2)
+               else
+                  traj%obs(i)%name = trim(traj%obs(i)%input_template(k+1:))
+               end if
+            end if
          end do
-
 
          _RETURN(_SUCCESS)
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
A bug in filename output is found then fixed when reading in 
template=`aist-nr/data/ioda_reshuffle/%y4%m2%d2/geos_atmosphere/omi_aura.%y4%m2%d2T%h2%n2%S2Z.nc4`

## Related Issue

