### PR TITLE
Implement ungridded dim mirroring and complete ungridded dim parsing

### DIFF
--- a/GeomIO/tests/Test_SharedIO.pf
+++ b/GeomIO/tests/Test_SharedIO.pf
@@ -13,8 +13,8 @@ module Test_SharedIO
        procedure, pass(this) :: assign_character_from_string
        generic :: assignment(=) => assign_character_from_string
     end type
-    
-    character(len=*), parameter :: DIM_CENTER = 'VERTICAL_DIM_CENTER' 
+
+    character(len=*), parameter :: DIM_CENTER = 'VERTICAL_DIM_CENTER'
     character(len=*), parameter :: DIM_EDGE = 'VERTICAL_DIM_EDGE'
     character(len=*), parameter :: DIM_UNK = 'UNKNOWN'
     character(len=*), parameter :: CENTER_NAME = 'lev'
@@ -33,13 +33,13 @@ contains
       ch = this%s_
 
    end subroutine assign_character_from_string
-       
+
     @Test
     subroutine test_get_vertical_dimension_name()
        character(len=:), allocatable :: name
        character(len=:), allocatable :: vertical_dim
        character(len=:), allocatable :: message
-       
+
        vertical_dim = DIM_CENTER
        name = CENTER_NAME
        message = make_message('Dimension name does not match for', vertical_dim)
@@ -65,12 +65,12 @@ contains
 
       vertical_dim = DIM_CENTER
       num_levels = NUMLEVELS
-      message = make_message('Num_levels does not match for', vertical_dim) 
+      message = make_message('Num_levels does not match for', vertical_dim)
       @assertEqual(num_levels, get_vertical_dimension_num_levels(vertical_dim, NUMLEVELS), message)
 
       vertical_dim = DIM_EDGE
       num_levels = NUMLEVELS+1
-      message = make_message('Num_levels does not match for', vertical_dim) 
+      message = make_message('Num_levels does not match for', vertical_dim)
       @assertEqual(num_levels, get_vertical_dimension_num_levels(vertical_dim, NUMLEVELS), message)
 
     end subroutine test_get_vertical_dimension_num_levels
@@ -79,9 +79,9 @@ contains
     subroutine test_cat_ungridded_dim_names()
        type(UngriddedDims) :: dims
        character(len=8), parameter :: NAMES(3) = [character(len=8) :: 'Alice', 'Bob', 'Mallory']
-       
+
        dims = make_ungridded_dims(NAMES)
-       
+
     end subroutine test_cat_ungridded_dim_names
 
     function make_message_string(message, String) result(msg)
@@ -103,7 +103,7 @@ contains
        allocate(dims_array(size(names)))
        do i = 1, size(names)
          name = trim(names(i))
-         dims_array(i) = UngriddedDim(name, len(name))
+         dims_array(i) = UngriddedDim(len(name), name=name)
        end do
 
        dims = UngriddedDims(dims_array)
@@ -122,5 +122,5 @@ contains
       end do
 
     end function make_string_array
-      
+
 end module Test_SharedIO

--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -28,7 +28,7 @@ module mapl3g_ComponentSpecParser
    implicit none
    private
 
-   ! 
+   !
    public :: parse_component_spec
 
    ! The following interfaces are public only for testing purposes.
@@ -54,7 +54,9 @@ module mapl3g_ComponentSpecParser
    character(*), parameter :: KEY_DEFAULT_VALUE = 'default_value'
    character(*), parameter :: KEY_UNGRIDDED_DIMS = 'ungridded_dims'
    character(*), parameter :: KEY_UNGRIDDED_DIM_NAME = 'dim_name'
+   character(*), parameter :: KEY_UNGRIDDED_DIM_UNITS = 'dim_units'
    character(*), parameter :: KEY_UNGRIDDED_DIM_EXTENT = 'extent'
