### PR TITLE
Remove macOS + Intel CMake logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed CMake logic for macOS + Intel as that is an unsupported configuration
+
 ### Deprecated
 
 ## [2.44.3] - 2024-03-28

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -27,25 +27,10 @@ set (EOS )
 
 set (lib MAPL_cfio_${precision})
 
-if (APPLE AND CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 20.2.1)
-   set (LIBRARY_TYPE STATIC)
-   ecbuild_warn (
-      "Found Intel oneAPI on macOS.\n"
-      "MAPL developers have found an issue with Intel oneAPI on macOS\n"
-      "where GEOSgcm.x would not work. Debugging found the issue was\n"
-      "that command_argument_count() would return -1 which should *NEVER*\n"
-      "happen per Fortran Standard and then this broke FLAP.\n"
-      "A workaround was found that if the ${this} library was compiled\n"
-      "as TYPE STATIC, the model would work. So we are setting ${this} as\n"
-      "a TYPE STATIC library. Note: This might interfere with coupled model.")
-else ()
-   set (LIBRARY_TYPE ${MAPL_LIBRARY_TYPE})
-endif ()
-
 esma_add_library (${lib}
   SRCS ${srcs}
   DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
-  TYPE ${LIBRARY_TYPE}
+  TYPE ${MAPL_LIBRARY_TYPE}
   )
 
 if (precision MATCHES "r8")


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR removes code from the `MAPL_cfio` CMake which was there due to an oddity found when building MAPL with Intel on macOS. This is now a non-supported configuration as Intel does not support macOS anymore and I know of no one building MAPL with macOS + Intel anymore. 

If this setup is needed by someone, setting `-DBUILD_SHARED_MAPL=NO` would be a workaround given what this says.

## Related Issue

