### PR TITLE
updates for geom manager and associated utilities

### DIFF
--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -209,6 +209,7 @@ contains
         outer_meta, &
         logger, &
         registry, &
+        geom, &
         rc)
 
       type(ESMF_GridComp), intent(inout) :: gridcomp
@@ -217,6 +218,7 @@ contains
       type(OuterMetaComponent), pointer, optional, intent(out) :: outer_meta
       class(Logger_t), optional, pointer, intent(out) :: logger
       type(HierarchicalRegistry), optional, pointer, intent(out) :: registry
+      type(ESMF_Geom), optional, intent(out) :: geom
       integer, optional, intent(out) :: rc
 
       integer :: status
@@ -228,6 +230,7 @@ contains
       if (present(outer_meta)) outer_meta => outer_meta_
       if (present(logger)) logger => outer_meta_%get_lgr()
       if (present(registry)) registry => outer_meta_%get_registry()
+      if (present(geom)) geom = outer_meta_%get_geom()
 
       _RETURN(_SUCCESS)
    end subroutine gridcomp_get

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -75,6 +75,7 @@ module mapl3g_OuterMetaComponent
       procedure :: get_user_gc_driver
       procedure :: set_hconfig
       procedure :: get_hconfig
+      procedure :: get_geom
       procedure :: get_registry
       procedure :: get_lgr
 
@@ -355,6 +356,13 @@ contains
 
    end function get_hconfig
 
+   function get_geom(this) result(geom)
+      type(ESMF_Geom) :: geom
+      class(OuterMetaComponent), intent(inout) :: this
+
+      geom = this%geom
+
+   end function get_geom
 
    ! ESMF initialize methods
 

--- a/geom_mgr/GeomFactory.F90
+++ b/geom_mgr/GeomFactory.F90
@@ -1,7 +1,6 @@
 #include "MAPL_Generic.h"
 
 module mapl3g_GeomFactory
-   use mapl3g_MaplGeom
    implicit none
    private
 

--- a/geom_mgr/GeomManager_smod.F90
+++ b/geom_mgr/GeomManager_smod.F90
@@ -292,7 +292,7 @@ contains
       geom = factory%make_geom(spec, _RC)
       file_metadata = factory%make_file_metadata(spec, _RC)
       gridded_dims = factory%make_gridded_dims(spec, _RC)
-      mapl_geom = MaplGeom(spec, geom, file_metadata, gridded_dims)
+      mapl_geom = MaplGeom(spec, geom, factory, file_metadata, gridded_dims)
 
       _RETURN(_SUCCESS)
    end function make_mapl_geom_from_spec

--- a/geom_mgr/MaplGeom.F90
+++ b/geom_mgr/MaplGeom.F90
@@ -3,6 +3,7 @@
 module mapl3g_MaplGeom
    use mapl3g_GeomSpec
    use mapl3g_VectorBasis
+   use mapl3g_GeomFactory
    use pfio_FileMetadataMod, only: FileMetadata
    use ESMF, only: ESMF_Geom
    use gftl_StringVector
@@ -28,6 +29,7 @@ module mapl3g_MaplGeom
       type(ESMF_Geom) :: geom
       type(FileMetadata) :: file_metadata
       type(StringVector) :: gridded_dims ! center staggered
+      class(GeomFactory), allocatable :: factory
 
       ! Derived - lazy initialization
       type(VectorBases) :: bases
@@ -35,6 +37,7 @@ module mapl3g_MaplGeom
       procedure :: set_id
       procedure :: get_spec
       procedure :: get_geom
+      procedure :: get_factory
 !!$      procedure :: get_grid
       procedure :: get_file_metadata
 !!$      procedure :: get_gridded_dims
@@ -48,10 +51,11 @@ module mapl3g_MaplGeom
    end interface MaplGeom
 
    interface 
-      module function new_MaplGeom(spec, geom, file_metadata, gridded_dims) result(mapl_geom)
+      module function new_MaplGeom(spec, geom, factory, file_metadata, gridded_dims) result(mapl_geom)
          class(GeomSpec), intent(in) :: spec
          type(MaplGeom) :: mapl_geom
          type(ESMF_Geom), intent(in) :: geom
