### PR TITLE
Fix GNU docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,8 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: mapl
           mpi_name: openmpi
-          mpi_version: 5.0.0
+          mpi_version: 5.0.2
           compiler_name: gcc
-          compiler_version: 12.1.0
+          compiler_version: 13.2.0
           image_name: geos-env-mkl
           tag_build_arg_name: *tag_build_arg_name


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

The release of 2.46 exposed a bug in the GNU Docker image build. This should fix it...for the next release. 

If this becomes critical, we could issue 2.46.1, but there will probably be a hotfix or new release at some point soon enough.

## Related Issue

