### PR TITLE
Fixes #2793 basic time spec

### DIFF
--- a/base/TimeStringConversion.F90
+++ b/base/TimeStringConversion.F90
@@ -11,6 +11,7 @@ module MAPL_TimeStringConversion
    public :: string_to_integer_date
    public :: string_to_esmf_time
    public :: string_to_esmf_timeinterval
+   public :: hconfig_to_esmf_timeinterval
 
 contains
 
@@ -238,5 +239,23 @@ contains
       _RETURN(_SUCCESS)
 
    end function string_to_esmf_timeinterval
+
+   function hconfig_to_esmf_timeinterval(hconfig, key, unusable, rc) result(time_interval)
+      type(ESMF_TimeInterval) :: time_interval
+      type(ESMF_HConfig), intent(in) :: hconfig
+      character(len=*), intent(in) :: key
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      character(len=:), allocatable :: iso_duration
+
+      _UNUSED_DUMMY(unusable)
+
+      iso_duration = ESMF_HConfigAsString(hconfig, keystring=key, _RC)
+      time_interval = string_to_esmf_timeinterval(iso_duration, _RC)
+
+      _RETURN(_SUCCESS)
+   end function hconfig_to_esmf_timeinterval
 
 end module MAPL_TimeStringConversion

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -16,7 +16,6 @@ module mapl3g_HistoryCollectionGridComp
    type :: HistoryCollectionGridComp
 !#      class(Client), pointer :: client
       type(ESMF_FieldBundle) :: output_bundle
-      type(ESMF_Alarm) :: write_alarm
       type(ESMF_Time) :: start_stop_times(2)
    end type HistoryCollectionGridComp
 
@@ -65,17 +64,19 @@ contains
       type(ESMF_HConfig) :: hconfig
       type(ESMF_Geom) :: geom
       type(ESMF_Alarm) :: alarm
+      character(len=ESMF_MAXSTR) :: name
 
       ! To Do:
       ! - determine run frequencey and offset (save as alarm)
       call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
+      call ESMF_GridCompGet(gridcomp, name=name, _RC)
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
       collection_gridcomp%output_bundle = create_output_bundle(hconfig, importState, _RC)
 
       call MAPL_GridCompGet(gridcomp, geom=geom, _RC)
 
-      collection_gridcomp%write_alarm = create_output_alarm(clock, hconfig, _RC)
+      call create_output_alarm(clock, hconfig, trim(name), _RC)
       collection_gridcomp%start_stop_times = set_start_stop_time(clock, hconfig, _RC)
 
       _RETURN(_SUCCESS)
@@ -112,10 +113,14 @@ contains
       character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       logical :: time_to_write, run_collection
       type(ESMF_Time) :: current_time
