### PR TITLE
Added timer to sampler codes in history directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Update `FindESMF.cmake` to match that in ESMF 8.6.1
-
+- Add timer to the sampler code
 ### Changed
 
 - Set required version of ESMF to 8.6.1

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -9,7 +9,7 @@ module MAPL_HistoryCollectionMod
   use MAPL_VerticalDataMod
   use MAPL_TimeDataMod
   use HistoryTrajectoryMod
-  use MaskSamplerGeosatMod  
+  use MaskSamplerGeosatMod
   use StationSamplerMod
   use gFTL_StringStringMap
   use MAPL_EpochSwathMod

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2423,7 +2423,6 @@ ENDDO PARSER
           end if
           if (list(n)%timeseries_output) then
              list(n)%trajectory = HistoryTrajectory(cfg,string,clock,genstate=GENSTATE,_RC)
-             !!list(n)%trajectory = HistoryTrajectory(cfg,string,clock,_RC)
              call list(n)%trajectory%initialize(items=list(n)%items,bundle=list(n)%bundle,timeinfo=list(n)%timeInfo,vdata=list(n)%vdata,_RC)
              IntState%stampoffset(n) = list(n)%trajectory%epoch_frequency
           elseif (list(n)%sampler_spec == 'mask') then
@@ -3526,7 +3525,7 @@ ENDDO PARSER
                ! it's tempting to use the variable "oneMonth" but it does not work
                ! instead we compute the differece between
                ! thisMonth and lastMonth and as a new timeInterval
-
+               !
                call ESMF_ClockGet(clock,currTime=current_time,_RC)
                call ESMF_TimeIntervalSet( oneMonth, MM=1, _RC)
                lastMonth = current_time - oneMonth
@@ -3538,13 +3537,11 @@ ENDDO PARSER
 
          lgr => logging%get_logger('HISTORY.sampler')
          if (list(n)%timeseries_output) then
-            !!call MAPL_TimerOn(GENSTATE,"TrajectoryRun")
             if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
                call list(n)%trajectory%create_file_handle(filename(n),_RC)
                list(n)%currentFile = filename(n)
                list(n)%unit = -1
             end if
-            !!call MAPL_TimerOff(GENSTATE,"TrajectoryRun")
          elseif (list(n)%sampler_spec == 'station') then
             call MAPL_TimerOn(GENSTATE,"Station_preRun")
             if (list(n)%unit.eq.0) then
@@ -3557,7 +3554,6 @@ ENDDO PARSER
             end if
             call MAPL_TimerOff(GENSTATE,"Station_preRun")
          elseif (list(n)%sampler_spec == 'mask') then
-            call MAPL_TimerOn(GENSTATE,"MaskRun")
             if (list(n)%unit.eq.0) then
                call lgr%debug('%a %a',&
                     "Mask_data output to new file:",trim(filename(n)))
@@ -3566,7 +3562,6 @@ ENDDO PARSER
                list(n)%currentFile = filename(n)
                list(n)%unit = -1
             end if
-            call MAPL_TimerOff(GENSTATE,"MaskRun")
          else
             if( list(n)%unit.eq.0 ) then
                if (list(n)%format == 'CFIO') then

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2423,7 +2423,7 @@ ENDDO PARSER
           end if
           if (list(n)%timeseries_output) then
              list(n)%trajectory = HistoryTrajectory(cfg,string,clock,genstate=GENSTATE,_RC)
-             !!list(n)%trajectory = HistoryTrajectory(cfg,string,clock,_RC)             
+             !!list(n)%trajectory = HistoryTrajectory(cfg,string,clock,_RC)
              call list(n)%trajectory%initialize(items=list(n)%items,bundle=list(n)%bundle,timeinfo=list(n)%timeInfo,vdata=list(n)%vdata,_RC)
              IntState%stampoffset(n) = list(n)%trajectory%epoch_frequency
           elseif (list(n)%sampler_spec == 'mask') then
@@ -3546,7 +3546,7 @@ ENDDO PARSER
             end if
             !!call MAPL_TimerOff(GENSTATE,"TrajectoryRun")
          elseif (list(n)%sampler_spec == 'station') then
-            call MAPL_TimerOn(GENSTATE,"StationRun")
+            call MAPL_TimerOn(GENSTATE,"Station_preRun")
             if (list(n)%unit.eq.0) then
                call lgr%debug('%a %a',&
                     "Station_data output to new file:",trim(filename(n)))
@@ -3555,7 +3555,7 @@ ENDDO PARSER
                list(n)%currentFile = filename(n)
                list(n)%unit = -1
             end if
-            call MAPL_TimerOff(GENSTATE,"StationRun")
+            call MAPL_TimerOff(GENSTATE,"Station_preRun")
          elseif (list(n)%sampler_spec == 'mask') then
             call MAPL_TimerOn(GENSTATE,"MaskRun")
             if (list(n)%unit.eq.0) then
