### PR TITLE
Make ESMF_CONTEXT_PARENT_VM default for ESMF_GridComp creation in generic3g/GenericGridComp.F90 (MAPL3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed all ESMF_AttributeGet and ESMF_AttributeSet to ESMF_InfoGet and ESMF_InfoSet respectively as old calls will be deprecated soon.
 - Update executables using FLAP to use fArgParse
 - Update `Findudunits.cmake` to link with libdl and look for the `udunits2.xml` file (as some MAPL tests require it)
+- Modified `ESMF_GridComp` creation in `GenericGridComp` to use `ESMF_CONTEXT_PARENT_VM` by default.
 
 ### Fixed
 

--- a/generic3g/GenericGridComp.F90
+++ b/generic3g/GenericGridComp.F90
@@ -102,12 +102,15 @@ contains
       type(OuterMetaComponent), pointer :: outer_meta
       type(ESMF_Clock) :: user_clock
       type(GriddedComponentDriver) :: user_gc_driver
+      type(ESMF_Context_Flag) :: contextFlag
       integer :: status
 
-      gridcomp = ESMF_GridCompCreate(name=outer_name(name), petlist=petlist,  _RC)
+      contextFlag = ESMF_CONTEXT_PARENT_VM
+      if(present(petlist)) contextFlag = ESMF_CONTEXT_OWN_VM
+      gridcomp = ESMF_GridCompCreate(name=outer_name(name), petlist=petlist, contextFlag=contextFlag, _RC)
       call set_is_generic(gridcomp, _RC)
 
-      user_gridcomp = ESMF_GridCompCreate(name=name, petlist=petlist,  _RC)
+      user_gridcomp = ESMF_GridCompCreate(name=name, petlist=petlist, contextFlag=contextFlag, _RC)
       call set_is_generic(user_gridcomp, .false., _RC)
 
       call attach_outer_meta(gridcomp, _RC)

--- a/generic3g/couplers/GenericCoupler.F90
+++ b/generic3g/couplers/GenericCoupler.F90
@@ -25,7 +25,7 @@ contains
       integer :: status
       type(CouplerMetaComponent), pointer :: coupler_meta
 
-      coupler_gridcomp = ESMF_GridCompCreate(name='coupler', _RC)
+      coupler_gridcomp = ESMF_GridCompCreate(name='coupler', contextFlag=ESMF_CONTEXT_PARENT_VM, _RC)
       call attach_coupler_meta(coupler_gridcomp, _RC)
       coupler_meta => get_coupler_meta(coupler_gridcomp, _RC)
 #ifndef __GFORTRAN__


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
Make `ESMF_CONTEXT_PARENT_VM` the default `ESMF_Context_Flag` in `create_grid_comp` in `mapl3g_GenericGridComp (generic3g/GenericGridComp.F90)`. This makes child components use the parent `ESMF_VM` by default.

## Related Issue
#2948 
