### PR TITLE
Revist the creation of submodules in geom_mgr

### DIFF
--- a/geom_mgr/GeomManager.F90
+++ b/geom_mgr/GeomManager.F90
@@ -78,6 +78,13 @@ module mapl3g_GeomManager
       procedure new_GeomManager
    end interface GeomManager
 
+   abstract interface
+      logical function I_FactoryPredicate(factory)
+         import GeomFactory
+         class(GeomFactory), intent(in) :: factory
+      end function I_FactoryPredicate
+   end interface
+
    interface
       module function new_GeomManager() result(mgr)
          type(GeomManager) :: mgr
@@ -172,6 +179,13 @@ module mapl3g_GeomManager
       module function get_geom_manager() result(geom_mgr)
          type(GeomManager), pointer :: geom_mgr
       end function get_geom_manager
+
+      module function find_factory(factories, predicate, rc) result(factory)
+         class(GeomFactory), pointer :: factory
+         type(GeomFactoryVector), pointer, intent(in) :: factories ! Force TARGET attr on actual
+         procedure(I_FactoryPredicate) :: predicate
+         integer, optional, intent(out) :: rc
+      end function find_factory
    end interface
 
 end module mapl3g_GeomManager

--- a/geom_mgr/GeomManager/CMakeLists.txt
+++ b/geom_mgr/GeomManager/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(MAPL.geom_mgr PRIVATE
   get_mapl_geom_from_id.F90
   get_mapl_geom_from_spec.F90
   add_mapl_geom.F90
+  find_factory.F90
   make_geom_spec_from_metadata.F90
   make_geom_spec_from_hconfig.F90
   make_mapl_geom_from_spec.F90

--- a/geom_mgr/GeomManager/add_factory.F90
+++ b/geom_mgr/GeomManager/add_factory.F90
@@ -1,26 +1,9 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) add_factory_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
-   abstract interface
-      logical function I_FactoryPredicate(factory)
-         import GeomFactory
-         class(GeomFactory), intent(in) :: factory
-      end function I_FactoryPredicate
-   end interface
-      
 contains
    
    module subroutine add_factory(this, factory)

--- a/geom_mgr/GeomManager/add_mapl_geom.F90
+++ b/geom_mgr/GeomManager/add_mapl_geom.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) add_mapl_geom_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/delete_mapl_geom.F90
+++ b/geom_mgr/GeomManager/delete_mapl_geom.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) delete_mapl_geom_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/find_factory.F90
+++ b/geom_mgr/GeomManager/find_factory.F90
@@ -1,0 +1,34 @@
+#include "MAPL_Generic.h"
+
+submodule (mapl3g_GeomManager) find_factory_smod
+
+   implicit none
+
+!   abstract interface
+!      logical function I_FactoryPredicate(factory)
+!         import GeomFactory
+!         class(GeomFactory), intent(in) :: factory
+!      end function I_FactoryPredicate
+!   end interface
+      
+contains
+   
+   ! If factory not found, return a null pointer _and_ a nonzero rc.
+   module function find_factory(factories, predicate, rc) result(factory)
+      class(GeomFactory), pointer :: factory
+      type(GeomFactoryVector), pointer, intent(in) :: factories ! Force TARGET attr on actual
+      procedure(I_FactoryPredicate) :: predicate
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(GeomFactoryVectorIterator) :: iter
+
+      factory => null()
+      iter = find_if(factories%begin(), factories%end(), predicate)
+      _ASSERT(iter /= factories%end(), "No factory found satisfying given predicate.")
+      factory => iter%of()
+
+      _RETURN(_SUCCESS)
+   end function find_factory
+
+end submodule find_factory_smod

