### PR TITLE
Backport Python3 changes to MAPL 2.8.0

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
-import sys
 import os
 import csv
 import pandas as pd
@@ -202,9 +201,8 @@ def read_specs(specs_filename):
     with open(specs_filename, 'r') as specs_file:
         specs_reader = csv.reader(specs_file, skipinitialspace=True,delimiter='|')
         gen = csv_record_reader(specs_reader)
-        schema_version = next(gen)[0].split(' ')[1]
-        component = next(gen)[0].split(' ')[1]
-#        print("Generating specification code for component: ",component)
+        #component = next(gen)[0].split(' ')[1]
+        #print("Generating specification code for component: ",component)
         while True:
             try:
                 gen = csv_record_reader(specs_reader)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
-## [2.8.0.10] - 2024-05-XX
+## [2.8.0.10] - 2024-05-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [2.8.0.10] - 2024-05-XX
+
+### Changed
+
+- Backport Python3 changes for `Python/` code to 2.8
+- Change shebang in `Apps/MAPL_GridCompSpecs_ACG.py` to use `python3`
+
 ## [2.8.0.9] - 2022-08-04
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   MAPL
-  VERSION 2.8.0.9
+  VERSION 2.8.0.10
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # mepo can now clone subrepos in three styles

--- a/Python/MAPL/Date.py
+++ b/Python/MAPL/Date.py
@@ -149,7 +149,7 @@ class Date(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         #Last day of the month.
         if self.day == NumberDaysMonth(self.month, self.year):
             self.day = 1
@@ -230,7 +230,7 @@ class Date(object):
             #Convert back to date format.
             return DateFromJDNumber(temp)
         else:
-            raise TypeError, "%s is not an integer." % str(n)
+            raise TypeError("%s is not an integer." % str(n))
 
     def __sub__(self, date):
         """Returns the (signed) difference of days between the dates."""
@@ -253,7 +253,7 @@ class Date(object):
                         ret += NumberDaysYear(year)
                     return ret
         else:
-            raise TypeError, "%s is neither an integer nor a Date." % str(date)
+            raise TypeError("%s is neither an integer nor a Date." % str(date))
 
     #Adding an integer is "commutative".
     def __radd__(self, n):
@@ -283,7 +283,7 @@ class Date(object):
 def DateFromJDNumber(n):
     """Returns a date corresponding to the given Julian day number."""
     if not isinstance(n, int):
-        raise TypeError, "%s is not an integer." % str(n)
+        raise TypeError("%s is not an integer." % str(n))
 
     a = n + 32044
     b = (4*a + 3)//146097
@@ -320,21 +320,21 @@ if __name__ == "__main__":
     temp = Date()
     curr_month = temp.month
     while temp.month == curr_month:
-        print temp
-        temp.next()
+        print(temp)
+        next(temp)
 
-    print "\n"
+    print("\n")
 
     #How many days until the end of the year?
     temp = Date()
     temp.day, temp.month = 1, 1
     curr_year = temp.year
     while temp.year == curr_year:
-        print "%s is %d days away from the end of the year." % (str(temp),
-                                                                temp.DaysToEndYear())
+        print("%s is %d days away from the end of the year." % (str(temp),
+                                                                temp.DaysToEndYear()))
         temp += NumberDaysMonth(temp.month)
 
-    print "\n"
+    print("\n")
 
     #Playing with __sub__.
     temp = Date()
@@ -344,11 +344,11 @@ if __name__ == "__main__":
         temp_list.append(temp)
         temp += NumberDaysMonth(temp.month)
     for elem in temp_list:
-        print "%s differs %d days from current date: %s" % (str(elem),
+        print("%s differs %d days from current date: %s" % (str(elem),
                                                             elem - Date(),
-                                                            str(Date()))
+                                                            str(Date())))
 
-    print "\n"
+    print("\n")
 
     #Swapping arguments works?
-    print 23 + Date()
+    print(23 + Date())

--- a/Python/MAPL/__init__.py
+++ b/Python/MAPL/__init__.py
@@ -11,7 +11,7 @@ exp
   carried out by means of several *jobs* which are submitted through a
   queueing system such as PBS.
 
-job 
+job
   This package defines the base class *Job* which inherits from
   *Exp*. A *job* carries out a portion of the *experiment*,
   itself consisting of several *run* segments.
@@ -38,19 +38,18 @@ with 2 run segments.
    |----------------------- Experiment ------------------------|
    |------ Job 1 ------|------ Job 2 ------|------ Job 3 ------|
    |- Run 1 -|- Run 2 -|- Run 3 -|- Run 4 -|- Run 5 -|- Run 6 -|
- 
+
 If each run segment is 2 weeks long, each job performs a 4 week
 integration, and the the whole experiment is about 3 month long.
 
 """
 
-__version__ = "0.1.2"
+__version__ = "1.0.0"
 
-from exp      import *
-from job      import *
-from run      import *
-from config   import *
-from history  import *
-from Date     import *
-from filelock import *
-
+from .exp      import *
+from .job      import *
+from .run      import *
+from .config   import *
+from .history  import *
+from .Date     import *
+from .filelock import *

--- a/Python/MAPL/config.py
+++ b/Python/MAPL/config.py
@@ -12,7 +12,7 @@ import os
 import sys
 from types import *
 from datetime import datetime
-    
+
 class Config(object):
 
     def __init__(self,RcFiles,delim=':',Environ=True):
@@ -23,7 +23,7 @@ class Config(object):
         the current value of environment variables.
         """
 
-        if type(RcFiles) is StringType:
+        if isinstance(RcFiles, str):
             Files = ( RcFiles, ) # in case a single file is given
         else:
             Files = RcFiles     # more often, a List/Tuple of RC files
@@ -39,10 +39,10 @@ class Config(object):
                     if value is not None:
                         value = string.Template(value).safe_substitute(os.environ)
                 if name:
-                    self.Rc[name] = {  'value': value, 
-                                     'comment': comment, 
+                    self.Rc[name] = {  'value': value,
+                                     'comment': comment,
                                         'flag': 0}
-                    
+
     def __call__(self,name,value=None):
         """Either get or set a resource depending on whether *value* is given"""
         if value == None:
@@ -50,11 +50,11 @@ class Config(object):
                 return self.Rc[name]['value']
         else:
             if self.Rc.__contains__(name):
-                self.Rc[name]['value'] = value 
+                self.Rc[name]['value'] = value
                 self.Rc[name]['flag'] = 1
                 return self.Rc[name]['value']
         return None
-        
+
     get = __call__
 
     def set(self,name,value):
@@ -65,7 +65,7 @@ class Config(object):
         if rcfile is None:
             f = sys.stdout
         else:
-            f = open(rcfile,'w') 
+            f = open(rcfile,'w')
         for line in self.Lines:
             line = line.rstrip()
             name, value, comment = _parseLine(line,self.delim)
@@ -76,16 +76,16 @@ class Config(object):
                     else:
                         comment = ''
                     value = self.Rc[name]['value']
-                    print >>f, name + self.delim+' ' + str(value) + comment # this line has been edited
+                    print(name + self.delim+' ' + str(value) + comment, file=f) # this line has been edited
                 else:
-                    print >>f, line
+                    print(line, file=f)
             else:
-                print >>f, line
+                print(line, file=f)
         f.close()
-       
+
     def upd(self,dict):
         pass
-         
+
     def interp(self,str,outFile=None,**kws):
         """
         Use the resource values for $-substitution (a.k.a.
@@ -108,7 +108,7 @@ class Config(object):
         for tmpl in Tmpl:
             Text.append(self.interpStr(tmpl,**kws))
         open(outFile,"w").writelines(Text)
-                    
+
     def interpStr(self,template,strict=False):
         """
         Replace occurences of resource variables in the
@@ -149,21 +149,21 @@ class Config(object):
         Use resources to set environment variables. Option,
         one can provide a list of strings (*Only*) with those
         resources to be turned into environment variables.
-        """ 
+        """
         for name in self.Rc:
             if Only is None:
                 os.environ[name] = self.Rc[name]['value']
             elif name in Only:
                 os.environ[name] = self.Rc[name]['value']
- 
+
     def keys(self):
-        """ 
+        """
         Return list of resource names.
         """
-        return self.Rc.keys()
+        return list(self.Rc.keys())
 
     def values(self):
-        """ 
+        """
         Return list of resource names.
         """
         vals = []
@@ -216,7 +216,7 @@ def strTemplate(templ,expid=None,nymd=None,nhms=None,
 
        dtime ---  python datetime
 
-    Unlike GrADS, notice that seconds are expanded using the %S2 token. 
+    Unlike GrADS, notice that seconds are expanded using the %S2 token.
     Input date/time can be either strings or integers.
 
     Examples:
@@ -229,9 +229,9 @@ def strTemplate(templ,expid=None,nymd=None,nhms=None,
 
     """
 
-    MMM = ( 'jan', 'feb', 'mar', 'apr', 'may', 'jun', 
-            'jul', 'aug', 'sep', 'oct', 'nov', 'dec' ) 
-    
+    MMM = ( 'jan', 'feb', 'mar', 'apr', 'may', 'jun',
+            'jul', 'aug', 'sep', 'oct', 'nov', 'dec' )
+
     str_ = templ[:]
 
     if dtime is not None:
@@ -244,34 +244,34 @@ def strTemplate(templ,expid=None,nymd=None,nhms=None,
 
     if nymd is not None:
         nymd = int(nymd)
-        yy = nymd/10000
-        mm = (nymd - yy*10000)/100
+        yy = nymd//10000
+        mm = (nymd - yy*10000)//100
         dd = nymd - (10000*yy + 100*mm )
 
     if nhms is not None:
         nhms = int(nhms)
-        h = nhms/10000
-        m = (nhms - h * 10000)/100
+        h = nhms//10000
+        m = (nhms - h * 10000)//100
         s = nhms - (10000*h + 100*m)
 
-    if expid is not None: 
+    if expid is not None:
         str_ = str_.replace('%s',expid)
-    if yy is not None: 
+    if yy is not None:
         y2 = yy%100
         str_ = str_.replace('%y4',str(yy))
         str_ = str_.replace('%y2',"%02d"%y2)
-    if mm is not None: 
+    if mm is not None:
         mm = int(mm)
         mmm = MMM[mm-1]
         str_ = str_.replace('%m2',"%02d"%mm)
         str_ = str_.replace('%m3',mmm)
-    if dd is not None: 
+    if dd is not None:
         str_ = str_.replace('%d2',"%02d"%int(dd))
-    if h  is not None: 
+    if h  is not None:
         str_ = str_.replace('%h2',"%02d"%int(h))
-    if m  is not None: 
+    if m  is not None:
         str_ = str_.replace('%n2',"%02d"%int(m))
-    if s  is not None: 
+    if s  is not None:
         str_ = str_.replace('%S2',"%02d"%int(s))
 
     return str_
@@ -284,14 +284,14 @@ def strTemplate(templ,expid=None,nymd=None,nhms=None,
 def _ut_strTemplate():
 
 
-    
+
     templ = "%s.aer_f.eta.%m3%y2.%y4%m2%d2_%h2:%n2:%S2z.nc"
 
     expid = "e0054A"
     yy = "2008"
     mm = "10"
     dd = "30"
-    
+
     h = "1"
     m = "30"
     s = "47"
@@ -301,20 +301,20 @@ def _ut_strTemplate():
     nymd = int(yy) * 10000 + int(mm)*100 + int(dd)
     nhms = int(h) * 10000 + int(m) * 100 + int(s)
 
-    print "Template: "+templ
-    print strTemplate(templ)
-    print strTemplate(templ,expid=expid)
-    print strTemplate(templ,expid=expid,yy=2008)
-    print strTemplate(templ,expid=expid,yy=2008,mm=mm)
-    print strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd)
-    print strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd,h=h)
-    print strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd,h=h,m=m,s=s)
-    print strTemplate(templ,expid=expid,nymd=nymd)
-    print strTemplate(templ,expid=expid,nymd=nymd,nhms=nhms)
-    print strTemplate(templ,expid=expid,dtime=dtime)
+    print("Template: "+templ)
+    print(strTemplate(templ))
+    print(strTemplate(templ,expid=expid))
+    print(strTemplate(templ,expid=expid,yy=2008))
+    print(strTemplate(templ,expid=expid,yy=2008,mm=mm))
+    print(strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd))
+    print(strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd,h=h))
+    print(strTemplate(templ,expid=expid,yy=2008,mm=mm,dd=dd,h=h,m=m,s=s))
+    print(strTemplate(templ,expid=expid,nymd=nymd))
+    print(strTemplate(templ,expid=expid,nymd=nymd,nhms=nhms))
+    print(strTemplate(templ,expid=expid,dtime=dtime))
 
 if __name__ == "__main__":
     cf = Config('test.rc', delim=' = ')
-    
+
 #    _ut_strTemplate()
 

--- a/Python/MAPL/constants.py
+++ b/Python/MAPL/constants.py
@@ -8,39 +8,33 @@ MAPL_RADIANS_TO_DEGREES = 180.0 / MAPL_PI
 
 MAPL_UNDEF   = 1.0e15
 
-MAPL_PSDRY   = 98305.0
-
+MAPL_PSDRY   = 98305.0                # dry surface pressure [Pa]
+MAPL_SECONDS_PER_SIDEREAL_DAY = 86164.0 #s
 MAPL_GRAV    = 9.80665                # m^2/s
 MAPL_RADIUS  = 6371.0E3               # m
-MAPL_OMEGA   = 2.0*MAPL_PI/86164.0    # 1/s
-MAPL_STFBOL  = 5.6734E-8              # W/(m^2 K^4)
-MAPL_AIRMW   = 28.965                 # kg/Kmole
-MAPL_H2OMW   = 18.015                 # kg/Kmole
-MAPL_O3MW    = 47.9982                # kg/Kmole
+MAPL_OMEGA   = 2.0*MAPL_PI/MAPL_SECONDS_PER_SIDEREAL_DAY    # 1/s
 MAPL_RUNIV   = 8314.47                # J/(Kmole K)
-MAPL_ALHL    = 2.4665E6               # J/kg @15C
-MAPL_ALHF    = 3.3370E5               # J/kg
-MAPL_ALHS    = MAPL_ALHL+MAPL_ALHF    # J/kg
+MAPL_H2OMW   = 18.015                 # kg/Kmole
+MAPL_EARTH_ECCENTRICITY = 8.1819190842622E-2 # --
+MAPL_EARTH_SEMIMAJOR_AXIS = 6378137 # m
+MAPL_KM_PER_DEG = (1.0/(MAPL_RADIUS/1000.)) * MAPL_RADIANS_TO_DEGREES
+MAPL_DEG_PER_KM = (MAPL_RADIUS/1000.) * MAPL_DEGREES_TO_RADIANS
 
+MAPL_AIRMW   = 28.965                 # kg/Kmole
 MAPL_RDRY    = MAPL_RUNIV/MAPL_AIRMW  # J/(kg K)
 MAPL_CPDRY   = 3.5*MAPL_RDRY          # J/(kg K)
 MAPL_CVDRY   = MAPL_CPDRY-MAPL_RDRY   # J/(kg K)
-
 MAPL_RVAP    = MAPL_RUNIV/MAPL_H2OMW  # J/(kg K)
 MAPL_CPVAP   = 4.*MAPL_RVAP           # J/(kg K)
 MAPL_CVVAP   = MAPL_CPVAP-MAPL_RVAP   # J/(kg K)
-
 MAPL_KAPPA   = MAPL_RDRY/MAPL_CPDRY   # (2.0/7.0)
-
 MAPL_EPSILON = MAPL_H2OMW/MAPL_AIRMW  # --
 MAPL_DELTAP  = MAPL_CPVAP/MAPL_CPDRY  # --
 MAPL_DELTAV  = MAPL_CVVAP/MAPL_CVDRY  # --
 MAPL_GAMMAD  = MAPL_CPDRY/MAPL_CVDRY  # --
-
 MAPL_RGAS    = MAPL_RDRY              # J/(kg K) (DEPRECATED)
 MAPL_CP      = MAPL_RGAS/MAPL_KAPPA   # J/(kg K) (DEPRECATED)
 MAPL_VIREPS  = 1.0/MAPL_EPSILON-1.0   #          (DEPRECATED)
-
 MAPL_P00     = 100000.0               # Pa
 MAPL_CAPICE  = 2000.                  # J/(K kg)
 MAPL_CAPWTR  = 4218.                  # J/(K kg)
@@ -50,9 +44,124 @@ MAPL_TICE    = 273.16                 # K
 MAPL_SRFPRS  = 98470                  # Pa
 MAPL_KARMAN  = 0.40                   # --
 MAPL_USMIN   = 1.00                   # m/s
-MAPL_AVOGAD  = 6.023E26               # 1/kmol
-
 MAPL_RHO_SEAWATER  = 1026.0          # sea water density [kg/m^3]. SA: should it be = 1026 kg/m^3?
 MAPL_RHO_SEAICE    = 917.0           # sea ice   density [kg/m^3]. SA: should it be = 917  kg/m^3?
 MAPL_RHO_SNOW      = 330.0           # snow density      [kg/m^3]. SA: should it be = 330  kg/m^3?
+MAPL_CELSIUS_TO_KELVIN = 273.15      # K
 
+MAPL_STFBOL  = 5.6734E-8              # W/(m^2 K^4)
+MAPL_AVOGAD  = 6.023E26               # 1/kmol
+
+MAPL_O3MW    = 47.9982                # kg/Kmole
+MAPL_ALHL    = 2.4665E6               # J/kg @15C
+MAPL_ALHF    = 3.3370E5               # J/kg
+MAPL_ALHS    = MAPL_ALHL+MAPL_ALHF    # J/kg
+
+
+#Internal constants
+MAPL_GRID_NAME_DEFAULT = 'UNKNOWN'
+MAPL_GRID_FILE_NAME_DEFAULT = 'UNKNOWN'
+MAPL_CF_COMPONENT_SEPARATOR = '.'
+
+MAPL_TimerModeOld = 0
+MAPL_TimerModeRootOnly = 1
+MAPL_TimerModeMax = 2
+MAPL_TimerModeMinMax = 3
+
+MAPL_UseStarrQsat = 1
+MAPL_UseGoffGratchQsat = 2
+MAPL_UseMurphyKoopQsat =3
+MAPL_UseCAMQsat =4
+
+MAPL_Unknown = 0
+MAPL_IsGather = 1
+MAPL_IsScatter = 2
+
+MAPL_TileNameLength = 128
+
+MAPL_NoShm = 255
+
+MAPL_SUCCESS = 0
+MAPL_FILE_NOT_FOUND = 1
+
+MAPL_DimTopoEdge = -1
+MAPL_DimTopoCyclic = 0
+MAPL_DimTopoCenter = 1
+
+MAPL_CplUNKNOWN = 0
+MAPL_CplSATISFIED = 1
+MAPL_CplNEEDED = 2
+MAPL_Cpl_NOTNEEDED = 4
+MAPL_FriendlyVariable = 8
+MAPL_FieldItem = 8
+MAPL_BundleItem = 16
+MAPL_StateItem = 32
+MAPL_NoRestart = 64
+
+MAPL_Write2Disk = 0
+MAPL_Write2RAM = 1
+
+MAPL_VLocationNone = 0
+MAPL_VLocationEdge = 1
+MAPL_VLocationCenter = 2
+
+MAPL_DimsUnknown = 0
+MAPL_DimsVertOnly = 1
+MAPL_DimsHorzOnly = 2
+MAPL_DimsHorzVert = 3
+MAPL_DimsTileOnly = 4
+MAPL_DimsTileTile = 5
+MAPL_DimsNone = 6
+
+MAPL_ScalarField = 1
+MAPL_VectorField = 2
+
+MAPL_CplAverage = 0
+MAPL_CplMin = 1
+MAPL_CplMax = 2
+MAPL_CplAccumulate = 3
+MAPL_MinMaxUnknown = 4
+
+MAPL_AttrGrid = 1
+MAPl_AttrTile = 2
+
+MAPL_Uninitialized = 0
+MAPL_InitialDefault = 1
+MAPL_InitialRestart = 2
+
+MAPL_DuplicateEntry = -99
+MAPL_ConnUnknown = -1
+MAPL_Self = 0 
+MAPL_Import = 1
+MAPL_Export = 2
+
+MAPL_FirstPhase = 1
+MAPL_SecondPhase = MAPL_FirstPhase + 1
+MAPL_ThirdPhase = MAPL_SecondPhase + 1
+MAPL_FourthPhase = MAPL_ThirdPhase + 1
+MAPL_FifthPhase = MAPL_FourthPhase + 1
+
+MAPL_Ocean = 0
+MAPL_Lake = 19
+MAPL_LandIce = 20
+MAPL_Land = 100
+MAPL_Vegetated = 101
+MAPL_NumVegTypes = 6
+
+MAPL_AGrid = 0
+MAPL_CGrid = 1
+MAPL_DGrid = 2
+
+MAPL_RotateLL = 0
+MAPL_RotateCube = 1
+
+MAPL_HorzTransOrderBinning = 0
+MAPL_HorzTransOrderBilinear = 1
+MAPL_HorzTransOrderFraction = 98
+MAPL_HorzTransOrderSample = 99
+
+MAPL_RestartOptional = 0
+MAPL_RestartSkip = 1
+MAPL_RestartRequired = 2
+MAPL_Restart_Bootstrap = 3
+MAPL_RestartSkipInitial = 4

--- a/Python/MAPL/exp.py
+++ b/Python/MAPL/exp.py
@@ -35,7 +35,7 @@ class Exp(object):
         self.submit()  # resubmit itsef
 
     def submit(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
         
 
 #                   --------------
@@ -74,7 +74,7 @@ def setup(inConfigFiles=None):
     os.mkdir(tmpdir)
     os.chdir(tmpdir)
     if os.system(cmd):
-       raise IOerror, "red_ma.pl did not complete successfully"
+       raise IOerror("red_ma.pl did not complete successfully")
 
 #   Resources as specified by user
 #   ------------------------------
@@ -82,7 +82,7 @@ def setup(inConfigFiles=None):
         
 #   Setup directory tree
 #   --------------------
-    for dir in  cf.regex('Dir$').values():
+    for dir in  list(cf.regex('Dir$').values()):
         os.mkdir(dir)
 
 #   Populate Resources

--- a/Python/MAPL/history.py
+++ b/Python/MAPL/history.py
@@ -2,7 +2,7 @@
 A special class for handling history resources.
 """
 
-from config import *
+from .config import *
 
 class History(Config):
 
@@ -35,15 +35,14 @@ class History(Config):
         *.temkplate resources.
         """
         dict = self.regex('template$')
-        Tmpl = [str.replace("'","").replace(",","") for str in dict.values()]
-        Coll = [ str.split('.')[0].replace(",","")  for str in dict.keys()  ]
+        Tmpl = [str.replace("'","").replace(",","") for str in list(dict.values())]
+        Coll = [ str.split('.')[0].replace(",","")  for str in list(dict.keys())  ]
         Arch = [str.replace("'","").replace(",","") \
-                for str in self.regex('archive$').values()]
+                for str in list(self.regex('archive$').values())]
 
         if len(Tmpl) != len(Arch):
-            raise IOError,\
-            "There are %d template resources but only %d archive resources."\
-            %(len(Tmpl),len(Arch))
+            raise IOError("There are %d template resources but only %d archive resources."\
+            %(len(Tmpl),len(Arch)))
 
         header = '# PESTO resource for History Collections ' + \
                  '(automatically generated - do not edit)'

--- a/Python/MAPL/job.py
+++ b/Python/MAPL/job.py
@@ -11,8 +11,8 @@ Design remarks:
 
 """
 
-import Abstract
-from exp import Exp
+from . import Abstract
+from .exp import Exp
 
 class Job(Exp):
     
@@ -72,13 +72,13 @@ class Job(Exp):
 #                         -----------------
 
     def getResources(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
     def getRecyclables(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
     def putRecyclables(self):
-        raise NotImplementedError, "Not implemented yet"
+        raise NotImplementedError("Not implemented yet")
 
 
 #                         ----------------

--- a/Python/MAPL/run.py
+++ b/Python/MAPL/run.py
@@ -5,7 +5,7 @@ experiment, whichever is sooner.)
 
 """
 
-from job import Job
+from .job import Job
 
 class Run(Job):
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR backports changes from `main` to Python3-ize MAPL 2.8.0 for work with older codes as Python2 is removed due to OS upgrades.

We will test build this with a tag from @rtodling to at least make sure things build.

## Related Issue

