### PR TITLE
Fixes #2903 Support for mirror geometry

### DIFF
--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -25,6 +25,7 @@ module mapl3g_OuterMetaComponent
    use mapl3g_ESMF_Interfaces, only: I_Run, MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
    use mapl3g_ComponentDriver
    use mapl3g_GriddedComponentDriver
+   use mapl3g_ComponentDriverVector
    use mapl3g_GriddedComponentDriverMap, only: GriddedComponentDriverMap
    use mapl3g_GriddedComponentDriverMap, only: GriddedComponentDriverMapIterator
    use mapl3g_GriddedComponentDriverMap, only: operator(/=)

--- a/generic3g/OuterMetaComponent/initialize_advertise.F90
+++ b/generic3g/OuterMetaComponent/initialize_advertise.F90
@@ -47,9 +47,9 @@ contains
          type(VariableSpecVectorIterator) :: iter
          type(VariableSpec), pointer :: var_spec
 
-         if (this%component_spec%var_specs%size() > 0) then
-            _ASSERT(allocated(this%geom),'Component must define a geom to advertise variables.')
-         end if
+!#         if (this%component_spec%var_specs%size() > 0) then
+!#            _ASSERT(allocated(this%geom),'Component must define a geom to advertise variables.')
+!#         end if
          associate (e => this%component_spec%var_specs%end())
            iter = this%component_spec%var_specs%begin()
            do while (iter /= e)
@@ -67,7 +67,7 @@ contains
       subroutine advertise_variable(var_spec, registry, geom, vertical_geom, unusable, rc)
          type(VariableSpec), intent(in) :: var_spec
          type(HierarchicalRegistry), intent(inout) :: registry
-         type(ESMF_Geom), intent(in) :: geom
+         type(ESMF_Geom), optional, intent(in) :: geom
          type(VerticalGeom), intent(in) :: vertical_geom
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc

--- a/generic3g/OuterMetaComponent/run_user.F90
+++ b/generic3g/OuterMetaComponent/run_user.F90
@@ -20,9 +20,10 @@ contains
       integer :: phase
 
       type(ActualPtComponentDriverMap), pointer :: export_Couplers
-      type(ActualPtComponentDriverMap), pointer :: import_Couplers
+      type(ComponentDriverVector), pointer :: import_Couplers
       type(ActualPtComponentDriverMapIterator) :: iter
-      type(GriddedComponentDriver), pointer :: drvr
+      type(ComponentDriverVectorIterator) :: import_iter
+      class(ComponentDriver), pointer :: drvr
 
       run_phases => this%get_phases(ESMF_METHOD_RUN)
       phase = get_phase_index(run_phases, phase_name, found=found)
@@ -30,10 +31,10 @@ contains
 
       import_couplers => this%registry%get_import_couplers()
       associate (e => import_couplers%ftn_end())
-        iter = import_couplers%ftn_begin()
-        do while (iter /= e)
-           call iter%next()
-           drvr => iter%second()
+        import_iter = import_couplers%ftn_begin()
+        do while (import_iter /= e)
+           call import_iter%next()
+           drvr => import_iter%of()
            call drvr%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
         end do
       end associate

--- a/generic3g/actions/ConvertUnitsAction.F90
+++ b/generic3g/actions/ConvertUnitsAction.F90
@@ -25,6 +25,7 @@ module mapl3g_ConvertUnitsAction
       procedure new_converter
    end interface ConvertUnitsAction
 
+
 contains
 
 
@@ -34,6 +35,7 @@ contains
       character(*), intent(in) :: units_in, units_out
 
       integer :: status
+
       ! TODO: move to place where only called
       call UDUNITS_GetConverter(action%converter, from=units_in, to=units_out, rc=status)
       action%f_in = f_in
@@ -54,8 +56,7 @@ contains
 
 
       call ESMF_FieldGet(this%f_in, typekind=typekind, _RC)
-      
-      
+
       if (typekind == ESMF_TYPEKIND_R4) then
 
          call assign_fptr(this%f_in, x4_in, _RC)

