### PR TITLE
Fix GCC 14 issue with profiler test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix profiler PercentageColumn test for GCC 14
+
 ### Removed
 
 ### Deprecated

--- a/profiler/tests/test_PercentageColumn.pf
+++ b/profiler/tests/test_PercentageColumn.pf
@@ -13,10 +13,10 @@ contains
       type (MeterNode), target :: node
       class (AbstractMeterNode), pointer :: child
       class (AbstractMeter), pointer :: t
-      type(UnlimitedVector) :: v
+      type(UnlimitedVector), target :: v
       integer :: i
       integer :: expected(2)
-      class(*), allocatable :: q
+      class(*), pointer :: q
 
       node = MeterNode('foo', AdvancedMeter(MpiTimerGauge()))
       t => node%get_meter()
@@ -26,19 +26,19 @@ contains
       child => node%get_child('a')
       t => child%get_meter()
       call t%add_cycle(5.0_REAL64)
-      
+
       c = PercentageColumn(InclusiveColumn(),'MAX')
 
       v = c%get_rows(node)
       expected = [100.,50.]
       do i = 1, 2
-         q = v%at(i)
+         q => v%at(i)
          select type (q)
          type is (real(kind=REAL64))
             @assertEqual(expected(i), q)
          end select
       end do
-      
+
    end subroutine test_percent_inclusive
 
 end module test_PercentageColumn


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is a fix via @tclune for #2943. The odd thing is the ExclusiveColumn test is nigh-identical to this PercentageColumn test. Yet it doesn't seem to be triggered. 🤷🏼 

## Related Issue

Closes #2943 

