### PR TITLE
Fix a bug for Nx Ny in swath grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- fixed a bug in generate_newnxy in MAPL_SwathGridFactory.F90 (NX*NY=Ncore)
 - pFIO Clients don't send "Done" message when there is no request
 - Update `components.yaml`
   - ESMA_cmake v3.45.1

--- a/base/MAPL_SwathGridFactory.F90
+++ b/base/MAPL_SwathGridFactory.F90
@@ -478,7 +478,7 @@ contains
       _ASSERT (this%lm /= MAPL_UNDEFINED_INTEGER, 'LM: is undefined in swath grid')
 
       call lgr%debug(' %a  %a', 'CurrTime =', trim(tmp))
-      call lgr%debug(' %a  %i5  %i5', 'nx, ny = ', this%nx, this%ny)
+
 
       if ( index(tmp, 'T') /= 0 .OR. index(tmp, '-') /= 0 ) then
          call ESMF_TimeSet(currTime, timeString=tmp, _RC)
@@ -715,6 +715,7 @@ contains
       endif
       ! ims is set at here
       call this%check_and_fill_consistency(_RC)
+      call lgr%debug(' %a  %i5  %i5', 'nx, ny (check_and_fill_consistency) = ', this%nx, this%ny)
 
       _RETURN(_SUCCESS)
 

--- a/base/MAPL_SwathGridFactory.F90
+++ b/base/MAPL_SwathGridFactory.F90
@@ -169,12 +169,8 @@ contains
 
       _UNUSED_DUMMY(unusable)
 
-      if (mapl_am_I_root()) write(6,*) 'MAPL_SwathGridFactory.F90:  bf this%create_basic_grid'
       grid = this%create_basic_grid(_RC)
-      if (mapl_am_I_root()) write(6,*) 'MAPL_SwathGridFactory.F90:  af this%create_basic_grid'
       call this%add_horz_coordinates_from_file(grid,_RC)
-      if (mapl_am_I_root()) write(6,*) 'MAPL_SwathGridFactory.F90:  af this%add_horz_coordinates_from_file'
-
       _RETURN(_SUCCESS)
    end function make_new_grid
 
@@ -482,7 +478,7 @@ contains
       _ASSERT (this%lm /= MAPL_UNDEFINED_INTEGER, 'LM: is undefined in swath grid')
 
       call lgr%debug(' %a  %a', 'CurrTime =', trim(tmp))
-      call lgr%debug(' %a  %i5 %i5', 'nx,ny =', this%nx, this%ny)
+      call lgr%debug(' %a  %i5  %i5', 'nx, ny = ', this%nx, this%ny)
 
       if ( index(tmp, 'T') /= 0 .OR. index(tmp, '-') /= 0 ) then
          call ESMF_TimeSet(currTime, timeString=tmp, _RC)
@@ -717,13 +713,6 @@ contains
       else
          call get_multi_integer(this%jms, 'JMS:', _RC)
       endif
-
-      if (mapl_am_i_root()) then
-!         write(6,*) 'ims ', this%ims
-!         write(6,*) 'jms ', this%jms         
-      end if
-
-
       ! ims is set at here
       call this%check_and_fill_consistency(_RC)
 
@@ -866,33 +855,12 @@ contains
       call verify(this%nx, this%im_world, this%ims, rc=status)
       call verify(this%ny, this%jm_world, this%jms, rc=status)
 
-
-      if (mapl_am_i_root()) then
-         write(6,*) 'bf check fill consistency'
-         write(6,*) 'ims ', this%ims
-         write(6,*) 'jms ', this%jms
-         write(6,*) 'im_world ', this%im_world
-         write(6,*) 'jm_world ', this%jm_world
-      end if
-      
       if (.not.this%force_decomposition) then
          verify_decomp = this%check_decomposition(_RC)
          if ( (.not.verify_decomp) ) then
             call this%generate_newnxy(_RC)
-            write(6,*) 'af  this%generate_newnxy'
          end if
       end if
-
-
-      if (mapl_am_i_root()) then
-         write(6,*) 'af check fill consistency'
-         write(6,*) 'ims ', this%ims
-         write(6,*) 'jms ', this%jms
-         write(6,*) 'im_world ', this%im_world
-         write(6,*) 'jm_world ', this%jm_world
-      end if
-      
-
       _RETURN(_SUCCESS)
 
    contains
@@ -1173,9 +1141,8 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
       integer :: n
-      integer :: pet_count
-      integer :: j, fac
-      
+      integer :: j, pet_count
+
       _UNUSED_DUMMY(unusable)
 
       pet_count = this%nx * this%ny
@@ -1189,7 +1156,7 @@ contains
          this%nx = j
          this%ny = pet_count/j
       end if
-      
+
       n = this%jm_world/this%ny
       if (n < 2) then
          do j = int(sqrt(real(this%jm_world))), 1, -1
@@ -1210,13 +1177,13 @@ contains
       call MAPL_DecomposeDim(this%im_world, this%ims, this%nx)
       deallocate(this%jms)
       allocate(this%jms(0:this%ny-1))
-      call MAPL_DecomposeDim(this%jm_world, this%jms, this%ny)      
+      call MAPL_DecomposeDim(this%jm_world, this%jms, this%ny)
 
       _RETURN(_SUCCESS)
 
    end subroutine generate_newnxy
 