+   character(*), parameter :: KEY_UNGRIDDED_DIM_COORDINATES = 'coordinates'
    character(*), parameter :: KEY_VERTICAL_DIM_SPEC = 'vertical_dim_spec'
 
    !>
@@ -103,5 +105,5 @@ module mapl3g_ComponentSpecParser
       end function parse_child
 
    END INTERFACE
-   
+
 end module mapl3g_ComponentSpecParser

--- a/generic3g/ComponentSpecParser/parse_var_specs.F90
+++ b/generic3g/ComponentSpecParser/parse_var_specs.F90
@@ -228,7 +228,7 @@ contains
             has_units = ESMF_HConfigIsDefined(dim_spec,keyString=KEY_UNGRIDDED_DIM_UNITS)
             has_extent = ESMF_HConfigIsDefined(dim_spec,keyString=KEY_UNGRIDDED_DIM_EXTENT)
             has_coordinates = ESMF_HConfigIsDefined(dim_spec,keyString=KEY_UNGRIDDED_DIM_COORDINATES)
-            _ASSERT(.not.(has_units .and. has_coordinates), "Both extent and coordinates specified")
+            _ASSERT(.not.(has_extent .and. has_coordinates), "Both extent and coordinates specified")
             if (has_name) then
                dim_name = ESMF_HConfigAsString(dim_spec, keyString=KEY_UNGRIDDED_DIM_NAME, _RC)
             end if

--- a/generic3g/ComponentSpecParser/parse_var_specs.F90
+++ b/generic3g/ComponentSpecParser/parse_var_specs.F90
@@ -240,7 +240,7 @@ contains
                temp_dim = UngriddedDim(dim_size, name=dim_name, units=dim_units)
             end if
             if (has_coordinates) then
-               coordinates = ESMF_HConfigAsR4(dim_spec, keyString=KEY_UNGRIDDED_DIM_COORDINATES, _RC)
+               coordinates = ESMF_HConfigAsR4Seq(dim_spec, keyString=KEY_UNGRIDDED_DIM_COORDINATES, _RC)
                temp_dim = UngriddedDim(coordinates, name=dim_name, units=dim_units)
             end if
             call ungridded_dims%add_dim(temp_dim, _RC)

--- a/generic3g/OutputInfo.F90
+++ b/generic3g/OutputInfo.F90
@@ -101,7 +101,7 @@ contains
 
       call ESMF_InfoGet(info, key=KEY_NUM_LEVELS, value=num, _RC)
       _RETURN(_SUCCESS)
-      
+
    end function get_num_levels_info
 
    function get_vertical_dim_spec_names_bundle(bundle, rc) result(names)
@@ -205,7 +205,7 @@ contains
    function make_ungridded_dims(info, rc) result(dims)
       type(UngriddedDims) :: dims
       type(ESMF_Info), intent(in) :: info
-      integer, optional, intent(out) :: rc 
+      integer, optional, intent(out) :: rc
       integer :: status
       integer :: num_dims, i
       type(UngriddedDim) :: ungridded
@@ -223,7 +223,7 @@ contains
       type(UngriddedDim) :: make_ungridded_dim
       integer, intent(in) :: n
       type(ESMF_Info), intent(in) :: info
-      integer, optional, intent(out) :: rc 
+      integer, optional, intent(out) :: rc
       integer :: status
       character(len=:), allocatable :: key
       type(ESMF_Info) :: dim_info
@@ -244,7 +244,7 @@ contains
       call ESMF_InfoGetCharAlloc(dim_info, key=KEY_UNGRIDDED_UNITS, value=units, _RC)
       call ESMF_InfoGetAlloc(dim_info, key=KEY_UNGRIDDED_COORD, values=coordinates, _RC)
       call ESMF_InfoDestroy(dim_info, _RC)
-      make_ungridded_dim = UngriddedDim(name, units, coordinates)
+      make_ungridded_dim = UngriddedDim(coordinates, name=name, units=units)
       _RETURN(_SUCCESS)
 
    end function make_ungridded_dim
