### PR TITLE
Improved mask sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
+
 ### Fixed
 
 ### Removed
@@ -21,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
 - Add new option to `Regrid_Util.x` to write and re-use ESMF pregenerated weights
 - If file path length exceeds `ESMF_MAXSTR`, add `_FAIL` in subroutine fglob
 - Add GNU UFS-like CI test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improve mask and xy-grid (geostationary) sampler
 - Add new option to `Regrid_Util.x` to write and re-use ESMF pregenerated weights
 - If file path length exceeds `ESMF_MAXSTR`, add `_FAIL` in subroutine fglob
 - Add GNU UFS-like CI test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Improve mask and xy-grid (geostationary) sampler
+- Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
 - Add new option to `Regrid_Util.x` to write and re-use ESMF pregenerated weights
 - If file path length exceeds `ESMF_MAXSTR`, add `_FAIL` in subroutine fglob
 - Add GNU UFS-like CI test

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -2426,8 +2426,10 @@ ENDDO PARSER
              call list(n)%trajectory%initialize(items=list(n)%items,bundle=list(n)%bundle,timeinfo=list(n)%timeInfo,vdata=list(n)%vdata,_RC)
              IntState%stampoffset(n) = list(n)%trajectory%epoch_frequency
           elseif (list(n)%sampler_spec == 'mask') then
+             call MAPL_TimerOn(GENSTATE,"mask_init")
              list(n)%mask_sampler = MaskSamplerGeosat(cfg,string,clock,genstate=GENSTATE,_RC)
              call list(n)%mask_sampler%initialize(items=list(n)%items,bundle=list(n)%bundle,timeinfo=list(n)%timeInfo,vdata=list(n)%vdata,_RC)
+             call MAPL_TimerOff(GENSTATE,"mask_init")
           elseif (list(n)%sampler_spec == 'station') then
              list(n)%station_sampler = StationSampler (list(n)%bundle, trim(list(n)%stationIdFile), nskip_line=list(n)%stationSkipLine, genstate=GENSTATE, _RC)
              call list(n)%station_sampler%add_metadata_route_handle(items=list(n)%items,bundle=list(n)%bundle,timeinfo=list(n)%timeInfo,vdata=list(n)%vdata,_RC)
@@ -3706,11 +3708,9 @@ ENDDO PARSER
             call MAPL_TimerOff(GENSTATE,"Station")
          elseif (list(n)%sampler_spec == 'mask') then
             call ESMF_ClockGet(clock,currTime=current_time,_RC)
-            call MAPL_TimerOn(GENSTATE,"Mask")
-            call MAPL_TimerOn(GENSTATE,"AppendFile")
+            call MAPL_TimerOn(GENSTATE,"Mask_append")
             call list(n)%mask_sampler%append_file(current_time,_RC)
-            call MAPL_TimerOff(GENSTATE,"AppendFile")
-            call MAPL_TimerOff(GENSTATE,"Mask")
+            call MAPL_TimerOff(GENSTATE,"Mask_append")
          endif
 
 

--- a/gridcomps/History/Sampler/MAPL_GeosatMaskMod.F90
+++ b/gridcomps/History/Sampler/MAPL_GeosatMaskMod.F90
@@ -21,6 +21,7 @@ module MaskSamplerGeosatMod
   use pFIO_FileMetadataMod, only : FileMetadata
   use pFIO_NetCDF4_FileFormatterMod, only : NetCDF4_FileFormatter
   use MAPL_GenericMod, only : MAPL_MetaComp, MAPL_TimerOn, MAPL_TimerOff
+  use MPI, only  :  MPI_INTEGER, MPI_REAL, MPI_REAL8
   use, intrinsic :: iso_fortran_env, only: REAL32
   use, intrinsic :: iso_fortran_env, only: REAL64
   use pflogger, only: Logger, logging

--- a/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
@@ -322,7 +322,6 @@ end subroutine initialize_
        
        call ESMF_VMAllFullReduce(vm, sendData=arr, recvData=nx, &
             count=1, reduceflag=ESMF_REDUCE_SUM, _RC)
-       write(6,*) 'ip, nx, nx2', ip, nx, nx2
 
        ! gatherV for lons/lats
        if (mapl_am_i_root()) then          
@@ -357,9 +356,7 @@ end subroutine initialize_
        call MPI_gatherv ( lats_chunk, nsend, MPI_REAL8, &
             lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
-
        this%nobs = nx
-       if (mapl_am_I_root()) write(6,*) 'nobs tot :', nx
 
        deallocate (this%recvcounts, this%displs, _STAT)
        deallocate (recvcounts_loc, displs_loc, _STAT)
@@ -400,8 +397,6 @@ end subroutine initialize_
        _VERIFY (ierr)
        call ESMF_FieldRedist      (fieldA, fieldB, RH, _RC)
        lats_ds = ptB
-
-       write(6,*)  'ip, size(lons_ds)=', mypet, size(lons_ds)
 
        call ESMF_FieldDestroy(fieldA,nogarbage=.true.,_RC)
        call ESMF_FieldDestroy(fieldB,nogarbage=.true.,_RC)

--- a/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
@@ -487,7 +487,7 @@ end subroutine initialize_
        !  - mpi_gatherV
        !
 
-       call MAPL_TimerOn(this%GENSTATE,"4_gathV")
+       call MAPL_TimerOn(this%GENSTATE,"4_gatherV")
 
        ! __ s4.1 find this%lons/lats on root for NC output
        !
@@ -544,7 +544,7 @@ end subroutine initialize_
             this%lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
 
-       call MAPL_TimerOff(this%GENSTATE,"4_gathV")
+       call MAPL_TimerOff(this%GENSTATE,"4_gatherV")
 
        _RETURN(_SUCCESS)
      end subroutine create_Geosat_grid_find_mask


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

In the Mask sampler (input =  OR_ABI-L1b-RadF-M6C04_G16_*.nc), the following improvement is added:
- parallelization for a do loop over 29.4 million points [nx=ny=5424]
- add LS_chunk (uniform distributed points) as intermediate step between LS_root and LS_distributed(bkg=CS-grid) to circumvent a slow down from ESMF_redist  between root and distributed case.

Time improvement on 126 cores (C360_L137)
HIST control:   49.6 s
new code:  25 s

Now the new code can run  with thin_factor = 1;  control code will crash with 126 cores. 



## Related Issue