-   
+
    subroutine init_halo(this, unusable, rc)
       class (SwathGridFactory), target, intent(inout) :: this
       class (KeywordEnforcer), optional, intent(in) :: unusable

--- a/base/MAPL_SwathGridFactory.F90
+++ b/base/MAPL_SwathGridFactory.F90
@@ -482,6 +482,7 @@ contains
       _ASSERT (this%lm /= MAPL_UNDEFINED_INTEGER, 'LM: is undefined in swath grid')
 
       call lgr%debug(' %a  %a', 'CurrTime =', trim(tmp))
+      call lgr%debug(' %a  %i5 %i5', 'nx,ny =', this%nx, this%ny)
 
       if ( index(tmp, 'T') /= 0 .OR. index(tmp, '-') /= 0 ) then
          call ESMF_TimeSet(currTime, timeString=tmp, _RC)
@@ -716,6 +717,13 @@ contains
       else
          call get_multi_integer(this%jms, 'JMS:', _RC)
       endif
+
+      if (mapl_am_i_root()) then
+!         write(6,*) 'ims ', this%ims
+!         write(6,*) 'jms ', this%jms         
+      end if
+
+
       ! ims is set at here
       call this%check_and_fill_consistency(_RC)
 
@@ -858,12 +866,32 @@ contains
       call verify(this%nx, this%im_world, this%ims, rc=status)
       call verify(this%ny, this%jm_world, this%jms, rc=status)
 
+
+      if (mapl_am_i_root()) then
+         write(6,*) 'bf check fill consistency'
+         write(6,*) 'ims ', this%ims
+         write(6,*) 'jms ', this%jms
+         write(6,*) 'im_world ', this%im_world
+         write(6,*) 'jm_world ', this%jm_world
+      end if
+      
       if (.not.this%force_decomposition) then
          verify_decomp = this%check_decomposition(_RC)
          if ( (.not.verify_decomp) ) then
             call this%generate_newnxy(_RC)
+            write(6,*) 'af  this%generate_newnxy'
          end if
       end if
+
+
+      if (mapl_am_i_root()) then
+         write(6,*) 'af check fill consistency'
+         write(6,*) 'ims ', this%ims
+         write(6,*) 'jms ', this%jms
+         write(6,*) 'im_world ', this%im_world
+         write(6,*) 'jm_world ', this%jm_world
+      end if
+      
 
       _RETURN(_SUCCESS)
 

--- a/base/MAPL_SwathGridFactory.F90
+++ b/base/MAPL_SwathGridFactory.F90
@@ -1148,9 +1148,9 @@ contains
       pet_count = this%nx * this%ny
       n = this%im_world/this%nx
       if (n < 2) then
-         do j = int(sqrt(real(this%im_world))), 1, -1
+         do j = this%im_world/2, 1, -1
             if ( mod(pet_count, j) == 0 .and. this%im_world/j >= 2 ) then
-               exit
+               exit  ! found a decomposition
             end if
          end do
          this%nx = j
@@ -1159,23 +1159,23 @@ contains
 
       n = this%jm_world/this%ny
       if (n < 2) then
-         do j = int(sqrt(real(this%jm_world))), 1, -1
+         do j = this%jm_world/2, 1, -1
             if ( mod(pet_count, j) == 0 .and. this%jm_world/j >=2 ) then
-               exit
+               exit  ! found a decomposition
             end if
          end do
          this%ny = j
          this%nx = pet_count/j
       end if
 
-      if ( this%im_world/this%nx < 2 .and. this%jm_world/this%ny < 2 ) then
+      if ( this%im_world/this%nx < 2 .OR. this%jm_world/this%ny < 2 ) then
          _FAIL ('Algorithm failed')
       end if
 
-      deallocate(this%ims)
+      if (allocated(this%ims)) deallocate(this%ims)
       allocate(this%ims(0:this%nx-1))
       call MAPL_DecomposeDim(this%im_world, this%ims, this%nx)
-      deallocate(this%jms)
+      if (allocated(this%jms)) deallocate(this%jms)
       allocate(this%jms(0:this%ny-1))
       call MAPL_DecomposeDim(this%jm_world, this%jms, this%ny)
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
In swath grid, e.g., 
 im_world          135
 jm_world         7851
when Ncore=3456
the default gives Nx ~ sqrt(2Ncore),  Ny= Ncore /Nx
such that   floor ( im_world / Nx ) = 1

`function generate_new_decomp` tries to correct it, but violate Nx * Ny = Ncore.
Printout below:
```
 bf check fill consistency
 ims            2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           2           2           2
           2           2           2           1           1           1
           1           1           1           1           1           1
 jms          164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         163         163         163
         163         163         163         163         163         163
         163         163         163         163         163         163
         163         163         163         163         163         163
 im_world          135
 jm_world         7851
 af  this%generate_newnxy
 af check fill consistency
 ims            4           4           4           4           4           4
           4           4           4           4           4           4
           4           4           4           4           4           4
           4           4           4           4           4           4
           4           4           4           3           3           3
           3           3           3           3           3           3
 jms          164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         164         164         164
         164         164         164         163         163         163
         163         163         163         163         163         163
         163         163         163         163         163         163
         163         163         163         163         163         163
 im_world          135
 jm_world         7851
```


## Related Issue

