### PR TITLE
Update to ESMA_cmake v3.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `components.yaml`
+  - ESMA_cmake v3.45.1
+    - Fix bug in meson detection
+
 ### Fixed
 
 ### Removed

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.0
+  tag: v3.45.1
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Updates the ESMA_cmake version in `components.yaml` to 3.45.1. 3.45.0 had a small bug with meson detection that affected f2py3 in CMake. Not crucial for MAPL use, but still a bug. 

Note: This "bug" doesn't seem to affect the one f2py code in MAPL. It builds with either meson or distutils. It is more crucial for GEOSgcm. But might as well update here.

## Related Issue