@@ -252,7 +252,7 @@ contains
    subroutine push_ungridded_dims(vec, dims, rc)
       class(UngriddedDimVector), intent(inout) :: vec
       class(UngriddedDims), intent(in) :: dims
-      integer, optional, intent(out) :: rc 
+      integer, optional, intent(out) :: rc
       integer :: status
       integer :: i
 
@@ -276,18 +276,18 @@ contains
          if(iter%of() == name) return
          call iter%next()
       end do
-      i = 0 
+      i = 0
 
    end function find_index
 
    subroutine check_duplicate(vec, udim, rc)
       class(UngriddedDimVector), intent(in) :: vec
       class(UngriddedDim), intent(in) :: udim
-      integer, optional, intent(out) :: rc 
+      integer, optional, intent(out) :: rc
       integer :: status
       type(UngriddedDimVectorIterator) :: iter
       type(UngriddedDim) :: vdim
-      
+
       iter = vec%ftn_begin()
       do while(iter < vec%ftn_end())
          call iter%next()
@@ -333,7 +333,7 @@ contains
 
    subroutine destroy_bundle_info(bundle_info, rc)
       type(ESMF_Info), intent(inout) :: bundle_info(:)
-      integer, optional, intent(out) :: rc 
+      integer, optional, intent(out) :: rc
       integer :: status, i
 
       do i=1, size(bundle_info)

--- a/generic3g/OutputInfo.F90
+++ b/generic3g/OutputInfo.F90
@@ -219,8 +219,8 @@ contains
 
    end function make_ungridded_dims
 
-   function make_ungridded_dim(info, n, rc)
-      type(UngriddedDim) :: make_ungridded_dim
+   function make_ungridded_dim(info, n, rc) result(ungridded_dim)
+      type(UngriddedDim) :: ungridded_dim
       integer, intent(in) :: n
       type(ESMF_Info), intent(in) :: info
       integer, optional, intent(out) :: rc
@@ -244,7 +244,7 @@ contains
       call ESMF_InfoGetCharAlloc(dim_info, key=KEY_UNGRIDDED_UNITS, value=units, _RC)
       call ESMF_InfoGetAlloc(dim_info, key=KEY_UNGRIDDED_COORD, values=coordinates, _RC)
       call ESMF_InfoDestroy(dim_info, _RC)
-      make_ungridded_dim = UngriddedDim(coordinates, name=name, units=units)
+      ungridded_dim = UngriddedDim(coordinates, name=name, units=units)
       _RETURN(_SUCCESS)
 
    end function make_ungridded_dim

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -87,6 +87,7 @@ module mapl3g_FieldSpec
       procedure :: match_typekind
       procedure :: match_string
       procedure :: match_vertical_dim_spec
+      procedure :: match_ungridded_dims
    end interface match
 
    interface get_cost
@@ -144,9 +145,9 @@ contains
 !#      type(ExtraDimsSpec), intent(in) :: ungridded_dims
 !#      type(ESMF_Geom), intent(in) :: geom
 !#      character(*), intent(in) :: units
-!#      
+!#
 !#      field_spec = FieldSpec(ungridded_dims, ESMF_TYPEKIND_R4, geom, units)
-!#      
+!#
 !#   end function new_FieldSpec_defaults
 !#
 
@@ -234,7 +235,7 @@ contains
       end if
 
       call this%set_info(this%payload, _RC)
-   
+
       _RETURN(ESMF_SUCCESS)
 
    contains
@@ -245,36 +246,36 @@ contains
          real(kind=ESMF_KIND_R8), pointer :: x_r8_1d(:),x_r8_2d(:,:),x_r8_3d(:,:,:),x_r8_4d(:,:,:,:)
          integer :: status, rank
 
