### PR TITLE
Fix support for external MPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.24.0
-bcs_version: &bcs_version v11.3.0
+baselibs_version: &baselibs_version v7.25.0
+bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
@@ -178,9 +178,9 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: mapl
           mpi_name: intelmpi
-          mpi_version: 2021.6.0
+          mpi_version: "2021.13"
           compiler_name: intel
-          compiler_version: 2022.1.0
+          compiler_version: "2024.2"
           image_name: geos-env
           tag_build_arg_name: *tag_build_arg_name
       - ci/publish_docker:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.24.0-openmpi_5.0.2-gcc_13.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.25.0-openmpi_5.0.2-gcc_13.2.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -86,7 +86,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.24.0-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.13-intel_2024.2
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.46.3] - 2024-08-19
+
+### Fixed
+
+- Fix bug in supporting externally initialized MPI
+
 ## [2.46.2] - 2024-05-31
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [2.46.3] - 2024-08-19
+## [2.46.3] - 2024-08-16
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.46.2
+  VERSION 2.46.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -447,17 +447,19 @@ contains
 
       _UNUSED_DUMMY(unusable)
 
-      !call MPI_Initialized(this%mpi_already_initialized, ierror)
-      !_VERIFY(ierror)
-      call  ESMF_InitializePreMPI(_RC)
+      call MPI_Initialized(this%mpi_already_initialized, ierror)
+      _VERIFY(ierror)
 
       if (.not. this%mpi_already_initialized) then
+         call ESMF_InitializePreMPI(_RC)
          call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierror)
-         _ASSERT(provided == MPI_THREAD_MULTIPLE, 'MPI_THREAD_MULTIPLE not supported by this MPI.')
-!         call MPI_Init_thread(MPI_THREAD_SINGLE, provided, ierror)
-!         _VERIFY(ierror)
-!         _ASSERT(provided == MPI_THREAD_SINGLE, "MPI_THREAD_SINGLE not supported by this MPI.")
+      else
+         ! If we are here, then MPI has already been initialized by the user
+         ! and we are just using it. But we need to make sure that the user
+         ! has initialized MPI with the correct threading level.
+         call MPI_Query_thread(provided, ierror)
       end if
+      _ASSERT(provided == MPI_THREAD_MULTIPLE, 'MPI_THREAD_MULTIPLE not supported by this MPI.')
 
       call MPI_Comm_rank(this%comm_world, this%rank, ierror); _VERIFY(ierror)
       call MPI_Comm_size(this%comm_world, npes_world, ierror); _VERIFY(ierror)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

It was [found by @DusanJovic-](https://github.com/ufs-community/ufs-weather-model/issues/2399#issuecomment-2291907478)NOAA (see below) that MAPL has broken externally-initialized MPI. The logic pretty much says "No you didn't" even if you did and, well, MPI stacks fail. Here we try and revive that functionality, though it is hard for us to test it. 

The code change enforces "You better have initialized at `MPI_THREAD_MULTIPLE`" since, well, the current code seems to enforce that. I'm not sure if it is truly required or not. I'll consult @aoloso and @tclune to see.

Note that also I am not sure what `ESMF_InitializePreMPI()` does other than what the docs say and if it should/can be called in both cases.

Current GEOS-MAPL is:

1. `ESMF_InitializePreMPI`
2. `MPI_Init_thread`
3. `ESMF_Initialize`

but the NOAA-MAPL case here will be be:

1. `MPI_Init_thread`
2. `MPI_Query_thread`
3. `ESMF_Initialize`

The [ESMF docs say](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node4.html#SECTION04024200000000000000):

> This method is only needed for cases where MPI is initialized explicitly by user code. In most typical cases ESMF_Initialize() is called before MPI is initialized, and takes care of all the internal initialization, including MPI.
> 
> There are circumstances where it is necessary or convenient to initialize MPI before calling into ESMF_Initialize(). This option is supported by ESMF, and for most cases no special action is required on the user side. However, for cases where ESMF_*CompSetVM*() methods are used to move processing elements (PEs), i.e. CPU cores, between persistent execution threads (PETs), ESMF uses POSIX signals between PETs. In order to do so safely, the proper signal handlers must be installed before MPI is initialized. This is accomplished by calling ESMF_InitializePreMPI() from the user code prior to the MPI initialization.

So, I mean, it seems wrong to call `ESMF_InitializePreMPI()` in the NOAA case because `MPI_Init_thread` has already been called. But I'm not sure what (if anything?) breaks in MAPL if one does not call `ESMF_InitializePreMPI`...

## Related Issue

https://github.com/ufs-community/ufs-weather-model/issues/2399#issuecomment-2291907478
