### PR TITLE
Draft:  add a few first level timer for sampelr code in MAPL_HistoryGridComp.F90

### DIFF
--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -9,7 +9,7 @@ module MAPL_HistoryCollectionMod
   use MAPL_VerticalDataMod
   use MAPL_TimeDataMod
   use HistoryTrajectoryMod
-  use MaskSamplerGeosatMod  
+  use MaskSamplerGeosatMod
   use StationSamplerMod
   use gFTL_StringStringMap
   use MAPL_EpochSwathMod


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

I added a few timers for samplers in MAPL_HistoryGridComp.F90.

One problem is I donot see any timing output, e.g., ` call MAPL_TimerOn(GENSTATE,"TrajectoryRun")`, how to turn on the profiler ?

My output shows:
```
                                                               Inclusive        Exclusive
                                                            ================ ================
Name                                               #-cycles  T (sec)    %     T (sec)    %
                                                   -------- --------- ------ --------- ------
All                                                       1     5.101 100.00     0.995  19.50
--Root                                                   45     2.554  50.06     2.554  50.06
--HIST                                                   45     1.526  29.91     1.526  29.91
--EXTDATA                                                45     0.027   0.54     0.027   0.54
```


## Related Issue
- I need to do some code cleanup for samplers in a separate PR. 