+         class(GeomFactory), intent(in) :: factory
          type(FileMetadata), optional, intent(in) :: file_metadata
          type(StringVector), optional, intent(in) :: gridded_dims
       end function new_MaplGeom
@@ -71,6 +75,11 @@ module mapl3g_MaplGeom
          type(ESMF_Geom) :: geom
          class(MaplGeom), intent(in) :: this
       end function get_geom
+
+      module function get_factory(this) result(factory)
+         class(GeomFactory), allocatable :: factory
+         class(MaplGeom), intent(in) :: this
+      end function get_factory
 
       module function get_file_metadata(this) result(file_metadata)
          type(FileMetadata) :: file_metadata

--- a/geom_mgr/MaplGeom.F90
+++ b/geom_mgr/MaplGeom.F90
@@ -40,7 +40,7 @@ module mapl3g_MaplGeom
       procedure :: get_factory
 !!$      procedure :: get_grid
       procedure :: get_file_metadata
-!!$      procedure :: get_gridded_dims
+      procedure :: get_gridded_dims
 
       ! Only used by regridder
       procedure :: get_basis
@@ -85,6 +85,11 @@ module mapl3g_MaplGeom
          type(FileMetadata) :: file_metadata
          class(MaplGeom), intent(in) :: this
       end function get_file_metadata
+
+      module function get_gridded_dims(this) result(gridded_dims)
+         type(StringVector) :: gridded_dims
+         class(MaplGeom), intent(in) :: this
+      end function get_gridded_dims
 
       recursive module function get_basis(this, mode, rc) result(basis)
          type(VectorBasis), pointer :: basis

--- a/geom_mgr/MaplGeom_smod.F90
+++ b/geom_mgr/MaplGeom_smod.F90
@@ -12,15 +12,17 @@ submodule (mapl3g_MaplGeom) MaplGeom_smod
 
 contains
    
-   module function new_MaplGeom(spec, geom, file_metadata, gridded_dims) result(mapl_geom)
+   module function new_MaplGeom(spec, geom, factory, file_metadata, gridded_dims) result(mapl_geom)
       class(GeomSpec), intent(in) :: spec
       type(MaplGeom) :: mapl_geom
       type(ESMF_Geom), intent(in) :: geom
+      class(GeomFactory), intent(in) :: factory
       type(FileMetadata), optional, intent(in) :: file_metadata
       type(StringVector), optional, intent(in) :: gridded_dims
 
       mapl_geom%spec = spec
       mapl_geom%geom = geom
+      mapl_geom%factory = factory
       if (present(file_metadata)) mapl_geom%file_metadata = file_metadata
       if (present(gridded_dims)) mapl_geom%gridded_dims = gridded_dims
 
@@ -51,11 +53,23 @@ contains
       geom = this%geom
    end function get_geom
 
+   module function get_factory(this) result(factory)
+     class(GeomFactory), allocatable :: factory
+      class(MaplGEOM), intent(in) :: this
+      factory = this%factory
+   end function get_factory
+
    module function get_file_metadata(this) result(file_metadata)
      type(FileMetadata) :: file_metadata
       class(MaplGeom), intent(in) :: this
       file_metadata = this%file_metadata
    end function get_file_metadata
+
+   module function get_gridded_dims(this) result(gridded_dims)
+      type(StringVector) :: gridded_dims
+      class(MaplGeom), intent(in) :: this
+      gridded_dims = this%gridded_dims
+   end function get_gridded_dims
 
    recursive module function get_basis(this, mode, rc) result(basis)
       type(VectorBasis), pointer :: basis


### PR DESCRIPTION
This is just some updates needed to use the geom manager and MAPL_Geom in ways that will be needed for the IO layer History3G will use
The changes are
1. Added a new option to MAPL_GridCompGet to retrieve the ESMF_Geom attached to the metacomp since the geometry manager works with the ESMF_Geom
2. Updates to MAPL_Geom to store the factory that made the MAPL_Geom if we need it. Just make a copy because @tclune said the factories are lightweight no need to store a pointer back to the original
3. Add function to MAPL_Geom to retrieve the gridded_dims

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

