### PR TITLE
Update to ESMA_cmake v3.49.0 (SMOD for submodules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Move to use Intel ifort 2021.13 at NCCS SLES15, NAS, and GMAO Desktops
     - Move to use Intel MPI at NCCS SLES15 and GMAO Desktops
     - Move to GEOSpyD Min24.4.4 Python 3.11
-  - ESMA_cmake v3.48.0
+  - ESMA_cmake v3.49.0
     - Update `esma_add_fortran_submodules` function
     - Move MPI detection out of FindBaselibs
+    - Add SMOD to submodule generator
 
 ### Fixed
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.48.0
+  tag: v3.49.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates to ESMA_cmake v3.49.0 which adds SMOD to submodule generator code (via @JulesKouatchou)

## Related Issue

