### PR TITLE
bubble up error from MAPL_getHorzIJindex function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Propgated the error message from MAPL_Horzijindex function
 - fixed a bug in generate_newnxy in MAPL_SwathGridFactory.F90 (NX*NY=Ncore)
 - pFIO Clients don't send "Done" message when there is no request
 - Update `components.yaml`

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -2629,7 +2629,7 @@ contains
     call ESMF_AttributeGet(grid, name='GridType', value=grid_type, _RC)
     if(trim(grid_type) == "Cubed-Sphere") then
 
-      call MAPL_GetGlobalHorzIJIndex(npts, II, JJ, lon=lon, lat=lat, lonR8=lonR8, latR8=latR8, Grid=Grid, rc=rc)
+      call MAPL_GetGlobalHorzIJIndex(npts, II, JJ, lon=lon, lat=lat, lonR8=lonR8, latR8=latR8, Grid=Grid, _RC)
 
       call MAPL_Grid_Interior(Grid,i1,i2,j1,j2)
       ! convert index to local, if it is not in domain, set it to -1 just as the legacy code
@@ -2770,7 +2770,10 @@ contains
 
     ! make sure the grid can be used in this subroutine
     good_grid = grid_is_ok(grid)
-    _ASSERT( good_grid, "MAPL_GetGlobalHorzIJIndex cannot handle this grid")
+
+    if ( .not. good_grid ) then
+       _FAIL( "MAPL_GetGlobalHorzIJIndex cannot handle this grid")
+    endif
 
     allocate(lons(npts),lats(npts))
     if (present(lon) .and. present(lat)) then


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
Stop the program when the grid is not a normal CS grid but compute the IJindex. It is partially address issue #2850 . Eventually, I think the Grid class should have information about stretched and the ij index is computed according to the info the grid provides 
## Related Issue