--- a/generic3g/connection/SimpleConnection.F90
+++ b/generic3g/connection/SimpleConnection.F90
@@ -116,7 +116,6 @@ contains
       dst_pt = this%get_destination()
 
       dst_specs = dst_registry%get_actual_pt_SpecPtrs(dst_pt%v_pt, _RC)
-      src_specs = src_registry%get_actual_pt_SpecPtrs(src_pt%v_pt, _RC)
 
       src_actual_pts => src_registry%get_actual_pts(src_pt%v_pt)
       _ASSERT(src_actual_pts%size() > 0, 'Empty virtual point?  This should not happen.')
@@ -126,6 +125,7 @@ contains
 
          ! Connection is transitive -- if any src_specs can connect, all can connect.
          ! So we can just check this property on the 1st item.
+         src_specs = src_registry%get_actual_pt_SpecPtrs(src_pt%v_pt, _RC)
          src_spec => src_specs(1)%ptr
          _ASSERT(dst_spec%can_connect_to(src_spec), "impossible connection")
 
@@ -159,7 +159,7 @@ contains
          ! referenced in the dst registry so that gridcomps can do update()
          ! requests.
          if (lowest_cost >= 1) then
-            call dst_registry%add_import_coupler(ActualConnectionPt(dst_pt%v_pt), source_coupler)
+            call dst_registry%add_import_coupler(source_coupler)
          end if
 
          ! In the case of wildcard specs, we need to pass an actual_pt to

--- a/generic3g/registry/HierarchicalRegistry.F90
+++ b/generic3g/registry/HierarchicalRegistry.F90
@@ -6,6 +6,7 @@ module mapl3g_HierarchicalRegistry
    use mapl3g_StateItemSpec
    use mapl3g_ActualPtSpecPtrMap
    use mapl3g_ActualPtComponentDriverMap
+   use mapl3g_ComponentDriverVector
    use mapl3g_GriddedComponentDriver
    use mapl3g_ConnectionPt
    use mapl3g_VirtualConnectionPt
@@ -48,7 +49,8 @@ module mapl3g_HierarchicalRegistry
       type(RegistryPtrMap) :: subregistries
 
       type(ActualPtComponentDriverMap) :: export_couplers
-      type(ActualPtComponentDriverMap) :: import_couplers
+!#      type(ActualPtComponentDriverMap), public :: import_couplers
+      type(ComponentDriverVector), public :: import_couplers
 
    contains
 
@@ -101,7 +103,7 @@ module mapl3g_HierarchicalRegistry
       procedure :: get_export_couplers
 
       procedure :: get_export_coupler
-      procedure :: get_import_coupler
+!#      procedure :: get_import_coupler
       procedure :: add_import_coupler
 
       procedure :: allocate
@@ -865,7 +867,7 @@ contains
    end function get_export_couplers
       
    function get_import_couplers(this) result(import_couplers)
-      type(ActualPtComponentDriverMap), pointer :: import_couplers
+      type(ComponentDriverVector), pointer :: import_couplers
       class(HierarchicalRegistry), target, intent(in) :: this
 
       import_couplers => this%import_couplers
@@ -884,28 +886,27 @@ contains
       _RETURN(_SUCCESS)
    end function get_export_coupler
 
-   function get_import_coupler(this, actual_pt, rc) result(coupler)
-      type(GriddedComponentDriver), pointer :: coupler
-      class(HierarchicalRegistry), target, intent(in) :: this
-      type(ActualConnectionPt), intent(in) :: actual_pt
-      integer, optional, intent(out) :: rc
+!#   function get_import_coupler(this, actual_pt, rc) result(coupler)
+!#      type(GriddedComponentDriver), pointer :: coupler
+!#      class(HierarchicalRegistry), target, intent(in) :: this
+!#      type(ActualConnectionPt), intent(in) :: actual_pt
+!#      integer, optional, intent(out) :: rc
+!#
+!#      integer :: status
+!#
+!#      coupler => this%import_couplers%at(actual_pt, _RC)
+!#
+!#      _RETURN(_SUCCESS)
+!#   end function get_import_coupler
 
-      integer :: status
 