-    
-      call ESMF_ClockGet(clock, currTime=current_time, _RC) 
+      type(ESMF_Alarm) :: write_alarm
+      character(len=ESMF_MAXSTR) :: name
+
+      call ESMF_GridCompGet(gridcomp, name=name, _RC)
+      call ESMF_ClockGet(clock, currTime=current_time, _RC)
+      call ESMF_ClockGetAlarm(clock, trim(name)//"_write_alarm", write_alarm, _RC)
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
-      time_to_write = ESMF_AlarmIsRinging(collection_gridcomp%write_alarm, _RC)
+      time_to_write = ESMF_AlarmIsRinging(write_alarm, _RC)
       run_collection = (current_time >= collection_gridcomp%start_stop_times(1)) .and. &
                            (current_time <= collection_gridcomp%start_stop_times(2))
 

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -6,7 +6,6 @@ module mapl3g_HistoryCollectionGridComp
    use mapl3g_esmf_utilities
    use mapl3g_HistoryCollectionGridComp_private
    use esmf
-   use mapl3g_BundleWriter
    implicit none
    private
 

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -110,9 +110,19 @@ contains
       integer :: status
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
-
+      logical :: time_to_write, run_collection
+      type(ESMF_Time) :: current_time
+    
+      call ESMF_ClockGet(clock, currTime=current_time, _RC) 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
+      time_to_write = ESMF_AlarmIsRinging(collection_gridcomp%write_alarm, _RC)
+      run_collection = (current_time >= collection_gridcomp%start_stop_times(1)) .and. &
+                           (current_time <= collection_gridcomp%start_stop_times(2))
+
+      _RETURN_UNLESS(run_collection .and. time_to_write)
+
       _RETURN(_SUCCESS)
+
    end subroutine run
 
 end module mapl3g_HistoryCollectionGridComp

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -6,6 +6,7 @@ module mapl3g_HistoryCollectionGridComp
    use mapl3g_esmf_utilities
    use mapl3g_HistoryCollectionGridComp_private
    use esmf
+   use mapl3g_BundleWriter
    implicit none
    private
 
@@ -15,6 +16,8 @@ module mapl3g_HistoryCollectionGridComp
    type :: HistoryCollectionGridComp
 !#      class(Client), pointer :: client
       type(ESMF_FieldBundle) :: output_bundle
+      type(ESMF_Alarm) :: write_alarm
+      type(ESMF_Time) :: start_stop_times(2)
    end type HistoryCollectionGridComp
 
 
@@ -60,6 +63,8 @@ contains
       character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       type(ESMF_HConfig) :: hconfig
+      type(ESMF_Geom) :: geom
+      type(ESMF_Alarm) :: alarm
 
       ! To Do:
       ! - determine run frequencey and offset (save as alarm)
@@ -67,6 +72,11 @@ contains
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
       collection_gridcomp%output_bundle = create_output_bundle(hconfig, importState, _RC)
+
+      call MAPL_GridCompGet(gridcomp, geom=geom, _RC)
+
+      collection_gridcomp%write_alarm = create_output_alarm(clock, hconfig, _RC)
+      collection_gridcomp%start_stop_times = set_start_stop_time(clock, hconfig, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine init
@@ -98,7 +108,10 @@ contains
       integer, intent(out)  :: rc
 
       integer :: status
+      type(HistoryCollectionGridComp), pointer :: collection_gridcomp
+      character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
 
+      _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
       _RETURN(_SUCCESS)
    end subroutine run
 

--- a/gridcomps/History3G/HistoryCollectionGridComp_private.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp_private.F90
@@ -143,12 +143,13 @@ contains
       _RETURN(_SUCCESS)
    end function create_output_bundle
 
-   function create_output_alarm(clock, hconfig, rc) result(alarm)
-      type(ESMF_Alarm) :: alarm
+   subroutine create_output_alarm(clock, hconfig, comp_name, rc) 
       type(ESMF_Clock), intent(inout) :: clock
       type(ESMF_HConfig), intent(in) :: hconfig
+      character(len=*), intent(in) :: comp_name
       integer, intent(out), optional :: rc
 
+      type(ESMF_Alarm) :: alarm
       integer :: status
       type(ESMF_HConfig) :: time_hconfig
       type(ESMF_TimeInterval) :: time_interval
@@ -183,10 +184,10 @@ contains
       if (first_ring_time < currTime) &
            first_ring_time = first_ring_time +(INT((currTime - first_ring_time)/time_interval)+1)*time_interval 
 
-      alarm = ESMF_AlarmCreate(clock=clock, RingInterval=time_interval, RingTime=first_ring_time, sticky=.false.,  _RC)
+      alarm = ESMF_AlarmCreate(clock=clock, RingInterval=time_interval, RingTime=first_ring_time, sticky=.false., name=comp_name//"_write_alarm",  _RC)
 
       _RETURN(_SUCCESS)
-   end function create_output_alarm
+   end subroutine create_output_alarm
 
    function set_start_stop_time(clock, hconfig, rc) result(start_stop_time)
       type(ESMF_Time) :: start_stop_time(2)

--- a/gridcomps/History3G/HistoryCollectionGridComp_private.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp_private.F90
@@ -159,7 +159,6 @@ contains
       logical :: has_ref_time, has_frequency
 
       call ESMF_ClockGet(clock, currTime=currTime, timeStep=time_interval, startTime = startTime, _RC)
-      int_time = 0 
 
       time_hconfig = ESMF_HConfigCreateAt(hconfig, keyString='time_spec', _RC)
 
@@ -168,6 +167,7 @@ contains
          time_interval = hconfig_to_esmf_timeinterval(time_hconfig, 'frequency', _RC)
       end if
     
+      int_time = 0 
       has_ref_time = ESMF_HConfigIsDefined(time_hconfig, keyString='ref_time', _RC) 
       if (has_ref_time) then
          iso_time = ESMF_HConfigAsString(time_hconfig, keyString='ref_time', _RC)

--- a/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
+++ b/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
@@ -120,7 +120,9 @@ contains
       type(ESMF_Alarm) :: alarm
       logical :: is_ringing
       type(ESMF_Time) currTime
+      character(len=:), allocatable :: comp_name
 
+      comp_name = "coll1"
       call ESMF_TimeIntervalSet(dt, h=1, _RC)
       call ESMF_TimeSet(start_time, timeString="2000-04-03T21:00:00", _RC)
       call ESMF_TimeSet(stop_time, timeString="2000-04-22T21:00:00", _RC)
@@ -128,7 +130,8 @@ contains
       hconfig = ESMF_HConfigCreate(content = &
         "{time_spec: {frequency: PT3H}}", _RC)
 
-      alarm = create_output_alarm(clock, hconfig, _RC)
+      call create_output_alarm(clock, hconfig, comp_name, _RC)
+      call ESMF_ClockGetAlarm(clock, comp_name//"_write_alarm", alarm, _RC)
      
       call ESMF_ClockAdvance(clock, _RC)
       is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 

--- a/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
+++ b/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
@@ -77,4 +77,71 @@ contains
 
    end subroutine test_create_output_bundle
 
+   @Test
+   subroutine test_set_start_stop_time()
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Time) :: time,start_stop_time(2)
+      integer :: status
+      type(ESMF_Time) :: start_time, stop_time
+      type(ESMF_TimeInterval) :: dt
+      type(ESMF_Clock) :: clock
+
+      call ESMF_TimeIntervalSet(dt, h=1, _RC)
+      call ESMF_TimeSet(start_time, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(stop_time, timeString="2000-04-22T21:00:00", _RC)
+      clock = ESMF_ClockCreate(timeStep=dt, startTime=start_time, stopTime=stop_time, _RC)
+
+      hconfig = ESMF_HConfigCreate(content = &
+        "{time_spec: {frequency: PT3H}}", _RC)
+
+      start_stop_time = set_start_stop_time(clock, hconfig, _RC)
+      @assert_that(start_time == start_stop_time(1), is(true()))
+      @assert_that(stop_time == start_stop_time(2), is(true()))
+ 
+      hconfig = ESMF_HConfigCreate(content = &
+        "{time_spec: {start: 2000-04-14T21:00:00, stop: 2000-04-15T21:00:00}}", _RC)
+      call ESMF_TimeSet(start_time, timeString="2000-04-14T21:00:00", _RC)
+      call ESMF_TimeSet(stop_time, timeString="2000-04-15T21:00:00", _RC)
+
+      start_stop_time = set_start_stop_time(clock, hconfig, _RC)
+      @assert_that(start_time == start_stop_time(1), is(true()))
+      @assert_that(stop_time == start_stop_time(2), is(true()))
+
+   end subroutine test_set_start_stop_time
+
+   @Test
+   subroutine test_create_output_alarm()
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Time) :: time,start_stop_time(2)
+      integer :: status
+      type(ESMF_Time) :: start_time, stop_time
+      type(ESMF_TimeInterval) :: dt
+      type(ESMF_Clock) :: clock
+      type(ESMF_Alarm) :: alarm
+      logical :: is_ringing
+      type(ESMF_Time) currTime
+
+      call ESMF_TimeIntervalSet(dt, h=1, _RC)
+      call ESMF_TimeSet(start_time, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(stop_time, timeString="2000-04-22T21:00:00", _RC)
+      clock = ESMF_ClockCreate(timeStep=dt, startTime=start_time, stopTime=stop_time, _RC)
+      hconfig = ESMF_HConfigCreate(content = &
+        "{time_spec: {frequency: PT3H}}", _RC)
+
+      alarm = create_output_alarm(clock, hconfig, _RC)
+     
+      call ESMF_ClockAdvance(clock, _RC)
+      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
+      @assert_that(is_ringing, is(false()))
+
+      call ESMF_ClockAdvance(clock, _RC)
+      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
+      @assert_that(is_ringing, is(false()))
+
+      call ESMF_ClockAdvance(clock, _RC) 
+      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
+      @assert_that(is_ringing, is(true()))
+ 
+   end subroutine test_create_output_alarm
+
 end module Test_HistoryCollectionGridComp

--- a/gridcomps/cap3g/tests/basic_captest/history.yaml
+++ b/gridcomps/cap3g/tests/basic_captest/history.yaml
@@ -20,9 +20,11 @@ active_collections:
 collections:
   coll1:
     geom: *geom1
+    time_spec: {}
     var_list:
       E1: {expr: E_1}
   coll2:
     geom: *geom2
+    time_spec: {}
     var_list:
       E2: {expr: E_2}

--- a/gridcomps/cap3g/tests/parent_child_captest/history.yaml
+++ b/gridcomps/cap3g/tests/parent_child_captest/history.yaml
@@ -20,9 +20,11 @@ active_collections:
 collections:
   coll1:
     geom: *geom1
+    time_spec: {}
     var_list:
       E1: {expr: AGCM.E_1}
   coll2:
     geom: *geom2
+    time_spec: {}
     var_list:
       E2: {expr: AGCM.E_2}

--- a/pfunit/MAPL_Initialize.F90
+++ b/pfunit/MAPL_Initialize.F90
@@ -7,7 +7,7 @@ contains
       use pflogger, only: pfl_initialize => initialize
       use udunits2f, only: UDUNITS_Initialize => Initialize
    
-      call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_MULTI)
+      call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_MULTI,defaultCalKind=ESMF_CALKIND_GREGORIAN)
       call MAPL_set_throw_method(throw)
       call pfl_initialize()
       call UDUNITS_Initialize()


### PR DESCRIPTION
This adds some basic timespec stuff to History3G as detailed in #2793 

Adds a basic frequency alarm and start/stop ability for the collection.

For the collection start/stop, if not specified assume it is the begin/end of the clock.

Note the alarm business is a bit mess, borrowed from old History all this to created an alarm that given a first time will ring periodically after that. This is due to the issues with ESMF alarms and is needed unfortunately.

For some reason in the ESMF_Initialized used by the PF units tests I had to set a default calendar, it I did not it would not let me create times that had a year in them.

Finally removed a little routine I added to Cap.F90 to parse an ISO duration to get an ESMF_TimeInterval because I remembered I had this in base and it's now needed two places. When ESMF supports TimeIntervals from strings, this can go away.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

