### PR TITLE
Mapl3/#2868 multiple coupler sources

### DIFF
--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -18,6 +18,7 @@ set(srcs
 
   ComponentDriver.F90
   ComponentDriverVector.F90
+  ComponentDriverPtrVector.F90
   GriddedComponentDriver.F90
   GriddedComponentDriverMap.F90
 

--- a/generic3g/ComponentDriver.F90
+++ b/generic3g/ComponentDriver.F90
@@ -9,6 +9,7 @@ module mapl3g_ComponentDriver
    private
 
    public :: ComponentDriver
+   public :: ComponentDriverPtr
    public :: initialize_phases
 
    type, abstract :: ComponentDriver
@@ -18,6 +19,10 @@ module mapl3g_ComponentDriver
       procedure(I_run), deferred :: initialize
       procedure(I_run), deferred :: finalize
    end type ComponentDriver
+
+   type :: ComponentDriverPtr
+      class(ComponentDriver), pointer :: ptr
+   end type ComponentDriverPtr
 
    abstract interface
 

--- a/generic3g/ComponentDriverPtrVector.F90
+++ b/generic3g/ComponentDriverPtrVector.F90
@@ -1,0 +1,14 @@
+module mapl3g_ComponentDriverPtrVector
+   use mapl3g_ComponentDriver
+
+#define T ComponentDriverPtr
+#define Vector ComponentDriverPtrVector
+#define VectorIterator ComponentDriverPtrVectorIterator
+
+#include "vector/template.inc"
+
+#undef VectorIterator
+#undef Vector
+#undef T
+
+end module mapl3g_ComponentDriverPtrVector

--- a/generic3g/couplers/GenericCoupler.F90
+++ b/generic3g/couplers/GenericCoupler.F90
@@ -28,11 +28,26 @@ contains
       coupler_gridcomp = ESMF_GridCompCreate(name='coupler', _RC)
       call attach_coupler_meta(coupler_gridcomp, _RC)
       coupler_meta => get_coupler_meta(coupler_gridcomp, _RC)
+#ifndef __GFORTRAN__
       coupler_meta = CouplerMetaComponent(action, source)
+#else
+      call ridiculous(coupler_meta, CouplerMetaComponent(action,source))
+#endif
 
       call ESMF_GridCompSetServices(coupler_gridComp, setServices, _RC)
 
       _RETURN(_SUCCESS)
+
+   contains
+
+#ifdef __GFORTRAN__
+      subroutine ridiculous(a, b)
+         type(CouplerMetaComponent), intent(out) :: a
+         type(CouplerMetaComponent), intent(in) :: b
+         a = b
+      end subroutine ridiculous
+#endif
+
    end function make_coupler
    
    subroutine setServices(gridcomp, rc)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Extended generic3g couplers to allow for multiple sources (dependencies)
## Related Issue

