### PR TITLE
Fixes #2771  

### DIFF
--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -195,7 +195,6 @@ contains
          type(ESMF_HConfigIter) :: iter,e,b
          character(:), allocatable :: name
          character(:), allocatable :: short_name
-         character(:), allocatable :: substate
          type(ESMF_HConfig) :: attributes
          type(ESMF_TypeKind_Flag) :: typekind
          real, allocatable :: default_value
@@ -226,7 +225,6 @@ contains
             name = ESMF_HConfigAsStringMapKey(iter, _RC)
             attributes = ESMF_HConfigCreateAtMapVal(iter,_RC)
 
-!#            call split(name, short_name, substate)
             short_name = name
             typekind = to_typekind(attributes, _RC)
             call val_to_float(default_value, attributes, 'default_value', _RC)
@@ -256,7 +254,6 @@ contains
                  standard_name=standard_name, &
                  units=units, &
                  typekind=typekind, &
-!#                 substate=substate, &
                  default_value=default_value, &
                  vertical_dim_spec=vertical_dim_spec, &
                  ungridded_dims=ungridded_dim_specs, &
@@ -275,23 +272,6 @@ contains
 
          _RETURN(_SUCCESS)
       end subroutine parse_state_specs
-
-      subroutine split(name, short_name, substate)
-         character(*), intent(in) :: name
-         character(:), allocatable, intent(out) :: short_name
-         character(:), allocatable, intent(out) :: substate
-
-         integer :: idx
-
-         idx = index(name, '/')
-         if (idx == 0) then
-            short_name = name
-            return
-         end if
-
-         short_name = name(idx+1:)
-         substate = name(:idx-1)
-      end subroutine split
 
       subroutine val_to_float(x, attributes, key, rc)
          real, allocatable, intent(out) :: x

--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -226,8 +226,8 @@ contains
             name = ESMF_HConfigAsStringMapKey(iter, _RC)
             attributes = ESMF_HConfigCreateAtMapVal(iter,_RC)
 
-            call split(name, short_name, substate)
-
+!#            call split(name, short_name, substate)
+            short_name = name
             typekind = to_typekind(attributes, _RC)
             call val_to_float(default_value, attributes, 'default_value', _RC)
             vertical_dim_spec = to_VerticalDimSpec(attributes,_RC)
@@ -256,7 +256,7 @@ contains
                  standard_name=standard_name, &
                  units=units, &
                  typekind=typekind, &
-                 substate=substate, &
+!#                 substate=substate, &
                  default_value=default_value, &
                  vertical_dim_spec=vertical_dim_spec, &
                  ungridded_dims=ungridded_dim_specs, &

--- a/generic3g/ESMF_Utilities.F90
+++ b/generic3g/ESMF_Utilities.F90
@@ -154,24 +154,22 @@ contains
       current_path = path
       do while (path /= '')
          idx = index(current_path, '/')
-         if (idx == 0) then
-            substate_name = current_path
-         else
+         substate_name = current_path
+         if (idx > 0) then
             substate_name = current_path(:idx-1)
          end if
 
          call ESMF_StateGet(substate, substate_name, itemType, _RC)
          
-         if (itemType == ESMF_STATEITEM_NOTFOUND) then ! New substate
+         if (itemType == ESMF_STATEITEM_NOTFOUND) then ! New tmp_state
             tmp_state = ESMF_StateCreate(name=substate_name, _RC)
             call ESMF_StateAdd(substate, [tmp_state], _RC)
-            substate = tmp_state
          else
