### PR TITLE
Add debug information to fglob function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Update `FindESMF.cmake` to match that in ESMF 8.6.1
+- If file path length exceeds ESMF_MAXSTR, add _FAIL in subroutine fglob
 
 ### Changed
 

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -941,11 +941,16 @@ contains
 
     character(kind=C_CHAR, len=:), allocatable :: c_search_name
     character(kind=C_CHAR, len=512) :: c_filename
-    integer slen
+    integer :: slen, lenmax
 
     c_search_name = trim(search_name)//C_NULL_CHAR
     rc = f_call_c_glob(c_search_name, c_filename, slen)
     filename=""
+    lenmax = len(filename)
+    if (lenmax < slen) then
+       if (MAPL_AM_I_ROOT())  write(6,*) 'pathlen vs filename_max_char_len: ', slen, lenmax
+       _FAIL ('PATHLEN is greater than filename_max_char_len')
+    end if
     if (slen>0) filename(1:slen)=c_filename(1:slen)
 
     return


### PR DESCRIPTION

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Added _FAIL to sub. fglob, if pathlen exceeds upper bound of filename length (ESMF_MAXSTR). 
I find this could be a potential problem and we need the debug information. 

## Related Issue

