### PR TITLE
Fix for change in Fortran 2023

### DIFF
--- a/generic3g/specs/ChildSpec.F90
+++ b/generic3g/specs/ChildSpec.F90
@@ -37,7 +37,7 @@ module mapl3g_ChildSpec
 
 contains
 
-   pure function new_ChildSpec(user_setservices, unusable, config_file) result(spec)
+   function new_ChildSpec(user_setservices, unusable, config_file) result(spec)
       type(ChildSpec) :: spec
       class(AbstractUserSetServices), intent(in) :: user_setservices
       class(KeywordEnforcer), optional, intent(in) :: unusable


### PR DESCRIPTION
F2023 disallows polymorphic assignment in a PURE procedure because of potential issues with FINAL procedures which might not be PURE.

Sort of annoying that there was not an exception made for the trivial case which should always work, but the result is that legal F2018 code is now illegal F2023 code.  And latest NAG compiler actually flags it as an error so ... PURE goes on the chopping block (again).

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

