### PR TITLE
Fix issue with Open MPI 4, GCC 13, and MPI_Group_range_incl

### DIFF
--- a/mapl3g/MaplFramework.F90
+++ b/mapl3g/MaplFramework.F90
@@ -56,7 +56,7 @@ module mapl3g_MaplFramework
       procedure :: is_initialized
    end type MaplFramework
 
-   ! Private singleton object.  Used 
+   ! Private singleton object.  Used
    type(MaplFramework), target :: the_mapl_object
 
    interface MAPL_Get
@@ -114,7 +114,7 @@ contains
       integer :: status
       type(ESMF_Config) :: config
       logical :: esmf_is_initialized
- 
+
      esmf_is_initialized = ESMF_IsInitialized(_RC)
       _RETURN_IF(esmf_is_initialized)
 
@@ -138,13 +138,13 @@ contains
 
          integer :: status
          logical :: has_keystring
-         
+
          has_keystring = ESMF_HConfigIsDefined(hconfig, keystring=keystring, _RC)
          if (has_keystring) then
             subcfg = ESMF_HConfigCreateAt(hconfig, keystring='mapl', _RC)
             _RETURN(_SUCCESS)
          end if
-         
+
          subcfg = ESMF_HConfigCreate(content='{}', _RC)
          _RETURN(_SUCCESS)
       end function get_subconfig
@@ -231,7 +231,7 @@ contains
       has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
       if (.not. has_server_section) then
          ! Should only run on model PETs
-         call MPI_Group_range_incl(world_group, 1, [0, model_petCount-1, 1], model_group, _IERROR)
+         call MPI_Group_range_incl(world_group, 1, reshape([0, model_petCount-1, 1], [3,1]), model_group, _IERROR)
          call MPI_Comm_create_group(world_comm, model_group, 0, this%model_comm, _IERROR)
          call MPI_Group_free(model_group, _IERROR)
          if (present(is_model_pet)) then
@@ -246,7 +246,7 @@ contains
       if (.not. present(servers)) then
          _RETURN(_SUCCESS)
       end if
-      
+
       num_model_ssis = get_num_ssis(model_petCount, ssiCount, ssiMap, ssiOffset=0, _RC)
 
       servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
@@ -307,7 +307,7 @@ contains
       type(ESMF_HConfig) :: server_hconfig, comms_hconfig
       character(:), allocatable :: sharedObj
       character(:), allocatable :: userRoutine
-      
+
       server_hconfig = ESMF_HConfigCreateAt(hconfig, _RC)
       comms_hconfig = ESMF_HConfigCreate(content='{}', _RC)
       call ESMF_HConfigAdd(comms_hconfig, comms(1), addKeyString='world_comm', _RC)
@@ -335,7 +335,7 @@ contains
 
       integer :: n_servers, i_server
       type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
-      
+
       n_servers = ESMF_HConfigGetSize(servers_hconfig, _RC)
       allocate(server_hconfigs(n_servers))
 
@@ -400,7 +400,7 @@ contains
       call this%directory_service%publish(PortInfo('o_server', this%o_server), this%o_server)
       clientPtr => o_Clients%current()
       call this%directory_service%connect_to_server('o_server', clientPtr, this%model_comm)
-      
+
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_simple_oserver


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

The nightly GNU MAPL3 runs on discover were failing with:

```
[ 97%] Building Fortran object mapl3g/CMakeFiles/mapl3g.dir/MaplFramework.F90.o
/discover/swdev/mathomp4/Models/MAPL3-GNU/mapl3g/MaplFramework.F90:234:105:
  234 |          call MPI_Group_range_incl(world_group, 1, [0, model_petCount-1, 1], model_group, _IERROR)
      |                                                                                                         1
Error: There is no specific subroutine for the generic 'mpi_group_range_incl' at (1)
gmake[2]: *** [mapl3g/CMakeFiles/mapl3g.dir/build.make:88: mapl3g/CMakeFiles/mapl3g.dir/MaplFramework.F90.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:4223: mapl3g/CMakeFiles/mapl3g.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```

So following the @rookiehpc [`MPI_Group_range_incl` example](https://rookiehpc.org/mpi/docs/mpi_group_range_incl/index.html) and with help from @tclune, a small fix is made.

Note: My guess as to why the CI works is that the CI uses Open MPI 5 (as does bucy and our laptops). But on discover, Open MPI 4.1.6 is used because Open MPI 5 does *not* like discover. So maybe something was fixed in Open MPI 5 at some point? I dunno, but this seems good.[^1]

## Related Issue


[^1]: I tried looking at the Open MPI commit history for Fortran-ish changes near this code. Any latest changes seem to be by @hppritcha but commits around `MPI_Group_range_incl` seem *years* old, so... 🤷🏼 