### PR TITLE
MAPL-V2: Error checking after mpi calls

### DIFF
--- a/Apps/Regrid_Util.F90
+++ b/Apps/Regrid_Util.F90
@@ -4,6 +4,7 @@
 
    use ESMF
    use MAPL
+   use MAPL_BaseMod
    use gFTL_StringVector
 
    implicit NONE

--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -5,6 +5,7 @@ program  time_ave
 
    use ESMF
    use MAPL
+   use MAPL_BaseMod
    use MAPL_FileMetadataUtilsMod
    use gFTL_StringVector
    use MPI

--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -133,9 +133,13 @@ program  time_ave
 
 !call timebeg ('main')
 
-   call mpi_init                ( ierror ) ; comm = mpi_comm_world
+   call mpi_init                ( ierror ) 
+   _VERIFY(ierror)
+   comm = mpi_comm_world
    call mpi_comm_rank ( comm,myid,ierror )
+   _VERIFY(ierror)
    call mpi_comm_size ( comm,npes,ierror )
+   _VERIFY(ierror)
    call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_NONE,mpiCommunicator=MPI_COMM_WORLD, _RC)
    call MAPL_Initialize(_RC)
    t_prof = DistributedProfiler('time_ave_util',MpiTImerGauge(),MPI_COMM_WORLD)
@@ -813,6 +817,7 @@ program  time_ave
       enddo    ! End ntime Loop within file
 
       call MPI_BARRIER(comm,status)
+      _VERIFY(status)
    enddo
 
    do k=0,ntods
@@ -1064,7 +1069,9 @@ call t_prof%start('Write_AVE')
          endif
 
          call mpi_reduce( qmin(nloc(n)+L-1),qming,1,mpi_real,mpi_min,0,comm,ierror )
+         _VERIFY(ierror)
          call mpi_reduce( qmax(nloc(n)+L-1),qmaxg,1,mpi_real,mpi_max,0,comm,ierror )
+         _VERIFY(ierror)
          if( root ) then
             if(L.eq.1) then
                write(6,3101) trim(vname2(n)),plev,qming,qmaxg
@@ -1076,6 +1083,7 @@ call t_prof%start('Write_AVE')
 3102     format(1x,'               ',a20,' Level: ',f9.3,'  Min: ',g15.8,'  Max: ',g15.8)
       enddo
       call MPI_BARRIER(comm,status)
+      _VERIFY(status)
       if( root ) print *
    enddo
    if( root ) print *

--- a/Tests/pfio_MAPL_demo.F90
+++ b/Tests/pfio_MAPL_demo.F90
@@ -92,6 +92,7 @@ program main
       call initialize_mpi(MPI_COMM_WORLD)
 
       call MPI_Comm_size(MPI_COMM_WORLD, npes, ierror)
+      _VERIFY(ierror)
       if ( cap_options%npes_model == -1) then
           cap_options%npes_model = npes
       endif
@@ -113,9 +114,11 @@ program main
 
             ! Get the number of PEs used for the model
             call MPi_Comm_size(client_comm, npes, ierror)
+            _VERIFY(ierror)
 
             ! Get the PE id
             call MPI_Comm_rank(client_comm, pe_id, ierror)
+            _VERIFY(ierror)
             if (npes /= cap_options%npes_model) stop "sanity check failed"
 
             !------------------------------------------------
@@ -194,6 +197,7 @@ CONTAINS
       integer :: provided
 
       call MPI_Initialized(mpi_already_initialized, ierror)
+      _VERIFY(ierror)
       if (.not. mpi_already_initialized) then
          call MPI_Init_thread(MPI_THREAD_SINGLE, provided, ierror)
          _VERIFY(ierror)

--- a/base/ApplicationSupport.F90
+++ b/base/ApplicationSupport.F90
@@ -118,6 +118,7 @@ module MAPL_ApplicationSupport
       else
 
          call MPI_COMM_Rank(comm_world,rank,status)
+         _VERIFY(status)
          console = StreamHandler(OUTPUT_UNIT)
          call console%set_level(INFO)
          call console%set_formatter(MpiFormatter(comm_world, fmt='%(short_name)a10~: %(message)a'))
@@ -186,7 +187,9 @@ module MAPL_ApplicationSupport
       call reporter%add_column(exclusive)
 
       call MPI_Comm_size(world_comm, npes, ierror)
+      _VERIFY(ierror)
       call MPI_Comm_Rank(world_comm, my_rank, ierror)
+      _VERIFY(ierror)
 
       if (my_rank == 0) then
          report_lines = reporter%generate_report(t_p)
@@ -197,6 +200,7 @@ module MAPL_ApplicationSupport
          end do
       end if
       call MPI_Barrier(world_comm, ierror)
+      _VERIFY(ierror)
 
       _RETURN(_SUCCESS)
    end subroutine report_global_profiler

--- a/base/Base.F90
+++ b/base/Base.F90
@@ -4,7 +4,7 @@ module MAPLBase_Mod
 
   use ESMFL_Mod         !  Stopgap
   use MAPL_ExceptionHandling
-  use MAPL_BaseMod
+!  use MAPL_BaseMod
   use MAPL_BaseMod, only: MAPL_GRID_INTERIOR
 ! For temporary backward compatibility after moving/renaming:
   use MAPL_BaseMod, only: ESMF_GRID_INTERIOR => MAPL_GRID_INTERIOR

--- a/base/MAPL_Comms.F90
+++ b/base/MAPL_Comms.F90
@@ -677,6 +677,7 @@ module MAPL_CommsMod
              call MPI_Recv(request%Var, size(request%Var), MPI_REAL, &
                            request%Root, request%tag, request%comm,  &
                            MPI_STATUS_IGNORE, status)
+             _VERIFY(status)
           endif
           k=0
           do J=1,request%JM0

