### PR TITLE
Add geom to VariableSpec

### DIFF
--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -21,7 +21,6 @@ module mapl3g_VariableSpec
    use mapl3g_ActualPtVector
    use mapl_ErrorHandling
    use mapl3g_StateRegistry
-   use mapl3g_GeomUtilities, only: MAPL_SameGeom
    use esmf
    use gFTL2_StringVector
    use nuopc

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -205,7 +205,7 @@ contains
       type(ActualPtVector) :: dependencies
 
       if (present(geom) .and. allocated(this%geom)) then
-         _ASSERT(MAPL_SameGeom(geom, this%geom), "specified geom is different from existing one")
+         _FAIL("Cannot pass in geom when VariableSpec contains its own geom")
       end if
 
       select case (this%itemtype%ot)
@@ -397,7 +397,7 @@ contains
     function make_WildcardSpec(this, geom, vertical_grid, rc) result(wildcard_spec)
       type(WildcardSpec) :: wildcard_spec
       class(VariableSpec), intent(in) :: this
-      type(ESMF_Geom), intent(in) :: geom
+      type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), intent(in) :: vertical_grid
       integer, optional, intent(out) :: rc
 

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -206,11 +206,6 @@ contains
       type(ActualPtVector) :: dependencies
       type(ESMF_Geom), allocatable :: geom_local
 
-      ! if (present(geom) .and. allocated(this%geom)) then
-      !    _FAIL("Cannot pass in geom when VariableSpec contains its own geom")
-      ! end if
-      ! if (present(geom)) geom_local = geom
-      ! if (allocated(this%geom)) geom_local = this%geom
       call this%pick_geom_(geom, geom_local, _RC)
 
       select case (this%itemtype%ot)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Added `geom` as an optional variable in `VariableSpec`. The case where this `geom` exists and someone specifies a `geom` via `make_itemspec` is not allowed.

## Related Issue

