### PR TITLE
Get simple server working in MaplFramework in MAPL3

### DIFF
--- a/mapl3g/MaplFramework.F90
+++ b/mapl3g/MaplFramework.F90
@@ -12,7 +12,8 @@ module mapl3g_MaplFramework
    use pfio_DirectoryServiceMod, only: DirectoryService
    use pfio_ClientManagerMod
    use pfio_MpiServerMod, only: MpiServer
-   use pfio
+   use pfio_ClientThreadMod, only: ClientThread
+   use pfio_AbstractDirectoryServiceMod, only: PortInfo
    use pflogger, only: logging
    use pflogger, only: Logger
    use esmf, only: ESMF_IsInitialized

--- a/mapl3g/MaplFramework.F90
+++ b/mapl3g/MaplFramework.F90
@@ -10,6 +10,9 @@ module mapl3g_MaplFramework
    use mapl_KeywordEnforcerMod
    use mapl_profiler, only: DistributedProfiler
    use pfio_DirectoryServiceMod, only: DirectoryService
+   use pfio_ClientManagerMod
+   use pfio_MpiServerMod, only: MpiServer
+   use pfio
    use pflogger, only: logging
    use pflogger, only: Logger
    use esmf, only: ESMF_IsInitialized
@@ -27,12 +30,14 @@ module mapl3g_MaplFramework
       private
       logical :: initialized = .false.
       type(DirectoryService) :: directory_service
+      type(MpiServer), pointer :: o_server => null()
       type(DistributedProfiler) :: time_profiler
    contains
       procedure :: initialize
       procedure :: get
       procedure :: is_initialized
       procedure :: finalize
+      procedure :: initialize_simple_oserver
    end type MaplFramework
 
    ! Private singleton object.  Used 
@@ -79,11 +84,38 @@ contains
 #endif
 !#      call initialize_profiler(comm=comm_world, enable_global_timeprof=enable_global_timeprof, enable_global_memprof=enable_global_memprof, _RC)
 
+      call this%initialize_simple_oserver(_RC)
+
       this%initialized = .true.
 
       _RETURN(_SUCCESS)
    end subroutine initialize
-      
+
+   subroutine initialize_simple_oserver(this, unusable, rc)
+      class(MaplFramework), target, intent(inout) :: this
+      class(KeywordEnforcer), optional, intent(out) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status, stat_alloc, comm_world
+      type(ESMF_VM) :: vm
+      type(ClientThread), pointer :: clientPtr
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm_world, _RC)
+
+      this%directory_service = DirectoryService(comm_world)
+      call init_IO_ClientManager(comm_world, _RC)
+      allocate(this%o_server, source = MpiServer(comm_world, 'o_server', rc=status), stat=stat_alloc)
+      _VERIFY(status)
+      _VERIFY(stat_alloc)
+      call this%directory_service%publish(PortInfo('o_server', this%o_server), this%o_server)
+      clientPtr => o_Clients%current()
+      call this%directory_service%connect_to_server('o_server', clientPtr, comm_world)
+ 
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize_simple_oserver
+ 
    subroutine get(this, unusable, directory_service, rc)
       class(MaplFramework), target, intent(in) :: this
       class(KeywordEnforcer), optional, intent(out) :: unusable
@@ -111,6 +143,7 @@ contains
 
 !#      call finalize_profiler(_RC)
       call logging%free()
+      call this%directory_service%free_directory_resources()
       
       _RETURN(_SUCCESS)
    end subroutine finalize


### PR DESCRIPTION
Just get the SIMPLE (not the mulitgroup) server working in the MaplFramework so we can use it in HISTORY3g development and actually write files when the time comes. Just a placeholder until this is fully fleshed out for the full server support.

I've already confirmed this works (I was able to use it to write something from the new history component).

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