--- a/geom_mgr/GeomManager/get_geom_from_id.F90
+++ b/geom_mgr/GeomManager/get_geom_from_id.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) get_geom_from_id_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/get_mapl_geom_from_hconfig.F90
+++ b/geom_mgr/GeomManager/get_mapl_geom_from_hconfig.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) get_mapl_geom_from_hconfig_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/get_mapl_geom_from_id.F90
+++ b/geom_mgr/GeomManager/get_mapl_geom_from_id.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) get_mapl_geom_from_id_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/get_mapl_geom_from_metadata.F90
+++ b/geom_mgr/GeomManager/get_mapl_geom_from_metadata.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) get_mapl_geom_from_metadata_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/get_mapl_geom_from_spec.F90
+++ b/geom_mgr/GeomManager/get_mapl_geom_from_spec.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) get_mapl_geom_from_spec_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/initialize.F90
+++ b/geom_mgr/GeomManager/initialize.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) initialize_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/make_geom_spec_from_hconfig.F90
+++ b/geom_mgr/GeomManager/make_geom_spec_from_hconfig.F90
@@ -1,46 +1,11 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) make_geom_spec_from_hconfig_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
-   abstract interface
-      logical function I_FactoryPredicate(factory)
-         import GeomFactory
-         class(GeomFactory), intent(in) :: factory
-      end function I_FactoryPredicate
-   end interface
-      
 contains
    
-   ! If factory not found, return a null pointer _and_ a nonzero rc.
-   function find_factory(factories, predicate, rc) result(factory)
-      class(GeomFactory), pointer :: factory
-      type(GeomFactoryVector), pointer, intent(in) :: factories ! Force TARGET attr on actual
-      procedure(I_FactoryPredicate) :: predicate
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      type(GeomFactoryVectorIterator) :: iter
-
-      factory => null()
-      iter = find_if(factories%begin(), factories%end(), predicate)
-      _ASSERT(iter /= factories%end(), "No factory found satisfying given predicate.")
-      factory => iter%of()
-
-      _RETURN(_SUCCESS)
-   end function find_factory
-
    module function make_geom_spec_from_hconfig(this, hconfig, rc) result(geom_spec)
       class(GeomSpec), allocatable :: geom_spec
       class(GeomManager), target, intent(inout) :: this

--- a/geom_mgr/GeomManager/make_geom_spec_from_metadata.F90
+++ b/geom_mgr/GeomManager/make_geom_spec_from_metadata.F90
@@ -1,46 +1,11 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) make_geom_spec_from_metadata_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
-   abstract interface
-      logical function I_FactoryPredicate(factory)
-         import GeomFactory
-         class(GeomFactory), intent(in) :: factory
-      end function I_FactoryPredicate
-   end interface
-      
 contains
    
-   ! If factory not found, return a null pointer _and_ a nonzero rc.
-   function find_factory(factories, predicate, rc) result(factory)
-      class(GeomFactory), pointer :: factory
-      type(GeomFactoryVector), pointer, intent(in) :: factories ! Force TARGET attr on actual
-      procedure(I_FactoryPredicate) :: predicate
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      type(GeomFactoryVectorIterator) :: iter
-
-      factory => null()
-      iter = find_if(factories%begin(), factories%end(), predicate)
-      _ASSERT(iter /= factories%end(), "No factory found satisfying given predicate.")
-      factory => iter%of()
-
-      _RETURN(_SUCCESS)
-   end function find_factory
-
    module function make_geom_spec_from_metadata(this, file_metadata, rc) result(geom_spec)
       class(GeomSpec), allocatable :: geom_spec
       class(GeomManager), target, intent(inout) :: this

--- a/geom_mgr/GeomManager/make_mapl_geom_from_spec.F90
+++ b/geom_mgr/GeomManager/make_mapl_geom_from_spec.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) make_mapl_geom_from_spec_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains

--- a/geom_mgr/GeomManager/new_GeomManager.F90
+++ b/geom_mgr/GeomManager/new_GeomManager.F90
@@ -1,17 +1,7 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_GeomManager) new_GeomManager_smod
-   use mapl3g_GeomSpec
-   use mapl3g_NullGeomSpec
-   use mapl3g_MaplGeom
-   use mapl3g_GeomFactory
-   use mapl3g_GeomFactoryVector
-   use mapl3g_GeomSpecVector
-   use mapl3g_IntegerMaplGeomMap
-   use mapl_ErrorHandlingMod
-   use pfio_FileMetadataMod
-   use esmf
-   use gftl2_IntegerVector
+
    implicit none
 
 contains


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Revist the creation of submodules in `geom_mgr`. We particularly focus on the submodules associated with `GeomManager.F90` and do the following:

- Include the function `find_factory` in its own submodule.
- Remove all the `use` statements from all the submodules

## Related Issue