-      coupler => this%import_couplers%at(actual_pt, _RC)
-
-      _RETURN(_SUCCESS)
-   end function get_import_coupler
-
-
-   subroutine add_import_coupler(this, actual_pt, coupler)
+   subroutine add_import_coupler(this, coupler)
       class(HierarchicalRegistry), target, intent(inout) :: this
-      type(ActualConnectionPt), intent(in) :: actual_pt
       type(GriddedComponentDriver), intent(in) :: coupler
 
       integer :: status
 
-      call this%import_couplers%insert(actual_pt, coupler)
+      call this%import_couplers%push_back(coupler)
 
    end subroutine add_import_coupler
 

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -89,6 +89,10 @@ module mapl3g_FieldSpec
       procedure :: match_vertical_dim_spec
    end interface match
 
+   interface can_match
+      procedure :: can_match_geom
+   end interface can_match
+
    interface get_cost
       procedure :: get_cost_geom
       procedure :: get_cost_typekind
@@ -104,12 +108,13 @@ module mapl3g_FieldSpec
 contains
 
 
-   function new_FieldSpec_geom(geom, vertical_geom, vertical_dim_spec, typekind, ungridded_dims, &
+   function new_FieldSpec_geom(unusable, geom, vertical_geom, vertical_dim_spec, typekind, ungridded_dims, &
         standard_name, long_name, units, &
         attributes, default_value) result(field_spec)
       type(FieldSpec) :: field_spec
 
-      type(ESMF_Geom), intent(in) :: geom
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_Geom), optional, intent(in) :: geom
       type(VerticalGeom), intent(in) :: vertical_geom
       type(VerticalDimSpec), intent(in) :: vertical_dim_spec
       type(ESMF_Typekind_Flag), intent(in) :: typekind
@@ -123,7 +128,7 @@ contains
       ! optional args last
       real, optional, intent(in) :: default_value
 
-      field_spec%geom = geom
+      if (present(geom)) field_spec%geom = geom
       field_spec%vertical_geom = vertical_geom
       field_spec%vertical_dim_spec = vertical_dim_spec
       field_spec%typekind = typekind
@@ -132,7 +137,6 @@ contains
       if (present(standard_name)) field_spec%standard_name = standard_name
       if (present(long_name)) field_spec%long_name = long_name
       if (present(units)) field_spec%units = units
-
       if (present(attributes)) field_spec%attributes = attributes
       if (present(default_value)) field_spec%default_value = default_value
 
@@ -157,6 +161,7 @@ contains
       integer :: status
 
       this%payload = ESMF_FieldEmptyCreate(_RC)
+      _RETURN_UNLESS(allocated(this%geom))  ! mirror 
       call MAPL_FieldEmptySet(this%payload, this%geom, _RC)
 
       _RETURN(ESMF_SUCCESS)
@@ -333,6 +338,7 @@ contains
 
       integer :: status
       interface mirror
+         procedure :: mirror_geom
          procedure :: mirror_typekind
          procedure :: mirror_string
          procedure :: mirror_real
@@ -346,6 +352,7 @@ contains
          ! ok
          call this%destroy(_RC)
          this%payload = src_spec%payload
+         call mirror(dst=this%geom, src=src_spec%geom)
          call mirror(dst=this%typekind, src=src_spec%typekind)
          call mirror(dst=this%units, src=src_spec%units)
          call mirror(dst=this%vertical_dim_spec, src=src_spec%vertical_dim_spec)
@@ -360,6 +367,24 @@ contains
 
    contains
       
+      subroutine mirror_geom(dst, src)
+         type(ESMF_Geom), allocatable, intent(inout) :: dst, src
+
+         _ASSERT(allocated(dst) .or. allocated(src), 'cannot double mirror')
+         if (allocated(dst) .and. .not. allocated(src)) then
+            src = dst
+            return
+         end if
+
+         if (allocated(src) .and. .not. allocated(dst)) then
+            dst = src
+            return
+         end if
+
+         _ASSERT(MAPL_SameGeom(dst, src), 'cannot connect mismatched geom without coupler.')
+
+      end subroutine mirror_geom
+
       subroutine mirror_typekind(dst, src)
          type(ESMF_TypeKind_Flag), intent(inout) :: dst, src
 
