### PR TITLE
Fix CMake in GeomIO

### DIFF
--- a/GeomIO/CMakeLists.txt
+++ b/GeomIO/CMakeLists.txt
@@ -12,7 +12,7 @@ set(srcs
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.geom_mgr MAPL.pfio MAPL.base MAPL.shared MAPL.hconfig_utils GFTL::gftl-v2
-  TYPE ${MAPL_LIBRARY_TYPE}
+  TYPE SHARED
   )
 
 target_include_directories (${this} PUBLIC


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Closes #2881 

Testing with ifx as shown in #2881 found a bug in MAPL 3. Namely, we had a stray `MAPL_LIBRARY_TYPE` in GeomIO. I (thought that I) removed all of those in #2825 , but nope.

Amazingly, MAPL 3 hasn't gone belly up. But this is a bug.

## Related Issue