--- a/base/MAPL_LocStreamMod.F90
+++ b/base/MAPL_LocStreamMod.F90
@@ -2741,6 +2741,7 @@ subroutine MAPL_LocStreamCreateXform ( Xform, LocStreamOut, LocStreamIn, NAME, M
           call MPI_GATHER(  lNumReceivers, 1, MPI_INTEGER, &
                allSenders(:,1), 1, MPI_INTEGER, &
                I-1, Xform%Ptr%Comm,  status )
+          _VERIFY(status)
        enddo
      end block
      call ESMF_VMBarrier(vm, rc=status)

--- a/base/MAPL_MemUtils.F90
+++ b/base/MAPL_MemUtils.F90
@@ -403,6 +403,7 @@ module MAPL_MemUtilsMod
     call mem_dump(mhwm, mrss, memused, swapused, commitlimit, committed_as)
 #endif
     call MPI_Comm_Size(comm_,npes,status)
+    _VERIFY(status)
     if (MAPL_MemUtilsMode == MAPL_MemUtilsModeFull) then
        lhwm = mhwm; call MPI_AllReduce(lhwm,ghwm,1,MPI_REAL,MPI_MAX,comm_,status)
        _VERIFY(STATUS)
@@ -414,6 +415,7 @@ module MAPL_MemUtilsMod
        _VERIFY(STATUS)
        gavg = gavg/npes
        mstd = (mrss-gavg)**2; call MPI_AllReduce(mstd,gstd,1,MPI_REAL,MPI_SUM,comm_,status)
+       _VERIFY(status)
        gstd = sqrt( gstd/npes )
        gmax_save = gmax
        lcommitlimit  = commitlimit;  call MPI_AllReduce(lcommitlimit,gcommitlimit,1,MPI_REAL,MPI_MAX,comm_,status)
@@ -784,6 +786,7 @@ subroutine MAPL_MemReport(comm,file_name,line,decorator,rc)
     _RETURN(ESMF_SUCCESS)
 #endif
     call MPI_Barrier(comm,status)
+    _VERIFY(status)
     if (present(decorator)) then
        extra_message = decorator
     else
@@ -792,6 +795,7 @@ subroutine MAPL_MemReport(comm,file_name,line,decorator,rc)
     call MAPL_MemUsed(mem_total,mem_used,percent_used)
     call MAPL_MemCommited(committed_total,committed,percent_committed)
     call MPI_Comm_Rank(comm,rank,status)
+    _VERIFY(status)
     if (rank == 0) write(*,'("Mem report ",A20," ",A30," ",i7," ",f5.1,"% : ",f5.1,"% Mem Comm:Used")')trim(extra_message),file_name,line,percent_committed,percent_used
 
 end subroutine

--- a/base/MAPL_SwathGridFactory.F90
+++ b/base/MAPL_SwathGridFactory.F90
@@ -551,6 +551,7 @@ contains
       !
       call ESMF_VMGet(vm, mpiCommunicator=mpic, _RC)
       call MPI_COMM_RANK(mpic, irank, ierror)
+      _VERIFY(ierror)
 
       if (irank==0) &
            write(6,'(10(2x,a20,2x,a40,/))') &
@@ -690,14 +691,21 @@ contains
 
 
       call MPI_bcast(this%M_file, 1, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
       do i=1, this%M_file
          call MPI_bcast(this%filenames(i), ESMF_MAXSTR, MPI_CHARACTER, 0, mpic, ierror)
+         _VERIFY(ierror)
       end do
       call MPI_bcast(this%epoch_index, 4, MPI_INTEGER8, 0, mpic, ierror)
+      _VERIFY(ierror)
       call MPI_bcast(this%im_world, 1, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
       call MPI_bcast(this%jm_world, 1, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
       call MPI_bcast(this%cell_across_swath, 1, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
       call MPI_bcast(this%cell_along_swath, 1, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
       ! donot need to bcast this%along_track (root only)
 
 
@@ -1352,6 +1360,7 @@ contains
       call ESMF_VmGetCurrent(VM, _RC)
       call ESMF_VMGet(vm, mpiCommunicator=mpic, _RC)
       call MPI_COMM_RANK(mpic, irank, ierror)
+      _VERIFY(ierror)
 
       if (irank==0) then
          ! xtrack
@@ -1406,6 +1415,7 @@ contains
       end if
 
       call MPI_bcast(xy_subset, 4, MPI_INTEGER, 0, mpic, ierror)
+      _VERIFY(ierror)
 
       _RETURN(_SUCCESS)
     end subroutine get_xy_subset

--- a/base/ServerManager.F90
+++ b/base/ServerManager.F90
@@ -153,6 +153,7 @@ contains
      if ( index(s_name, 'model') /=0 ) then
         client_comm = this%split_comm%get_subcommunicator()
         call MPI_Comm_Rank(client_comm,rank,status)
+        _VERIFY(status)
         if (npes_in(1)  == 0 .and. nodes_in(1)  == 0) profiler_name = "i_server_client"
         if (npes_out(1) == 0 .and. nodes_out(1) == 0) profiler_name = "o_server_client"
         if (npes_out(1) == 0 .and. nodes_out(1) == 0 .and. &
@@ -194,6 +195,7 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%i_server), this%i_server)
            call this%directory_service%connect_to_client(s_name, this%i_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
+           _VERIFY(status)
            if (rank == 0 .and. nodes_in(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO input server on ",nodes_in(i)," nodes"
            else if (rank==0 .and. npes_in(1) /=0 ) then
@@ -210,6 +212,7 @@ contains
         endif
 
         call mpi_barrier(comm, status)
+        _VERIFY(status)
 
      enddo
 
@@ -246,6 +249,7 @@ contains
            call this%directory_service%publish(PortInfo(s_name,this%o_server), this%o_server)
            call this%directory_service%connect_to_client(s_name, this%o_server)
            call MPI_Comm_Rank(this%split_comm%get_subcommunicator(),rank,status)
+           _VERIFY(status)
            if (rank == 0 .and. nodes_out(1) /=0 ) then
               write(*,'(A,I0,A)')"Starting pFIO output server on ",nodes_out(i)," nodes"
            else if (rank==0 .and. npes_out(1) /=0 ) then
@@ -262,6 +266,7 @@ contains
         endif
 
         call mpi_barrier(comm, status)
+        _VERIFY(status)
 
      enddo
 

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -559,7 +559,7 @@ contains
       integer :: p
       integer, allocatable :: counts(:)
       integer, allocatable :: displs(:)
-      integer :: ierror
+      integer :: ierror, rc
 
       allocate(counts(0:pet_count-1))
       allocate(displs(0:pet_count-1))

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -566,6 +566,7 @@ contains
 
       call mpi_allgather(len(local), 1, MPI_INTEGER, &
            & counts, 1, MPI_INTEGER, MPI_COMM_WORLD, ierror)
+      _VERIFY(ierror)
 
       displs(0) = 0
       do p = 1, pet_count - 1
@@ -575,6 +576,7 @@ contains
       allocate(character(len=sum(counts)) :: global)
       call mpi_allgatherv(local, len(local), MPI_CHAR, &
            global, counts, displs, MPI_CHAR, MPI_COMM_WORLD, ierror)
+      _VERIFY(ierror)
 
    end function all_gather
 
@@ -600,6 +602,8 @@ contains
      if (present(missing)) then
         have_missing = any(missing == src_array)
         call MPI_AllReduce(have_missing, any_missing, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
+        _VERIFY(ierror)
+
         if (any_missing) then
            local_key = run_length_encode(reshape(src_array,[size(src_array)]) == missing)
            global_key = all_gather(local_key)

--- a/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
+++ b/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
@@ -65,7 +65,7 @@ contains
       type(ESMF_Config) :: config
 
       logical :: is_present
-      integer :: comm_size, status,error_code
+      integer :: comm_size, status,error_code, rc
 
       config = ESMF_ConfigCreate()
       this%extra_info = .false.
@@ -183,7 +183,7 @@ contains
       integer, allocatable :: seeds(:)
 
       call MPI_COMM_RANK(MPI_COMM_WORLD,rank,status)
-      _VERIFY(status)
+      !_VERIFY(status)
       call random_seed(size=seed_size)
       allocate(seeds(seed_size))
       seeds = rank
@@ -204,7 +204,7 @@ contains
       class(test_support), intent(inout) :: this
 
       integer, allocatable :: ims(:),jms(:)
-      integer :: rank, status,comm_size,n,i,j,rank_counter,offset,index_offset
+      integer :: rank, status,comm_size,n,i,j,rank_counter,offset,index_offset, rc
 
       call MPI_Comm_Rank(MPI_COMM_WORLD,rank,status)
       _VERIFY(status)
@@ -258,7 +258,7 @@ contains
   subroutine create_communicators(this)
      class(test_support), intent(inout) :: this
 
-     integer :: myid,status,nx0,ny0,color,j,ny_by_writers,local_ny,key
+     integer :: myid,status,nx0,ny0,color,j,ny_by_writers,local_ny,key,rc
 
      local_ny = this%ny*6
      call MPI_Comm_Rank(mpi_comm_world,myid,status)
@@ -299,7 +299,7 @@ contains
   subroutine close_file(this)
      class(test_support), intent(inout) :: this
 
-     integer :: status
+     integer :: status, rc
 
      integer(kind=INT64) :: sub_start,sub_end
 
@@ -321,7 +321,7 @@ contains
   subroutine create_file(this)
      class(test_support), intent(inout) :: this
 
-     integer :: status
+     integer :: status,rc
      integer :: info
      integer :: xdim,ydim,zdim,i,varid,create_mode
      character(len=:), allocatable :: fname
@@ -405,7 +405,7 @@ contains
 
   subroutine write_file(this)
      class(test_support), intent(inout) :: this
-     integer :: status,i,l
+     integer :: status,i,l,rc
 
      integer(kind=INT64) :: sub_start,sub_end
 
@@ -437,7 +437,7 @@ contains
      class(test_support), intent(inout) :: this
      character(len=*), intent(in) :: var_name
      real, intent(in) :: local_var(:,:,:)
-     integer :: status
+     integer :: status,rc
      real,  allocatable :: recvbuf(:)
      integer                               :: I,J,N,K,L,myrow,myiorank,ndes_x
      integer                               :: start(3), cnt(3)
@@ -557,7 +557,7 @@ contains
      character(len=*), intent(in) :: var_name
      real, intent(in) :: local_var(:,:)
      integer, intent(in) :: z_index
-     integer :: status
+     integer :: status, rc
      real,  allocatable :: recvbuf(:)
      integer                               :: I,J,N,K,L,myrow,myiorank,ndes_x
      integer                               :: start(3), cnt(3)
@@ -673,15 +673,17 @@ contains
 end module
 
 #include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
 program checkpoint_tester
    use ESMF
+   use MAPL_ErrorHandlingMod
    use MPI
    use NetCDF
    use mapl_checkpoint_support_mod
    use, intrinsic :: iso_fortran_env, only: REAL64, INT64
    implicit NONE
 
-   integer :: status,rank,writer_size,writer_rank,comm_size,i
+   integer :: status,rank,writer_size,writer_rank,comm_size,i,rc
    type(test_support) :: support
    integer(kind=INT64) :: start_write,end_time,count_rate,start_app,end_app
    real(kind=REAL64) :: time_sum,write_time,create_time,close_time,write_3d_time,write_2d_time
@@ -693,29 +695,29 @@ program checkpoint_tester
 
    call system_clock(count=start_app,count_rate=count_rate)
    call MPI_Init(status)
-   _VERIFY(status)
+   !_VERIFY(status)
    call MPI_Barrier(MPI_COMM_WORLD,status)
-   _VERIFY(status)
+   !_VERIFY(status)
 
    call MPI_Comm_Rank(MPI_COMM_WORLD,rank,status)
-   _VERIFY(status)
+   !_VERIFY(status)
    call MPI_Comm_Size(MPI_COMM_WORLD,comm_size,status)
-   _VERIFY(status)
+   !_VERIFY(status)
    call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_NONE,mpiCommunicator=MPI_COMM_WORLD)
    call MPI_Barrier(MPI_COMM_WORLD,status)
-   _VERIFY(status)
+   !_VERIFY(status)
 
    call support%set_parameters("checkpoint_benchmark.rc")
    call MPI_Barrier(MPI_COMM_WORLD,status)
-   _VERIFY(status)
+   !_VERIFY(status)
 
    call support%create_arrays()
    call MPI_Barrier(MPI_COMM_WORLD,status)
-   _VERIFY(status)
+   !_VERIFY(status)
 
    call support%create_communicators()
    call MPI_Barrier(MPI_COMM_WORLD,status)
-   _VERIFY(status)
+   !_VERIFY(status)
 
    allocate(total_throughput(support%n_trials))
    allocate(all_proc_throughput(support%n_trials))
@@ -725,18 +727,18 @@ program checkpoint_tester
 
       call system_clock(count=start_write)
       call MPI_Barrier(MPI_COMM_WORLD,status)
-      _VERIFY(status)
+      !_VERIFY(status)
       if (support%do_writes) call support%create_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
-      _VERIFY(status)
+      !_VERIFY(status)
 
       call support%write_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
-      _VERIFY(status)
+      !_VERIFY(status)
 
       if (support%do_writes) call support%close_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
-      _VERIFY(status)
+      !_VERIFY(status)
 
       call system_clock(count=end_time)
       write_time = real(end_time-start_write,kind=REAL64)/real(count_rate,kind=REAL64)
@@ -748,14 +750,14 @@ program checkpoint_tester
 
       if (support%write_counter > 0) then
          call MPI_COMM_SIZE(support%writers_comm,writer_size,status)
-         _VERIFY(status)
+         !_VERIFY(status)
          call MPI_COMM_RANK(support%writers_comm,writer_rank,status)
-         _VERIFY(status)
+         !_VERIFY(status)
          call MPI_AllReduce(support%data_volume,average_volume,1,MPI_DOUBLE_PRECISION,MPI_SUM,support%writers_comm,status)
-         _VERIFY(status)
+         !_VERIFY(status)
          average_volume = average_volume/real(writer_size,kind=REAL64)
          call MPI_AllReduce(support%time_writing,average_time,1,MPI_DOUBLE_PRECISION,MPI_SUM,support%writers_comm,status)
-         _VERIFY(status)
+         !_VERIFY(status)
          average_time = average_time/real(writer_size,kind=REAL64)
       end if
       if (rank == 0) then

--- a/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
+++ b/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
@@ -97,7 +97,11 @@ contains
       this%time_writing = 0.d0
       this%mpi_time = 0.0
       call MPI_COMM_SIZE(MPI_COMM_WORLD,comm_size,status)
-      if (comm_size /= (this%nx*this%ny*6)) call MPI_Abort(mpi_comm_world,error_code,status)
+      _VERIFY(status)
+      if (comm_size /= (this%nx*this%ny*6)) then
+         call MPI_Abort(mpi_comm_world,error_code,status)
+         _VERIFY(status)
+      endif
 
       contains
 
@@ -179,6 +183,7 @@ contains
       integer, allocatable :: seeds(:)
 
       call MPI_COMM_RANK(MPI_COMM_WORLD,rank,status)
+      _VERIFY(status)
       call random_seed(size=seed_size)
       allocate(seeds(seed_size))
       seeds = rank
@@ -202,7 +207,9 @@ contains
       integer :: rank, status,comm_size,n,i,j,rank_counter,offset,index_offset
 
       call MPI_Comm_Rank(MPI_COMM_WORLD,rank,status)
+      _VERIFY(status)
       call MPI_Comm_Size(MPI_COMM_WORLD,comm_size,status)
+      _VERIFY(status)
       allocate(this%bundle(this%num_arrays))
       ims = this%compute_decomposition(axis=1)
       jms = this%compute_decomposition(axis=2)
@@ -255,12 +262,15 @@ contains
 
      local_ny = this%ny*6
      call MPI_Comm_Rank(mpi_comm_world,myid,status)
+      _VERIFY(status)
      nx0 = mod(myid,this%nx) + 1
      ny0 = myid/this%nx + 1
      color = nx0
      call MPI_Comm_Split(MPI_COMM_WORLD,color,myid,this%ycomm,status)
+      _VERIFY(status)
      color = ny0
      call MPI_Comm_Split(MPI_COMM_WORLD,color,myid,this%xcomm,status)
+      _VERIFY(status)
 
 
      ny_by_writers = local_ny/this%num_writers
@@ -270,15 +280,18 @@ contains
         color = MPI_UNDEFINED
      end if
      call MPI_COMM_SPLIT(MPI_COMM_WORLD,color,myid,this%writers_comm,status)
+      _VERIFY(status)
 
      if (this%num_writers == local_ny) then
         this%gather_comm = this%xcomm
      else
         j = ny0 - mod(ny0-1,ny_by_writers)
         call MPI_COMM_SPLIT(MPI_COMM_WORLD,j,myid,this%gather_comm,status)
+        _VERIFY(status)
      end if
 
      call MPI_BARRIER(mpi_comm_world,status)
+     _VERIFY(status)
 
 
   end subroutine
@@ -300,6 +313,7 @@ contains
         end if
      end if
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      call system_clock(count=sub_end)
      this%close_file_time =  sub_end-sub_start
   end subroutine
@@ -323,15 +337,21 @@ contains
         create_mode = IOR(create_mode,NF90_SHARE)
         create_mode = IOR(create_mode,NF90_MPIIO)
         call MPI_INFO_CREATE(info,status)
+        _VERIFY(status)
         call MPI_INFO_SET(info,"cb_buffer_size","16777216",status)
+        _VERIFY(status)
         call MPI_INFO_SET(info,"romio_cb_write","enable",status)
+        _VERIFY(status)
         if (this%extra_info) then
            call MPI_INFO_SET(info,"IBM_largeblock_io","true",status)
+           _VERIFY(status)
            call MPI_INFO_SET(info,"striping_unit","4194304",status)
+           _VERIFY(status)
         end if
         if (this%writers_comm /= MPI_COMM_NULL) then
            if (this%split_file) then
               call MPI_COMM_RANK(this%writers_comm,writer_rank,status)
+              _VERIFY(status)
               write(fc,'(I0.3)')writer_rank
               fname = "checkpoint_"//fc//".nc4"
               status = nf90_create(fname,ior(NF90_NETCDF4,NF90_CLOBBER), this%ncid)
@@ -369,6 +389,7 @@ contains
         if (this%writers_comm /= MPI_COMM_NULL) then
            if (this%split_file) then
               call MPI_COMM_RANK(this%writers_comm,writer_rank,status)
+              _VERIFY(status)
               write(fc,'(I0.3)')writer_rank
               fname = "checkpoint_"//fc//".bin"
               open(file=fname,newunit=this%ncid,status='replace',form='unformatted',access='sequential')
@@ -376,6 +397,7 @@ contains
         end if
      end if
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      call system_clock(count=sub_end)
      this%create_file_time = sub_end-sub_start
   end subroutine
@@ -388,8 +410,10 @@ contains
      integer(kind=INT64) :: sub_start,sub_end
 
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      call system_clock(count=sub_start)
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      do i=1,this%num_arrays
         if (this%gather_3d) then
            call this%write_variable(this%bundle(i)%field_name,this%bundle(i)%field)
@@ -400,10 +424,13 @@ contains
         end if
      enddo
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      call system_clock(count=sub_end)
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
      this%write_3d_time = sub_end-sub_start
      call MPI_BARRIER(MPI_COMM_WORLD,status)
+     _VERIFY(status)
   end subroutine
 
   subroutine write_variable(this,var_name,local_var)
@@ -428,8 +455,11 @@ contains
      ndes_x = size(this%in)
 
        call mpi_comm_rank(this%ycomm,myrow,status)
+       _VERIFY(status)
        call mpi_comm_rank(this%gather_comm,myiorank,status)
+       _VERIFY(status)
        call mpi_comm_size(this%gather_comm,num_io_rows,status)
+       _VERIFY(status)
        num_io_rows=num_io_rows/ndes_x
 
        allocate (recvcounts(ndes_x*num_io_rows), displs(ndes_x*num_io_rows), stat=status)
@@ -459,9 +489,13 @@ contains
 
        call mpi_gatherv( local_var, size(local_var), MPI_REAL, recvbuf, recvcounts, displs, MPI_REAL, &
                       0, this%gather_comm, status )
+       _VERIFY(status)
        call system_clock(count=end_mpi)
        this%time_mpi = this%mpi_time  + (end_mpi - start_mpi)
-       if (this%write_barrier) call MPI_Barrier(MPI_COMM_WORLD,status)
+       if (this%write_barrier) then
+          call MPI_Barrier(MPI_COMM_WORLD,status)
+          _VERIFY(status)
+       endif
 
        if(myiorank==0) then
 
@@ -541,8 +575,11 @@ contains
      ndes_x = size(this%in)
 
        call mpi_comm_rank(this%ycomm,myrow,status)
+       _VERIFY(status)
        call mpi_comm_rank(this%gather_comm,myiorank,status)
+       _VERIFY(status)
        call mpi_comm_size(this%gather_comm,num_io_rows,status)
+       _VERIFY(status)
        num_io_rows=num_io_rows/ndes_x
 
        allocate (recvcounts(ndes_x*num_io_rows), displs(ndes_x*num_io_rows), stat=status)
@@ -572,9 +609,13 @@ contains
 
        call mpi_gatherv( local_var, size(local_var), MPI_REAL, recvbuf, recvcounts, displs, MPI_REAL, &
                       0, this%gather_comm, status )
+       _VERIFY(status)
        call system_clock(count=end_mpi)
        this%mpi_time = this%mpi_time + (end_mpi - start_mpi)
-       if (this%write_barrier) call MPI_Barrier(MPI_COMM_WORLD,status)
+       if (this%write_barrier) then
+          call MPI_Barrier(MPI_COMM_WORLD,status)
+          _VERIFY(status)
+       endif
 
        if(myiorank==0) then
 
@@ -652,21 +693,29 @@ program checkpoint_tester
 
    call system_clock(count=start_app,count_rate=count_rate)
    call MPI_Init(status)
+   _VERIFY(status)
    call MPI_Barrier(MPI_COMM_WORLD,status)
+   _VERIFY(status)
 
    call MPI_Comm_Rank(MPI_COMM_WORLD,rank,status)
+   _VERIFY(status)
    call MPI_Comm_Size(MPI_COMM_WORLD,comm_size,status)
+   _VERIFY(status)
    call ESMF_Initialize(logKindFlag=ESMF_LOGKIND_NONE,mpiCommunicator=MPI_COMM_WORLD)
    call MPI_Barrier(MPI_COMM_WORLD,status)
+   _VERIFY(status)
 
    call support%set_parameters("checkpoint_benchmark.rc")
    call MPI_Barrier(MPI_COMM_WORLD,status)
+   _VERIFY(status)
 
    call support%create_arrays()
    call MPI_Barrier(MPI_COMM_WORLD,status)
+   _VERIFY(status)
 
    call support%create_communicators()
    call MPI_Barrier(MPI_COMM_WORLD,status)
+   _VERIFY(status)
 
    allocate(total_throughput(support%n_trials))
    allocate(all_proc_throughput(support%n_trials))
@@ -676,14 +725,18 @@ program checkpoint_tester
 
       call system_clock(count=start_write)
       call MPI_Barrier(MPI_COMM_WORLD,status)
+      _VERIFY(status)
       if (support%do_writes) call support%create_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
+      _VERIFY(status)
 
       call support%write_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
+      _VERIFY(status)
 
       if (support%do_writes) call support%close_file()
       call MPI_Barrier(MPI_COMM_WORLD,status)
+      _VERIFY(status)
 
       call system_clock(count=end_time)
       write_time = real(end_time-start_write,kind=REAL64)/real(count_rate,kind=REAL64)
@@ -695,10 +748,14 @@ program checkpoint_tester
 
       if (support%write_counter > 0) then
          call MPI_COMM_SIZE(support%writers_comm,writer_size,status)
+         _VERIFY(status)
          call MPI_COMM_RANK(support%writers_comm,writer_rank,status)
+         _VERIFY(status)
          call MPI_AllReduce(support%data_volume,average_volume,1,MPI_DOUBLE_PRECISION,MPI_SUM,support%writers_comm,status)
+         _VERIFY(status)
          average_volume = average_volume/real(writer_size,kind=REAL64)
          call MPI_AllReduce(support%time_writing,average_time,1,MPI_DOUBLE_PRECISION,MPI_SUM,support%writers_comm,status)
+         _VERIFY(status)
          average_time = average_time/real(writer_size,kind=REAL64)
       end if
       if (rank == 0) then

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -10999,6 +10999,7 @@ contains
          call ArrDescrCreateWriterComm(arrdes,mpl%grid%comm,mpl%grid%num_writers,_RC)
          call ArrDescrCreateReaderComm(arrdes,mpl%grid%comm,mpl%grid%num_readers,_RC)
          call mpi_comm_rank(arrdes%ycomm,arrdes%myrow,status)
+         _VERIFY(status)
          arrdes%split_restart = mpl%grid%split_restart
          arrdes%split_checkpoint = mpl%grid%split_checkpoint
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -286,11 +286,13 @@ contains
       ! broadcast the result to the other ranks
 
       call MPI_COMM_RANK(comm, rank, ierror)
+      _VERIFY(ierror)
 
       if (rank == 0) then
          inquire(file='ESMF.rc', exist=file_exists)
       end if
       call MPI_BCAST(file_exists, 1, MPI_LOGICAL, 0, comm, ierror)
+      _VERIFY(ierror)
 
       ! If the file exists, we pass it into ESMF_Initialize, else, we
       ! use the one from the command line arguments

--- a/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_GeosatMaskMod_smod.F90
@@ -341,6 +341,7 @@ end subroutine initialize_
        call MPI_gatherv ( nx2, 1, MPI_INTEGER, &
             this%recvcounts, recvcounts_loc, displs_loc, MPI_INTEGER,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
        if (.not. mapl_am_i_root()) then
           this%recvcounts(:) = 0
        end if
@@ -353,9 +354,11 @@ end subroutine initialize_
        call MPI_gatherv ( lons_chunk, nsend, MPI_REAL8, &
             lons, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
        call MPI_gatherv ( lats_chunk, nsend, MPI_REAL8, &
             lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
 
 
 !!       if (mapl_am_I_root()) write(6,*) 'nobs tot :', nx
@@ -525,6 +528,7 @@ end subroutine initialize_
        call MPI_gatherv ( this%npt_mask, 1, MPI_INTEGER, &
             this%recvcounts, recvcounts_loc, displs_loc, MPI_INTEGER,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
        if (.not. mapl_am_i_root()) then
           this%recvcounts(:) = 0
        end if
@@ -540,9 +544,11 @@ end subroutine initialize_
        call MPI_gatherv ( lons, nsend, MPI_REAL8, &
             this%lons, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
        call MPI_gatherv ( lats, nsend, MPI_REAL8, &
             this%lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
+       _VERIFY(ierr)
 
        call MAPL_TimerOff(this%GENSTATE,"4_gatherV")
 
@@ -731,6 +737,7 @@ module subroutine  add_metadata(this,rc)
              call MPI_gatherv ( p_dst_2d, nsend, MPI_REAL, &
                   p_dst_2d_full, this%recvcounts, this%displs, MPI_REAL,&
                   iroot, mpic, ierr )
+             _VERIFY(ierr)
              call MAPL_TimerOn(this%GENSTATE,"put2D")
              if (mapl_am_i_root()) then
                 call this%formatter%put_var(item%xname,p_dst_2d_full,&
@@ -755,6 +762,7 @@ module subroutine  add_metadata(this,rc)
              call MPI_gatherv ( p_dst_3d, nsend, MPI_REAL, &
                   p_dst_3d_full, recvcounts_3d, displs_3d, MPI_REAL,&
                   iroot, mpic, ierr )
+             _VERIFY(ierr)
              call MAPL_TimerOn(this%GENSTATE,"put3D")
              if (mapl_am_i_root()) then
                 allocate(arr(nz, this%npt_mask_tot), _STAT)

--- a/gridcomps/History/Sampler/MAPL_StationSamplerMod.F90
+++ b/gridcomps/History/Sampler/MAPL_StationSamplerMod.F90
@@ -287,10 +287,12 @@ contains
     call MPI_Scatterv( sampler%lons, sendcount, &
          displs, MPI_REAL8,  lons_chunk, &
          recvcount, MPI_REAL8, 0, mpic, ierr)
+    _VERIFY(ierr)
 
     call MPI_Scatterv( sampler%lats, sendcount, &
          displs, MPI_REAL8,  lats_chunk, &
          recvcount, MPI_REAL8, 0, mpic, ierr)
+    _VERIFY(ierr)
 
     ! -- root
     sampler%LSF   = LocStreamFactory(sampler%lons, sampler%lats, _RC)
@@ -618,6 +620,7 @@ contains
              call MPI_gatherv ( p_chunk_2d, nsend, MPI_REAL, &
                   p_rt_2d, recvcount, displs, MPI_REAL,&
                   iroot, mpic, ierr )
+             _VERIFY(ierr)
 
              call MAPL_TimerOn(this%GENSTATE,"put2D")
              if (mapl_am_i_root()) then
@@ -664,6 +667,7 @@ contains
                 call MPI_gatherv ( p_chunk_3d, nsend_v, MPI_REAL, &
                      p_rt_3d, recvcount_v, displs_v, MPI_REAL,&
                      iroot, mpic, ierr )
+                _VERIFY(ierr)
              end if
              call MAPL_TimerOff(this%GENSTATE,"gatherv")
 

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -891,14 +891,17 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call MPI_Scatterv( this%lons, sendcount, &
               displs, MPI_REAL8,  lons_chunk, &
               recvcount, MPI_REAL8, 0, mpic, ierr)
+         _VERIFY(ierr)
 
          call MPI_Scatterv( this%lats, sendcount, &
               displs, MPI_REAL8,  lats_chunk, &
               recvcount, MPI_REAL8, 0, mpic, ierr)
+         _VERIFY(ierr)
 
          call MPI_Scatterv( this%times_R8, sendcount, &
               displs, MPI_REAL8,  times_R8_chunk, &
               recvcount, MPI_REAL8, 0, mpic, ierr)
+         _VERIFY(ierr)
 
          ! -- root
          this%locstream_factory = LocStreamFactory(this%lons,this%lats,_RC)
@@ -1072,6 +1075,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   call MPI_gatherv ( p_acc_chunk_2d, nsend, MPI_REAL, &
                        p_acc_rt_2d, recvcount, displs, MPI_REAL,&
                        iroot, mpic, ierr )
+                  _VERIFY(ierr)
 
                   if (mapl_am_i_root()) then
                      !
@@ -1136,12 +1140,14 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                         call MPI_gatherv ( p_dst_t(1,k), nsend, MPI_REAL, &
                              p_acc_rt_3d(1,k), recvcount, displs, MPI_REAL,&
                              iroot, mpic, ierr )
+                        _VERIFY(ierr)
                      end do
                      deallocate (p_dst_t)
                   else
                      call MPI_gatherv ( p_dst, nsend_v, MPI_REAL, &
                           p_dst_rt, recvcount_v, displs_v, MPI_REAL,&
                           iroot, mpic, ierr )
+                     _VERIFY(ierr)
                      p_acc_rt_3d = reshape ( p_dst_rt, shape(p_acc_rt_3d), order=[2,1] )
                   end if
 

--- a/pfio/AbstractServer.F90
+++ b/pfio/AbstractServer.F90
@@ -357,7 +357,7 @@ contains
       class(AbstractServer),intent(in) :: this
       integer, intent(in) :: id
       integer :: rank
-      integer :: rank_tmp, ierror
+      integer :: rank_tmp, ierror, rc
 
       integer :: node_rank,innode_rank
       logical :: yes
@@ -371,6 +371,7 @@ contains
       rank = 0
       if (yes) rank_tmp = this%rank
       call Mpi_Allreduce(rank_tmp,rank,1, MPI_INTEGER, MPI_SUM, this%comm, ierror)
+      _VERIFY(ierror)
 
    end function get_writing_PE
 

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -109,6 +109,7 @@ contains
 
       c_manager%client_comm = client_comm
       call MPI_Comm_rank(client_comm, c_manager%rank, rc)
+      _VERIFY(rc)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end function new_ClientManager

--- a/pfio/DirectoryService.F90
+++ b/pfio/DirectoryService.F90
@@ -114,6 +114,7 @@ contains
       ! Need to be sure that the directories have been initialized before
       ! proceeding
       call MPI_Barrier(comm, ierror)
+      _VERIFY(ierror)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end function new_DirectoryService
@@ -129,16 +130,19 @@ contains
 #if !defined (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
       integer(kind=MPI_ADDRESS_KIND) :: baseaddr
 #endif
-      integer :: ierror, rank
+      integer :: ierror, rank, rc
 
       call MPI_Comm_Rank(comm, rank, ierror)
+      _VERIFY(ierror)
 
       if (rank == 0)  then
          sz = sizeof_directory()
 #if defined(SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
          call MPI_Alloc_mem(sz, MPI_INFO_NULL, addr, ierror)
+         _VERIFY(ierror)
 #else
          call MPI_Alloc_mem(sz, MPI_INFO_NULL, baseaddr, ierror)
+         _VERIFY(ierror)
          addr = transfer(baseaddr, addr)
 #endif
          call c_f_pointer(addr, dir)
@@ -148,6 +152,7 @@ contains
       endif
 
       call MPI_Win_create(dir, sz, 1, MPI_INFO_NULL, comm, win, ierror)
+      _VERIFY(ierror)
 
    end function make_directory_window
 
@@ -205,6 +210,7 @@ contains
       end do
 
       call MPI_Comm_rank(client_comm, rank_in_client, ierror)
+      _VERIFY(ierror)
 
       if (rank_in_client == 0) then
 
@@ -232,6 +238,7 @@ contains
 
             dir_entry%port_name = port_name
             call MPI_Comm_rank(this%comm, dir_entry%partner_root_rank, ierror) ! global comm
+            _VERIFY(ierror)
 
             dir%entries(n) = dir_entry
 
@@ -242,8 +249,10 @@ contains
 
          if (found) then
             call MPI_Send(this%rank, 1, MPI_INTEGER, server_root_rank, DISCOVERY_TAG, this%comm, ierror)
+            _VERIFY(ierror)
          else
             call MPI_Recv(server_root_rank, 1, MPI_INTEGER, MPI_ANY_SOURCE, DISCOVERY_TAG, this%comm, status, ierror)
+            _VERIFY(ierror)
          end if
 
       end if
@@ -251,6 +260,7 @@ contains
       ! complete handshake
       if (rank_in_client == 0) then
          call MPI_Comm_size(client_comm, client_npes, ierror)
+         _VERIFY(ierror)
          allocate(client_ranks(client_npes))
          allocate(server_ranks(client_npes))
       else
@@ -259,22 +269,29 @@ contains
       end if
 
       call MPI_Gather(this%rank, 1, MPI_INTEGER, client_ranks, 1, MPI_INTEGER, 0, client_comm, ierror)
+      _VERIFY(ierror)
       if (rank_in_client == 0) then
          call MPI_Send(client_npes, 1, MPI_INTEGER, server_root_rank, NPES_TAG, this%comm, ierror)
+         _VERIFY(ierror)
          call MPI_Send(client_ranks, client_npes, MPI_INTEGER, server_root_rank, RANKS_TAG, this%comm, ierror)
+         _VERIFY(ierror)
          call MPI_Recv(server_ranks, client_npes, MPI_INTEGER, server_root_rank, 0, this%comm, status, ierror)
+         _VERIFY(ierror)
          call MPI_Recv(server_npes, 1, MPI_INTEGER, server_root_rank, 0, this%comm, status, ierror)
+         _VERIFY(ierror)
          if (present(server_size)) server_size = server_npes
       end if
 
       call MPI_Scatter(server_ranks, 1, MPI_INTEGER, &
         & server_rank, 1, MPI_INTEGER, &
         & 0, client_comm, ierror)
+      _VERIFY(ierror)
 
       if (present(server_size)) call MPI_Bcast(server_size, 1, MPI_INTEGER, 0, client_comm,ierror)
 
       ! Construct the connection
       call MPI_Recv(tmp_rank, 1, MPI_INTEGER, server_rank, CONNECT_TAG, this%comm, status, ierror)
+      _VERIFY(ierror)
       _ASSERT(tmp_rank == server_rank, "shake the wrong hand")
 
       allocate(sckt, source=MpiSocket(this%comm, server_rank, this%parser))
@@ -321,6 +338,7 @@ contains
       endif
 
       call MPI_Comm_rank(server_comm, rank_in_server, ierror)
+      _VERIFY(ierror)
 
       if (rank_in_server == 0) then
 
@@ -352,14 +370,18 @@ contains
 
          if (found) then
             call MPI_Send(this%rank, 1, MPI_INTEGER, client_root_rank, DISCOVERY_TAG, this%comm, ierror)
+            _VERIFY(ierror)
          else
             call MPI_Recv(client_root_rank, 1, MPI_INTEGER, MPI_ANY_SOURCE, DISCOVERY_TAG, this%comm, status, ierror)
+            _VERIFY(ierror)
          end if
 
          if (client_root_rank /= TERMINATE) then ! not a termination signal
             call MPI_Recv(client_npes, 1, MPI_INTEGER, client_root_rank, NPES_TAG, this%comm, status, ierror)
+            _VERIFY(ierror)
             allocate(client_ranks(client_npes))
             call MPI_Recv(client_ranks, client_npes, MPI_INTEGER, client_root_rank, RANKS_TAG, this%comm, status, ierror)
+            _VERIFY(ierror)
          else
             client_npes = TERMINATE
          end if
@@ -368,7 +390,9 @@ contains
 
 
       call MPI_Comm_size(server_comm, server_npes, ierror)
+      _VERIFY(ierror)
       call MPI_Bcast(client_npes, 1, MPI_INTEGER, 0, server_comm, ierror)
+      _VERIFY(ierror)
 
       if (client_npes == TERMINATE) then
         server%terminate = .true.
@@ -394,10 +418,13 @@ contains
       call MPI_GatherV(my_server_ranks, cnts, MPI_INTEGER, &
            & server_ranks, counts, displs, MPI_INTEGER, &
            & 0, server_comm, ierror)
+      _VERIFY(ierror)
 
       if (rank_in_server == 0) then
         call MPI_Send(server_ranks, client_npes, MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
+        _VERIFY(ierror)
         call MPI_Send(server_npes,   1,          MPI_INTEGER, client_root_rank, 0, this%comm, ierror)
+        _VERIFY(ierror)
       endif
 
       if (rank_in_server /= 0) then
@@ -406,10 +433,12 @@ contains
       call MPI_ScatterV(client_ranks, counts, displs, MPI_INTEGER, &
            & my_client_ranks, cnts, MPI_INTEGER, &
            & 0, server_comm, ierror)
+      _VERIFY(ierror)
 
       do p = 1, cnts
          client_rank = my_client_ranks(p)
          call MPI_Send(this%rank, 1, MPI_INTEGER, client_rank, CONNECT_TAG, this%comm, ierror)
+         _VERIFY(ierror)
          allocate(sckt, source=MpiSocket(this%comm, client_rank, this%parser))
          call server%add_connection(sckt)
          nullify(sckt)
@@ -448,6 +477,7 @@ contains
       endif
 
       call MPI_Comm_rank(server_comm, rank_in_server, ierror)
+      _VERIFY(ierror)
       port_name = port%port_name
 
       if (rank_in_server == 0) then
@@ -520,15 +550,18 @@ contains
 
       integer :: sz
       integer(kind=MPI_ADDRESS_KIND) :: disp
-      integer :: ierror
+      integer :: ierror, rc
 
       call MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, win, ierror)
+      _VERIFY(ierror)
 
       sz = sizeof_directory()
       disp = 0
       call MPI_Get(dir, sz, MPI_BYTE, 0, disp, sz, MPI_BYTE, win, ierror)
+      _VERIFY(ierror)
 
       call MPI_Win_unlock(0, win, ierror)
+      _VERIFY(ierror)
       return
       _UNUSED_DUMMY(this)
    end function get_directory
@@ -541,16 +574,19 @@ contains
 
       integer :: sz
       integer(kind=MPI_ADDRESS_KIND) :: disp
-      integer :: ierror
+      integer :: ierror, rc
 
 
       call MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, win, ierror)
+      _VERIFY(ierror)
 
       sz = sizeof_directory()
       disp = 0
       call MPI_put(dir, sz, MPI_BYTE, 0, disp, sz, MPI_BYTE, win, ierror)
+      _VERIFY(ierror)
 
       call MPI_Win_unlock(0, win, ierror)
+      _VERIFY(ierror)
       return
       _UNUSED_DUMMY(this)
    end subroutine put_directory
@@ -564,8 +600,10 @@ contains
       integer :: ierror, rank_in_client,i
 
       call MPI_Comm_rank(client_comm, rank_in_client, ierror)
+      _VERIFY(ierror)
 
       call MPI_BARRIER(client_comm,ierror)
+      _VERIFY(ierror)
 
       if (rank_in_client ==0) then
 
@@ -577,6 +615,7 @@ contains
 
             call MPI_Send(TERMINATE, 1, MPI_INTEGER, dir%entries(i)%partner_root_rank, DISCOVERY_TAG, &
                 & this%comm, ierror)
+            _VERIFY(ierror)
 
          enddo
 
@@ -594,20 +633,26 @@ contains
       ! Release resources
 
       call MPI_Barrier(this%comm, ierror)
+      _VERIFY(ierror)
 
       call this%mutex%free_mpi_resources()
 
       call MPI_Win_free(this%win_server_directory, ierror)
+      _VERIFY(ierror)
       call MPI_Win_free(this%win_client_directory, ierror)
+      _VERIFY(ierror)
 
       if (this%rank == 0) then
          call c_f_pointer(this%server_dir, dir)
          call MPI_Free_mem(dir, ierror)
+         _VERIFY(ierror)
          call c_f_pointer(this%client_dir, dir)
          call MPI_Free_mem(dir, ierror)
+         _VERIFY(ierror)
       end if
 
       call Mpi_Comm_free(this%comm, ierror)
+      _VERIFY(ierror)
       _RETURN(_SUCCESS)
    end subroutine free_directory_resources
 

--- a/pfio/MpiMutex.F90
+++ b/pfio/MpiMutex.F90
@@ -1,8 +1,12 @@
 ! Lifted from logger project and renamed from MpiLock.  Tests were not
 ! brought over, but was tested using MockMpi prototype.
 
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
+
 module pFIO_MpiMutexMod
    use mpi
+   use MAPL_ExceptionHandling
    use iso_c_binding, only: c_ptr, c_f_pointer
    implicit none
    private
@@ -37,15 +41,18 @@ contains
       type (MpiMutex) :: lock
       integer, intent(in) :: comm
 
-      integer :: ierror
+      integer :: ierror, rc
       integer(kind=MPI_ADDRESS_KIND) :: sz
 #if !defined (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
       integer(kind=MPI_ADDRESS_KIND) :: baseaddr
 #endif
 
       call MPI_Comm_dup(comm, lock%comm, ierror)
+      _VERIFY(ierror)
       call MPI_Comm_rank(lock%comm, lock%rank, ierror)
+      _VERIFY(ierror)
       call MPI_Comm_size(lock%comm, lock%npes, ierror)
+      _VERIFY(ierror)
 
       ! This type is used to copy the status of locks on other PE's
       ! into a table that can be examined on the local process.
@@ -55,7 +62,9 @@ contains
         blklens = [lock%rank, lock%npes - lock%rank - 1]
         displs = [0, lock%rank + 1]
         call MPI_Type_indexed(2, blklens, displs, MPI_LOGICAL, lock%pe_locks_type, ierror);
+        _VERIFY(ierror)
         call MPI_Type_commit(lock%pe_locks_type, ierror)
+        _VERIFY(ierror)
       end block
 
       ! Create windows
@@ -66,11 +75,14 @@ contains
            integer :: sizeof_logical
 
            call MPI_Type_extent(MPI_LOGICAL, sizeof_logical, ierror)
+           _VERIFY(ierror)
            sz = lock%npes * sizeof_logical
 #if defined(SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
            call MPI_Alloc_mem(sz, MPI_INFO_NULL, lock%locks_ptr, ierror)
+           _VERIFY(ierror)
 #else
            call MPI_Alloc_mem(sz, MPI_INFO_NULL, baseaddr, ierror)
+           _VERIFY(ierror)
            lock%locks_ptr = transfer(baseaddr, lock%locks_ptr)
 #endif
 
@@ -79,6 +91,7 @@ contains
 
            call MPI_Win_create(scratchpad, sz, sizeof_logical, &
                 & MPI_INFO_NULL, lock%comm, lock%window, ierror)
+           _VERIFY(ierror)
          end block
 
       else ! local window memory is size 0, but have to pass something
@@ -86,6 +99,7 @@ contains
            logical :: buffer(1)
            sz = 0
            call MPI_Win_create(buffer, sz, 1, MPI_INFO_NULL, lock%comm, lock%window, ierror)
+           _VERIFY(ierror)
          end block
       end if
 
@@ -98,15 +112,19 @@ contains
    subroutine acquire(this)
       class (MpiMutex), intent(inout) :: this
 
-      integer :: ierror
+      integer :: ierror, rc
 
       call MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, this%window, ierror)
+      _VERIFY(ierror)
       call MPI_Get(this%local_data, this%npes-1, MPI_LOGICAL, 0, &
            & 0_MPI_ADDRESS_KIND, 1, this%pe_locks_type, this%window, ierror)
+      _VERIFY(ierror)
       call MPI_Put(.true., 1, MPI_LOGICAL, 0, int(this%rank,kind=MPI_ADDRESS_KIND), &
            & 1, MPI_LOGICAL, this%window, ierror)
+      _VERIFY(ierror)
 
       call MPI_Win_unlock(0, this%window, ierror)
+      _VERIFY(ierror)
 
       ! Check other processes for holding the lock
       if (any(this%local_data)) then ! wait for signal from process with the lock
@@ -114,6 +132,7 @@ contains
            integer :: buffer ! unused
            call MPI_Recv(buffer, 0, MPI_LOGICAL, MPI_ANY_SOURCE, &
                 & LOCK_TAG, this%comm, MPI_STATUS_IGNORE, ierror)
+           _VERIFY(ierror)
          end block
       end if
 
@@ -124,14 +143,18 @@ contains
    subroutine release(this)
       class (MpiMutex), intent(inout) :: this
 
-      integer :: ierror
+      integer :: ierror, rc
 
       call MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, this%window, ierror)
+      _VERIFY(ierror)
       call MPI_Get(this%local_data, this%npes-1, MPI_LOGICAL, 0, &
            & 0_MPI_ADDRESS_KIND, 1, this%pe_locks_type, this%window, ierror)
+      _VERIFY(ierror)
       call MPI_Put(.false., 1, MPI_LOGICAL, 0, int(this%rank,kind=MPI_ADDRESS_KIND), &
            & 1, MPI_LOGICAL, this%window, ierror)
+      _VERIFY(ierror)
       call MPI_Win_unlock(0, this%window, ierror)
+      _VERIFY(ierror)
 
       ! who needs the lock next (if anyone)?
       block
@@ -156,6 +179,7 @@ contains
         if (next_rank /= -1) then
            call MPI_Send(buffer, 0, MPI_LOGICAL, next_rank, &
                 & LOCK_TAG, this%comm, ierror)
+           _VERIFY(ierror)
         end if
       end block
 
@@ -165,17 +189,21 @@ contains
       class (MpiMutex), intent(inout) :: this
 
       logical, pointer :: scratchpad(:)
-      integer :: ierror
+      integer :: ierror, rc
 
       ! Release resources
       call MPI_Type_free(this%pe_locks_type, ierror)
+      _VERIFY(ierror)
       call MPI_Win_free(this%window, ierror)
+      _VERIFY(ierror)
 
       if (this%rank == 0) then
          call c_f_pointer(this%locks_ptr, scratchpad, [this%npes])
          call MPI_Free_mem(scratchpad, ierror)
+         _VERIFY(ierror)
       end if
       call Mpi_comm_free(this%comm, ierror)
+      _VERIFY(ierror)
 
    end subroutine free_mpi_resources
 

--- a/pfio/MpiSocket.F90
+++ b/pfio/MpiSocket.F90
@@ -78,9 +78,11 @@ contains
       s%world_remote_rank = remote_rank
 
       call MPI_Comm_rank(comm, local_rank, ierror)
+      _VERIFY(ierror)
       s%world_local_rank = local_rank
 
       call MPI_Comm_group(comm, world_group, ierror)
+      _VERIFY(ierror)
 
       ! Enforce consistent ordering in new communicator/group
       if (local_rank < remote_rank) then
@@ -93,7 +95,9 @@ contains
          s%pair_remote_rank = 0
       end if
       call MPI_Group_incl(world_group, 2, ranks, pair_group, ierror)
+      _VERIFY(ierror)
       call MPI_Comm_create_group(comm, pair_group, PAIR_TAG, s%pair_comm, ierror)
+      _VERIFY(ierror)
       _RETURN(_SUCCESS)
    end function new_MpiSocket
 
@@ -108,11 +112,14 @@ contains
       integer :: count
 
       call MPI_Probe(this%pair_remote_rank, MESSAGE_TAG, this%pair_comm, status, ierror)
+      _VERIFY(ierror)
       call MPI_Get_count(status, MPI_INTEGER, count, ierror)
+      _VERIFY(ierror)
 
       allocate(buffer(count))
       call MPI_Recv(buffer, count, MPI_INTEGER, this%pair_remote_rank, MESSAGE_TAG, this%pair_comm, &
            & status, ierror)
+      _VERIFY(ierror)
 
       allocate(message, source=this%parser%decode(buffer))
       _RETURN(_SUCCESS)
@@ -129,6 +136,7 @@ contains
       buffer = this%parser%encode(message)
       call MPI_Send(buffer, size(buffer), MPI_INTEGER, this%pair_remote_rank, MESSAGE_TAG, this%pair_comm, &
            & ierror)
+      _VERIFY(ierror)
       _RETURN(_SUCCESS)      
    end subroutine send
 
@@ -163,8 +171,9 @@ contains
       _ASSERT( big_n < huge(0), "Increase the number of processors to decrease the local size of data to be sent")
       n_words = big_n
       call c_f_pointer(local_reference%base_address, data, shape=[n_words])
-      if (n_words ==0) allocate(data(1))
+      if (n_words ==0) allocate(data(1)) 
       call MPI_Isend(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
+      _VERIFY(ierror)
       allocate(handle, source=MpiRequestHandle(local_reference, request))
       if (n_words ==0) deallocate(data)
       _RETURN(_SUCCESS)
@@ -190,6 +199,7 @@ contains
       call c_f_pointer(local_reference%base_address, data, shape=[n_words])
       if (n_words ==0) allocate(data(1))
       call MPI_Irecv(data, n_words, MPI_INTEGER, this%pair_remote_rank, tag, this%pair_comm, request, ierror)
+      _VERIFY(ierror)
       allocate(handle, source=MpiRequestHandle(local_reference, request))
       if (n_words ==0) deallocate(data)
       _RETURN(_SUCCESS)

--- a/pfio/MultiCommServer.F90
+++ b/pfio/MultiCommServer.F90
@@ -90,6 +90,7 @@ contains
 
       s%server_comm = server_comm
       call MPI_Comm_size(s%server_comm, s_size , ierror)
+      _VERIFY(ierror)
 
       s%splitter = SimpleCommsplitter(s%server_comm)
       node_sizes = s%splitter%get_node_sizes()
@@ -108,6 +109,7 @@ contains
       allocate(s%back_ranks(nwriter))
       allocate(s%front_ranks(s%nfront))
       call MPI_Comm_rank(s%server_comm, s_rank, ierror)
+      _VERIFY(ierror)
       s_name = s_comm%get_name()
       s%I_am_front_root = .false.
       s%I_am_back_root = .false.
@@ -116,16 +118,21 @@ contains
          call s%init(s%front_comm, s_name)
          s%port_name = trim(port_name)
          call MPI_Comm_rank(s%front_comm, local_rank, ierror)
+         _VERIFY(ierror)
          if (s_rank == 0) then
            _ASSERT( local_rank == 0, "re-arrange the rank of the server_comm")
            s%I_am_front_root = .true.
            call MPI_recv(s%back_ranks, nwriter, MPI_INTEGER, MPI_ANY_SOURCE, 666, s%server_comm, MPI_STAT,ierror)
+           _VERIFY(ierror)
          endif
          call MPI_Bcast(s%back_ranks, nwriter, MPI_INTEGER, 0, s%front_comm, ierror)
+         _VERIFY(ierror)
 
          call MPI_AllGather(s_rank, 1, MPI_INTEGER, s%front_ranks, 1, MPI_INTEGER, s%front_comm, ierror)
+         _VERIFY(ierror)
          if (local_rank ==0 ) then
             call MPI_Send(s%front_ranks, s_size-nwriter, MPI_INTEGER, s%back_ranks(1), 777, s%server_comm, ierror)
+            _VERIFY(ierror)
          endif
 
       endif
@@ -133,18 +140,23 @@ contains
       if (index(s_name, 'o_server_back') /=0) then
          s%back_comm = s_comm%get_subcommunicator()
          call MPI_AllGather(s_rank, 1, MPI_INTEGER, s%back_ranks, 1, MPI_INTEGER, s%back_comm, ierror)
+         _VERIFY(ierror)
          call MPI_Comm_rank(s%back_comm, local_rank, ierror)
+         _VERIFY(ierror)
          if (local_rank ==0 ) then
             s%I_am_back_root = .true.
             call MPI_Send(s%back_ranks, nwriter, MPI_INTEGER, 0, 666, s%server_comm, ierror)
+            _VERIFY(ierror)
          endif
 
          if (s_rank == s%back_ranks(1)) then
             _ASSERT( local_rank == 0, "re-arrange the rank of the server_comm")
+            _VERIFY(ierror)
             call MPI_recv(s%front_ranks, s%nfront, MPI_INTEGER, MPI_ANY_SOURCE, 777, s%server_comm, MPI_STAT,ierror)
          endif
 
          call MPI_Bcast(s%front_ranks, s%nfront, MPI_INTEGER, 0, s%back_comm, ierror)
+         _VERIFY(ierror)
          call s%set_status(1)
          call s%add_connection(dummy_socket)
       endif
@@ -174,12 +186,14 @@ contains
          integer :: my_rank, cmd, status
 
          call MPI_Comm_rank(this%server_comm, my_rank, ierr)
+         _VERIFY(ierr)
          allocate(this%serverthread_done_msgs(1))
          this%serverthread_done_msgs(:) = .false.
 
          do while (.true.)
 
             call MPI_Bcast(cmd, 1, MPI_INTEGER, 0, this%server_comm, ierr)
+            _VERIFY(ierr)
             if (cmd == -1) exit
             call this%create_remote_win(_RC)
             call this%receive_output_data(_RC)
@@ -228,6 +242,7 @@ contains
 
          call this%threads%clear()
          call MPI_Bcast(terminate, 1, MPI_INTEGER, 0, this%server_comm, ierr)
+         _VERIFY(ierr)
          deallocate(mask)
          _RETURN(_SUCCESS)
       end subroutine start_front
@@ -264,6 +279,7 @@ contains
 
       if (this%front_comm /= MPI_COMM_NULL) then
          call MPI_Bcast(cmd, 1, MPI_INTEGER, 0, this%server_comm, ierr)
+         _VERIFY(ierr)
       endif
 
       this%stage_offset = StringInteger64map()
@@ -274,12 +290,16 @@ contains
          call serialize_message_vector(thread_ptr%request_backlog,buffer)
          bsize = size(buffer)
          call MPI_send(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         _VERIFY(ierr)
          call MPI_send(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         _VERIFY(ierr)
 
          call HistoryCollectionVector_serialize(thread_ptr%hist_collections, buffer)
          bsize = size(buffer)
          call MPI_send(bsize,  1,     MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         _VERIFY(ierr)
          call MPI_send(buffer, bsize, MPI_INTEGER, this%back_ranks(1), this%back_ranks(1), this%server_Comm, ierr)
+         _VERIFY(ierr)
 
       endif
 
@@ -288,14 +308,18 @@ contains
            call MPI_recv( bsize, 1, MPI_INTEGER,    &
              this%front_ranks(1), this%back_ranks(1), this%server_comm, &
              MPI_STAT, ierr)
+           _VERIFY(ierr)
            allocate(buffer(bsize))
            call MPI_recv( buffer,bsize, MPI_INTEGER,    &
              this%front_ranks(1), this%back_ranks(1), this%server_comm, &
              MPI_STAT, ierr)
+           _VERIFY(ierr)
          endif
          call MPI_Bcast(bsize, 1, MPI_INTEGER, 0, this%back_comm, ierr)
+         _VERIFY(ierr)
          if (.not. allocated(buffer)) allocate(buffer(bsize))
          call MPI_Bcast(buffer, bsize, MPI_INTEGER, 0, this%back_comm, ierr)
+         _VERIFY(ierr)
          call deserialize_message_vector(buffer, thread_ptr%request_backlog)
          deallocate (buffer)
 
@@ -303,14 +327,18 @@ contains
            call MPI_recv( bsize, 1, MPI_INTEGER,    &
              this%front_ranks(1), this%back_ranks(1), this%server_comm, &
              MPI_STAT, ierr)
+           _VERIFY(ierr)
            allocate(buffer(bsize))
            call MPI_recv( buffer,bsize, MPI_INTEGER,    &
              this%front_ranks(1), this%back_ranks(1), this%server_comm, &
              MPI_STAT, ierr)
+           _VERIFY(ierr)
          endif
          call MPI_Bcast(bsize, 1, MPI_INTEGER, 0, this%back_comm, ierr)
+         _VERIFY(ierr)
          if (.not. allocated(buffer)) allocate(buffer(bsize))
          call MPI_Bcast(buffer, bsize, MPI_INTEGER, 0, this%back_comm, ierr)
+         _VERIFY(ierr)
          call HistoryCollectionVector_deserialize(buffer, thread_ptr%hist_collections)
          deallocate (buffer)
       endif
@@ -394,6 +422,7 @@ contains
      if (this%back_comm /= MPI_COMM_NULL) then
 
         call MPI_comm_rank(this%back_comm, l_rank, ierr)
+        _VERIFY(ierr)
         ! copy and save the data
         do collection_counter = 1, this%dataRefPtrs%size()
               dataRefPtr => this%get_dataReference(collection_counter)
@@ -464,6 +493,7 @@ contains
       if (this%back_Comm /= MPI_COMM_NULL) then
         ! time to write file
          call MPI_comm_rank(this%back_comm, l_rank, ierr)
+         _VERIFY(ierr)
 
          threadPtr=>this%threads%at(1)
          msg_iter = threadPtr%request_backlog%begin()

--- a/pfio/MultiLayerServer.F90
+++ b/pfio/MultiLayerServer.F90
@@ -119,14 +119,16 @@ contains
    subroutine terminate_writers(this)
       class (MultiLayerServer), intent(inout) :: this
       integer :: terminate = -1
-      integer :: ierr
+      integer :: ierr, rc
       integer :: MPI_STAT(MPI_STATUS_SIZE)
       ! The root rank sends termination signal to the root of the spawned children which would
       ! send terminate back for synchronization
       ! if no syncrohization, the writer may be still writing while the main testing node is comparing
       if( this%rank == 0 .and. this%nwriters > 1 ) then
         call MPI_send(terminate, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
+        _VERIFY(ierr)
         call MPI_recv(terminate, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, MPI_STAT, ierr)
+        _VERIFY(ierr)
       endif
 
    end subroutine terminate_writers
@@ -218,6 +220,7 @@ contains
               call forData%clear()
            endif
            call MPI_Barrier(this%comm, status)
+           _VERIFY(status)
         endif ! first thread n==1
         call threadPtr%clear_backlog()
         call threadPtr%clear_hist_collections()
@@ -244,17 +247,23 @@ contains
          bsize = size(buffer)
 
          call MPI_send(command, 1, MPI_INTEGER, 0, pFIO_s_tag, this%Inter_Comm, ierr)
+         _VERIFY(ierr)
          call MPI_recv(writer_rank, 1, MPI_INTEGER, &
                    0, pFIO_s_tag, this%Inter_Comm , &
                    MPI_STAT, ierr)
+         _VERIFY(ierr)
          !forward Message
          call MPI_send(bsize,  1,     MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         _VERIFY(ierr)
          call MPI_send(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         _VERIFY(ierr)
          !send number of collections
          call StringAttributeMap_serialize(forwardData,buffer)
          bsize = size(buffer)
+         _VERIFY(ierr)
          call MPI_send(bsize,  1, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
          call MPI_send(buffer, bsize, MPI_INTEGER, writer_rank, pFIO_s_tag, this%Inter_Comm, ierr)
+         _VERIFY(ierr)
          !2) send the data
 
          _RETURN(_SUCCESS)

--- a/pfio/RDMAReference.F90
+++ b/pfio/RDMAReference.F90
@@ -48,6 +48,7 @@ contains
       reference%msize_word = msize_word
       reference%type_kind  = type_kind
       call Mpi_comm_dup(Comm,reference%comm,status)
+      _VERIFY(status)
       reference%mem_rank = rank
       call reference%allocate(rc=status)
       _VERIFY(status)
@@ -123,6 +124,7 @@ contains
       n_bytes    = this%msize_word * int_size
 
       call MPI_Comm_rank(this%comm,Rank,status)
+      _VERIFY(status)
 
       windowsize = 0_MPI_ADDRESS_KIND
       if (Rank == this%mem_rank) windowsize = n_bytes

--- a/pfio/ServerThread.F90
+++ b/pfio/ServerThread.F90
@@ -389,6 +389,7 @@ contains
         call MPI_AllGATHERV(locals, local_size,            MPI_INTEGER, &
                             i_ptr,  int(offsets),  int(g_offsets),  MPI_INTEGER, &
                             this%containing_server%NodeRoot_Comm,status)
+        _VERIFY(status)
         deallocate(locals)
 
       endif

--- a/pfio/ShmemReference.F90
+++ b/pfio/ShmemReference.F90
@@ -45,6 +45,7 @@ contains
       reference%msize_word = msize_word
       reference%type_kind  = type_kind
       call Mpi_comm_dup(InNode_Comm,reference%InNode_Comm,status)
+      _VERIFY(status)
 
       call reference%allocate(rc=status)
       _VERIFY(status)
@@ -117,6 +118,7 @@ contains
       n_bytes =  this%msize_word * 4_MPI_ADDRESS_KIND
 
       call MPI_Comm_rank(this%InNode_Comm,InNode_Rank,ierr)
+      _VERIFY(ierr)
 
       disp_unit  = 1
       windowsize = 0_MPI_ADDRESS_KIND
@@ -125,17 +127,21 @@ contains
 #if defined(SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
       call MPI_Win_allocate_shared(windowsize, disp_unit, MPI_INFO_NULL, this%InNode_Comm, &
                this%base_address, this%win, ierr)
+      _VERIFY(ierr)
 #else
       call MPI_Win_allocate_shared(windowsize, disp_unit, MPI_INFO_NULL, this%InNode_Comm, &
                baseaddr, this%win, ierr)
+      _VERIFY(ierr)
       this%base_address = transfer(baseaddr, this%base_address)
 #endif
 
       if (InNode_Rank /= 0)  then
 #if defined(SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
           call MPI_Win_shared_query(this%win, 0, windowsize, disp_unit, this%base_address,ierr)
+          _VERIFY(ierr)
 #else
           call MPI_Win_shared_query(this%win, 0, windowsize, disp_unit, baseaddr,ierr)
+          _VERIFY(ierr)
           this%base_address = transfer(baseaddr, this%base_address)
 #endif
       endif
@@ -154,8 +160,11 @@ contains
       endif
 
       call MPI_Win_fence(0, this%win, ierr)
+      _VERIFY(ierr)
       call MPI_Win_free(this%win,ierr)
+      _VERIFY(ierr)
       call MPI_Comm_free(this%InNode_Comm, ierr)
+      _VERIFY(ierr)
       this%shmem_allocated = .false.
       _RETURN(_SUCCESS)
    end subroutine deallocate

--- a/pfio/pfio_base.F90
+++ b/pfio/pfio_base.F90
@@ -1,14 +1,18 @@
+#include "MAPL_ErrLog.h"
 module pfio_base
+   use MAPL_ErrorHandlingMod
+   implicit none
    integer, save :: debug_unit = 0
 contains
 
    subroutine pfio_init()
       use MPI
       character(len=5) :: buf
-      integer :: rank, ierror
+      integer :: rank, ierror, rc
 
       if (debug_unit == 0) then
          call MPI_Comm_rank(MPI_Comm_world, rank, ierror)
+         _VERIFY(ierror)
          write(buf,'(i5.5)') rank
          open(newunit=debug_unit,file='pfio_debug.'//buf,status='unknown', form='formatted')
       end if

--- a/pfio/pfio_collective_demo.F90
+++ b/pfio/pfio_collective_demo.F90
@@ -114,6 +114,8 @@ contains
 
 end module collective_demo_CLI
 
+#include "MAPL_ErrLog.h"
+#include "unused_dummy.H"
 module FakeExtDataMod_collective
    use, intrinsic :: iso_fortran_env, only: INT64
    use MAPL_ExceptionHandling
@@ -165,7 +167,7 @@ contains
       class (AbstractDirectoryService), target,intent(inout) :: d_s
       character(*), intent(in) :: port_name
 
-      integer :: ierror
+      integer :: ierror, rc
       type (FileMetadata) :: file_metadata
       type (NetCDF4_FileFormatter) :: formatter
       type (StringIntegerMap) :: dims
@@ -183,7 +185,9 @@ contains
 
       this%comm = comm
       call MPI_Comm_rank(comm,this%rank,ierror)
+      _VERIFY(ierror)
       call MPI_Comm_size(comm,this%npes,ierror)
+      _VERIFY(ierror)
 
       allocate(this%bundle(this%vars%size()))
 
@@ -318,8 +322,11 @@ program main
 
    required = MPI_THREAD_MULTIPLE
    call MPI_init_thread(required, provided, ierror)
+   !_VERIFY(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+   !_VERIFY(ierror)
    call MPI_Comm_size(MPI_COMM_WORLD, npes, ierror)
+   !_VERIFY(ierror)
 
    call process_command_line(options, rc=status)
 
@@ -337,6 +344,7 @@ program main
    key = 0
 
    call MPI_Comm_split(MPI_COMM_WORLD, color, key, comm, ierror)
+   !_VERIFY(ierror)
 
    if (color == SERVER_COLOR .or. color == BOTH_COLOR) then ! server
       

--- a/pfio/pfio_parallel_netcdf_reproducer.F90
+++ b/pfio/pfio_parallel_netcdf_reproducer.F90
@@ -85,7 +85,9 @@ contains
       character(3) :: field_idx_str
 
       call mpi_comm_size(MPI_COMM_WORLD, npes, ierror)
+      _VERIFY(ieeror)
       call mpi_comm_rank(MPI_COMM_WORLD, rank, ierror)
+      _VERIFY(ieeror)
 
       jm = im*6 ! pseudo cubed sphere
       call metadata%add_dimension('IM_WORLD', im)

--- a/pfio/pfio_server_demo.F90
+++ b/pfio/pfio_server_demo.F90
@@ -117,7 +117,9 @@ contains
 
 end module server_demo_CLI
 
+#include "MAPL_ErrLog.h"
 module FakeExtDataMod_server
+   use MAPL_ErrorHandlingMod
    use server_demo_CLI
    use pFIO
    use gFTL_StringVector
@@ -165,7 +167,7 @@ contains
       integer, intent(in) :: comm
       class (AbstractDirectoryService), target,intent(inout) :: d_s
 
-      integer :: ierror
+      integer :: ierror, rc
       type (FileMetadata) :: file_metadata
       type (NetCDF4_FileFormatter) :: formatter
       type (StringIntegerMap) :: dims
@@ -179,7 +181,9 @@ contains
 
       this%comm = comm
       call MPI_Comm_rank(comm,this%rank,ierror)
+      _VERIFY(ierror)
       call MPI_Comm_size(comm,this%npes,ierror)
+      _VERIFY(ierror)
 
       allocate(this%bundle(this%vars%size()))
 
@@ -285,8 +289,11 @@ program main
    class(AbstractDirectoryService), pointer :: d_s=>null()
 
    call MPI_init_thread(MPI_THREAD_MULTIPLE, provided, ierror)
+   !_VERIFY(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+   !_VERIFY(ierror)
    call MPI_Comm_size(MPI_COMM_WORLD, npes, ierror)
+   !_VERIFY(ierror)
 
    call process_command_line(options, rc=status)
 
@@ -299,6 +306,7 @@ program main
    key = 0
 
    call MPI_Comm_split(MPI_COMM_WORLD, color, key, comm, ierror)
+   !_VERIFY(ierror)
 
 !C$   num_threads = 20
    allocate(d_s, source = DirectoryService(MPI_COMM_WORLD))

--- a/pfio/pfio_writer.F90
+++ b/pfio/pfio_writer.F90
@@ -22,7 +22,7 @@ program main
 
    implicit none
    integer :: Inter_Comm
-   integer :: ierr
+   integer :: ierr, rc
    integer :: rank
    integer :: server_rank
 
@@ -42,9 +42,13 @@ program main
    class (AbstractMessage), pointer :: msg
  
    call MPI_Init(ierr)
+   !_VERIFY(ierr)
    call MPI_Comm_get_parent(Inter_Comm, ierr);
+   !_VERIFY(ierr)
    call MPI_Comm_rank(MPI_COMM_WORLD,rank, ierr)
+   !_VERIFY(ierr)
    call MPI_Comm_size(MPI_COMM_WORLD,n_workers, ierr)
+   !_VERIFY(ierr)
 
    allocate(busy(n_workers-1), source =0)
 
@@ -55,6 +59,7 @@ program main
          call MPI_recv( command, 1, MPI_INTEGER, &
                 MPI_ANY_SOURCE, pFIO_s_tag, Inter_Comm, &
                 MPI_STAT, ierr)
+         !_VERIFY(ierr)
          server_rank = MPI_STAT(MPI_SOURCE)
 
          if (command == 1) then ! server is asking for a writing node 
@@ -74,26 +79,32 @@ program main
                call MPI_recv( idle, 1, MPI_INTEGER, &
                    MPI_ANY_SOURCE, pFIO_w_m_tag , MPI_COMM_WORLD, &
                    MPI_STAT, ierr)
+               !_VERIFY(ierr)
                idle_worker = idle
             endif
 
             ! tell server the idel_worker
             call MPI_send(idle_worker, 1, MPI_INTEGER, server_rank, pFIO_s_tag, Inter_Comm, ierr)
+            !_VERIFY(ierr)
             busy(idle_worker) = 1
             ! tell the idle_worker which server has work
             call MPI_send(server_rank, 1, MPI_INTEGER, idle_worker, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+            !_VERIFY(ierr)
 
          else ! command /=1, notify the worker to quit and finalize
             no_job = -1
             do i = 1, n_workers -1
                if ( busy(i) == 0) then
                   call MPI_send(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+                  !_VERIFY(ierr)
                else
                   call MPI_recv( idle, 1, MPI_INTEGER, &
                        i, pFIO_w_m_tag, MPI_COMM_WORLD, &
                        MPI_STAT, ierr)
+                  !_VERIFY(ierr)
                    if (idle /= i ) stop ("idle should be i")
                    call MPI_send(no_job, 1, MPI_INTEGER, i, pFIO_m_w_tag, MPI_COMM_WORLD, ierr)
+                  !_VERIFY(ierr)
                endif  
             enddo  
             exit
@@ -108,6 +119,7 @@ program main
         call MPI_recv( server_rank, 1, MPI_INTEGER, &
                0, pFIO_m_w_tag, MPI_COMM_WORLD, &
                MPI_STAT, ierr)
+        !_VERIFY(ierr)
 
         if (server_rank == -1 ) exit
         !---------------------------------------------------
@@ -116,19 +128,23 @@ program main
         call MPI_recv( msg_size, 1, MPI_INTEGER,    &
             server_rank, pFIO_s_tag, Inter_comm, &
                MPI_STAT, ierr)
+        !_VERIFY(ierr)
         allocate(bufferm(msg_size))
         call MPI_recv( bufferm, msg_size, MPI_INTEGER, &
              server_rank, pFIO_s_tag, Inter_comm,   &
                MPI_STAT, ierr)
+        !_VERIFY(ierr)
 
         call MPI_recv( data_size, 1, MPI_INTEGER,&
              server_rank, pFIO_s_tag, Inter_comm,     &
              MPI_STAT, ierr)
+        !_VERIFY(ierr)
 
         allocate(bufferd(data_size))
         call MPI_recv( bufferd, data_size, MPI_INTEGER, &
              server_rank, pFIO_s_tag, Inter_comm,   &
                MPI_STAT, ierr)
+        !_VERIFY(ierr)
 
         ! deserilize message and data
         call deserialize_message_vector(bufferm, forwardVec)
@@ -168,17 +184,20 @@ program main
  
         ! telling captain, I am the soldier that is ready to have more work
         call MPI_send(rank, 1, MPI_INTEGER, 0, pFIO_w_m_tag, MPI_COMM_WORLD , ierr)
+        !_VERIFY(ierr)
 
       enddo
    endif
 
    call MPI_Barrier(MPI_COMM_WORLD, ierr)
+   !_VERIFY(ierr)
 
    if ( rank == 0) then
       ! send done message to server
       ! this serves the syncronization with oserver
       command = -1
       call MPI_send(command, 1, MPI_INTEGER, 0, pFIO_s_tag, Inter_Comm, ierr)
+      !_VERIFY(ierr)
    endif
      
    call MPI_Finalize(ierr)

--- a/profiler/AbstractMeter.F90
+++ b/profiler/AbstractMeter.F90
@@ -65,9 +65,13 @@ module MAPL_AbstractMeter
         ierror = 0
         if (dist_initialized) then
            call MPI_type_free(type_dist_struct, ierror)
+           _VERIFY(ierror)
            call MPI_type_free(type_dist_real64, ierror)
+           _VERIFY(ierror)
            call MPI_type_free(type_dist_integer, ierror)
+           _VERIFY(ierror)
            call MPI_Op_free(dist_reduce_op,ierror)
+           _VERIFY(ierror)
            dist_initialized = .false.
         endif
         if (present(rc)) rc = ierror

--- a/profiler/AbstractMeter.F90
+++ b/profiler/AbstractMeter.F90
@@ -1,3 +1,4 @@
+#include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 module MAPL_AbstractMeter
    use, intrinsic :: iso_fortran_env, only: REAL64

--- a/profiler/AbstractMeter.F90
+++ b/profiler/AbstractMeter.F90
@@ -2,6 +2,7 @@
 #include "unused_dummy.H"
 module MAPL_AbstractMeter
    use, intrinsic :: iso_fortran_env, only: REAL64
+   use mapl_ErrorHandlingMod
    implicit none
    private
 

--- a/profiler/DistributedMeter.F90
+++ b/profiler/DistributedMeter.F90
@@ -1,7 +1,9 @@
+#include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
 module MAPL_DistributedMeter
    use, intrinsic :: iso_fortran_env, only: REAL64
+   use mapl_ErrorHandlingMod
    use MAPL_AbstractMeter
    use MAPL_AdvancedMeter
    use MAPL_AbstractGauge
@@ -140,6 +142,7 @@ contains
 
       type (DistributedMeter) :: dummy
       logical :: commute
+      integer :: ierr, rc
       
       call dummy%make_mpi_type(dummy%statistics, type_dist_struct, ierror)
       call MPI_Type_commit(type_dist_struct, ierror)
@@ -274,7 +277,7 @@ contains
       integer, intent(in) :: comm
       real(kind=REAL64), intent(in) :: exclusive
 
-      integer :: ierror
+      integer :: ierror, rc
 
       integer :: rank
       type(DistributedStatistics) :: tmp
@@ -304,6 +307,7 @@ contains
 
       integer(kind=MPI_ADDRESS_KIND) :: displacements(2)
       integer(kind=MPI_ADDRESS_KIND) :: lb, sz
+      integer :: rc
 
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(r64)
@@ -324,6 +328,7 @@ contains
       integer, intent(out) :: ierror
 
       integer(kind=MPI_ADDRESS_KIND) :: displacements(1)
+      integer :: rc
 
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(int)
@@ -342,6 +347,7 @@ contains
 
       integer(kind=MPI_ADDRESS_KIND) :: displacements(2)
       integer(kind=MPI_ADDRESS_KIND) :: lb, sz, sz2
+      integer :: rc
 
       _UNUSED_DUMMY(d)
       call this%make_mpi_type(this%statistics%total, type_dist_real64, ierror)

--- a/profiler/DistributedMeter.F90
+++ b/profiler/DistributedMeter.F90
@@ -143,9 +143,11 @@ contains
       
       call dummy%make_mpi_type(dummy%statistics, type_dist_struct, ierror)
       call MPI_Type_commit(type_dist_struct, ierror)
+      _VERIFY(ierror)
 
       commute = .true.
       call MPI_Op_create(true_reduce, commute, dist_reduce_op, ierror)
+      _VERIFY(ierror)
 
    end subroutine initialize
 
@@ -278,6 +280,7 @@ contains
       type(DistributedStatistics) :: tmp
 
       call MPI_Comm_rank(comm, rank, ierror)
+      _VERIFY(ierror)
 
       this%statistics%total = DistributedReal64(this%get_total(), rank)
       this%statistics%exclusive = DistributedReal64(exclusive, rank)
@@ -288,6 +291,7 @@ contains
 
       tmp = this%statistics
       call MPI_Reduce(tmp, this%statistics, 1, type_dist_struct, dist_reduce_op, 0, comm, ierror)
+      _VERIFY(ierror)
 
    end subroutine reduce_mpi
 
@@ -304,9 +308,11 @@ contains
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(r64)
       call MPI_Type_get_extent_x(MPI_REAL8, lb, sz, ierror)
+      _VERIFY(ierror)
       displacements = [0_MPI_ADDRESS_KIND, 3*sz]
 
       call MPI_Type_create_struct(2, [3,4], displacements, [MPI_REAL8, MPI_INTEGER], new_type, ierror)
+      _VERIFY(ierror)
 
    end subroutine make_mpi_type_distributed_real64
 
@@ -323,6 +329,7 @@ contains
       _UNUSED_DUMMY(int)
       displacements = [0_MPI_ADDRESS_KIND]
       call MPI_Type_create_struct(1, [6], displacements, [MPI_INTEGER], new_type, ierror)
+      _VERIFY(ierror)
 
    end subroutine make_mpi_type_distributed_integer
 
@@ -341,9 +348,12 @@ contains
       call this%make_mpi_type(this%statistics%num_cycles, type_dist_integer, ierror)
 
       call MPI_Type_get_extent_x(type_dist_real64, lb, sz, ierror)
+      _VERIFY(ierror)
       displacements = [0_MPI_ADDRESS_KIND, 6*sz]
       call MPI_Type_create_struct(2, [6,1], displacements, [type_dist_real64, type_dist_integer], new_type, ierror)
+      _VERIFY(ierror)
       call MPI_Type_get_extent_x(new_type, lb, sz2, ierror)
+      _VERIFY(ierror)
 
    end subroutine make_mpi_type_distributed_data
 

--- a/profiler/VmstatMemoryGauge.F90
+++ b/profiler/VmstatMemoryGauge.F90
@@ -1,3 +1,4 @@
+#include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 module MAPL_VmstatMemoryGauge
    use, intrinsic :: iso_fortran_env, only: REAL64, INT64
@@ -40,9 +41,10 @@ contains
       _UNUSED_DUMMY(this)
       block
         use MPI
+       ! use mapl_ErrorHandlingMod
         integer :: rank, ierror
         call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
-        _VERIFY(ierror)
+       ! _VERIFY(ierror)
         allocate(character(4) :: tmp_file)
         write(tmp_file,'(i4.4)')rank
         tmp_file = 'tmp_' // tmp_file // '.dat'

--- a/profiler/VmstatMemoryGauge.F90
+++ b/profiler/VmstatMemoryGauge.F90
@@ -42,6 +42,7 @@ contains
         use MPI
         integer :: rank, ierror
         call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+        _VERIFY(ierror)
         allocate(character(4) :: tmp_file)
         write(tmp_file,'(i4.4)')rank
         tmp_file = 'tmp_' // tmp_file // '.dat'

--- a/profiler/demo/demo.F90
+++ b/profiler/demo/demo.F90
@@ -15,6 +15,7 @@ program main
    integer :: ierror
 
    call MPI_Init(ierror)
+   _VERIFY(ierror)
    main_prof = TimeProfiler('TOTAL')   ! timer 1
    call main_prof%start()
    lap_prof = TimeProfiler('Lap')

--- a/profiler/demo/mpi_demo.F90
+++ b/profiler/demo/mpi_demo.F90
@@ -18,7 +18,9 @@ program main
 !$   mem_prof = MemoryProfiler('TOTAL')
 
    call MPI_Init(ierror)
+   _VERIFY(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+   _VERIFY(ierror)
 
    main_prof = DistributedProfiler('TOTAL', MpiTimerGauge(), MPI_COMM_WORLD)   ! timer 1
    call main_prof%start()
@@ -109,6 +111,7 @@ program main
       write(*,'(a)') ''
    end if
    call MPI_Barrier(MPI_COMM_WORLD, ierror)
+   _VERIFY(ierror)
    if (rank == 1) then
       write(*,'(a)')'Final profile (1)'
       write(*,'(a)')'================'
@@ -118,6 +121,7 @@ program main
       write(*,'(a)') ''
    end if
    call MPI_Barrier(MPI_COMM_WORLD, ierror)
+   _VERIFY(ierror)
 
    report_lines = main_reporter%generate_report(main_prof)
    if (rank == 0) then

--- a/shared/MAPL_ErrorHandling.F90
+++ b/shared/MAPL_ErrorHandling.F90
@@ -244,7 +244,7 @@ contains
       integer :: status
       integer :: error_code = -1
       call MPI_Abort(MPI_COMM_WORLD,error_code,status)
-      _VERIFY(status)
+      !_VERIFY(status)
   end subroutine MAPL_abort
 
   function get_error_message(error_code) result(description)

--- a/shared/MAPL_ErrorHandling.F90
+++ b/shared/MAPL_ErrorHandling.F90
@@ -244,6 +244,7 @@ contains
       integer :: status
       integer :: error_code = -1
       call MPI_Abort(MPI_COMM_WORLD,error_code,status)
+      _VERIFY(status)
   end subroutine MAPL_abort
 
   function get_error_message(error_code) result(description)

--- a/shared/MAPL_Throw.F90
+++ b/shared/MAPL_Throw.F90
@@ -60,6 +60,7 @@ contains
       logical :: is_mpi_initialized
 
       call MPI_Initialized(is_mpi_initialized,ierror)
+      _VERIFY(ierror)
   
       base_name = get_base_name(filename)
       if (len(base_name) > FIELD_WIDTH) then
@@ -75,6 +76,7 @@ contains
       ! other PEs
       if (is_mpi_initialized) then
          call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+         _VERIFY(ierror)
          !$omp critical (MAPL_Throw1)
          write(ERROR_UNIT,'(a,i5.5,1x,a,i5.5,1x,a3,a40,1x,a)') &
               & 'pe=', rank, 'FAIL at line=', line, prefix, use_name, &

--- a/shared/MAPL_Throw.F90
+++ b/shared/MAPL_Throw.F90
@@ -56,11 +56,11 @@ contains
       character(3) :: prefix
       character(:), allocatable :: base_name
       
-      integer :: rank, ierror
+      integer :: rank, ierror, rc
       logical :: is_mpi_initialized
 
       call MPI_Initialized(is_mpi_initialized,ierror)
-      _VERIFY(ierror)
+      !_VERIFY(ierror)
   
       base_name = get_base_name(filename)
       if (len(base_name) > FIELD_WIDTH) then
@@ -76,7 +76,7 @@ contains
       ! other PEs
       if (is_mpi_initialized) then
          call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
-         _VERIFY(ierror)
+         !_VERIFY(ierror)
          !$omp critical (MAPL_Throw1)
          write(ERROR_UNIT,'(a,i5.5,1x,a,i5.5,1x,a3,a40,1x,a)') &
               & 'pe=', rank, 'FAIL at line=', line, prefix, use_name, &

--- a/shared/SimpleCommSplitter.F90
+++ b/shared/SimpleCommSplitter.F90
@@ -195,7 +195,6 @@ contains
       call MPI_Comm_split_type(shared_communicator, MPI_COMM_TYPE_SHARED, 0, info, node_comm, ierror)
       _VERIFY(ierror)
       call MPI_Comm_rank(node_comm, rank_on_node, ierror); _VERIFY(ierror)
-      _VERIFY(ierror)
 
       node_id = this%get_node_id(rc=status); _VERIFY(status)
       node_sizes = this%get_node_sizes(rc=status); _VERIFY(status)
@@ -250,11 +249,8 @@ contains
       call MPI_Comm_split_type(shared_communicator, MPI_COMM_TYPE_SHARED, 0, info, node_comm, ierror)
       _VERIFY(ierror)
       call MPI_Comm_size(shared_communicator, npes, ierror); _VERIFY(ierror)
-      _VERIFY(ierror)
       call MPI_Comm_rank(shared_communicator, rank, ierror); _VERIFY(ierror)
-      _VERIFY(ierror)
       call MPI_Comm_rank(node_comm, rank_on_node, ierror); _VERIFY(ierror)
-      _VERIFY(ierror)
 
       allocate(node_ranks(0:npes-1), stat=status);  _VERIFY(status)
       call MPI_Allgather(rank_on_node, 1, MPI_INTEGER, node_ranks, 1, MPI_INTEGER, shared_communicator, ierror)
@@ -319,7 +315,7 @@ contains
      integer :: ierror
      if (this%is_split) then
         call MPI_Comm_free(this%sub_comm, ierror)
-        _VERIFY(ierror)
+        !_VERIFY(ierror)
      endif
   end subroutine free_sub_comm
 
@@ -332,7 +328,7 @@ contains
 
      if (from%is_split) then
        call MPI_Comm_rank(comm, rank, ierror)
-       _VERIFY(ierror)
+       !_VERIFY(ierror)
        if (rank == 0) print*, "WARNING, try not to duplicate a splitter that has been split. Only one split splitter should be called free_sub_comm"
      endif
      call this%set_shared_communicator(comm)

--- a/shared/SimpleCommSplitter.F90
+++ b/shared/SimpleCommSplitter.F90
@@ -195,6 +195,7 @@ contains
       call MPI_Comm_split_type(shared_communicator, MPI_COMM_TYPE_SHARED, 0, info, node_comm, ierror)
       _VERIFY(ierror)
       call MPI_Comm_rank(node_comm, rank_on_node, ierror); _VERIFY(ierror)
+      _VERIFY(ierror)
 
       node_id = this%get_node_id(rc=status); _VERIFY(status)
       node_sizes = this%get_node_sizes(rc=status); _VERIFY(status)
@@ -249,8 +250,11 @@ contains
       call MPI_Comm_split_type(shared_communicator, MPI_COMM_TYPE_SHARED, 0, info, node_comm, ierror)
       _VERIFY(ierror)
       call MPI_Comm_size(shared_communicator, npes, ierror); _VERIFY(ierror)
+      _VERIFY(ierror)
       call MPI_Comm_rank(shared_communicator, rank, ierror); _VERIFY(ierror)
+      _VERIFY(ierror)
       call MPI_Comm_rank(node_comm, rank_on_node, ierror); _VERIFY(ierror)
+      _VERIFY(ierror)
 
       allocate(node_ranks(0:npes-1), stat=status);  _VERIFY(status)
       call MPI_Allgather(rank_on_node, 1, MPI_INTEGER, node_ranks, 1, MPI_INTEGER, shared_communicator, ierror)
@@ -315,6 +319,7 @@ contains
      integer :: ierror
      if (this%is_split) then
         call MPI_Comm_free(this%sub_comm, ierror)
+        _VERIFY(ierror)
      endif
   end subroutine free_sub_comm
 
@@ -327,6 +332,7 @@ contains
 
      if (from%is_split) then
        call MPI_Comm_rank(comm, rank, ierror)
+       _VERIFY(ierror)
        if (rank == 0) print*, "WARNING, try not to duplicate a splitter that has been split. Only one split splitter should be called free_sub_comm"
      endif
      call this%set_shared_communicator(comm)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Whenever possible, we add a `_VERIFY(ierror)` statement after each MPI call.

## Related Issue
This is to address Issue #2896 
