### PR TITLE
Handmerge develop into MAPL3 2024-Jun-21, remove explicit esma_add_fortran_submodules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ workflows:
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
+          fixture_branch: release/MAPL-v3
           mepodevelop: true
           checkout_mapl3_release_branch: true
           checkout_mapl_branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,27 +60,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add new option to Regrid_Util.x to write and re-use ESMF pregenerated weights
-- If file path length exceeds ESMF_MAXSTR, add `_FAIL` in subroutine fglob
+- Add new option to `Regrid_Util.x` to write and re-use ESMF pregenerated weights
+- If file path length exceeds `ESMF_MAXSTR`, add `_FAIL` in subroutine fglob
 - Add GNU UFS-like CI test
-- Add capability to mangle `LONG_NAME in ACG with a different prefix
+- Add capability to mangle `LONG_NAME` in ACG with a different prefix
 
 ### Changed
 
-- fixed a bug in generate_newnxy in MAPL_SwathGridFactory.F90 (`NX*NY=Ncore`)
 - pFIO Clients don't send "Done" message when there is no request
 - Update `components.yaml`
-  - ESMA_cmake v3.45.3
+  - ESMA_cmake v3.46.0
     - Fix bugs in meson detection
     - Fix for building on older macOS
+    - Add `esma_add_fortran_submodules` function
 - Updated `checkpoint_simulator` to not create and close file if not writing
 - Update ExtData tests
   - Add new category of `SLOW` tests that take 10-30 seconds and remove them from the `ESSENTIAL`
     label run in CI
-  - Remove ExtData1G tests from `ESSENTIAL` label
+  - Remove ExtData1G tests from `ESSENTIAL` label, but run them in the UFS-like CI test
 
 ### Fixed
 
+- Fixed a bug in `generate_newnxy` in `MAPL_SwathGridFactory.F90` (`NX*NY=Ncore`)
 - Fixes for NVHPC 24.5
   - Convert `MAPL_GeosatMaskMod` to "interface-in-both-files" submodule style
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.3
+  tag: v3.46.0
   develop: develop
 
 ecbuild:

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -59,33 +59,6 @@ esma_add_library(${this}
   TYPE SHARED
   )
 
-##### New function to avoid conflicts with files with the same name
-function(esma_add_fortran_submodules)
-  set(options)
-  set(oneValueArgs TARGET SUBDIRECTORY)
-  set(multiValueArgs SOURCES)
-  cmake_parse_arguments(
-    ARG "${options}" "${oneValueArgs}"
-    "${multiValueArgs}" ${ARGN}
-  )
-
-  foreach(file ${ARG_SOURCES})
-
-    set(input ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SUBDIRECTORY}/${file})
-    set(output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_SUBDIRECTORY}_${file})
-    add_custom_command(
-      OUTPUT ${output}
-      COMMAND ${CMAKE_COMMAND} -E copy ${input} ${output}
-      DEPENDS ${input}
-    )
-    set_property(SOURCE ${output} PROPERTY GENERATED 1)
-    target_sources(${ARG_TARGET} PRIVATE ${output})
-
-  endforeach()
-
-endfunction()
-#####
-
 add_subdirectory(specs)
 add_subdirectory(registry)
 add_subdirectory(connection)
@@ -97,7 +70,7 @@ add_subdirectory(GriddedComponentDriver)
 esma_add_fortran_submodules(
   TARGET MAPL.generic3g
   SUBDIRECTORY OuterMetaComponent
-  SOURCES SetServices.F90 add_child_by_name.F90 new_outer_meta.F90 init_meta.F90 
+  SOURCES SetServices.F90 add_child_by_name.F90 new_outer_meta.F90 init_meta.F90
       get_child_by_name.F90 run_child_by_name.F90 run_children.F90
       get_outer_meta_from_outer_gc.F90 attach_outer_meta.F90 free_outer_meta.F90
       get_phases.F90 set_hconfig.F90 get_hconfig.F90 get_geom.F90


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This is a handmerge of `develop` into `release/MAPL-v3` which brings in ESMA_cmake v3.46.0. Because of that, we can also remove the explicit `esma_add_fortran_submodules()` code added by @JulesKouatchou in the generic3g CMake as it should get it from ESMA_cmake.

If the CI builds, this works.

## Related Issue

