### PR TITLE
Update CI Baselibs to 7.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:2212ed5b102cce44add21afe2c1f86f118b92b78
+  ci: geos-esm/circleci-tools@2
 
 workflows:
   build-and-test-MAPL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@dev:2212ed5b102cce44add21afe2c1f86f118b92b78
 
 workflows:
   build-and-test-MAPL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.23.0
+baselibs_version: &baselibs_version v7.25.0
 bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,9 +179,9 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: mapl
           mpi_name: intelmpi
-          mpi_version: 2021.6.0
+          mpi_version: 2021.13
           compiler_name: intel
-          compiler_version: 2022.1.0
+          compiler_version: 2024.2
           image_name: geos-env
           tag_build_arg_name: *tag_build_arg_name
       - ci/publish_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,9 +179,9 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: mapl
           mpi_name: intelmpi
-          mpi_version: 2021.13
+          mpi_version: "2021.13"
           compiler_name: intel
-          compiler_version: 2024.2
+          compiler_version: "2024.2"
           image_name: geos-env
           tag_build_arg_name: *tag_build_arg_name
       - ci/publish_docker:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -86,7 +86,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.13-intel_2024.2
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.24.0-openmpi_5.0.2-gcc_13.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.25.0-openmpi_5.0.2-gcc_13.2.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -86,7 +86,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.24.0-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.6.0-intel_2022.1.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
+- Update Baselibs in CI to 7.25.0
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
 - Update Baselibs in CI to 7.25.0
+  - NOTE: The docker image also updates to Intel 2024.2 and Intel MPI 2021.13
 - Update `components.yaml`
   - ESMA_cmake v3.48.0
     - Update `esma_add_fortran_submodules` function


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This is a PR to update the CI to use Baselibs 7.25.0 (which has an update needed for MAPL3 work by @tclune). But, let's make sure it's good to work with MAPL2 as well. (Keeps the GitFlow a bit simpler).

NOTE: The GEOSadas CI has exposed a bug in GEOSadas. Until this can be built locally, this will fail. I'll work on it soon.

## Related Issue

