### PR TITLE
Activated clock advance.

### DIFF
--- a/generic3g/GenericPhases.F90
+++ b/generic3g/GenericPhases.F90
@@ -13,6 +13,7 @@ module mapl3g_GenericPhases
    public :: GENERIC_INIT_USER
 
    ! Run phases
+   public :: GENERIC_RUN_PHASES
    public :: GENERIC_RUN_CLOCK_ADVANCE
    public :: GENERIC_RUN_USER
 
@@ -47,6 +48,15 @@ module mapl3g_GenericPhases
         GENERIC_INIT_POST_ADVERTISE, &
         GENERIC_INIT_REALIZE, &
         GENERIC_INIT_USER &
+        ]
+
+
+   ! Probably will only ever have one phase here,
+   ! but still useful to count offset for user phases.
+   ! See GenericGridComp.
+   integer, parameter :: GENERIC_RUN_PHASES(*) = &
+        [ &
+        GENERIC_RUN_CLOCK_ADVANCE &
         ]
 
 

--- a/generic3g/GriddedComponentDriver_smod.F90
+++ b/generic3g/GriddedComponentDriver_smod.F90
@@ -17,6 +17,7 @@ contains
 
       integer :: status, user_status
 
+      _ASSERT(present(phase_idx), 'until made not optional')
       call this%run_import_couplers(_RC)
       
       associate ( &
@@ -28,7 +29,9 @@ contains
              exportState=exportState, &
              clock=this%clock, &
              phase=phase_idx, _USERRC)
+
       end associate
+
       call this%run_export_couplers(phase_idx=phase_idx, _RC)
 
       _RETURN(_SUCCESS)
@@ -149,7 +152,7 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      
+
       call ESMF_ClockAdvance(this%clock, _RC)
 
       _RETURN(_SUCCESS)

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -260,7 +260,7 @@ contains
          _ASSERT(found, "run phase: <"//phase_name//"> not found.")
       end if
 
-      call child%run(phase_idx=phase_idx, _RC)
+      call child%run(phase_idx=phase_idx+size(GENERIC_RUN_PHASES), _RC)
 
       _RETURN(_SUCCESS)
    end subroutine run_child_by_name
@@ -734,7 +734,7 @@ contains
            call drvr%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
         end do
       end associate
-      
+
       call this%user_gc_driver%run(phase_idx=phase, _RC)
    
       export_couplers => this%registry%get_export_couplers()

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -180,7 +180,7 @@ contains
 
            call ESMF_GridCompRun(outer_gc, & 
                   importState=importState, exportState=exportState, clock=clock, &
-                  userRC=user_status, _RC)
+                  userRC=user_status, phase=GENERIC_RUN_USER, _RC)
            _VERIFY(user_status)
 
       end associate
@@ -508,11 +508,6 @@ contains
            select case(rank)
            case(2)
               call ESMF_FieldGet(field, farrayptr=x2, _RC)
-              if (any (x2 /= expected_field_value)) then
-                 print*,'x2:',x2
-                 print*,'expected:',expected_field_value
-              end if
-
               @assert_that('value of '//short_name, all(x2 == expected_field_value), is(true()))
            case(3)
               call ESMF_FieldGet(field, farrayptr=x3, _RC)

--- a/generic3g/tests/Test_SimpleLeafGridComp.pf
+++ b/generic3g/tests/Test_SimpleLeafGridComp.pf
@@ -68,7 +68,7 @@ contains
       call setup(outer_gc, config, status)
       @assert_that('DSO problem', status, is(0))
 
-      call ESMF_GridCompRun(outer_gc, userRC=userRC, phase=1, rc=status)
+      call ESMF_GridCompRun(outer_gc, userRC=userRC, phase=GENERIC_RUN_USER, rc=status)
       @assert_that(status, is(0))
       @assert_that(userRC, is(0))
       @assertEqual("wasRun_A", log)
@@ -98,7 +98,7 @@ contains
       call setup(outer_gc, config, status)
       @assert_that(status, is(0))
 
-      call ESMF_GridCompRun(outer_gc, phase=2, rc=status)
+      call ESMF_GridCompRun(outer_gc, phase=3, rc=status)
       @assert_that(status, is(0))
       @assertEqual("wasRun_extra_A", log)
 

--- a/gridcomps/History3G/HistoryGridComp.F90
+++ b/gridcomps/History3G/HistoryGridComp.F90
@@ -81,7 +81,7 @@ contains
       integer, intent(out)  :: rc
 
       integer :: status
- 
+
       call MAPL_RunChildren(gridcomp, phase_name='run', _RC)
 
       _RETURN(_SUCCESS)

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -186,7 +186,7 @@ contains
       integer :: status
       type(ESMF_Clock) :: clock
       type(ESMF_Time) :: currTime, stopTime
-      
+
       clock = driver%get_clock()
       call ESMF_ClockGet(clock, currTime=currTime, stopTime=stopTime, _RC)
 

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -192,8 +192,9 @@ contains
 
       do while (currTime < stopTime)
          ! TODO:  include Bill's monitoring log messages here
-         call driver%run(_RC)
-         call ESMF_ClockAdvance(clock, _RC)
+         call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+         call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+         call driver%clock_advance(_RC)
          call ESMF_ClockGet(clock, currTime=currTime, _RC)
       end do
       call ESMF_TimePrint(currTime, options='string', preString='Cap time after loop: ', _RC)


### PR DESCRIPTION

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

There was a bit of missing logic to manage the difference between user gc run phases and generic run phases.  Generic has at least one additional phase to advance the clock of the user gc driver and children drivers.  (Gridcomps should not update their clock directly.)

## Related Issue

