### PR TITLE
Remove slow tests from ESSENTIAL ExtData tests, turn off ExtData1G as ESSENTIAL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ workflows:
           remove_pflogger: true
           extra_cmake_options: "-DBUILD_WITH_FLAP=OFF -DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF -DUSE_EXTDATA2G=OFF -DBUILD_SHARED_MAPL=OFF"
           run_unit_tests: true
-          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
+          # ExtData1G tests were removed from ESSENTIAL, so we run them separately here as UFS might still use 1G?
+          ctest_options: "-L 'ESSENTIAL|EXTDATA1G_SMALL_TESTS' --output-on-failure"
 
       # Run MAPL Tutorials
       - ci/run_mapl_tutorial:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v3.45.1
     - Fix bug in meson detection
 - Updated `checkpoint_simulator` to not create and close file if not writing
-- Update ExtData2G tests
+- Update ExtData tests
   - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIAL`
     label run in CI
+  - Remove ExtData1G tests from `ESSENTIAL` label
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fixed a bug in generate_newnxy in MAPL_SwathGridFactory.F90 (`NX*NY=Ncore`)
 - pFIO Clients don't send "Done" message when there is no request
 - Update `components.yaml`
-  - ESMA_cmake v3.45.1
-    - Fix bug in meson detection
+  - ESMA_cmake v3.45.3
+    - Fix bugs in meson detection
+    - Fix for building on older macOS
 - Updated `checkpoint_simulator` to not create and close file if not writing
 - Update ExtData tests
   - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIAL`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v3.45.1
     - Fix bug in meson detection
 - Updated `checkpoint_simulator` to not create and close file if not writing
+- Update ExtData2G tests
+  - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIALS`
+    label run in CI
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Fix bug in meson detection
 - Updated `checkpoint_simulator` to not create and close file if not writing
 - Update ExtData2G tests
-  - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIALS`
+  - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIAL`
     label run in CI
 
 ### Fixed

--- a/Tests/ExtData_Testing_Framework/CMakeLists.txt
+++ b/Tests/ExtData_Testing_Framework/CMakeLists.txt
@@ -2,37 +2,51 @@
 string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
 list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
 if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
-   list(APPEND MPIEXEC_PREFLAGS "-oversubscribe")
+  list(APPEND MPIEXEC_PREFLAGS "-oversubscribe")
 endif()
 
 file(STRINGS "test_cases/extdata_1g_cases.txt" TEST_CASES_1G)
 
 set(cutoff "7")
 
+# We want to make a list of tests that are slow and can
+# be skipped for ESSENTIAL testing. Most ExtData tests
+# take 1-2 seconds at most, but some take 20-30 seconds.
+set(SLOW_TESTS
+  "case6"
+  "case14"
+  "case15"
+  "case16"
+  "case20"
+  "case22"
+  "case23"
+)
+
 foreach(TEST_CASE ${TEST_CASES_1G})
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc)
-     file(READ ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc num_procs)
+    file(READ ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc num_procs)
   else()
-     set(num_procs "1")
+    set(num_procs "1")
   endif()
   add_test(
-     NAME "ExtData1G_${TEST_CASE}"
-     COMMAND ${CMAKE_COMMAND}
-       -DTEST_CASE=${TEST_CASE}
-       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
-       -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
-       -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
-       -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
-       -DIS_EXTDATA2G=NO
-       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_extdata.cmake
-       )
-  if (${num_procs} LESS ${cutoff})
-     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SMALL_TESTS")
-     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
+    NAME "ExtData1G_${TEST_CASE}"
+    COMMAND ${CMAKE_COMMAND}
+      -DTEST_CASE=${TEST_CASE}
+      -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
+      -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
+      -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
+      -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
+      -DIS_EXTDATA2G=NO
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_extdata.cmake
+  )
+  if (${num_procs} GREATER ${cutoff})
+    set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_BIG_TESTS")
+  elseif (${TEST_CASE} IN_LIST SLOW_TESTS)
+    set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SLOW_TESTS")
   else()
-     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_BIG_TESTS")
+    set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SMALL_TESTS")
+    set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
   endif()
-
 endforeach()
 
 file(STRINGS "test_cases/extdata_2g_cases.txt" TEST_CASES_2G)
@@ -40,25 +54,27 @@ file(STRINGS "test_cases/extdata_2g_cases.txt" TEST_CASES_2G)
 foreach(TEST_CASE ${TEST_CASES_2G})
 
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc)
-     file(READ ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc num_procs)
+    file(READ ${CMAKE_CURRENT_LIST_DIR}/test_cases/${TEST_CASE}/nproc.rc num_procs)
   else()
-     set(num_procs "1")
+    set(num_procs "1")
   endif()
   add_test(
-     NAME "ExtData2G_${TEST_CASE}"
-     COMMAND ${CMAKE_COMMAND}
-       -DTEST_CASE=${TEST_CASE}
-       -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
-       -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
-       -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
-       -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
-       -DIS_EXTDATA2G=YES
-       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_extdata.cmake
-     )
-  if (${num_procs} LESS ${cutoff})
-     set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_SMALL_TESTS")
-     set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
+    NAME "ExtData2G_${TEST_CASE}"
+    COMMAND ${CMAKE_COMMAND}
+      -DTEST_CASE=${TEST_CASE}
+      -DMPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}
+      -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
+      -DMY_BINARY_DIR=${CMAKE_BINARY_DIR}/bin
+      -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
+      -DIS_EXTDATA2G=YES
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_extdata.cmake
+  )
+  if (${num_procs} GREATER ${cutoff})
+    set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_BIG_TESTS")
+  elseif (${TEST_CASE} IN_LIST SLOW_TESTS)
+    set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_SLOW_TESTS")
   else()
-     set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_BIG_TESTS")
+    set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA2G_SMALL_TESTS")
+    set_tests_properties ("ExtData2G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
   endif()
 endforeach()

--- a/Tests/ExtData_Testing_Framework/CMakeLists.txt
+++ b/Tests/ExtData_Testing_Framework/CMakeLists.txt
@@ -45,7 +45,6 @@ foreach(TEST_CASE ${TEST_CASES_1G})
     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SLOW_TESTS")
   else()
     set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "EXTDATA1G_SMALL_TESTS")
-    set_tests_properties ("ExtData1G_${TEST_CASE}" PROPERTIES LABELS "ESSENTIAL")
   endif()
 endforeach()
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.1
+  tag: v3.45.3
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR removes a few cases of ExtData tests from the `ESSENTIAL` label. In working with @darianboggs, we noticed that some ExtData tests can take 10 to 30 seconds to run. Which if one does `make tests` can be a bit annoying as most unit tests in MAPL take 1-2 seconds.

Testing identified 7 tests like this for both 1G and 2G. So a list was made and they are now labeled as `SLOW` tests, though I'm willing to fix this up

This PR changes things such that we do not run these tests in our "default" `ESSENTIAL` label. 

Moreover, I removed the ExtData1G tests from `ESSENTIAL` as well. In my opinion, ExtData1G isn't really used much anymore. But, as @bena-nasa mentioned it might be run in UFS land? So, the UFS-like MAPL CI test runs both `ESSENTIAL` and `EXTDATA1G_SMALL_TESTS`

That said, in the end, it is up to @tclune whether we should do this or not. But it was a thought.


## Related Issue