@@ -391,7 +416,7 @@ contains
             src = dst
          end if
 
-         _ASSERT(dst == src, 'unsupported typekind mismatch')
+         _ASSERT(dst == src, 'unsupported vertical_dim_spec mismatch')
       end subroutine mirror_vertical_dim_spec
 
       subroutine mirror_string(dst, src)
@@ -440,7 +465,7 @@ contains
       class is (FieldSpec)
          can_convert_units_ = can_connect_units(this%units, src_spec%units, _RC)
          can_connect_to = all ([ &
-              this%ungridded_dims == src_spec%ungridded_dims, &
+              can_match(this%geom,src_spec%geom), &
               match(this%vertical_dim_spec,src_spec%vertical_dim_spec), &
               this%ungridded_dims == src_spec%ungridded_dims, & 
               includes(this%attributes, src_spec%attributes), &
@@ -624,16 +649,37 @@ contains
       _RETURN(_SUCCESS)
    end function make_action
 
+   logical function can_match_geom(a, b) result(can_match)
+      type(ESMF_Geom), allocatable, intent(in) :: a, b
+
+      integer :: status
+      integer :: n_mirror
+
+      ! At most one geom can be mirror (unallocated).
+      ! Otherwise, assume ESMF can provide regrid
+      n_mirror = count([.not. allocated(a), .not. allocated(b)])
+      can_match = n_mirror <= 1
+
+   end function can_match_geom
+
    logical function match_geom(a, b) result(match)
       type(ESMF_Geom), allocatable, intent(in) :: a, b
 
       integer :: status
+      integer :: n_mirror
 
-      match = .false.
-      
-      if (allocated(a) .and. allocated(b)) then
-         match = MAPL_SameGeom(a, b)
-      end if
+      ! At most one geom can be mirror (unallocated).
+      ! Otherwise, assume ESMF can provide regrid
+      n_mirror = count([.not. allocated(a), .not. allocated(b)])
+
+      select case (n_mirror)
+      case (0)
+         match = MAPL_SameGeom(a,b)
+      case (1)
+         match = .true.
+      case (2)
+         match = .true.
+      end select
 
    end function match_geom
 
@@ -703,7 +749,7 @@ contains
    integer function get_cost_geom(a, b) result(cost)
       type(ESMF_GEOM), allocatable, intent(in) :: a, b
       cost = 0
-      if (.not. match(a, b)) cost = 1
+      if (.not. match(a,b)) cost = 1
    end function get_cost_geom
 
    integer function get_cost_typekind(a, b) result(cost)
@@ -723,10 +769,19 @@ contains
       type(ESMF_GEOM), allocatable, intent(in) :: b
 
       update_item_geom = .false.
-      if (.not. match(a, b)) then
+
+      if (.not. allocated(b)) return ! nothing to do (no coupler)
+
+      if (.not. allocated(a)) then ! Fill-in ExtData (no coupler)
          a = b
-         update_item_geom = .true.
+         return
       end if
+
+      if (MAPL_SameGeom(a,b)) return
+      update_item_geom = .true.
+      a = b
+
+
    end function update_item_geom
 
    logical function update_item_typekind(a, b)
@@ -738,6 +793,7 @@ contains
          a = b
          update_item_typekind = .true.
       end if
+
    end function update_item_typekind
 
    logical function update_item_string(a, b)

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -190,7 +190,7 @@ contains
    function make_ItemSpec(this, geom, vertical_geom, registry, rc) result(item_spec)
       class(StateItemSpec), allocatable :: item_spec
       class(VariableSpec), intent(in) :: this
-      type(ESMF_Geom), intent(in) :: geom
+      type(ESMF_Geom), optional, intent(in) :: geom
       type(VerticalGeom), intent(in) :: vertical_geom
       type(HierarchicalRegistry), intent(in) :: registry
       integer, optional, intent(out) :: rc
@@ -229,7 +229,7 @@ contains
    function make_BracketSpec(this, geom, vertical_geom, rc) result(bracket_spec)
       type(BracketSpec) :: bracket_spec
       class(VariableSpec), intent(in) :: this
-      type(ESMF_Geom), intent(in) :: geom
+      type(ESMF_Geom), optional, intent(in) :: geom
       type(VerticalGeom), intent(in) :: vertical_geom
       integer, optional, intent(out) :: rc
 
@@ -296,7 +296,7 @@ contains
    function make_FieldSpec(this, geom, vertical_geom, rc) result(field_spec)
       type(FieldSpec) :: field_spec
       class(VariableSpec), intent(in) :: this
-      type(ESMF_Geom), intent(in) :: geom
+      type(ESMF_Geom), optional, intent(in) :: geom
       type(VerticalGeom), intent(in) :: vertical_geom
       integer, optional, intent(out) :: rc
 

--- a/generic3g/tests/Test_AddFieldSpec.pf
+++ b/generic3g/tests/Test_AddFieldSpec.pf
@@ -24,8 +24,9 @@ contains
       type(VerticalDimSpec) :: vertical_dim_spec
       type(StringVector) :: attributes
       call state_spec%add_item('A', &
-           FieldSpec(geom, vertical_geom, vertical_dim_spec, ESMF_TYPEKIND_R4, UngriddedDims(), &
-           '', '', 'unknown', attributes))
+           FieldSpec(geom=geom, vertical_geom=vertical_geom, vertical_dim_spec=vertical_dim_spec, &
+           typekind=ESMF_TYPEKIND_R4, ungridded_dims=UngriddedDims()))
+
 
    end subroutine test_add_one_field
    
@@ -45,10 +46,9 @@ contains
       type(ESMF_Geom) :: geom
       type(VerticalGeom) :: vertical_geom
       type(VerticalDimSpec) :: vertical_dim_spec
-      type(StringVector) :: attributes
 
-      field_spec = FieldSpec(geom, vertical_geom, vertical_dim_spec, ESMF_TYPEKIND_R4, UngriddedDims(), &
-           '', '', 'unknown', attributes)
+      field_spec = FieldSpec(geom=geom, vertical_geom=vertical_geom, vertical_dim_spec=vertical_dim_spec, &
+           typekind=ESMF_TYPEKIND_R4, ungridded_dims=UngriddedDims())
       call state_spec%add_item('A', field_spec)
 
       ! Different name/key
@@ -78,15 +78,14 @@ contains
       type(ESMF_Field) :: f
       integer :: rank
       integer :: status
-      type(StringVector) :: attributes
 
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', rc=status)
       call ESMF_InfoGetFromHost(grid, info, rc=status)
       call ESMF_InfoSet(info, '/MAPL/GEOM/VERTICAL', 'CENTER', rc=status)
       geom = ESMF_GeomCreate(grid, ESMF_STAGGERLOC_INVALID)
       vertical_dim_spec = VERTICAL_DIM_CENTER
-      field_spec = FieldSpec(geom, vertical_geom, vertical_dim_spec, ESMF_TYPEKIND_R4, UngriddedDims(), &
-           '', '', '', attributes)
+      field_spec = FieldSpec(geom=geom, vertical_geom=vertical_geom, vertical_dim_spec=vertical_dim_spec, &
+           typekind=ESMF_TYPEKIND_R4, ungridded_dims=UngriddedDims())
       call field_spec%create(rc=status)
       call field_spec%allocate(rc=status)
 

--- a/generic3g/tests/Test_BracketSpec.pf
+++ b/generic3g/tests/Test_BracketSpec.pf
@@ -1,3 +1,5 @@
+#include "MAPL_TestErr.h"
+
 module Test_BracketSpec
    use funit
    use mapl3g_BracketSpec
@@ -8,16 +10,31 @@ module Test_BracketSpec
    use mapl3g_ActualConnectionPt
    use mapl3g_StateItemSpec
    use mapl3g_ESMF_Utilities, only: MAPL_TYPEKIND_MIRROR
+   use mapl3g_geom_mgr
    use gftl2_StringVector
    use esmf
    implicit none
 
+   type(ESMF_Geom) :: geom
+
 contains
+
+   @before
+   subroutine setup()
+      type(ESMF_HConfig) :: hconfig
+      type(MaplGeom) :: mapl_geom
+      type(GeomManager), pointer :: geom_mgr
+      integer :: status
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 12, jm_world: 13, pole: PC, dateline: DC}", _RC)
+      geom_mgr => get_geom_manager()
+      mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
+      geom = mapl_geom%get_geom()
+   end subroutine setup
 
    @test
    subroutine test_mirror_bracket_size()
       type(BracketSpec) :: spec_1, spec_2, spec_mirror
