### PR TITLE
Clean up NAG + OpenMP CMake

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -26,25 +26,13 @@ install(
   DESTINATION bin/forcing_converter)
 
 ecbuild_add_executable (TARGET Regrid_Util.x SOURCES Regrid_Util.F90)
-target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
+target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (Regrid_Util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(Regrid_Util.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
 
 ecbuild_add_executable (TARGET time_ave_util.x SOURCES time_ave_util.F90)
-target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
+target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (time_ave_util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(time_ave_util.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
 
 ecbuild_add_executable (TARGET Comp_Testing_Driver.x SOURCES Comp_Testing_Driver.F90)
-target_link_libraries (Comp_Testing_Driver.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF)
+target_link_libraries (Comp_Testing_Driver.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (Comp_Testing_Driver.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(Comp_Testing_Driver.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Move to use Intel ifort 2021.13 at NCCS SLES15, NAS, and GMAO Desktops
     - Move to use Intel MPI at NCCS SLES15 and GMAO Desktops
     - Move to GEOSpyD Min24.4.4 Python 3.11
-  - ESMA_cmake v3.49.0
+  - ESMA_cmake v3.50.0
     - Update `esma_add_fortran_submodules` function
     - Move MPI detection out of FindBaselibs
     - Add SMOD to submodule generator
+    - NAG OpenMP Workaround
 - Add support for preliminary CF Conventions quantization properties
   - Add new quantization keyword `granular_bitround` to History. This will be the preferred keyword for quantization in the future
     replacing `GranularBR`

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -12,36 +12,21 @@ esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL NetCDF::NetCDF_Fortran 
 if (BUILD_WITH_FARGPARSE)
 
   ecbuild_add_executable (TARGET ExtDataDriver.x SOURCES ExtDataDriver.F90 ExtDataDriverGridComp.F90 ExtDataDriverMod.F90)
-  target_link_libraries (ExtDataDriver.x PRIVATE MAPL MAPL.test_utilities FARGPARSE::fargparse ESMF::ESMF)
-  # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-  if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-    target_link_libraries(ExtDataDriver.x PRIVATE OpenMP::OpenMP_Fortran)
-  endif ()
+  target_link_libraries (ExtDataDriver.x PRIVATE MAPL MAPL.test_utilities FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
   set_target_properties(ExtDataDriver.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
   target_compile_definitions (ExtDataDriver.x PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)
   add_subdirectory(ExtData_Testing_Framework EXCLUDE_FROM_ALL)
 
   ecbuild_add_executable (TARGET pfio_MAPL_demo.x SOURCES pfio_MAPL_demo.F90)
-  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF)
-  # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-  if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-    target_link_libraries(pfio_MAPL_demo.x PRIVATE OpenMP::OpenMP_Fortran)
-  endif ()
+  target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
   set_target_properties(pfio_MAPL_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+
   ecbuild_add_executable (TARGET MAPL_demo_fargparse.x SOURCES MAPL_demo_fargparse.F90)
-  target_link_libraries (MAPL_demo_fargparse.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF)
-  # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-  if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-    target_link_libraries(MAPL_demo_fargparse.x PRIVATE OpenMP::OpenMP_Fortran)
-  endif ()
+  target_link_libraries (MAPL_demo_fargparse.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
   set_target_properties(MAPL_demo_fargparse.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
   ecbuild_add_executable (TARGET CapDriver.x SOURCES CapDriver.F90)
-  target_link_libraries (CapDriver.x PRIVATE MAPL MAPL.test_utilities FARGPARSE::fargparse ESMF::ESMF)
-  # CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-  if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-    target_link_libraries(CapDriver.x PRIVATE OpenMP::OpenMP_Fortran)
-  endif ()
+  target_link_libraries (CapDriver.x PRIVATE MAPL MAPL.test_utilities FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
   set_target_properties(CapDriver.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 endif ()

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -71,11 +71,7 @@ esma_add_library(
                GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE ${MAPL_LIBRARY_TYPE})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 
 if(DISABLE_GLOBAL_NAME_WARNING)
   target_compile_options (${this} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${DISABLE_GLOBAL_NAME_WARNING}>)
@@ -91,11 +87,7 @@ foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
 endforeach()
 
 ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS ESMF::ESMF MAPL.shared)
-target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio MPI::MPI_Fortran)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(cub2latlon.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 set_target_properties(cub2latlon.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 if (EXTENDED_SOURCE)

--- a/benchmarks/io/checkpoint_simulator/CMakeLists.txt
+++ b/benchmarks/io/checkpoint_simulator/CMakeLists.txt
@@ -6,11 +6,6 @@ ecbuild_add_executable (
   SOURCES checkpoint_simulator.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse ESMF::ESMF )
+target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${exe} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${exe} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/benchmarks/io/combo/CMakeLists.txt
+++ b/benchmarks/io/combo/CMakeLists.txt
@@ -6,11 +6,6 @@ ecbuild_add_executable (
   SOURCES Kernel.F90 GathervKernel.F90 BW_Benchmark.F90 ComboSpec.F90 driver.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
+target_link_libraries (${exe} PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse OpenMP::OpenMP_Fortran)
 target_include_directories (${exe} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${exe} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${exe} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/benchmarks/io/gatherv/CMakeLists.txt
+++ b/benchmarks/io/gatherv/CMakeLists.txt
@@ -5,11 +5,6 @@ ecbuild_add_executable (
   SOURCES GathervKernel.F90 GathervSpec.F90 driver.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (gatherv.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
+target_link_libraries (gatherv.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse OpenMP::OpenMP_Fortran)
 target_include_directories (gatherv.x PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (gatherv.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(gatherv.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/benchmarks/io/raw_bw/CMakeLists.txt
+++ b/benchmarks/io/raw_bw/CMakeLists.txt
@@ -5,11 +5,6 @@ ecbuild_add_executable (
   SOURCES BW_Benchmark.F90 BW_BenchmarkSpec.F90 driver.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (raw_bw.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse)
+target_link_libraries (raw_bw.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse OpenMP::OpenMP_Fortran)
 target_include_directories (raw_bw.x PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (raw_bw.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(raw_bw.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.49.0
+  tag: v3.50.0
   develop: develop
 
 ecbuild:

--- a/docs/tutorial/driver_app/CMakeLists.txt
+++ b/docs/tutorial/driver_app/CMakeLists.txt
@@ -3,9 +3,6 @@ set (srcs
     )
 
 ecbuild_add_executable (TARGET Example_Driver.x SOURCES ${srcs})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(Example_Driver.x PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(Example_Driver.x PRIVATE MAPL)
+target_link_libraries(Example_Driver.x PRIVATE MAPL OpenMP::OpenMP_Fortran)
 target_compile_definitions (Example_Driver.x PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)
 

--- a/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/automatic_code_generator_example/CMakeLists.txt
@@ -6,7 +6,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
 
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
@@ -15,7 +15,3 @@ set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${t
 mapl_acg (${this}   ACG_StateSpecs.rc
           IMPORT_SPECS EXPORT_SPECS
           GET_POINTERS DECLARE_POINTERS)
-
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()

--- a/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/hello_world_gridcomp/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_a/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/leaf_comp_b/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_no_children/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_one_child/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
+++ b/docs/tutorial/grid_comps/parent_with_two_children/CMakeLists.txt
@@ -4,10 +4,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL TYPE ${MAPL_LIBRARY_TYPE})
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-  target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${this} PRIVATE ESMF::ESMF)
+target_link_libraries(${this} PRIVATE ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 #target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -69,12 +69,8 @@ esma_add_library(${this}
   )
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-target_link_libraries (${this} PUBLIC ESMF::ESMF NetCDF::NetCDF_Fortran)
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries (${this} PUBLIC ESMF::ESMF NetCDF::NetCDF_Fortran
+  PRIVATE OpenMP::OpenMP_Fortran)
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/gridcomps/Cap/CMakeLists.txt
+++ b/gridcomps/Cap/CMakeLists.txt
@@ -17,16 +17,12 @@ endif()
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.profiler MAPL.history
                   MAPL.ExtData ${EXTDATA2G_TARGET} TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran
+                               PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran
                                $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
                                $<$<BOOL:${BUILD_WITH_FARGPARSE}>:FARGPARSE::fargparse>)
 
 target_compile_definitions (${this} PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)
 
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/gridcomps/ExtData/CMakeLists.txt
+++ b/gridcomps/ExtData/CMakeLists.txt
@@ -9,12 +9,8 @@ set (srcs
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.pfio
         MAPL.griddedio MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran)
+                               PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -14,12 +14,7 @@ set (srcs
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic MAPL.profiler MAPL.griddedio
                                                     TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran)
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+                               PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/gridcomps/Orbit/CMakeLists.txt
+++ b/gridcomps/Orbit/CMakeLists.txt
@@ -6,12 +6,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran)
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+                               PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -13,12 +13,8 @@ set (srcs
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio
          MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
-                               PRIVATE MPI::MPI_Fortran)
+                               PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -22,7 +22,7 @@ set (srcs
   FileMetadata.F90
   FileMetadataVector.F90
   NetCDF4_FileFormatter.F90
-  pfio_nf90_supplement.c 
+  pfio_nf90_supplement.c
   NetCDF_Supplement.F90
   pFIO_Utilities.F90
   pFIO.F90
@@ -120,11 +120,7 @@ endif ()
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
 
-target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC
           $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
@@ -150,20 +146,14 @@ ecbuild_add_executable (
    SOURCES pfio_server_demo.F90
    LIBS ${this} MPI::MPI_Fortran)
 set_target_properties (pfio_server_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(pfio_server_demo.x OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(pfio_server_demo.x OpenMP::OpenMP_Fortran)
 
 ecbuild_add_executable (
    TARGET pfio_collective_demo.x
    SOURCES pfio_collective_demo.F90
    LIBS ${this} MPI::MPI_Fortran)
 set_target_properties (pfio_collective_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(pfio_collective_demo.x OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(pfio_collective_demo.x OpenMP::OpenMP_Fortran)
 
 ecbuild_add_executable (
   TARGET pfio_writer.x

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -64,10 +64,7 @@ ecbuild_add_executable (
   SOURCES pfio_ctest_io.F90
   LIBS MAPL.shared MAPL.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   DEFINITIONS USE_MPI)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${TESTO} OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(${TESTO} OpenMP::OpenMP_Fortran)
 set_target_properties(${TESTO} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # Detect if we are using Open MPI and add oversubscribe
@@ -126,11 +123,7 @@ ecbuild_add_executable (
   SOURCES pfio_performance.F90
   DEFINITIONS USE_MPI
   LIBS MAPL.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran)
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${TESTPERF} OpenMP::OpenMP_Fortran)
-endif ()
-target_link_libraries(${TESTPERF} MAPL.pfio NetCDF::NetCDF_Fortran)
+target_link_libraries(${TESTPERF} MAPL.pfio NetCDF::NetCDF_Fortran OpenMP::OpenMP_Fortran)
 set_target_properties(${TESTPERF} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 add_test(NAME pFIO_performance

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -51,11 +51,7 @@ set (srcs
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl-v1 GFTL::gftl-v2 MAPL.shared MPI::MPI_Fortran TYPE ${MAPL_LIBRARY_TYPE})
 target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 
 add_subdirectory (demo EXCLUDE_FROM_ALL)
 if (PFUNIT_FOUND)

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -35,11 +35,7 @@ set (srcs
     )
 
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.constants GFTL_SHARED::gftl-shared MPI::MPI_Fortran PFLOGGER::pflogger TYPE ${MAPL_LIBRARY_TYPE})
-
-# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
-if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
-   target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
-endif ()
+target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR cleans up the CMake in MAPL to avoid the ugly:
```cmake
# CMake has an OpenMP issue with NAG Fortran: https://gitlab.kitware.com/cmake/cmake/-/issues/21280
if (NOT CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
  target_link_libraries(Regrid_Util.x PRIVATE OpenMP::OpenMP_Fortran)
endif ()
```
sprinkled all around. 

NOTE: This update *REQUIRES* ESMA_cmake v3.50.0 (or v4.5.0) when compiling with NAG. Without it, MAPL will not build. Other compilers do not care.

## Related Issue

