### PR TITLE
Update to ESMA_cmake v3.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add new option to Regrid_Util.x to write and re-use ESMF pregenerated weights
-- If file path length exceeds ESMF_MAXSTR, add `_FAIL` in subroutine fglob
+- Add new option to `Regrid_Util.x` to write and re-use ESMF pregenerated weights
+- If file path length exceeds `ESMF_MAXSTR`, add `_FAIL` in subroutine fglob
 - Add GNU UFS-like CI test
-- Add capability to mangle `LONG_NAME in ACG with a different prefix
+- Add capability to mangle `LONG_NAME` in ACG with a different prefix
 
 ### Changed
 
-- fixed a bug in generate_newnxy in MAPL_SwathGridFactory.F90 (`NX*NY=Ncore`)
 - pFIO Clients don't send "Done" message when there is no request
 - Update `components.yaml`
-  - ESMA_cmake v3.45.3
+  - ESMA_cmake v3.46.0
     - Fix bugs in meson detection
     - Fix for building on older macOS
+    - Add `esma_add_fortran_submodules` function
 - Updated `checkpoint_simulator` to not create and close file if not writing
 - Update ExtData tests
   - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIAL`
     label run in CI
-  - Remove ExtData1G tests from `ESSENTIAL` label
+  - Remove ExtData1G tests from `ESSENTIAL` label, but run them in the UFS-like CI test
 
 ### Fixed
 
+- Fixed a bug in `generate_newnxy` in `MAPL_SwathGridFactory.F90` (`NX*NY=Ncore`)
 - Fixes for NVHPC 24.5
   - Convert `MAPL_GeosatMaskMod` to "interface-in-both-files" submodule style
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.3
+  tag: v3.46.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates `components.yaml` to ESMA_cmake v3.46.0. This version has the `esma_add_fortran_submodules` function from @JulesKouatchou that is being used in MAPL 3 work.

Even though MAPL 2 does not use this, we start here as it cannot hurt (and maybe someday we use it).

## Related Issue