-            _ASSERT(itemType == ESMF_STATEITEM_STATE, 'incorrect object in state')
+            _ASSERT(itemType == ESMF_STATEITEM_STATE, 'expected ' // substate_name // ' to be an ESMF_State.')
             call ESMF_StateGet(substate, substate_name, tmp_state, _RC)
-            substate = tmp_state
          end if
-         _RETURN_IF(idx == 0)
+         substate = tmp_state
+         if (idx == 0) exit
          current_path = current_path(idx+1:)
       end do
 

--- a/generic3g/ESMF_Utilities.F90
+++ b/generic3g/ESMF_Utilities.F90
@@ -131,39 +131,50 @@ contains
 
    end subroutine write_state_
 
-   ! If name is empty string then return the existing state.
-   ! Otherwise, return the named substate; creating it if it does
-   ! not already exist.
-   subroutine get_substate(state, name, substate, rc)
+   ! Traverse nested states to return the innermost substate specified by path.
+   ! Intermediate states are created if they do not exist.
+   subroutine get_substate(state, path, substate, rc)
       use mapl_ErrorHandling
       type(ESMF_State), intent(inout) :: state
-      character(*), intent(in) :: name
+      character(*), intent(in) :: path
       type(ESMF_State), intent(out) :: substate
       integer, optional, intent(out) :: rc
 
       integer :: status
       type(ESMF_StateItem_Flag) :: itemType
-      character(:), allocatable :: substate_name
+      character(:), allocatable :: substate_name, current_path
+      type(ESMF_State) :: tmp_state
+      integer :: idx
 
-      if (name == '') then ! no substate
-         substate = state
+      substate = state
+      if (path == '') then ! no substate
          _RETURN(_SUCCESS)
       end if
 
-!!$      substate_name = '[' // name // ']'
-      substate_name = name
-      call ESMF_StateGet(state, substate_name, itemType, _RC)
+      current_path = path
+      do while (path /= '')
+         idx = index(current_path, '/')
+         if (idx == 0) then
+            substate_name = current_path
+         else
+            substate_name = current_path(:idx-1)
+         end if
 
-      if (itemType == ESMF_STATEITEM_NOTFOUND) then ! New substate
-         substate = ESMF_StateCreate(name=substate_name, _RC)
-         call ESMF_StateAdd(state, [substate], _RC)
-         _RETURN(_SUCCESS)
-      end if
+         call ESMF_StateGet(substate, substate_name, itemType, _RC)
+         
+         if (itemType == ESMF_STATEITEM_NOTFOUND) then ! New substate
+            tmp_state = ESMF_StateCreate(name=substate_name, _RC)
+            call ESMF_StateAdd(substate, [tmp_state], _RC)
+            substate = tmp_state
+         else
+            _ASSERT(itemType == ESMF_STATEITEM_STATE, 'incorrect object in state')
+            call ESMF_StateGet(substate, substate_name, tmp_state, _RC)
+            substate = tmp_state
+         end if
+         _RETURN_IF(idx == 0)
+         current_path = current_path(idx+1:)
+      end do
 
-      _ASSERT(itemType == ESMF_STATEITEM_STATE, 'incorrect object in state')
-
-      ! Substate exists so ...
-      call ESMF_StateGet(state, substate_name, substate, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine get_substate

--- a/generic3g/MultiState.F90
+++ b/generic3g/MultiState.F90
@@ -35,21 +35,22 @@ contains
       type(ESMF_State), optional, intent(in) :: exportState
       type(ESMF_State), optional, intent(in) :: internalState
 
-      multi_state%importState = get_state(importState)
-      multi_state%exportState = get_state(exportState)
-      multi_state%internalState = get_state(internalState)
+      multi_state%importState = get_state('import', importState)
+      multi_state%exportState = get_state('export', exportState)
+      multi_state%internalState = get_state('internal', internalState)
 
    contains
 
-      function get_state(state) result(new_state)
+      function get_state(name, state) result(new_state)
          type(ESMF_State) :: new_state
+         character(*), intent(in) :: name
          type(ESMF_State), optional, intent(in) :: state
 
          if (present(state)) then
             new_state = state
             return
          end if
-         new_state = ESMF_StateCreate()
+         new_state = ESMF_StateCreate(name=name)
 
       end function get_state
  

--- a/generic3g/connection/ActualConnectionPt.F90
+++ b/generic3g/connection/ActualConnectionPt.F90
@@ -207,8 +207,8 @@ contains
       integer, intent(out) :: iostat
       character(*), intent(inout) :: iomsg
 
-      write(unit, '("Actual{intent: <",a,">, name: <",a,">}")', iostat=iostat, iomsg=iomsg) &
-           this%get_state_intent(), this%get_full_name()
+      write(unit, '("Actual{intent: <",a,">, comp: <",a,">, full name: <",a,">}")', iostat=iostat, iomsg=iomsg) &
+           this%get_state_intent(), this%get_comp_name(), this%get_full_name()
    end subroutine write_formatted
 
    function get_comp_name(this) result(name)

--- a/generic3g/connection/SimpleConnection.F90
+++ b/generic3g/connection/SimpleConnection.F90
@@ -166,6 +166,8 @@ contains
          ! the dst_spec to support multiple matches.  A bit of a kludge.
          effective_pt = ActualConnectionPt(VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
               src_pt%v_pt%get_esmf_name(), comp_name=src_pt%v_pt%get_comp_name()))
+         effective_pt = ActualConnectionPt(VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
+              src_pt%v_pt%get_comp_name()//'/'//src_pt%v_pt%get_esmf_name()))
          call dst_spec%connect_to(last_spec, effective_pt, _RC)
          call dst_spec%set_active()
             

--- a/generic3g/registry/HierarchicalRegistry.F90
+++ b/generic3g/registry/HierarchicalRegistry.F90
@@ -710,7 +710,6 @@ contains
         do while (actual_iter /= e)
 
            actual_pt => actual_iter%first()
-
            if (actual_pt%is_represented_in(mode)) then
               item_spec_ptr =>  actual_iter%second()
               item_spec => item_spec_ptr%ptr

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -480,13 +480,18 @@ contains
       type(ESMF_Field) :: alias
       integer :: status
       type(ESMF_State) :: state, substate
-      character(:), allocatable :: short_name
+      character(:), allocatable :: full_name, inner_name
+      integer :: idx
 
       call multi_state%get_state(state, actual_pt%get_state_intent(), _RC)
-      call get_substate(state, actual_pt%get_comp_name(), substate=substate, _RC)
 
-      short_name = actual_pt%get_esmf_name()
-      alias = ESMF_NamedAlias(this%payload, name=short_name, _RC)
+      full_name = actual_pt%get_full_name()
+      idx = index(full_name, '/', back=.true.)
+      call get_substate(state, full_name(:idx-1), substate=substate, _RC)
+      inner_name = full_name(idx+1:)
+      
+
+      alias = ESMF_NamedAlias(this%payload, name=inner_name, _RC)
       call ESMF_StateAdd(substate, [alias], _RC)
 
       _RETURN(_SUCCESS)

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -489,7 +489,6 @@ contains
       idx = index(full_name, '/', back=.true.)
       call get_substate(state, full_name(:idx-1), substate=substate, _RC)
       inner_name = full_name(idx+1:)
-      
 
       alias = ESMF_NamedAlias(this%payload, name=inner_name, _RC)
       call ESMF_StateAdd(substate, [alias], _RC)

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -126,7 +126,7 @@ contains
          spec => this%matched_items%of(actual_pt)
          call spec%create(_RC)
          call spec%connect_to(src_spec, actual_pt, _RC)
-
+         
          _RETURN(ESMF_SUCCESS)
       end subroutine with_target_attribute
    end subroutine connect_to
@@ -166,6 +166,8 @@ contains
          type(ActualPtStateItemSpecMapIterator) :: iter
          class(StateItemSpec), pointer :: spec_ptr
          type(ActualConnectionPt), pointer :: effective_pt
+         type(ActualConnectionPt) :: use_pt
+         character(:), allocatable :: comp_name
          
          associate (e => this%matched_items%ftn_end())
            iter = this%matched_items%ftn_begin()
@@ -173,8 +175,14 @@ contains
               iter = next(iter)
               ! Ignore actual_pt argument and use internally recorded name
               effective_pt => iter%first()
+              comp_name = actual_pt%get_comp_name()
+              if (comp_name /= '') then
+                 use_pt = effective_pt%add_comp_name(comp_name)
+              else
+                 use_pt = effective_pt
+              end if
               spec_ptr => iter%second()
-              call spec_ptr%add_to_state(multi_state, effective_pt, _RC)
+              call spec_ptr%add_to_state(multi_state, use_pt, _RC)
            end do
          end associate
          

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -250,14 +250,13 @@ contains
             return
          end if
 
-   
+         call comp_states%get_state(state, state_intent, _RC)
+
          msg = comp_path // '::' // state_intent
+   
          state_items = ESMF_HConfigCreateAt(comp_expectations,keyString=state_intent,_RC)
          @assertTrue(ESMF_HConfigIsMap(state_items), msg)
 
-         call comp_states%get_state(state, state_intent, _RC)
-
-!!$         print*, state
 
          hconfigIter = ESMF_HConfigIterBegin(state_items)
          hconfigIterBegin = ESMF_HConfigIterBegin(state_items)
@@ -289,18 +288,25 @@ contains
 
       integer :: status
       integer :: idx
-      type(ESMF_State) :: substate
+      type(ESMF_State) :: substate, tmp_state
+      character(:), allocatable :: name
 
+      integer :: itemcount
+      
       rc = 0
-      idx = index(short_name,'/')
-
-      substate = state ! unless
-      if (idx /= 0) then
-         call ESMF_StateGet(state, short_name(:idx-1), itemtype=itemtype, _RC)
-         @assert_that('get item type of '//short_name, itemtype == ESMF_STATEITEM_STATE, is(true()))
-         call ESMF_StateGet(state, short_name(:idx-1), substate, _RC)
-      end if
-      call ESMF_StateGet(substate, short_name(idx+1:), itemtype=itemtype, _RC)
+      name = short_name
+      substate = state
+      do
+         idx = index(name, '/')
+         if (idx == 0) then
+            call ESMF_StateGet(substate, name, itemtype=itemtype, _RC)
+            return
+         end if
+         call ESMF_StateGet(substate, name(:idx-1), tmp_state, rc=status)
+         @assert_that(short_name, status, is(0))
+         name = name(idx+1:)
+         substate = tmp_state
+      end do
 
       rc = 0
    end function get_itemtype
@@ -321,7 +327,7 @@ contains
       expected_itemtype = get_expected_itemtype(expectations, _RC)
 
 
-      itemtype=get_itemtype(state, short_name, _RC)
+      itemtype = get_itemtype(state, short_name, _RC)
       @assert_that('check item type of '//short_name, expected_itemtype == itemtype, is(true()))
 
       rc = 0
@@ -477,7 +483,7 @@ contains
       end if
 
       expected_field_value = ESMF_HConfigAsR4(expectations,keyString='value',_RC)
-      
+
       call ESMF_StateGet(state, short_name, field, _RC)
       call ESMF_FieldGet(field, typekind=typekind, rank=rank, rc=status)
       @assert_that('field get failed '//short_name,  status, is(0))
@@ -507,6 +513,7 @@ contains
                  print*,'x2:',x2
                  print*,'expected:',expected_field_value
               end if
+
               @assert_that('value of '//short_name, all(x2 == expected_field_value), is(true()))
            case(3)
               call ESMF_FieldGet(field, farrayptr=x3, _RC)

--- a/generic3g/tests/scenarios/history_1/expectations.yaml
+++ b/generic3g/tests/scenarios/history_1/expectations.yaml
@@ -41,18 +41,18 @@
 
 - component: history/collection_1
   import:
-    "A/E_A1": {status: complete, value: 100.} # m -> cm
-    "B/E_B2": {status: complete, value: 1.}
-    "B/E_B3": {status: complete, value: 17.}
+    A/E_A1: {status: complete, value: 100.} # m -> cm
+    B/E_B2: {status: complete, value: 1.}
+    B/E_B3: {status: complete, value: 17.}
 
 - component: history/<user>
   import: {}
 
 - component: history
   import:
-    "A/E_A1": {status: complete, value: 100.} # m -> cm
-    "B/E_B2": {status: complete, value: 1.}
-    "B/E_B3": {status: complete, value: 17.}
+    collection_1/A/E_A1: {status: complete, value: 100.} # m -> cm
+    collection_1/B/E_B2: {status: complete, value: 1.}
+    collection_1/B/E_B3: {status: complete, value: 17.}
 
 - component: <user>
   import: {}

--- a/generic3g/tests/scenarios/history_1/expectations.yaml
+++ b/generic3g/tests/scenarios/history_1/expectations.yaml
@@ -37,7 +37,10 @@
     B/E_B3: {status: complete, value: 17.}
 
 - component: history/collection_1/<user>
-  import: {}
+  import:
+    A/E_A1: {status: complete, value: 100.} # m -> cm
+    B/E_B2: {status: complete, value: 1.}
+    B/E_B3: {status: complete, value: 17.}
 
 - component: history/collection_1
   import:
@@ -62,7 +65,7 @@
 - component: <root>
   import: {}
   export:
-    "A/E_A1": {status: complete}
-    "A/E_A2": {status: gridset}
-    "B/E_B1": {status: gridset}
-    "B/E_B2": {status: complete}
+    A/E_A1: {status: complete}
+    A/E_A2: {status: gridset}
+    B/E_B1: {status: gridset}
+    B/E_B2: {status: complete}

--- a/generic3g/tests/scenarios/history_wildcard/expectations.yaml
+++ b/generic3g/tests/scenarios/history_wildcard/expectations.yaml
@@ -35,9 +35,9 @@
     B/E_B2: {status: complete}
 
 - component: history/collection_1/<user>
-  import: {}
-#    "A/E_A1": {status: complete}
-#    "B/E_B2": {status: complete}
+  import:
+    A/E_A1: {status: complete}
+    B/E_B2: {status: complete}
 
 - component: history/collection_1
   import:
@@ -49,9 +49,6 @@
 
 - component: history
   import:
-#    A/E_A1: {status: complete}
-#    A/E_A2: {status: complete}
-#    collection_1/B/E_B2: {status: complete}
     collection_1/A/E_A1: {status: complete}
     collection_1/A/E_A2: {status: complete}
     collection_1/B/E_B2: {status: complete}

--- a/generic3g/tests/scenarios/history_wildcard/expectations.yaml
+++ b/generic3g/tests/scenarios/history_wildcard/expectations.yaml
@@ -29,10 +29,10 @@
 
 - component: root
   export:
-    "A/E_A1": {status: complete}
-    "A/E_A2": {status: gridset}
-    "B/E_B1": {status: gridset}
-    "B/E_B2": {status: complete}
+    A/E_A1: {status: complete}
+    A/E_A2: {status: gridset}
+    B/E_B1: {status: gridset}
+    B/E_B2: {status: complete}
 
 - component: history/collection_1/<user>
   import: {}
@@ -41,17 +41,20 @@
 
 - component: history/collection_1
   import:
-    "A/E_A1": {status: complete}
-    "B/E_B2": {status: complete}
+    A/E_A1: {status: complete}
+    B/E_B2: {status: complete}
 
 - component: history/<user>
   import: {}
 
 - component: history
   import:
-    "A/E_A1": {status: complete}
-    "A/E_A2": {status: complete}
-    "B/E_B2": {status: complete}
+#    A/E_A1: {status: complete}
+#    A/E_A2: {status: complete}
+#    collection_1/B/E_B2: {status: complete}
+    collection_1/A/E_A1: {status: complete}
+    collection_1/A/E_A2: {status: complete}
+    collection_1/B/E_B2: {status: complete}
 
 - component: <user>
   import: {}
@@ -61,7 +64,7 @@
 - component: <root>
   import: {}
   export:
-    "A/E_A1": {status: complete}
-    "A/E_A2": {status: complete}
-    "B/E_B1": {status: gridset}
-    "B/E_B2": {status: complete}
+    A/E_A1: {status: complete}
+    A/E_A2: {status: complete}
+    B/E_B1: {status: gridset}
+    B/E_B2: {status: complete}


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Fixed various issues with managing fields stored in substates.   These arise in MAPL3 when dealing with History which needs to be able to control which component is satisfying an import.

## Related Issue