@@ -3771,12 +3771,12 @@ ENDDO PARSER
          call MAPL_TimerOn(GENSTATE,"TrajectoryRun")
          call MAPL_TimerOn(GENSTATE,"regrid_accum")
          call list(n)%trajectory%regrid_accumulate(_RC)
-         call MAPL_TimerOff(GENSTATE,"regrid_accum")         
+         call MAPL_TimerOff(GENSTATE,"regrid_accum")
          if( ESMF_AlarmIsRinging ( list(n)%trajectory%alarm ) ) then
             call MAPL_TimerOn(GENSTATE,"append_close_handle")
             call list(n)%trajectory%append_file(current_time,_RC)
             call list(n)%trajectory%close_file_handle(_RC)
-            call MAPL_TimerOff(GENSTATE,"append_close_handle")            
+            call MAPL_TimerOff(GENSTATE,"append_close_handle")
             if ( .not. ESMF_AlarmIsRinging(list(n)%end_alarm) ) then
                call MAPL_TimerOn(GENSTATE,"destroy_reg_rh")
                call list(n)%trajectory%destroy_rh_regen_LS (_RC)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -8,7 +8,7 @@ module HistoryTrajectoryMod
   use MAPL_LocstreamRegridderMod
   use MAPL_ObsUtilMod
   use MAPL_GenericMod, only : MAPL_MetaComp
-  
+
   use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
 
@@ -29,7 +29,7 @@ module HistoryTrajectoryMod
      integer,           allocatable :: obstype_id(:)
      integer,           allocatable :: location_index_ioda(:)   ! location index in its own ioda file
      type(MAPL_MetaComp), pointer   :: GENSTATE
-     
+
      type(ESMF_FieldBundle) :: bundle
      type(ESMF_FieldBundle) :: output_bundle
      type(ESMF_FieldBundle) :: acc_bundle

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -7,6 +7,8 @@ module HistoryTrajectoryMod
   use LocStreamFactoryMod
   use MAPL_LocstreamRegridderMod
   use MAPL_ObsUtilMod
+  use MAPL_GenericMod, only : MAPL_MetaComp
+  
   use, intrinsic :: iso_fortran_env, only: REAL64
   implicit none
 
@@ -26,7 +28,8 @@ module HistoryTrajectoryMod
      real(kind=REAL64), allocatable :: times_R8(:)
      integer,           allocatable :: obstype_id(:)
      integer,           allocatable :: location_index_ioda(:)   ! location index in its own ioda file
-
+     type(MAPL_MetaComp), pointer   :: GENSTATE
+     
      type(ESMF_FieldBundle) :: bundle
      type(ESMF_FieldBundle) :: output_bundle
      type(ESMF_FieldBundle) :: acc_bundle
@@ -97,11 +100,12 @@ module HistoryTrajectoryMod
 
 
   interface
-     module function HistoryTrajectory_from_config(config,string,clock,rc) result(traj)
+     module function HistoryTrajectory_from_config(config,string,clock,GENSTATE,rc) result(traj)
        type(HistoryTrajectory) :: traj
        type(ESMF_Config), intent(inout)        :: config
        character(len=*),  intent(in)           :: string
        type(ESMF_Clock),  intent(in)           :: clock
+       type(MAPL_MetaComp), pointer, intent(in), optional  :: GENSTATE
        integer, optional, intent(out)          :: rc
      end function HistoryTrajectory_from_config
 

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -51,6 +51,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
 
          traj%clock=clock
+         if (present(GENSTATE)) traj%GENSTATE => GENSTATE
          call ESMF_ClockGet ( clock, CurrTime=currTime, _RC )
          call ESMF_ConfigGetAttribute(config, value=time_integer, label=trim(string)//'Epoch:', default=0, _RC)
          _ASSERT(time_integer /= 0, 'Epoch value in config wrong')
@@ -1105,7 +1106,6 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                         if (nx>0) then
                            do ig = 1, this%obs(k)%ngeoval
                               if (trim(item%xname) == trim(this%obs(k)%geoval_xname(ig))) then
-                                 call lgr%debug('%a %a', 'append:2d inner put_var item%xname', trim(item%xname))
                                  call this%obs(k)%file_handle%put_var(trim(item%xname), this%obs(k)%p2d(1:nx), &
                                       start=[is],count=[nx])
                               end if
@@ -1173,7 +1173,6 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                         if (nx>0) then
                            do ig = 1, this%obs(k)%ngeoval
                               if (trim(item%xname) == trim(this%obs(k)%geoval_xname(ig))) then
-                                 call lgr%debug('%a %a', 'append:3d inner put_var item%xname', trim(item%xname))
                                  call this%obs(k)%file_handle%put_var(trim(item%xname), this%obs(k)%p3d(:,:), &
                                       start=[is,1],count=[nx,size(p_acc_rt_3d,2)])
                               end if


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Adding timer to history_gc reviews station sampler slows down the full sampler code. 
This PR completes the Timer task. 
Next PR will correct station sampler code. 

## Related Issue