-         call ESMF_FieldGet(this%payload,rank=rank,_RC) 
+         call ESMF_FieldGet(this%payload,rank=rank,_RC)
          if (this%typekind == ESMF_TYPEKIND_R4) then
             if (rank == 1) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r4_1d,_RC)
-               x_r4_1d = this%default_value   
+               x_r4_1d = this%default_value
             else if (rank == 2) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r4_2d,_RC)
-               x_r4_2d = this%default_value   
+               x_r4_2d = this%default_value
             else if (rank == 3) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r4_3d,_RC)
-               x_r4_3d = this%default_value   
+               x_r4_3d = this%default_value
             else if (rank == 4) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r4_4d,_RC)
-               x_r4_4d = this%default_value   
+               x_r4_4d = this%default_value
             else
                _FAIL('unsupported rank')
             end if
          else if (this%typekind == ESMF_TYPEKIND_R8) then
             if (rank == 1) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r8_1d,_RC)
-               x_r8_1d = this%default_value   
+               x_r8_1d = this%default_value
             else if (rank == 2) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r8_2d,_RC)
-               x_r8_2d = this%default_value   
+               x_r8_2d = this%default_value
             else if (rank == 3) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r8_3d,_RC)
-               x_r8_3d = this%default_value   
+               x_r8_3d = this%default_value
             else if (rank == 4) then
                call ESMF_FieldGet(this%payload,farrayptr=x_r8_4d,_RC)
-               x_r8_4d = this%default_value   
+               x_r8_4d = this%default_value
             else
                _FAIL('unsupported rank')
             end if
@@ -283,7 +284,7 @@ contains
          end if
          _RETURN(ESMF_SUCCESS)
       end subroutine set_field_default
-            
+
    end subroutine allocate
 
    function get_ungridded_bounds(this, rc) result(bounds)
@@ -337,6 +338,7 @@ contains
          procedure :: mirror_string
          procedure :: mirror_real
          procedure :: mirror_vertical_dim_spec
+         procedure :: mirror_ungriddedDims
       end interface mirror
 
       _ASSERT(this%can_connect_to(src_spec), 'illegal connection')
@@ -350,6 +352,7 @@ contains
          call mirror(dst=this%units, src=src_spec%units)
          call mirror(dst=this%vertical_dim_spec, src=src_spec%vertical_dim_spec)
          call mirror(dst=this%default_value, src=src_spec%default_value)
+         call mirror(dst=this%ungridded_dims, src=src_spec%ungridded_dims)
 
       class default
          _FAIL('Cannot connect field spec to non field spec.')
@@ -359,7 +362,7 @@ contains
       _UNUSED_DUMMY(actual_pt)
 
    contains
-      
+
       subroutine mirror_typekind(dst, src)
          type(ESMF_TypeKind_Flag), intent(inout) :: dst, src
 
@@ -424,6 +427,24 @@ contains
 
       end subroutine mirror_real
 
+      subroutine mirror_ungriddedDims(dst, src)
+         type(UngriddedDims), intent(inout) :: dst, src
+
+         type(UngriddedDims) :: mirror_dims
+         mirror_dims = mirror_ungridded_dims()
+
+         if (dst == src) return
+
+         if (dst == mirror_dims) then
+            dst = src
+         end if
+
+         if (src == mirror_dims) then
+            src = dst
+         end if
+
+      end subroutine mirror_ungriddedDims
+
    end subroutine connect_to
 
 
@@ -440,9 +461,8 @@ contains
       class is (FieldSpec)
          can_convert_units_ = can_connect_units(this%units, src_spec%units, _RC)
          can_connect_to = all ([ &
-              this%ungridded_dims == src_spec%ungridded_dims, &
               match(this%vertical_dim_spec,src_spec%vertical_dim_spec), &
-              this%ungridded_dims == src_spec%ungridded_dims, & 
+              match(this%ungridded_dims,src_spec%ungridded_dims), &
               includes(this%attributes, src_spec%attributes), &
               can_convert_units_ &
               ])
