### PR TITLE
Update to ESMA_cmake v3.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve mask sampler by adding an MPI step and a LS_chunk (intermediate step)
+- Update `components.yaml`
+  - ESMA_cmake v3.48.0
+    - Update `esma_add_fortran_submodules` function
+    - Move MPI detection out of FindBaselibs
 
 ### Fixed
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.46.0
+  tag: v3.48.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This updates the `components.yaml` to ESMA_cmake v3.48.0. This has a CMake fix beneficial to Spack work.

## Related Issue

