### PR TITLE
cleanup tests to use _RC

### DIFF
--- a/gridcomps/ExtData3G/tests/Test_ExtDataGridComp.pf
+++ b/gridcomps/ExtData3G/tests/Test_ExtDataGridComp.pf
@@ -1,3 +1,4 @@
+#include "MAPL_TestErr.h"
 module Test_ExtDataGridComp
    use pfunit
    use mapl3g_ExtDataGridComp_private
@@ -18,39 +19,25 @@ contains
       integer :: status
 
       hc_main = ESMF_HConfigCreate( content=&
-           '{subconfigs: [hc1.yaml, hc2.yaml]}',rc=status)
-      @assert_that(status, is(0))
-      hc_1 = ESMF_HConfigCreate(content='{Collections: {foo: {template: filea}}}', rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigFileSave(hc_1, "hc1.yaml", rc=status)
-      @assert_that(status, is(0))
-      hc_2 = ESMF_HConfigCreate(content='{Collections: {bar: {template: fileb}}}', rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigFileSave(hc_2, "hc2.yaml", rc=status)
-      @assert_that(status, is(0))
+           '{subconfigs: [hc1.yaml, hc2.yaml]}', _RC)
+      hc_1 = ESMF_HConfigCreate(content='{Collections: {foo: {template: filea}}}', _RC)
+      call ESMF_HConfigFileSave(hc_1, "hc1.yaml", _RC)
+      hc_2 = ESMF_HConfigCreate(content='{Collections: {bar: {template: fileb}}}', _RC)
+      call ESMF_HConfigFileSave(hc_2, "hc2.yaml", _RC)
 
 
       expected_config = ESMF_HConfigCreate(content= &
-          '{Collections: {foo: {template: filea}, bar: {template: fileb}}}' &
-           , rc=status)
-      @assert_that(status, is(0))
+          '{Collections: {foo: {template: filea}, bar: {template: fileb}}}', _RC)
 
-      merged_config = ESMF_HConfigCreate(rc=status)  
-      @assert_that(status, is(0))
-      call merge_config(merged_config, hc_main, rc=status)
-      @assert_that(status, is(0))
+      merged_config = ESMF_HConfigCreate(_RC)
+      call merge_config(merged_config, hc_main, _RC)
       @assertTrue(MAPL_HConfigMatch(merged_config, expected_config))
       
-      call ESMF_HConfigDestroy(hc_main, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(hc_1, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(hc_2, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(expected_config, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(merged_config, rc=status)
-      @assert_that(status, is(0))
+      call ESMF_HConfigDestroy(hc_main, _RC)
+      call ESMF_HConfigDestroy(hc_1, _RC)
+      call ESMF_HConfigDestroy(hc_2, _RC)
+      call ESMF_HConfigDestroy(expected_config, _RC)
+      call ESMF_HConfigDestroy(merged_config, _RC)
 
    end subroutine test_merge_hconfig
 

--- a/gridcomps/History3G/tests/Test_HistoryGridComp.pf
+++ b/gridcomps/History3G/tests/Test_HistoryGridComp.pf
@@ -1,3 +1,4 @@
+#include "MAPL_TestErr.h"
 module Test_HistoryGridComp
    use pfunit
    use mapl3g_HistoryGridComp_private
@@ -28,23 +29,16 @@ contains
       integer :: status
 
       hconfig = ESMF_HConfigCreate( content=&
-           '{geoms: {geom1: &geom1 {class: latlon}}, collections: {c1: {geom: *geom1}}}', &
-           rc=status)
-      @assert_that(status, is(0))
+           '{geoms: {geom1: &geom1 {class: latlon}}, collections: {c1: {geom: *geom1}}}', _RC)
       expected_child_hconfig = ESMF_HConfigCreate(content=&
            '{collection_name: c1, geom: {class: latlon}}', rc=status)
-      @assert_that(status, is(0))
 
-      found_child_hconfig = make_child_hconfig(hconfig, 'c1', rc=status)
-      @assert_that(status, is(0))
+      found_child_hconfig = make_child_hconfig(hconfig, 'c1', _RC)
        @assertTrue(MAPL_HConfigMatch(found_child_hconfig, expected_child_hconfig))
       
-      call ESMF_HConfigDestroy(hconfig, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(expected_child_hconfig, rc=status)
-      @assert_that(status, is(0))
-      call ESMF_HConfigDestroy(found_child_hconfig, rc=status)
-      @assert_that(status, is(0))
+      call ESMF_HConfigDestroy(hconfig, _RC)
+      call ESMF_HConfigDestroy(expected_child_hconfig, _RC)
+      call ESMF_HConfigDestroy(found_child_hconfig, _RC)
 
    end subroutine test_make_child_hconfig
 


### PR DESCRIPTION
Just a little PR to use the `_RC` macro in some MAPL3 tests that were not
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

