### PR TITLE
Build MAPL3 as SHARED only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,20 +42,20 @@ workflows:
           ctest_options: "-L 'ESSENTIAL' --output-on-failure"
           persist_workspace: true # Needed for MAPL tutorials
 
-      # Builds MAPL like UFS does (no pFlogger, static)
+      # Builds MAPL without PFLOGGER and FARGPARSE
       - ci/build:
-          name: build-UFS-MAPL-on-<< matrix.compiler >>
+          name: build-MAPL-without-pFlogger-and-fArgParse-on-<< matrix.compiler >>
           context:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort]
+              compiler: [gfortran, ifort]
           baselibs_version: *baselibs_version
           repo: MAPL
           mepodevelop: false
           remove_flap: true
           remove_pflogger: true
-          extra_cmake_options: "-DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF -DUSE_EXTDATA2G=OFF -DBUILD_SHARED_MAPL=OFF"
+          extra_cmake_options: "-DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF"
           run_unit_tests: true
           ctest_options: "-L 'ESSENTIAL' --output-on-failure"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removes backward compatibility for MAPL_FargparseCLI functions. Only accepts function usage in which the result is of
   MAPL_CapOptions type.
 - Remove FLAP support.
+- Remove `BUILD_SHARED_MAPL` CMake option. MAPL3 is now always built as a shared library.
 
 ### Added
 
@@ -42,9 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Now gives the name of the timer that has not been stopped when
   finalizing a profiler.
 - Changed all ESMF_AttributeGet and ESMF_AttributeSet to ESMF_InfoGet and ESMF_InfoSet respectively as old calls will be deprecated soon.
-- Updated `components.yaml`
-  - ESMA_env v4.0.0 (Baselibs 7, new yaFyaml interfaces)
-- Updated CI to use Baselibs 7
 - Update executables using FLAP to use fArgParse
 - Update `Findudunits.cmake` to link with libdl and look for the `udunits2.xml` file (as some MAPL tests require it)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,14 +61,6 @@ endif ()
 # This tells cmake to assume MAPL's cmake directory is the first place to look
 list (PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-option (BUILD_SHARED_MAPL "Build shared MAPL libraries" ON)
-if (BUILD_SHARED_MAPL)
-  set (MAPL_LIBRARY_TYPE SHARED)
-else ()
-  set (MAPL_LIBRARY_TYPE STATIC)
-endif()
-message (STATUS "Building MAPL as ${MAPL_LIBRARY_TYPE} libraries")
-
 # Some users of MAPL build GFE libraries inline with their application
 # using an add_subdirectory() call rather than as a pre-build library.
 # This would then populate the target already leading to find_package()

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -5,7 +5,7 @@ esma_add_library (${this}
   SRCS MAPL.F90
   DEPENDENCIES MAPL.base MAPL.generic MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps MAPL.orbit MAPL.griddedio MAPL.field_utils ${EXTDATA_TARGET}
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 target_compile_definitions (${this} PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)

--- a/MAPL_cfio/CMakeLists.txt
+++ b/MAPL_cfio/CMakeLists.txt
@@ -30,7 +30,7 @@ set (lib MAPL_cfio_${precision})
 esma_add_library (${lib}
   SRCS ${srcs}
   DEPENDENCIES ESMF::ESMF NetCDF::NetCDF_Fortran
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 if (precision MATCHES "r8")

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -70,7 +70,7 @@ esma_add_library(
   DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 MAPL.field_utils PFLOGGER::pflogger
                GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-  TYPE ${MAPL_LIBRARY_TYPE})
+  TYPE SHARED)
 
 # We don't want to disable good NAG debugging flags everywhere, but we still need to do it for
 # interfaces (e.g. MPI) that allow multiple types for the same argument (eg buffer).

--- a/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
@@ -4,7 +4,7 @@ set (srcs
     ACG_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 
 target_link_libraries(${this} PRIVATE ESMF::ESMF)
 

--- a/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     HelloWorld_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     AAA_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     BBB_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     ParentNoChildren_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     ParentOneChild_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
@@ -3,7 +3,7 @@ set (srcs
     ParentTwoSiblings_GridComp.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE SHARED)
 if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 endif ()

--- a/field_utils/CMakeLists.txt
+++ b/field_utils/CMakeLists.txt
@@ -25,7 +25,7 @@ endif ()
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.shared PFLOGGER::pflogger udunits2f
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 #add_subdirectory(specs)

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -65,7 +65,7 @@ esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.oomph MAPL.shared MAPL.profiler MAPL.base
                PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -57,7 +57,7 @@ endif ()
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.regridder_mgr MAPL.geom_mgr MAPL.shared MAPL.profiler MAPL.base MAPL.hconfig_utils YAFYAML::yafyaml PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 add_subdirectory(specs)
 add_subdirectory(registry)

--- a/geom_mgr/CMakeLists.txt
+++ b/geom_mgr/CMakeLists.txt
@@ -25,7 +25,7 @@ set(srcs
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.pfio MAPL.base MAPL.shared MAPL.field_utils MAPL.hconfig_utils GFTL::gftl-v2
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 add_subdirectory(MaplGeom)

--- a/gridcomps/CMakeLists.txt
+++ b/gridcomps/CMakeLists.txt
@@ -4,7 +4,7 @@ esma_add_library (${this}
      SRCS MAPL_GridComps.F90
      DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.cap
                   $<$<BOOL:${BUILD_WITH_FARGPARSE}>:FARGPARSE::fargparse>
-     TYPE ${MAPL_LIBRARY_TYPE}
+     TYPE SHARED
      )
 
 target_include_directories (${this} PUBLIC

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.profiler MAPL.history
-                  MAPL.ExtData ${EXTDATA2G_TARGET} TYPE ${MAPL_LIBRARY_TYPE})
+                  MAPL.ExtData ${EXTDATA2G_TARGET} TYPE SHARED)
 # We don't want to disable good NAG debugging flags everywhere, but we still need to do it for
 # interfaces (e.g. MPI) that allow multiple types for the same argument (eg buffer).
 if (DUSTY)

--- a/gridcomps/ExtData/CMakeLists.txt
+++ b/gridcomps/ExtData/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.pfio
-        MAPL.griddedio MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
+        MAPL.griddedio MAPL_cfio_r4  TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 

--- a/gridcomps/ExtData2G/CMakeLists.txt
+++ b/gridcomps/ExtData2G/CMakeLists.txt
@@ -23,7 +23,7 @@ set (srcs
     )
 
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.generic MAPL.griddedio TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.base MAPL.generic MAPL.griddedio TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -12,7 +12,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.profiler MAPL.griddedio
-                                                    TYPE ${MAPL_LIBRARY_TYPE})
+                                                    TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 

--- a/gridcomps/Orbit/CMakeLists.txt
+++ b/gridcomps/Orbit/CMakeLists.txt
@@ -4,7 +4,7 @@ set (srcs
         MAPL_OrbGridCompMod.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 

--- a/gridcomps/cap3g/CMakeLists.txt
+++ b/gridcomps/cap3g/CMakeLists.txt
@@ -9,6 +9,6 @@ find_package (MPI REQUIRED)
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.generic3g TYPE ${MAPL_LIBRARY_TYPE})
+  DEPENDENCIES MAPL.generic3g TYPE SHARED)
 
 add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -11,7 +11,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio
-         MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
+         MAPL_cfio_r4  TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran)
 