@@ -610,13 +630,13 @@ contains
             action = CopyAction(this%payload, dst_spec%payload)
             _RETURN(_SUCCESS)
          end if
-         
+
          if (.not. match(this%units,dst_spec%units)) then
             deallocate(action)
             action = ConvertUnitsAction(this%payload, this%units, dst_spec%payload, dst_spec%units)
             _RETURN(_SUCCESS)
          end if
-         
+
       class default
          _FAIL('Dst spec is incompatible with FieldSpec.')
       end select
@@ -630,7 +650,7 @@ contains
       integer :: status
 
       match = .false.
-      
+
       if (allocated(a) .and. allocated(b)) then
          match = MAPL_SameGeom(a, b)
       end if
@@ -674,6 +694,18 @@ contains
       match = (n_mirror == 1) .or. (n_mirror == 0 .and. a == b)
 
    end function match_vertical_dim_spec
+
+   logical function match_ungridded_dims(a, b) result(match)
+      type(UngriddedDims), intent(in) :: a, b
+
+      type(UngriddedDims) :: mirror_dims
+      integer :: n_mirror
+
+      mirror_dims = MIRROR_UNGRIDDED_DIMS()
+      n_mirror = count([a == mirror_dims, b == mirror_dims])
+      match = (n_mirror == 1) .or. (n_mirror == 0 .and. a == b)
+
+   end function match_ungridded_dims
 
    logical function mirror(str)
       character(:), allocatable :: str
@@ -743,7 +775,7 @@ contains
    logical function update_item_string(a, b)
       character(:), allocatable, intent(inout) :: a
       character(:), allocatable, intent(in) :: b
-      
+
       update_item_string = .false.
       if (.not. match(a, b)) then
          a = b

--- a/generic3g/specs/UngriddedDim.F90
+++ b/generic3g/specs/UngriddedDim.F90
@@ -28,9 +28,7 @@ module mapl3g_UngriddedDim
 
    interface UngriddedDim
       module procedure new_UngriddedDim_extent
-      module procedure new_UngriddedDim_name_and_extent
-      module procedure new_UngriddedDim_name_and_coords
-      module procedure new_UngriddedDim_name_units_and_coords
+      module procedure new_UngriddedDim_coordinates
    end interface UngriddedDim
 
    interface operator(==)
@@ -46,38 +44,34 @@ module mapl3g_UngriddedDim
 
 contains
 
-   pure function new_UngriddedDim_name_units_and_coords(name, units, coordinates) result(spec)
-      type(UngriddedDim) :: spec
-      character(*), intent(in) :: name
-      character(*), intent(in) :: units
-      real, intent(in) :: coordinates(:)
 
-      spec%name = name
-      spec%units = units
+   pure function new_UngriddedDim_extent(extent, name, units) result(spec)
+      integer, intent(in) :: extent
+      character(len=*), optional, intent(in) :: name
+      character(len=*), optional, intent(in) :: units
+      type(UngriddedDim) :: spec
+
+      spec%name = UNKNOWN_DIM_NAME
+      if (present(name)) spec%name = name
+      spec%units = UNKNOWN_DIM_UNITS
+      if (present(units)) spec%units = units
+      spec%coordinates = default_coords(extent)
+
+   end function new_UngriddedDim_extent
+
+   pure function new_UngriddedDim_coordinates(coordinates, name, units) result(spec)
+      real, intent(in) :: coordinates(:)
+      character(len=*), optional, intent(in) :: name
+      character(len=*), optional, intent(in) :: units
+      type(UngriddedDim) :: spec
+
+      spec%name = UNKNOWN_DIM_NAME
+      if (present(name)) spec%name = name
+      spec%units = UNKNOWN_DIM_UNITS
+      if (present(units)) spec%units = units
       spec%coordinates = coordinates
 
