### PR TITLE
Mapl3/tclune/refactor coupler meta

### DIFF
--- a/generic3g/GriddedComponentDriver/initialize.F90
+++ b/generic3g/GriddedComponentDriver/initialize.F90
@@ -4,7 +4,6 @@ submodule(mapl3g_GriddedComponentDriver) initialize_smod
    use :: mapl_ErrorHandling
    use :: mapl3g_OuterMetaComponent
    use :: mapl3g_MethodPhasesMapUtils
-   use mapl3g_CouplerMetaComponent, only: GENERIC_COUPLER_INVALIDATE, GENERIC_COUPLER_UPDATE
    implicit none
 
 contains

--- a/generic3g/OuterMetaComponent/initialize_realize.F90
+++ b/generic3g/OuterMetaComponent/initialize_realize.F90
@@ -1,7 +1,9 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_OuterMetaComponent) initialize_realize_smod
-   implicit none
+   use mapl3g_ComponentDriverPtrVector
+   use mapl3g_CouplerMetaComponent, only: GENERIC_COUPLER_INITIALIZE
+   IMPLICIT none
 
 contains
 
@@ -13,14 +15,22 @@ contains
 
       integer :: status
       character(*), parameter :: PHASE_NAME = 'GENERIC::INIT_REALIZE'
+      type(ComponentDriverPtrVector) :: export_Couplers
+      type(ComponentDriverPtr) :: drvr
+      integer :: i
 
       call this%run_custom(ESMF_METHOD_INITIALIZE, PHASE_NAME, _RC)
       call recurse(this, phase_idx=GENERIC_INIT_REALIZE, _RC)
       call this%registry%allocate(_RC)
 
+      export_couplers = this%registry%get_export_couplers()
+      do i = 1, export_couplers%size()
+         drvr = export_couplers%of(i)
+         call drvr%ptr%initialize(phase_idx=GENERIC_COUPLER_INITIALIZE, _RC)
+      end do
+
       _RETURN(ESMF_SUCCESS)
       _UNUSED_DUMMY(unusable)
-   contains
 
    end subroutine initialize_realize
 

--- a/generic3g/actions/BundleAction.F90
+++ b/generic3g/actions/BundleAction.F90
@@ -13,7 +13,9 @@ module mapl3g_BundleAction
       private
       type(ActionVector) :: actions
    contains
-      procedure :: run
+      procedure :: initialize
+      procedure :: run_old
+      procedure :: run_new
       procedure :: add_action
    end type BundleAction
 
@@ -28,7 +30,30 @@ contains
       action%actions = ActionVector()
    end function new_BundleAction
 