-      type(ESMF_Geom) :: geom
 
       spec_1 = BracketSpec( &
            field_spec=FieldSpec(geom=geom, vertical_geom=VerticalGeom(), &
@@ -60,16 +77,9 @@ contains
    ! specs with bracket size the same as first connection.
    subroutine test_connect_unique_mirror()
       type(BracketSpec) :: spec_1, spec_1b, spec_2, spec_mirror
-      type(ESMF_Geom) :: geom
       type(ActualConnectionPt) :: actual_pt
 
       integer :: status
-      type(ESMF_Grid) :: grid
-      type(ESMF_Info) :: info
-
-      grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', rc=status)
-      call ESMF_InfoGetFromHost(grid, info, rc=status)
-      geom = ESMF_GeomCreate(grid, ESMF_STAGGERLOC_INVALID)
 
       spec_1 = BracketSpec( &
            field_spec=FieldSpec(geom=geom, vertical_geom=VerticalGeom(), &

--- a/generic3g/tests/Test_FieldInfo.pf
+++ b/generic3g/tests/Test_FieldInfo.pf
@@ -33,9 +33,10 @@ contains
       call ungridded_dims%add_dim(UngriddedDim('a', 'm', [1.,2.]))
       call ungridded_dims%add_dim(UngriddedDim('b', 's', [1.,2.,3.]))
 
-      spec = FieldSpec(geom, vertical_geom, VERTICAL_DIM_CENTER, &
-           ESMF_TYPEKIND_R4, ungridded_dims, &
-           't', 'p', 'unknown')
+      spec = FieldSpec(geom=geom, vertical_geom=vertical_geom, &
+           vertical_dim_spec=VERTICAL_DIM_CENTER, &
+           typekind=ESMF_TYPEKIND_R4, ungridded_dims=ungridded_dims, &
+           standard_name='t', long_name='p', units='unknown')
 
       f = ESMF_FieldCreate(geom, ESMF_TYPEKIND_R4, ungriddedLbound=[1,1], ungriddedUbound=[2,3], _RC)
       call spec%set_info(f, _RC)

--- a/generic3g/tests/Test_FieldSpec.pf
+++ b/generic3g/tests/Test_FieldSpec.pf
@@ -1,5 +1,8 @@
+#include "MAPL_TestErr.h"
+
 module Test_FieldSpec
    use funit
+   use mapl3g_geom_mgr
    use mapl3g_FieldSpec
    use mapl3g_UngriddedDims
    use mapl3g_VerticalDimSpec
@@ -9,12 +12,28 @@ module Test_FieldSpec
    use esmf
    implicit none
 
+   type(ESMF_Geom) :: geom
+
 contains
 
+   
+   @before
+   subroutine setup()
+      type(ESMF_HConfig) :: hconfig
+      type(MaplGeom) :: mapl_geom
+      type(GeomManager), pointer :: geom_mgr
+      integer :: status
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 12, jm_world: 13, pole: PC, dateline: DC}", _RC)
+      geom_mgr => get_geom_manager()
+      mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
+      geom = mapl_geom%get_geom()
+   end subroutine setup
+
+   
    @test
    subroutine test_can_connect_typekind()
       type(FieldSpec) :: spec_r4, spec_r8, spec_mirror
-      type(ESMF_Geom) :: geom
       type(StringVector) :: import_attributes, export_attributes
 
       spec_r4 = FieldSpec( &
@@ -50,12 +69,10 @@ contains
    subroutine test_mismatched_attribute()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
       type(StringVector) :: import_attributes, export_attributes
 
       call import_attributes%push_back('radius')
 
-      
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
            typekind=ESMF_TYPEKIND_R4, &
@@ -78,7 +95,6 @@ contains
    subroutine test_matched_attribute()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
       type(StringVector) :: import_attributes, export_attributes
 
       call import_attributes%push_back('radius')
@@ -107,7 +123,6 @@ contains
    subroutine test_multiple_attribute()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
       type(StringVector) :: import_attributes, export_attributes
 
       call import_attributes%push_back('radius')
@@ -140,7 +155,6 @@ contains
    subroutine test_mismatched_units()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
 
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
@@ -164,7 +178,6 @@ contains
    subroutine test_convertible_units()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
 
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
@@ -188,7 +201,6 @@ contains
    subroutine test_same_units()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
 
       import_spec = FieldSpec( &
            geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
@@ -212,7 +224,6 @@ contains
    subroutine test_mirror_units()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec
-      type(ESMF_Geom) :: geom
 
       
       import_spec = FieldSpec( &

--- a/generic3g/tests/Test_FieldSpec.pf
+++ b/generic3g/tests/Test_FieldSpec.pf
@@ -243,4 +243,50 @@ contains
       
    end subroutine test_mirror_units
 
+   @test
+   subroutine test_mirror_geom()
+      type(FieldSpec) :: import_spec
+      type(FieldSpec) :: export_spec
+
+      
+      import_spec = FieldSpec( &
+           vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = UngriddedDims(), &
+           standard_name='A', long_name='AA', attributes=StringVector())
+
+      export_spec = FieldSpec( &
+           geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = UngriddedDims(), &
+           standard_name='A', long_name='AA', attributes=StringVector(), &
+           units='m')
+
+      @assert_that(import_spec%can_connect_to(export_spec), is(true()))
+
+   end subroutine test_mirror_geom
+
+   @test
+   subroutine test_mirror_geom_cost()
+      type(FieldSpec) :: import_spec
+      type(FieldSpec) :: export_spec
+
+      
+      import_spec = FieldSpec( &
+           vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = UngriddedDims(), &
+           standard_name='A', long_name='AA', attributes=StringVector())
+
+      export_spec = FieldSpec( &
+           geom=geom, vertical_geom=VerticalGeom(), vertical_dim_spec=VerticalDimSpec(), &
+           typekind=ESMF_TYPEKIND_R4, &
+           ungridded_dims = UngriddedDims(), &
+           standard_name='A', long_name='AA', attributes=StringVector(), &
+           units='m')
+
+      @assert_that(export_spec%extension_cost(import_spec), is(0))
+
+   end subroutine test_mirror_geom_cost
+
 end module Test_FieldSpec

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -251,8 +251,9 @@ contains
 
          call comp_states%get_state(state, state_intent, _RC)
 
+         
          msg = comp_path // '::' // state_intent
-   
+
          state_items = ESMF_HConfigCreateAt(comp_expectations,keyString=state_intent,_RC)
          @assertTrue(ESMF_HConfigIsMap(state_items), msg)
 

--- a/generic3g/tests/scenarios/extdata_1/cap.yaml
+++ b/generic3g/tests/scenarios/extdata_1/cap.yaml
@@ -1,13 +1,5 @@
 mapl:
 
-  geometry:
-    esmf_geom:
-      class: latlon
-      im_world: 12
-      jm_world: 13
-      pole: PC
-      dateline: DC
-
   children:
     extdata:
       dso: libproto_extdata_gc

--- a/generic3g/tests/scenarios/extdata_1/extdata.yaml
+++ b/generic3g/tests/scenarios/extdata_1/extdata.yaml
@@ -1,18 +1,26 @@
 mapl:
+  geometry:
+    esmf_geom:
+      class: latlon
+      im_world: 12
+      jm_world: 13
+      pole: PC
+      dateline: DC
+
   states:
     export:
-       E1:
-         standard_name: 'T1'
-         units: none
-         typekind: mirror
-         vertical_dim_spec: NONE
-       E2:
-         standard_name: 'T1'
-         units: none
-         typekind: mirror
-         vertical_dim_spec: NONE
+      E1:
+        standard_name: 'T1'
+        units: none
+        typekind: mirror
+        vertical_dim_spec: NONE
+      E2:
+        standard_name: 'T1'
+        units: none
+        typekind: mirror
+        vertical_dim_spec: NONE
 
   children:
     collection_1:
-      dso:  libsimple_leaf_gridcomp
+      dso: libsimple_leaf_gridcomp
       config_file: scenarios/extdata_1/collection_1.yaml

--- a/generic3g/tests/scenarios/extdata_1/root.yaml
+++ b/generic3g/tests/scenarios/extdata_1/root.yaml
@@ -1,4 +1,11 @@
 mapl:
+  geometry:
+    esmf_geom:
+      class: latlon
+      im_world: 12
+      jm_world: 13
+      pole: PC
+      dateline: DC
 
   states:
     import:

--- a/generic3g/tests/scenarios/history_1/A.yaml
+++ b/generic3g/tests/scenarios/history_1/A.yaml
@@ -3,12 +3,12 @@ mapl:
     import: {}
     export:
       E_A1:
-        standard_name:  'E_A1'
+        standard_name: 'E_A1'
         units: 'm'
         default_value: 1.
         vertical_dim_spec: NONE
       E_A2:
-        standard_name:  'E_A2'
+        standard_name: 'E_A2'
         units: ''
         default_value: 1.
         vertical_dim_spec: NONE

--- a/generic3g/tests/scenarios/history_1/expectations.yaml
+++ b/generic3g/tests/scenarios/history_1/expectations.yaml
@@ -48,6 +48,18 @@
     B/E_B2: {status: complete, value: 1.}
     B/E_B3: {status: complete, value: 17.}
 
+- component: history/mirror_geom_collection/<user>
+  import:
+    A/E_A1: {status: complete, value: 100.} # m -> cm
+    B/E_B2: {status: complete, value: 1.}
+    B/E_B3: {status: complete, value: 17.}
+
+- component: history/mirror_geom_collection
+  import:
+    A/E_A1: {status: complete, value: 100.} # m -> cm
+    B/E_B2: {status: complete, value: 1.}
+    B/E_B3: {status: complete, value: 17.}
+
 - component: history/<user>
   import: {}
 
@@ -56,6 +68,9 @@
     collection_1/A/E_A1: {status: complete, value: 100.} # m -> cm
     collection_1/B/E_B2: {status: complete, value: 1.}
     collection_1/B/E_B3: {status: complete, value: 17.}
+    mirror_geom_collection/A/E_A1: {status: complete, value: 100.} # m -> cm
+    mirror_geom_collection/B/E_B2: {status: complete, value: 1.}
+    mirror_geom_collection/B/E_B3: {status: complete, value: 17.}
 
 - component: <user>
   import: {}

--- a/generic3g/tests/scenarios/history_1/history.yaml
+++ b/generic3g/tests/scenarios/history_1/history.yaml
@@ -1,7 +1,10 @@
 mapl:
   children:
     collection_1:
-      dso:  libsimple_leaf_gridcomp
+      dso: libsimple_leaf_gridcomp
       config_file: scenarios/history_1/collection_1.yaml
+    mirror_geom_collection:
+      dso: libsimple_leaf_gridcomp
+      config_file: scenarios/history_1/mirror_geom_collection.yaml
 
   states: {}

--- a/generic3g/tests/scenarios/history_1/mirror_geom_collection.yaml
+++ b/generic3g/tests/scenarios/history_1/mirror_geom_collection.yaml
@@ -1,0 +1,16 @@
+mapl:
+  geometry:
+    kind: none
+
+  states:
+    import:
+      A/E_A1:
+        units: 'cm'
+        typekind: R8
+        vertical_dim_spec: MIRROR
+      B/E_B2:
+        typekind: mirror
+        vertical_dim_spec: MIRROR
+      B/E_B3:
+        typekind: mirror
+        vertical_dim_spec: MIRROR


### PR DESCRIPTION
Exposed 2 bugs in the process:
1. Identical imports were generating redundant couplers/extensions if coupled at the same level.
2. Same scenario resulted in a duplicate key in the table of import couplers which prevent some couplers from updating.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