-   end function new_UngriddedDim_name_units_and_coords
-
-   pure function new_UngriddedDim_name_and_coords(name, coordinates) result(spec)
-      type(UngriddedDim) :: spec
-      character(*), intent(in) :: name
-      real, intent(in) :: coordinates(:)
-      spec = UngriddedDim(name, UNKNOWN_DIM_UNITS, coordinates)
-   end function new_UngriddedDim_name_and_coords
-
-
-   pure function new_UngriddedDim_name_and_extent(name, extent) result(spec)
-      character(*), intent(in) :: name
-      integer, intent(in) :: extent
-      type(UngriddedDim) :: spec
-      spec = UngriddedDim(name, default_coords(extent))
-   end function new_UngriddedDim_name_and_extent
-
-   pure function new_UngriddedDim_extent(extent) result(spec)
-      integer, intent(in) :: extent
-      type(UngriddedDim) :: spec
-      spec = UngriddedDim(UNKNOWN_DIM_NAME, default_coords(extent))
-   end function new_UngriddedDim_extent
+   end function new_UngriddedDim_coordinates
 
    pure function default_coords(extent, lbound) result(coords)
       real, allocatable :: coords(:)

--- a/generic3g/specs/UngriddedDims.F90
+++ b/generic3g/specs/UngriddedDims.F90
@@ -14,6 +14,7 @@ module mapl3g_UngriddedDims
    private
 
    public :: UngriddedDims
+   public :: mirror_ungridded_dims
    public :: operator(==)
    public :: operator(/=)
 
@@ -21,6 +22,7 @@ module mapl3g_UngriddedDims
    ! before any other ungridded dim specs.
    type :: UngriddedDims
       private
+      logical :: is_mirror = .false.
       type(UngriddedDimVector) :: dim_specs
    contains
       procedure :: add_dim
@@ -47,6 +49,13 @@ module mapl3g_UngriddedDims
 
 contains
 
+   function mirror_ungridded_dims() result(spec)
+      type(UngriddedDims) :: spec
+
+      spec%dim_specs = UngriddedDimVector()
+      spec%is_mirror = .true.
+
+   end function mirror_ungridded_dims
 
    function new_UngriddedDims_empty() result(spec)
       type(UngriddedDims) :: spec
@@ -97,7 +106,7 @@ contains
       class(UngriddedDims), intent(in) :: this
 
       get_num_ungridded = this%dim_specs%size()
-      
+
    end function get_num_ungridded
 
 
@@ -108,7 +117,7 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      
+
       dim_spec => this%dim_specs%at(i, _RC)
       _RETURN(_SUCCESS)
 
@@ -137,8 +146,10 @@ contains
       integer :: i
 
       equal_to = .false.
+
+      if (a%is_mirror .neqv. b%is_mirror) return
       associate (n => a%dim_specs%size())
-      
+
         if (b%dim_specs%size() /= n) return
         do i = 1, n
            if (a%dim_specs%of(i) /= b%dim_specs%of(i)) return
@@ -147,7 +158,7 @@ contains
       end associate
 
       equal_to = .true.
-        
+
    end function equal_to
 
 

--- a/generic3g/tests/Test_FieldInfo.pf
+++ b/generic3g/tests/Test_FieldInfo.pf
@@ -25,13 +25,13 @@ contains
       real, allocatable :: coords(:)
       character(len=:), allocatable :: temp_string
       integer :: temp_int
-      
+
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom = ESMF_GeomCreate(grid, _RC)
       vertical_geom = VerticalGeom(4)
 