-   subroutine run(this, rc)
+   ! BundleAction may not make sense with a shared import/export state.
+   subroutine initialize(this, importState, exportState, clock, rc)
+      use esmf
+      class(BundleAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ActionVectorIterator) :: iter
+
+!#      associate (e => this%actions%ftn_end())
+!#        iter = this%actions%ftn_begin()
+!#        do while (iter /= e)
+!#           call iter%next()
+!#           subaction => iter%of()
+!#           call subaction%initialize(importState, exportState, clock, _RC)
+!#        end do
+!#      end associate
+      _FAIL('Not implemented')
+   end subroutine initialize
+
+   subroutine run_old(this, rc)
       class(BundleAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       
@@ -42,8 +67,31 @@ contains
       end do
       
       _RETURN(_SUCCESS)
-   end subroutine run
+   end subroutine run_old
    
+   ! BundleAction may not make sense with a shared import/export state.
+   subroutine run_new(this, importState, exportState, clock, rc)
+      use esmf
+      class(BundleAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ActionVectorIterator) :: iter
+
+!#      associate (e => this%actions%ftn_end())
+!#        iter = this%actions%ftn_begin()
+!#        do while (iter /= e)
+!#           call iter%next()
+!#           subaction => iter%of()
+!#           call subaction%initialize(importState, exportState, clock, _RC)
+!#        end do
+!#      end associate
+      _FAIL('Not implemented')
+   end subroutine run_new
+
    subroutine add_action(this, action)
       class(BundleAction), intent(inout) :: this
       class(ExtensionAction), intent(in) :: action

--- a/generic3g/actions/ConvertUnitsAction.F90
+++ b/generic3g/actions/ConvertUnitsAction.F90
@@ -16,6 +16,7 @@ module mapl3g_ConvertUnitsAction
       private
       type(UDUNITS_converter) :: converter
       type(ESMF_Field) :: f_in, f_out
+      character(:), allocatable :: src_units, dst_units
    contains
       procedure :: run
    end type ConvertUnitsAction
@@ -23,25 +24,36 @@ module mapl3g_ConvertUnitsAction
 
    interface ConvertUnitsAction
       procedure new_converter
+      procedure new_converter2
    end interface ConvertUnitsAction
 
 
 contains
 
 
-   function new_converter(f_in, units_in, f_out, units_out) result(action)
+   function new_converter(f_in, src_units, f_out, dst_units) result(action)
       type(ConvertUnitsAction) :: action
       type(ESMF_Field), intent(in) :: f_in, f_out
-      character(*), intent(in) :: units_in, units_out
+      character(*), intent(in) :: src_units, dst_units
 
       integer :: status
 
       ! TODO: move to place where only called
-      call UDUNITS_GetConverter(action%converter, from=units_in, to=units_out, rc=status)
+      call UDUNITS_GetConverter(action%converter, from=src_units, to=dst_units, rc=status)
       action%f_in = f_in
       action%f_out = f_out
       
    end function new_converter
+
+   function new_converter2(src_units, dst_units) result(action)
+      type(ConvertUnitsAction) :: action
+      character(*), intent(in) :: src_units, dst_units
+
+      action%src_units = src_units
+      action%dst_units = dst_units
+
+   end function new_converter2
+
 
    subroutine run(this, rc)
       class(ConvertUnitsAction), intent(inout) :: this

--- a/generic3g/actions/CopyAction.F90
+++ b/generic3g/actions/CopyAction.F90
@@ -15,7 +15,9 @@ module mapl3g_CopyAction
       type(ESMF_TypeKind_Flag) :: dst_typekind
       type(ESMF_Field) :: f_in, f_out
    contains
-      procedure :: run
+      procedure :: initialize
+      procedure :: run_old
+      procedure :: run_new
    end type CopyAction
 
    interface CopyAction
@@ -47,7 +49,22 @@ contains
 
    end function new_CopyAction2
 
-   subroutine run(this, rc)
+   subroutine initialize(this, importState, exportState, clock, rc)
+      use esmf
+      class(CopyAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      ! No-op
+
+      _RETURN(_SUCCESS)
+   end subroutine initialize
+
+   subroutine run_old(this, rc)
       class(CopyAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
@@ -56,6 +73,26 @@ contains
       call FieldCopy(this%f_in, this%f_out, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine run
+   end subroutine run_old
+
+   subroutine run_new(this, importState, exportState, clock, rc)
+      use esmf
+      class(CopyAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: f_in, f_out
+
+      call ESMF_StateGet(importState, itemName='import[1]', field=f_in, _RC)
+      call ESMF_StateGet(exportState, itemName='export[1]', field=f_out, _RC)
+
+      call FieldCopy(f_in, f_out, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine run_new
+
 
 end module mapl3g_CopyAction

--- a/generic3g/actions/CopyAction.F90
+++ b/generic3g/actions/CopyAction.F90
@@ -11,6 +11,8 @@ module mapl3g_CopyAction
 
    type, extends(ExtensionAction) :: CopyAction
       private
+      type(ESMF_TypeKind_Flag) :: src_typekind
+      type(ESMF_TypeKind_Flag) :: dst_typekind
       type(ESMF_Field) :: f_in, f_out
    contains
       procedure :: run
@@ -18,6 +20,7 @@ module mapl3g_CopyAction
 
    interface CopyAction
       module procedure new_CopyAction
+      module procedure new_CopyAction2
    end interface CopyAction
 
 contains
@@ -30,6 +33,19 @@ contains
       action%f_in = f_in
       action%f_out = f_out
    end function new_CopyAction
+
+   ! We don't really need to know the typekind as the low level conversion routines
+   ! will accept whatever is handed. So these arguments are more to preserve
+   ! a consistent form for constructions across Action subclasses.
+   function new_CopyAction2(src_typekind, dst_typekind) result(action)
+      type(CopyAction) :: action
+      type(ESMF_Typekind_Flag), intent(in) :: src_typekind
+      type(ESMF_Typekind_Flag), intent(in) :: dst_typekind
+
+      action%src_typekind = src_typekind
+      action%dst_typekind = dst_typekind
+
+   end function new_CopyAction2
 
    subroutine run(this, rc)
       class(CopyAction), intent(inout) :: this

--- a/generic3g/actions/ExtensionAction.F90
+++ b/generic3g/actions/ExtensionAction.F90
@@ -6,7 +6,10 @@ module mapl3g_ExtensionAction
 
    type, abstract :: ExtensionAction
    contains
-      procedure(I_run_extension), deferred :: run
+      procedure(I_run_extension), deferred :: run_old
+      procedure(I_Run), deferred :: run_new
+      generic :: run => run_old, run_new
+      procedure(I_run), deferred :: initialize
    end type ExtensionAction
 
 
@@ -16,8 +19,16 @@ module mapl3g_ExtensionAction
          class(ExtensionAction), intent(inout) :: this
          integer, optional, intent(out) :: rc
       end subroutine I_run_extension
+
+      subroutine I_run(this, importState, exportState, clock, rc)
+         use ESMF
+         import ExtensionAction
+         class(ExtensionAction), intent(inout) :: this
+         type(ESMF_State) :: importState
+         type(ESMF_State) :: exportState
+         type(ESMF_Clock) :: clock
+         integer, optional, intent(out) :: rc
+      end subroutine I_run
    end interface
 
 end module mapl3g_ExtensionAction
-
-

--- a/generic3g/actions/NullAction.F90
+++ b/generic3g/actions/NullAction.F90
@@ -14,7 +14,9 @@ module mapl3g_NullAction
 
    type, extends(ExtensionAction) :: NullAction
    contains
-      procedure :: run
+      procedure :: initialize
+      procedure :: run_old
+      procedure :: run_new
    end type NullAction
 
    interface NullAction
@@ -27,10 +29,30 @@ contains
       type(NullAction) :: action
    end function new_NullAction
 
-   subroutine run(this, rc)
+   subroutine initialize(this, importState, exportState, clock, rc)
+      use esmf
+      class(NullAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('This procedure should not be called.')
+   end subroutine initialize
+
+   subroutine run_old(this, rc)
       class(NullAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       _FAIL('This procedure should not be called.')
-   end subroutine run
+   end subroutine run_old
+
+   subroutine run_new(this, importState, exportState, clock, rc)
+      use esmf
+      class(NullAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('This procedure should not be called.')
+   end subroutine run_new
 
 end module mapl3g_NullAction

--- a/generic3g/actions/RegridAction.F90
+++ b/generic3g/actions/RegridAction.F90
@@ -13,6 +13,8 @@ module mapl3g_RegridAction
    public :: RegridAction
 
    type, extends(ExtensionAction) :: ScalarRegridAction
+      type(ESMF_Geom) :: src_geom
+      type(ESMF_Geom) :: dst_geom
       class(Regridder), pointer :: regrdr
       type(ESMF_Field) :: f_src, f_dst
    contains
@@ -28,6 +30,7 @@ module mapl3g_RegridAction
 
    interface RegridAction
       module procedure :: new_ScalarRegridAction
+      module procedure :: new_ScalarRegridAction2
 !#      module procedure :: new_RegridAction_vector
 !#      module procedure :: new_RegridAction_bundle
    end interface RegridAction
@@ -55,6 +58,21 @@ contains
       action%f_dst = f_dst
 
    end function new_ScalarRegridAction
+
+  function new_ScalarRegridAction2(src_geom, dst_geom, dst_param) result(action)
+      type(ScalarRegridAction) :: action
+      type(ESMF_Geom), intent(in) :: src_geom
+      type(ESMF_Geom), intent(in) :: dst_geom
+      type(EsmfRegridderParam), intent(in) :: dst_param
+
+      type(RegridderSpec) :: spec
+      type(RegridderManager), pointer :: regridder_manager
+      integer :: status
+
+      action%src_geom = src_geom
+      action%dst_geom = dst_geom
+
+   end function new_ScalarRegridAction2
 
 !#   function new_RegridAction_vector(uv_src, uv_dst) then (action)
 !#      use mapl_RegridderManager

--- a/generic3g/actions/SequenceAction.F90
+++ b/generic3g/actions/SequenceAction.F90
@@ -12,12 +12,24 @@ module mapl3g_SequenceAction
    type, extends(ExtensionAction) :: SequenceAction
       type(ActionVector) :: actions
    contains
-      procedure :: run
+      procedure :: initialize
+      procedure :: run_old
+      procedure :: run_new
    end type SequenceAction
 
 contains
 
-   subroutine run(this, rc)
+   subroutine initialize(this, importState, exportState, clock, rc)
+      use esmf
+      class(SequenceAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('Not implemented')
+   end subroutine initialize
+
+subroutine run_old(this, rc)
       class(SequenceAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
@@ -32,6 +44,16 @@ contains
       end do
 
       _RETURN(_SUCCESS)
-   end subroutine run
+   end subroutine run_old
+
+   subroutine run_new(this, importState, exportState, clock, rc)
+      use esmf
+      class(SequenceAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('Not implemented')
+   end subroutine run_new
 
 end module mapl3g_SequenceAction

--- a/generic3g/couplers/CouplerMetaComponent.F90
+++ b/generic3g/couplers/CouplerMetaComponent.F90
@@ -34,6 +34,7 @@ module mapl3g_CouplerMetaComponent
       logical :: stale = .true.
    contains
       ! ESMF methods
+      procedure :: initialize
       procedure :: update
       procedure :: invalidate
       procedure :: clock_advance
@@ -86,6 +87,19 @@ contains
 
    end function new_CouplerMetaComponent
 
+  recursive subroutine initialize(this, importState, exportState, clock, rc)
+      class(CouplerMetaComponent), intent(inout) :: this
+      type(ESMF_State), intent(inout) :: importState
+      type(ESMF_State), intent(inout) :: exportState
+      type(ESMF_Clock), intent(inout) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call this%action%initialize(importState, exportState, clock, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine initialize
 
    recursive subroutine update(this, importState, exportState, clock, rc)
       class(CouplerMetaComponent), intent(inout) :: this
@@ -101,7 +115,7 @@ contains
 !#      call this%propagate_attributes(_RC)
       call this%update_sources(_RC)
       
-      call this%action%run(_RC)
+      call this%action%run(importState, exportState, clock, _RC)
       call this%set_up_to_date()
 
       _RETURN(_SUCCESS)

--- a/generic3g/couplers/GenericCoupler.F90
+++ b/generic3g/couplers/GenericCoupler.F90
@@ -56,7 +56,7 @@ contains
 
       integer :: status
 
-      call ESMF_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, initialize, phase=GENERIC_COUPLER_INITIALIZE, _RC)
+      call ESMF_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_INITIALIZE, initialize, phase=GENERIC_COUPLER_INITIALIZE, _RC)
 
       call ESMF_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, update, phase=GENERIC_COUPLER_UPDATE, _RC)
       call ESMF_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, invalidate, phase=GENERIC_COUPLER_INVALIDATE, _RC)
@@ -77,7 +77,7 @@ contains
       type(CouplerMetaComponent), pointer :: meta
 
       meta => get_coupler_meta(gridcomp, _RC)
-!#      call meta%initialize(importState, exportState, clock, _RC)
+      call meta%initialize(importState, exportState, clock, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine initialize

--- a/generic3g/registry/StateItemExtension.F90
+++ b/generic3g/registry/StateItemExtension.F90
@@ -113,12 +113,14 @@ contains
       type(GriddedComponentDriver) :: producer
       type(ESMF_GridComp) :: coupler_gridcomp
       type(ESMF_Clock) :: fake_clock
-      
-      new_spec = this%spec%make_extension(goal, _RC)
+
+      call this%spec%new_make_extension(goal, new_spec, action, _RC)
+!#      new_spec = this%spec%make_extension(goal, _RC)
+      call new_spec%create(_RC)
       call new_spec%set_active()
       call this%spec%set_active
 
-      action = this%spec%make_action(new_spec, _RC)
+!#      action = this%spec%make_action(new_spec, _RC)
       coupler_gridcomp = make_coupler(action, _RC)
       producer = GriddedComponentDriver(coupler_gridcomp, fake_clock, MultiState())
 

--- a/generic3g/registry/StateItemExtension.F90
+++ b/generic3g/registry/StateItemExtension.F90
@@ -114,13 +114,11 @@ contains
       type(ESMF_GridComp) :: coupler_gridcomp
       type(ESMF_Clock) :: fake_clock
 
-      call this%spec%new_make_extension(goal, new_spec, action, _RC)
-!#      new_spec = this%spec%make_extension(goal, _RC)
+      call this%spec%make_extension(goal, new_spec, action, _RC)
       call new_spec%create(_RC)
       call new_spec%set_active()
       call this%spec%set_active
 
-!#      action = this%spec%make_action(new_spec, _RC)
       coupler_gridcomp = make_coupler(action, _RC)
       producer = GriddedComponentDriver(coupler_gridcomp, fake_clock, MultiState())
 

--- a/generic3g/specs/BracketSpec.F90
+++ b/generic3g/specs/BracketSpec.F90
@@ -47,6 +47,7 @@ module mapl3g_BracketSpec
 
       procedure :: extension_cost
       procedure :: make_extension
+      procedure :: new_make_extension
       procedure :: make_action
    end type BracketSpec
 
@@ -296,6 +297,20 @@ contains
       _RETURN(_SUCCESS)
    end function make_extension
 
+   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+      class(BracketSpec), intent(in) :: this
+      class(StateItemSpec), intent(in) :: dst_spec
+      class(StateItemSpec), allocatable, intent(out) :: new_spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      action = NullAction() ! default
+      new_spec = this
+
+      _FAIL('not implemented')
+   end subroutine new_make_extension
 
    ! Return an atomic action that tranforms payload of "this"
    ! to payload of "goal".

--- a/generic3g/specs/BracketSpec.F90
+++ b/generic3g/specs/BracketSpec.F90
@@ -47,8 +47,6 @@ module mapl3g_BracketSpec
 
       procedure :: extension_cost
       procedure :: make_extension
-      procedure :: new_make_extension
-      procedure :: make_action
    end type BracketSpec
 
    interface BracketSpec
@@ -279,25 +277,7 @@ contains
       _RETURN(_SUCCESS)
    end function extension_cost
 
-   function make_extension(this, dst_spec, rc) result(extension)
-      class(StateItemSpec), allocatable :: extension
-      class(BracketSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      integer :: i
-
-!#      extension = this
-!#      do i = 1, this%bracket_size
-!#         extension%field_specs(i) = this%field_specs(i)%make_extension(dst_spec, _RC)
-!#      end do
-!#      call extension%create(_RC)
-
-      _RETURN(_SUCCESS)
-   end function make_extension
-
-   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+   subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(BracketSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       class(StateItemSpec), allocatable, intent(out) :: new_spec
@@ -310,41 +290,7 @@ contains
       new_spec = this
 
       _FAIL('not implemented')
-   end subroutine new_make_extension
-
-   ! Return an atomic action that tranforms payload of "this"
-   ! to payload of "goal".
-   function make_action(this, dst_spec, rc) result(action)
-      class(ExtensionAction), allocatable :: action
-      class(BracketSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      class(ExtensionAction), allocatable :: subaction
-      integer :: i
-      type(BundleAction) :: bundle_action
-
-      action = NullAction() ! default
-
-      select type (dst_spec)
-      type is (BracketSpec)
-         _ASSERT(this%bracket_size == dst_spec%bracket_size, 'bracket size mismatch')
-         bundle_action = BundleAction()
-         do i = 1, this%bracket_size
-            subaction = this%field_specs(i)%make_action(dst_spec%field_specs(i), _RC)
-            call bundle_action%add_action(subaction)
-         end do
-!##ifdef __GFORTRAN__
-!#         deallocate(action)
-!##endif
-         action = bundle_action
-      class default
-         _FAIL('Dst_spec is incompatible with BracketSpec.')
-      end select
-
-      _RETURN(_SUCCESS)
-   end function make_action
+   end subroutine make_extension
 
 
 end module mapl3g_BracketSpec

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -607,7 +607,7 @@ contains
       select type(dst_spec)
       type is (FieldSpec)
          call make_extension_safely(this, dst_spec, tmp_spec, action, _RC)
-         new_spec = tmp_spec
+         allocate(new_spec, source=tmp_spec)
       class default
          _FAIL('Unsupported subclass.')
       end select

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -604,15 +604,10 @@ contains
       integer :: status
       type(FieldSpec) :: tmp_spec
 
-      new_spec = this ! plus one modification from below
-      action = NullAction() ! need default in case of premature return
-
       select type(dst_spec)
       type is (FieldSpec)
          call make_extension_safely(this, dst_spec, tmp_spec, action, _RC)
-         deallocate(new_spec) ! gfortran workaround
-         allocate(new_spec, source=tmp_spec)
-!#         new_spec = tmp_spec
+         new_spec = tmp_spec
       class default
          _FAIL('Unsupported subclass.')
       end select
@@ -630,8 +625,6 @@ contains
       integer :: status
 
       new_spec = this ! plus one modification from below
-      action = NullAction() ! need default in case of premature return
-
       _ASSERT(allocated(this%geom), 'Source spec must specify a valid geom.')
       if (.not. same_geom(this%geom, dst_spec%geom)) then
          action = RegridAction(this%geom, dst_spec%geom, dst_spec%regrid_param)
@@ -643,11 +636,13 @@ contains
 !#   if (.not. same_vgrid(this%v_grid, dst_spec%v_grid)) then
 !#      action = VerticalRegridAction(this%v_grid, dst_spec%v_grid)
 !#      new_spec%v_grid = dst_spec%v_grid
+!!$         _RETURN(_SUCCESS)
 !#   end if
       
 !#   if (.not. same_freq_spec(this%freq_spec, dst_spec%freq_spec)) then
 !#      action = VerticalRegridAction(this%freq_spec, dst_spec%freq_spec
 !#      new_spec%freq_spec = dst_spec%freq_spec
+!!$         _RETURN(_SUCCESS)
 !#   end if
       
       if (this%typekind  /=  dst_spec%typekind) then

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -691,7 +691,8 @@ contains
       type is (FieldSpec)
          call new_make_extension_safely(this, dst_spec, tmp_spec, action, _RC)
          deallocate(new_spec) ! gfortran workaround
-         new_spec = tmp_spec
+         allocate(new_spec, source=tmp_spec)
+!#         new_spec = tmp_spec
       class default
          _FAIL('Unsupported subclass.')
       end select
@@ -715,6 +716,7 @@ contains
       if (.not. same_geom(this%geom, dst_spec%geom)) then
          action = RegridAction(this%geom, dst_spec%geom, dst_spec%regrid_param)
          new_spec%geom = dst_spec%geom
+         _RETURN(_SUCCESS)
       end if
       
 !#   _ASSERT(allocated(this%v_grid), 'Source spec must specify a valid vertical grid.')
@@ -731,11 +733,13 @@ contains
       if (this%typekind  /=  dst_spec%typekind) then
          action = CopyAction(this%typekind, dst_spec%typekind)
          new_spec%typekind = dst_spec%typekind
+         _RETURN(_SUCCESS)
       end if
       
       if (.not. same_units(this%units, dst_spec%units)) then
          action = ConvertUnitsAction(this%units, dst_spec%units)
          new_spec%units = dst_spec%units
+         _RETURN(_SUCCESS)
       end if
       
       _FAIL('No extensions found for this.')

--- a/generic3g/specs/InvalidSpec.F90
+++ b/generic3g/specs/InvalidSpec.F90
@@ -34,7 +34,6 @@ module mapl3g_InvalidSpec
       procedure :: add_to_bundle
 
       procedure :: make_extension
-      procedure :: new_make_extension
       procedure :: extension_cost
    end type InvalidSpec
 
@@ -130,18 +129,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
 
-   function make_extension(this, dst_spec, rc) result(extension)
-      class(StateItemSpec), allocatable :: extension
-      class(InvalidSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      _FAIL('Attempt to use item of type InvalidSpec')
-
-   end function make_extension
-
-   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+   subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(InvalidSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       class(StateItemSpec), allocatable, intent(out) :: new_spec
@@ -154,7 +142,7 @@ contains
       new_spec = this
 
       _FAIL('attempt to use item of type InvalidSpec')
-   end subroutine new_make_extension
+   end subroutine make_extension
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(InvalidSpec), intent(in) :: this

--- a/generic3g/specs/InvalidSpec.F90
+++ b/generic3g/specs/InvalidSpec.F90
@@ -5,9 +5,10 @@ module mapl3g_InvalidSpec
    use mapl3g_AbstractActionSpec
    use mapl3g_MultiState
    use mapl3g_ActualConnectionPt
-
+   use mapl3g_ExtensionAction
    use mapl3g_ActualPtVector
    use mapl3g_ActualPtSpecPtrMap
+   use mapl3g_NullAction
    use esmf, only: ESMF_FieldBundle
    use esmf, only: ESMF_Geom
    use esmf, only: ESMF_State
@@ -33,6 +34,7 @@ module mapl3g_InvalidSpec
       procedure :: add_to_bundle
 
       procedure :: make_extension
+      procedure :: new_make_extension
       procedure :: extension_cost
    end type InvalidSpec
 
@@ -138,6 +140,21 @@ contains
       _FAIL('Attempt to use item of type InvalidSpec')
 
    end function make_extension
+
+   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+      class(InvalidSpec), intent(in) :: this
+      class(StateItemSpec), intent(in) :: dst_spec
+      class(StateItemSpec), allocatable, intent(out) :: new_spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      action = NullAction() ! default
+      new_spec = this
+
+      _FAIL('attempt to use item of type InvalidSpec')
+   end subroutine new_make_extension
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(InvalidSpec), intent(in) :: this

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -35,9 +35,7 @@ module mapl3g_ServiceSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
-      procedure :: new_make_extension
       procedure :: extension_cost
-      procedure :: make_action
       procedure :: add_to_state
       procedure :: add_to_bundle
 !!$      procedure :: check_complete
@@ -177,28 +175,7 @@ contains
    end subroutine destroy
 
 
-   function make_action(this, dst_spec, rc) result(action)
-      class(ExtensionAction), allocatable :: action
-      class(ServiceSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      action = NullAction()
-
-      _RETURN(_SUCCESS)
-   end function make_action
-
-   function make_extension(this, dst_spec, rc) result(extension)
-      class(StateItemSpec), allocatable :: extension
-      class(ServiceSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-      _FAIL('not implemented')
-   end function make_extension
-   
-   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+   subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(ServiceSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       class(StateItemSpec), allocatable, intent(out) :: new_spec
@@ -211,7 +188,7 @@ contains
       new_spec = this
 
       _FAIL('not implemented')
-   end subroutine new_make_extension
+   end subroutine make_extension
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(ServiceSpec), intent(in) :: this

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -35,6 +35,7 @@ module mapl3g_ServiceSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
+      procedure :: new_make_extension
       procedure :: extension_cost
       procedure :: make_action
       procedure :: add_to_state
@@ -194,9 +195,24 @@ contains
       class(ServiceSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       integer, optional, intent(out) :: rc
-      _RETURN(_SUCCESS)
+      _FAIL('not implemented')
    end function make_extension
    
+   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+      class(ServiceSpec), intent(in) :: this
+      class(StateItemSpec), intent(in) :: dst_spec
+      class(StateItemSpec), allocatable, intent(out) :: new_spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      action = NullAction() ! default
+      new_spec = this
+
+      _FAIL('not implemented')
+   end subroutine new_make_extension
+
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(ServiceSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: src_spec

--- a/generic3g/specs/StateItemSpec.F90
+++ b/generic3g/specs/StateItemSpec.F90
@@ -28,6 +28,7 @@ module mapl3g_StateItemSpec
       procedure(I_can_connect), deferred :: can_connect_to
       procedure(I_make_extension), deferred :: make_extension
       procedure(I_extension_cost), deferred :: extension_cost
+      procedure(I_new_make_extension), deferred :: new_make_extension
 
       procedure(I_add_to_state), deferred :: add_to_state
       procedure(I_add_to_bundle), deferred :: add_to_bundle
@@ -95,6 +96,16 @@ module mapl3g_StateItemSpec
          integer, optional, intent(out) :: rc
       end function I_make_extension
          
+      subroutine I_new_make_extension(this, dst_spec, new_spec, action, rc)
+         use mapl3g_ExtensionAction
+         import StateItemSpec
+         class(StateItemSpec), intent(in) :: this
+         class(StateItemSpec), intent(in) :: dst_spec
+         class(StateItemSpec), allocatable, intent(out) :: new_spec
+         class(ExtensionAction), allocatable, intent(out) :: action
+         integer, optional, intent(out) :: rc
+      end subroutine I_new_make_extension
+
       integer function I_extension_cost(this, src_spec, rc) result(cost)
          import StateItemSpec
          class(StateItemSpec), intent(in) :: this

--- a/generic3g/specs/StateItemSpec.F90
+++ b/generic3g/specs/StateItemSpec.F90
@@ -28,7 +28,6 @@ module mapl3g_StateItemSpec
       procedure(I_can_connect), deferred :: can_connect_to
       procedure(I_make_extension), deferred :: make_extension
       procedure(I_extension_cost), deferred :: extension_cost
-      procedure(I_new_make_extension), deferred :: new_make_extension
 
       procedure(I_add_to_state), deferred :: add_to_state
       procedure(I_add_to_bundle), deferred :: add_to_bundle
@@ -38,7 +37,6 @@ module mapl3g_StateItemSpec
       procedure, non_overridable :: is_active
       procedure, non_overridable :: set_active
 
-      procedure :: make_action
       procedure :: get_dependencies
       procedure :: get_raw_dependencies
       procedure :: set_dependencies
@@ -88,15 +86,7 @@ module mapl3g_StateItemSpec
          integer, optional, intent(out) :: rc
       end subroutine I_allocate
 
-      function I_make_extension(this, dst_spec, rc) result(extension)
-         import StateItemSpec
-         class(StateItemSpec), allocatable :: extension
-         class(StateItemSpec), intent(in) :: this
-         class(StateItemSpec), intent(in) :: dst_spec
-         integer, optional, intent(out) :: rc
-      end function I_make_extension
-         
-      subroutine I_new_make_extension(this, dst_spec, new_spec, action, rc)
+      subroutine I_make_extension(this, dst_spec, new_spec, action, rc)
          use mapl3g_ExtensionAction
          import StateItemSpec
          class(StateItemSpec), intent(in) :: this
@@ -104,7 +94,7 @@ module mapl3g_StateItemSpec
          class(StateItemSpec), allocatable, intent(out) :: new_spec
          class(ExtensionAction), allocatable, intent(out) :: action
          integer, optional, intent(out) :: rc
-      end subroutine I_new_make_extension
+      end subroutine I_make_extension
 
       integer function I_extension_cost(this, src_spec, rc) result(cost)
          import StateItemSpec
@@ -178,19 +168,6 @@ contains
       class(StateItemSpec), intent(in) :: this
       is_active = this%active
    end function is_active
-
-
-   function make_action(this, dst_spec, rc) result(action)
-      use mapl3g_ExtensionAction
-      use mapl3g_NullAction
-      class(ExtensionAction), allocatable :: action
-      class(StateItemSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      action = NullAction()
-      _FAIL('Subclass has not implemented make_action')
-   end function make_action
 
    function get_dependencies(this) result(dependencies)
       type(ActualPtVector) :: dependencies

--- a/generic3g/specs/StateSpec.F90
+++ b/generic3g/specs/StateSpec.F90
@@ -9,6 +9,8 @@ module mapl3g_StateSpec
    use mapl3g_ActualConnectionPt
    use mapl3g_ActualPtVector
    use mapl_ErrorHandling
+   use mapl3g_ExtensionAction
+   use mapl3g_NullAction
    use ESMF
    use mapl_KeywordEnforcer
    implicit none
@@ -31,6 +33,7 @@ module mapl3g_StateSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
+      procedure :: new_make_extension
       procedure :: extension_cost
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -178,6 +181,21 @@ contains
       _RETURN(_SUCCESS)
    end function make_extension
    
+   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+      class(StateSpec), intent(in) :: this
+      class(StateItemSpec), intent(in) :: dst_spec
+      class(StateItemSpec), allocatable, intent(out) :: new_spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      action = NullAction() ! default
+      new_spec = this
+
+      _FAIL('not implemented')
+   end subroutine new_make_extension
+
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(StateSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: src_spec

--- a/generic3g/specs/StateSpec.F90
+++ b/generic3g/specs/StateSpec.F90
@@ -33,7 +33,6 @@ module mapl3g_StateSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
-      procedure :: new_make_extension
       procedure :: extension_cost
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -173,15 +172,7 @@ contains
    end subroutine add_to_bundle
    
 
-   function make_extension(this, dst_spec, rc) result(extension)
-      class(StateItemSpec), allocatable :: extension
-      class(StateSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-      _RETURN(_SUCCESS)
-   end function make_extension
-   
-   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+   subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(StateSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       class(StateItemSpec), allocatable, intent(out) :: new_spec
@@ -194,7 +185,7 @@ contains
       new_spec = this
 
       _FAIL('not implemented')
-   end subroutine new_make_extension
+   end subroutine make_extension
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(StateSpec), intent(in) :: this

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -31,6 +31,7 @@ module mapl3g_WildcardSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
+      procedure :: new_make_extension
       procedure :: make_action
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -216,6 +217,21 @@ contains
 
       _FAIL('wildcard cannot be extended - only used for imports')
    end function make_extension
+
+   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+      class(WildcardSpec), intent(in) :: this
+      class(StateItemSpec), intent(in) :: dst_spec
+      class(StateItemSpec), allocatable, intent(out) :: new_spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      action = NullAction() ! default
+      new_spec = this
+
+      _FAIL('not implemented')
+   end subroutine new_make_extension
 
    function make_action(this, dst_spec, rc) result(action)
       class(ExtensionAction), allocatable :: action

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -31,8 +31,6 @@ module mapl3g_WildcardSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
-      procedure :: new_make_extension
-      procedure :: make_action
       procedure :: add_to_state
       procedure :: add_to_bundle
       procedure :: extension_cost
@@ -209,16 +207,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
 
-   function make_extension(this, dst_spec, rc) result(extension)
-      class(StateItemSpec), allocatable :: extension
-      class(WildcardSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      _FAIL('wildcard cannot be extended - only used for imports')
-   end function make_extension
-
-   subroutine new_make_extension(this, dst_spec, new_spec, action, rc)
+   subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(WildcardSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: dst_spec
       class(StateItemSpec), allocatable, intent(out) :: new_spec
@@ -231,19 +220,7 @@ contains
       new_spec = this
 
       _FAIL('not implemented')
-   end subroutine new_make_extension
-
-   function make_action(this, dst_spec, rc) result(action)
-      class(ExtensionAction), allocatable :: action
-      class(WildcardSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: dst_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      action = NullAction()
-      _FAIL('wildcard cannot be extended - only used for imports')
-   end function make_action
+   end subroutine make_extension
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(WildcardSpec), intent(in) :: this

--- a/generic3g/tests/MockItemSpec.F90
+++ b/generic3g/tests/MockItemSpec.F90
@@ -41,7 +41,9 @@ module MockItemSpecMod
    type, extends(ExtensionAction) :: MockAction
       character(:), allocatable :: details
    contains
-      procedure :: run => mock_run
+      procedure :: initialize
+      procedure :: run_old => mock_run
+      procedure :: run_new
    end type MockAction
 
    interface MockItemSpec
@@ -250,11 +252,11 @@ contains
 
       action = NullAction() ! default
       new_spec = this
-
        select type(dst_spec)
        type is (MockItemSpec)
           call new_make_extension_typesafe(this, dst_spec, tmp_spec, action, _RC)
           deallocate(new_spec)
+          allocate(new_spec, source=tmp_spec)
           new_spec = tmp_spec
       class default
          _FAIL('incompatible spec')
@@ -271,6 +273,8 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
+
+      action = NullAction()
 
       if (this%name /= dst_spec%name) then
          new_spec%name = dst_spec%name
@@ -309,4 +313,24 @@ contains
       _RETURN(_SUCCESS)
    end function extension_cost
 
+   subroutine initialize(this, importState, exportState, clock, rc)
+      use esmf
+      class(MockAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('This procedure should not be called.')
+   end subroutine initialize
+
+   subroutine run_new(this, importState, exportState, clock, rc)
+      use esmf
+      class(MockAction), intent(inout) :: this
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, optional, intent(out) :: rc
+      _FAIL('This procedure should not be called.')
+   end subroutine run_new
+   
 end module MockItemSpecMod

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -396,6 +396,8 @@ contains
          expected_field_status = ESMF_FIELDSTATUS_COMPLETE
       case ('gridset')
          expected_field_status = ESMF_FIELDSTATUS_GRIDSET
+      case ('empty')
+         expected_field_status = ESMF_FIELDSTATUS_EMPTY
       case default
          _VERIFY(-1)
       end select

--- a/generic3g/tests/Test_SimpleParentGridComp.pf
+++ b/generic3g/tests/Test_SimpleParentGridComp.pf
@@ -460,14 +460,14 @@ contains
       outer_meta => get_outer_meta(outer_gc, rc=status)
       @assert_that(status, is(0))
 
-      call check('child_A', 'import', 'I_A1', ESMF_FIELDSTATUS_GRIDSET, rc=status)
+      call check('child_A', 'import', 'I_A1', ESMF_FIELDSTATUS_EMPTY, rc=status)
       @assert_that(status, is(0))
       call check('child_A', 'export', 'E_A1', ESMF_FIELDSTATUS_COMPLETE, rc=status)
       @assert_that(status, is(0))
 
       call check('child_B', 'import', 'I_B1', ESMF_FIELDSTATUS_COMPLETE, rc=status)
       @assert_that(status, is(0))
-      call check('child_B', 'export', 'E_B1', ESMF_FIELDSTATUS_GRIDSET, rc=status)
+      call check('child_B', 'export', 'E_B1', ESMF_FIELDSTATUS_EMPTY, rc=status)
       @assert_that(status, is(0))
 
       if(.false.) print*,shape(this)

--- a/generic3g/tests/scenarios/history_1/expectations.yaml
+++ b/generic3g/tests/scenarios/history_1/expectations.yaml
@@ -6,22 +6,22 @@
 - component: root/A/<user>
   export:
     E_A1: {status: complete}
-    E_A2: {status: gridset}
+    E_A2: {status: empty}
 
 - component: root/A
   export:
     E_A1: {status: complete}
-    E_A2: {status: gridset}
+    E_A2: {status: empty}
 
 - component: root/B/<user>
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
     E_B2: {status: complete}
     E_B3: {status: complete, value: 17.}
 
 - component: root/B
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
     E_B2: {status: complete}
     E_B3: {status: complete, value: 17.}
 
@@ -31,8 +31,8 @@
 - component: root
   export:
     A/E_A1: {status: complete, value: 1.}
-    A/E_A2: {status: gridset}
-    B/E_B1: {status: gridset}
+    A/E_A2: {status: empty}
+    B/E_B1: {status: empty}
     B/E_B2: {status: complete, value: 1.}
     B/E_B3: {status: complete, value: 17.}
 
@@ -81,6 +81,6 @@
   import: {}
   export:
     A/E_A1: {status: complete}
-    A/E_A2: {status: gridset}
-    B/E_B1: {status: gridset}
+    A/E_A2: {status: empty}
+    B/E_B1: {status: empty}
     B/E_B2: {status: complete}

--- a/generic3g/tests/scenarios/history_wildcard/expectations.yaml
+++ b/generic3g/tests/scenarios/history_wildcard/expectations.yaml
@@ -7,7 +7,7 @@
   export:
     E_A1: {status: complete}
     E_A2: {status: complete}
-    E1_A0: {status: gridset}
+    E1_A0: {status: empty}
 
 - component: root/A
   export:
@@ -16,12 +16,12 @@
 
 - component: root/B/<user>
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
     E_B2: {status: complete}
 
 - component: root/B
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
     E_B2: {status: complete}
 
 - component: root/<user>
@@ -30,8 +30,8 @@
 - component: root
   export:
     A/E_A1: {status: complete}
-    A/E_A2: {status: gridset}
-    B/E_B1: {status: gridset}
+    A/E_A2: {status: empty}
+    B/E_B1: {status: empty}
     B/E_B2: {status: complete}
 
 - component: history/collection_1/<user>
@@ -65,5 +65,5 @@
   export:
     A/E_A1: {status: complete}
     A/E_A2: {status: complete}
-    B/E_B1: {status: gridset}
+    B/E_B1: {status: empty}
     B/E_B2: {status: complete}

--- a/generic3g/tests/scenarios/propagate_geom/expectations.yaml
+++ b/generic3g/tests/scenarios/propagate_geom/expectations.yaml
@@ -5,7 +5,7 @@
 
 - component: child_A/<user>
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     Z_A1: {status: complete}
@@ -13,7 +13,7 @@
     Z_A1: {status: complete}
 - component: child_A
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     Z_A1: {status: complete}
@@ -22,22 +22,22 @@
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
   internal:
     Z_B1: {status: complete}
 - component: child_B
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
 - component: <user>
   import: {}
   export: {}
   internal: {}
 - component: <root>
   import:
-    I_A1(1): {status: gridset}  # unsatisfied
+    I_A1(1): {status: empty}  # unsatisfied
   export:
     child_A/E_A1: {status: complete}
     child_A/Z_A1: {status: complete} # re-export
-    child_B/E_B1: {status: gridset} # re-export
+    child_B/E_B1: {status: empty} # re-export

--- a/generic3g/tests/scenarios/scenario_1/expectations.yaml
+++ b/generic3g/tests/scenarios/scenario_1/expectations.yaml
@@ -5,7 +5,7 @@
 
 - component: child_A/<user>
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     Z_A1: {status: complete}
@@ -13,7 +13,7 @@
     Z_A1: {status: complete}
 - component: child_A
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     Z_A1: {status: complete}
@@ -22,22 +22,22 @@
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
   internal:
     Z_B1: {status: complete}
 - component: child_B
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
 - component: <user>
   import: {}
   export: {}
   internal: {}
 - component: <root>
   import:
-    I_A1(1): {status: gridset}   # unsatisfied
+    I_A1(1): {status: empty}   # unsatisfied
   export:
     child_A/E_A1: {status: complete}
     child_A/Z_A1: {status: complete}  # re-export
-    child_B/E_B1: {status: gridset}   # re-export
+    child_B/E_B1: {status: empty}   # re-export

--- a/generic3g/tests/scenarios/scenario_2/expectations.yaml
+++ b/generic3g/tests/scenarios/scenario_2/expectations.yaml
@@ -5,7 +5,7 @@
 
 - component: child_A/<user>
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     ZZ_A1: {status: complete}
@@ -13,7 +13,7 @@
     Z_A1: {status: complete}
 - component: child_A
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
     E_A1: {status: complete}
     ZZ_A1: {status: complete}
@@ -22,24 +22,24 @@
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
   internal:
     Z_B1: {status: complete}
 - component: child_B
   import:
     I_B1: {status: complete}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
 - component: <user>
   import: {}
   export:
-    EE_B1: {status: gridset} # re-export
+    EE_B1: {status: empty} # re-export
   internal: {}
 - component: <root>
   import:
-    I_A1(1): {status: gridset}  # unsatisfied
+    I_A1(1): {status: empty}  # unsatisfied
   export:
     child_A/E_A1: {status: complete}
     child_A/ZZ_A1: {status: complete} # re-export
-    child_B/E_B1: {status: gridset} # re-export
-    EE_B1: {status: gridset} # re-export
+    child_B/E_B1: {status: empty} # re-export
+    EE_B1: {status: empty} # re-export

--- a/generic3g/tests/scenarios/scenario_reexport_twice/expectations.yaml
+++ b/generic3g/tests/scenarios/scenario_reexport_twice/expectations.yaml
@@ -5,57 +5,57 @@
 
 - component: parent/child_A/<user>
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
-    E_A1: {status: gridset}
+    E_A1: {status: empty}
   internal:
     Z_A1: {status: complete}
 
 - component: parent/child_A
   import:
-    I_A1: {status: gridset}
+    I_A1: {status: empty}
   export:
-    E_A1: {status: gridset}
+    E_A1: {status: empty}
 
 - component: parent/child_B/<user>
   import:
-    I_B1: {status: gridset}
+    I_B1: {status: empty}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
   internal:
     Z_B1: {status: complete}
 - component: parent/child_B
   import:
-    I_B1: {status: gridset}
+    I_B1: {status: empty}
   export:
-    E_B1: {status: gridset}
+    E_B1: {status: empty}
 
 - component: parent/<user>
   import: {}
   export:
-    Eparent_B1: {status: gridset} # re-export
+    Eparent_B1: {status: empty} # re-export
   internal: {}
 
 - component: parent
   import:
-    "I_A1(1)": {status: gridset}  # unsatisfied
-    "I_B1(1)": {status: gridset}  # unsatisfied
+    "I_A1(1)": {status: empty}  # unsatisfied
+    "I_B1(1)": {status: empty}  # unsatisfied
   export:
-    "child_A/E_A1": {status: gridset}
-    "child_B/E_B1": {status: gridset} # re-export
-    Eparent_B1: {status: gridset} # re-export
+    "child_A/E_A1": {status: empty}
+    "child_B/E_B1": {status: empty} # re-export
+    Eparent_B1: {status: empty} # re-export
 
 - component: <user>
   import: {}
   export:
-    Egrandparent_B1: {status: gridset} # re-export
+    Egrandparent_B1: {status: empty} # re-export
   internal: {}
 
 - component: <root>
   import:
-    "I_A1(1)": {status: gridset}  # unsatisfied
-    "I_B1(1)": {status: gridset}  # unsatisfied
+    "I_A1(1)": {status: empty}  # unsatisfied
+    "I_B1(1)": {status: empty}  # unsatisfied
   export:
-    "child_A/E_A1": {status: gridset}
-    "child_B/E_B1": {status: gridset} # re-export
-    Egrandparent_B1: {status: gridset} # re-export
+    "child_A/E_A1": {status: empty}
+    "child_B/E_B1": {status: empty} # re-export
+    Egrandparent_B1: {status: empty} # re-export


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Widespread changes to allow coupler component methods to use proper ESMF import/export states.

ExtensionAction subclasses are now very similar to simple user gridcomps, which hints at future changes to make CouplerMetaComponent and OuterMetaComponent even more similar.   Not pursuing for now because coupler metadata is not known during early init phases of grid comps, and the analogy becomes weak at best.

## Related Issue

