### PR TITLE
Fixed missing error condition.

### DIFF
--- a/generic3g/connection/MatchConnection.F90
+++ b/generic3g/connection/MatchConnection.F90
@@ -87,7 +87,6 @@ contains
       dst_v_pts = dst_registry%filter(dst_pt%v_pt)
 
       do i = 1, dst_v_pts%size()
-         _HERE, i
          dst_pattern => dst_v_pts%of(i)
          src_pattern = VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
               '^'//dst_pattern%get_esmf_name()//'$', comp_name=dst_pattern%get_comp_name())

--- a/generic3g/connection/MatchConnection.F90
+++ b/generic3g/connection/MatchConnection.F90
@@ -76,6 +76,7 @@ contains
       integer :: i, j, k
       class(StateItemSpec), allocatable :: new_spec
       type(ConnectionPt) :: s_pt, d_pt
+      character(1000) :: message
 
       src_pt = this%get_source()
       dst_pt = this%get_destination()
@@ -86,6 +87,7 @@ contains
       dst_v_pts = dst_registry%filter(dst_pt%v_pt)
 
       do i = 1, dst_v_pts%size()
+         _HERE, i
          dst_pattern => dst_v_pts%of(i)
          src_pattern = VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
               '^'//dst_pattern%get_esmf_name()//'$', comp_name=dst_pattern%get_comp_name())
@@ -95,6 +97,10 @@ contains
               dst_pattern%get_esmf_name(), comp_name=dst_pattern%get_comp_name())
 
          src_v_pts = src_registry%filter(src_pattern)
+         if (src_v_pts%size() == 0) then
+            write(message,*) dst_pattern
+            _FAIL('No matching source found for connection dest: ' // trim(message))
+         end if
          do j = 1, src_v_pts%size()
             src_v_pt => src_v_pts%of(j)
 


### PR DESCRIPTION


## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Previously, MatchConnection would not fail if any of the destination
points lacked a matching source point.     Essentially a loop would
become degenerate and skip the destination.   Failure would still
happen much later, but in a far less clear manner.

With the change an error of the form below is generated:

   <No matching source found for connection dest:  Virtual{intent: <import>, name: <AGCM/E_1>}>

(A proper unit test is called for.)

## Related Issue