--- a/hconfig_utils/CMakeLists.txt
+++ b/hconfig_utils/CMakeLists.txt
@@ -16,7 +16,7 @@ endif ()
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.shared PFLOGGER::pflogger
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 target_include_directories (${this} PUBLIC

--- a/mapl3g/CMakeLists.txt
+++ b/mapl3g/CMakeLists.txt
@@ -5,7 +5,7 @@ esma_add_library (${this}
   SRCS mapl3g.F90 MaplFramework.F90
   DEPENDENCIES MAPL.generic3g MAPL.pfio MAPL.cap3g MAPL.gridcomps MAPL.griddedio MAPL.field_utils ${EXTDATA_TARGET}
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran PFLOGGER::pflogger
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 target_compile_definitions (${this} PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)

--- a/oomph/CMakeLists.txt
+++ b/oomph/CMakeLists.txt
@@ -30,5 +30,5 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.base GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2 TYPE ${MAPL_LIBRARY_TYPE}
+  DEPENDENCIES MAPL.base GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2 TYPE SHARED
   )

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -118,7 +118,7 @@ if (BUILD_WITH_PFLOGGER)
   find_package (PFLOGGER REQUIRED)
 endif ()
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE SHARED)
 
 target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran)
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/pflogger_stub/CMakeLists.txt
+++ b/pflogger_stub/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
   pflogger_stub.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared TYPE SHARED)
 add_library(PFLOGGER::pflogger ALIAS ${this})
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/pfunit/CMakeLists.txt
+++ b/pfunit/CMakeLists.txt
@@ -8,7 +8,7 @@ set (srcs
   MAPL_Initialize.F90
 )
 
-esma_add_library (${this} EXCLUDE_FROM_ALL SRCS ${srcs} NOINSTALL TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} EXCLUDE_FROM_ALL SRCS ${srcs} NOINSTALL TYPE SHARED)
 
 target_link_libraries (${this} MAPL.shared MAPL.field_utils PFUNIT::pfunit ESMF::ESMF NetCDF::NetCDF_Fortran)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -53,7 +53,7 @@ set (srcs
   MAPL_Profiler.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl-v1 GFTL::gftl-v2 PFLOGGER::pflogger MAPL.shared MPI::MPI_Fortran TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl-v1 GFTL::gftl-v2 PFLOGGER::pflogger MAPL.shared MPI::MPI_Fortran TYPE SHARED)
 target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
 
 # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280

--- a/regridder_mgr/CMakeLists.txt
+++ b/regridder_mgr/CMakeLists.txt
@@ -30,7 +30,7 @@ set(srcs
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.geom_mgr MAPL.pfio MAPL.base MAPL.shared MAPL.field_utils GFTL::gftl-v2
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 target_include_directories (${this} PUBLIC

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -34,7 +34,7 @@ set (srcs
     Shmem/Shmem.F90   Shmem/Shmem_implementation.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.constants GFTL_SHARED::gftl-shared GFTL_SHARED::gftl-shared-v2 MPI::MPI_Fortran PFLOGGER::pflogger TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.constants GFTL_SHARED::gftl-shared GFTL_SHARED::gftl-shared-v2 MPI::MPI_Fortran PFLOGGER::pflogger TYPE SHARED)
 
 # We don't want to disable good NAG debugging flags everywhere, but we still need to do it for
 # interfaces (e.g. MPI) that allow multiple types for the same argument (eg buffer).

--- a/shared/Constants/CMakeLists.txt
+++ b/shared/Constants/CMakeLists.txt
@@ -7,7 +7,7 @@ set (srcs
     Constants.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} TYPE SHARED)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 

--- a/udunits2f/CMakeLists.txt
+++ b/udunits2f/CMakeLists.txt
@@ -13,7 +13,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 esma_add_library(${this}
   SRCS ${srcs}
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
 )
 
 find_package(udunits REQUIRED)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Due to how MAPL3 works, we can no longer mix `STATIC` and `SHARED` libraries in MAPL. This PR removes the `BUILD_SHARED_MAPL` CMake option and makes all libraries `SHARED`.

## Related Issue

