### PR TITLE
Regrid_Util.x and file weights

### DIFF
--- a/Apps/Regrid_Util.F90
+++ b/Apps/Regrid_Util.F90
@@ -26,6 +26,7 @@
       integer :: deflate, shave
       integer :: quantize_algorithm
       integer :: quantize_level
+      logical :: use_weights
    contains
       procedure :: create_grid
       procedure :: process_command_line
@@ -97,6 +98,7 @@
     this%deflate=0
     this%quantize_algorithm=1
     this%quantize_level=0
+    this%use_weights = .false.
     nargs = command_argument_count()
     do i=1,nargs
       call get_command_argument(i,str)
@@ -159,6 +161,8 @@
       case('-quantize_level')
          call get_command_argument(i+1,astr)
          read(astr,*)this%quantize_level
+      case('-file_weights')
+         this%use_weights = .true.
       case('--help')
          if (mapl_am_I_root()) then
 
@@ -413,9 +417,9 @@ CONTAINS
          if (mapl_am_i_root()) write(*,*)'processing timestep from '//trim(filename)
          time = tSeries(i)
          if (support%onlyvars) then
-            call MAPL_Read_bundle(bundle,trim(filename),time=time,regrid_method=support%regridMethod,only_vars=support%vars,_RC)
+            call MAPL_Read_bundle(bundle,trim(filename),time=time,regrid_method=support%regridMethod,only_vars=support%vars,file_weights=support%use_weights, _RC)
          else
-            call MAPL_Read_bundle(bundle,trim(filename),time=time,regrid_method=support%regridMethod,_RC)
+            call MAPL_Read_bundle(bundle,trim(filename),time=time,regrid_method=support%regridMethod,file_weights=support%use_weights, _RC)
          end if
          call t_prof%stop("Read")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add new option to Regrid_Util.x to write and re-use ESMF pregenerated weights
 - If file path length exceeds ESMF_MAXSTR, add _FAIL in subroutine fglob
 - Add GNU UFS-like CI test
 

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -21,6 +21,7 @@ module MAPL_ESMFFieldBundleRead
    use MAPL_SimpleAlarm
    use MAPL_StringTemplate
    use gFTL_StringVector
+   use MAPL_RegridMethods
    use, intrinsic :: iso_fortran_env, only: REAL32
    implicit none
    private
@@ -152,7 +153,7 @@ module MAPL_ESMFFieldBundleRead
 
       end subroutine MAPL_create_bundle_from_metdata_id
 
-      subroutine MAPL_read_bundle(bundle,file_tmpl,time,only_vars,regrid_method,noread,file_override,rc)
+      subroutine MAPL_read_bundle(bundle,file_tmpl,time,only_vars,regrid_method,noread,file_override,file_weights,rc)
          type(ESMF_FieldBundle), intent(inout) :: bundle
          character(len=*), intent(in) :: file_tmpl
          type(ESMF_Time), intent(in) :: time
@@ -160,10 +161,11 @@ module MAPL_ESMFFieldBundleRead
          integer, optional, intent(in) :: regrid_method
          logical, optional, intent(in) :: noread
          character(len=*), optional, intent(in) :: file_override
+         logical, optional, intent(in) :: file_weights
          integer, optional, intent(out) :: rc
 
          integer :: status
-         integer :: num_fields, metadata_id, collection_id, time_index, i
+         integer :: num_fields, metadata_id, collection_id, time_index, i, regrid_hints
          type(MAPL_GriddedIO) :: cfio
          character(len=ESMF_MAXPATHLEN) :: file_name
          type(MAPLDataCollection), pointer :: collection => null()
@@ -181,7 +183,7 @@ module MAPL_ESMFFieldBundleRead
          metadata_id = MAPL_DataAddCollection(trim(file_tmpl))
          collection => DataCollections%at(metadata_id)
          if (present(file_override)) file_name = file_override
-        
+
          metadata => collection%find(trim(file_name), _RC)
          call metadata%get_time_info(timeVector=time_series,rc=status)
          _VERIFY(status)
@@ -221,6 +223,13 @@ module MAPL_ESMFFieldBundleRead
 
          cfio=MAPL_GriddedIO(output_bundle=bundle,metadata_collection_id=metadata_id,read_collection_id=collection_id,items=items)
          call cfio%set_param(regrid_method=regrid_method)
+         if (present(file_weights)) then
+            if (file_weights) then
+               regrid_hints = 0
+               regrid_hints = IOR(regrid_hints,REGRID_HINT_FILE_WEIGHTS)
+               call cfio%set_param(regrid_hints=regrid_hints)
+            end if
+         end if
          call cfio%request_data_from_file(trim(file_name),timeindex=time_index,rc=status)
          _VERIFY(status)
          call i_clients%done_collective_prefetch()


### PR DESCRIPTION
This adds a new option to Regrid_Util.x so that it will write or use the already existing ESMF regridding weights when regridding if the user desires.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [X] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