-      call ungridded_dims%add_dim(UngriddedDim('a', 'm', [1.,2.]))
-      call ungridded_dims%add_dim(UngriddedDim('b', 's', [1.,2.,3.]))
+      call ungridded_dims%add_dim(UngriddedDim([1.,2.], name='a', units='m'))
+      call ungridded_dims%add_dim(UngriddedDim([1.,2.,3.], name='b', units='s'))
 
       spec = FieldSpec(geom, vertical_geom, VERTICAL_DIM_CENTER, &
            ESMF_TYPEKIND_R4, ungridded_dims, &

--- a/generic3g/tests/Test_FieldSpec.pf
+++ b/generic3g/tests/Test_FieldSpec.pf
@@ -2,6 +2,8 @@ module Test_FieldSpec
    use funit
    use mapl3g_FieldSpec
    use mapl3g_UngriddedDims
+   use mapl3g_UngriddedDim
+   use mapl3g_UngriddedDimVector
    use mapl3g_VerticalDimSpec
    use mapl3g_VerticalGeom
    use mapl3g_ESMF_Utilities, only: MAPL_TYPEKIND_MIRROR
@@ -55,7 +57,7 @@ contains
 
       call import_attributes%push_back('radius')
 
-      
+
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
            typekind=ESMF_TYPEKIND_R4, &
@@ -72,7 +74,7 @@ contains
       @assert_that(import_spec%can_connect_to(export_spec), is(false()))
 
    end subroutine test_mismatched_attribute
-   
+
    @test
    ! Only the import attributes need to match. Not all.
    subroutine test_matched_attribute()
@@ -84,7 +86,7 @@ contains
       call import_attributes%push_back('radius')
       call export_attributes%push_back('radius')
       call export_attributes%push_back('other')
-      
+
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
            typekind=ESMF_TYPEKIND_R4, &
@@ -118,7 +120,7 @@ contains
       call export_attributes%push_back('other2')
       call export_attributes%push_back('diameter')
 
-      
+
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
            typekind=ESMF_TYPEKIND_R4, &
@@ -205,7 +207,7 @@ contains
            units='m')
 
       @assert_that(import_spec%can_connect_to(export_spec), is(true()))
-      
+
    end subroutine test_same_units
 
    @test
@@ -214,7 +216,7 @@ contains
       type(FieldSpec) :: export_spec
       type(ESMF_Geom) :: geom
 
-      
+
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
            typekind=ESMF_TYPEKIND_R4, &
@@ -229,7 +231,40 @@ contains
            units='m')
 
       @assert_that(import_spec%can_connect_to(export_spec), is(true()))
-      
+
    end subroutine test_mirror_units
+
+   @test
+   subroutine test_mirror_ungridded_dims()
+      type(FieldSpec) :: import_spec
+      type(FieldSpec) :: export_spec
+      type(ESMF_Geom) :: geom
+
+      type(UngriddedDims) :: mirror_ungrid, export_dims
+      type(UngriddedDimVector) :: ungrid_dims
+      type(UngriddedDim) :: ungrid_dim
+
+      mirror_ungrid = mirror_ungridded_dims()
+      ungrid_dim = UngriddedDim(2)
+      call ungrid_dims%push_back(ungrid_dim)
+      export_dims = UngriddedDims(ungrid_dims)
+
+      import_spec = FieldSpec( &
+           geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = mirror_ungrid, &
+           standard_name='A', long_name='AA', attributes=StringVector(), &
+           units='m')
+
+      export_spec = FieldSpec( &
+           geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = export_dims, &
+           standard_name='A', long_name='AA', attributes=StringVector(), &
+           units='m')
+
+      @assert_that(import_spec%can_connect_to(export_spec), is(true()))
+
+   end subroutine test_mirror_ungridded_dims
 
 end module Test_FieldSpec


### PR DESCRIPTION
Fixes #2900 
This PR implements mirroring of ungridded dims in MAPL3. In addition it also completes the parsing of the ungridded dim from the yaml file since that had not been completed; only the extent had actually been read from the file,  the name, the units, if the user specified coordinates rather than the extent, none of that was being parsed. 

I did change the constructor for the ungriddedDim class so it would be easier to use when parsing the yaml file.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

