### PR TITLE
Mapl3/refactor phases

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_advertise.F90
+++ b/generic3g/OuterMetaComponent/initialize_advertise.F90
@@ -95,7 +95,6 @@ contains
          call item_spec%create(_RC)
 
          virtual_pt = var_spec%make_virtualPt()
-!#         call registry%add_item_spec(virtual_pt, item_spec)
          call registry%add_primary_spec(virtual_pt, item_spec)
 
          _RETURN(_SUCCESS)
@@ -115,7 +114,7 @@ contains
           iter = this%component_spec%connections%begin()
           do while (iter /= e)
              c => iter%of()
-             call c%connect(this%registry, _RC)
+             call c%activate(this%registry, _RC)
              call iter%next()
           end do
         end associate

--- a/generic3g/OuterMetaComponent/initialize_modify_advertise.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertise.F90
@@ -19,6 +19,8 @@ contains
       type(MultiState) :: outer_states, user_states
 
       call this%run_custom(ESMF_METHOD_INITIALIZE, PHASE_NAME, _RC)
+      call process_connections(this, _RC)
+      call this%registry%propagate_exports(_RC)
 
       user_states = this%user_gc_driver%get_states()
       call this%registry%add_to_states(user_states, mode='user', _RC)
@@ -31,5 +33,25 @@ contains
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_modify_advertise
+   
+   subroutine process_connections(this, rc)
+      class(OuterMetaComponent), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ConnectionVectorIterator) :: iter
+      class(Connection), pointer :: c
+
+      associate (e => this%component_spec%connections%end())
+        iter = this%component_spec%connections%begin()
+        do while (iter /= e)
+           c => iter%of()
+           call c%connect(this%registry, _RC)
+           call iter%next()
+        end do
+      end associate
+
+      _RETURN(_SUCCESS)
+   end subroutine process_connections
 
 end submodule initialize_modify_advertise_smod

--- a/generic3g/connection/ReexportConnection.F90
+++ b/generic3g/connection/ReexportConnection.F90
@@ -67,7 +67,15 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
+      type(StateRegistry), pointer :: src_registry
+      type(ConnectionPt) :: src_pt
         
+      src_pt = this%get_source()
+      src_registry => registry%get_subregistry(src_pt)
+      _ASSERT(associated(src_registry), 'Unknown source registry')
+
+      call this%connect_export_to_export(registry, src_registry, _RC)
+
       _RETURN(_SUCCESS)
    end subroutine activate
 
@@ -76,15 +84,15 @@ contains
       type(StateRegistry), target, intent(inout) :: registry
       integer, optional, intent(out) :: rc
 
-      integer :: status
-      type(StateRegistry), pointer :: src_registry
-      type(ConnectionPt) :: src_pt
-
-      src_pt = this%get_source()
-      src_registry => registry%get_subregistry(src_pt)
-      _ASSERT(associated(src_registry), 'Unknown source registry')
-
-      call this%connect_export_to_export(registry, src_registry, _RC)
+!#      integer :: status
+!#      type(StateRegistry), pointer :: src_registry
+!#      type(ConnectionPt) :: src_pt
+!#
+!#      src_pt = this%get_source()
+!#      src_registry => registry%get_subregistry(src_pt)
+!#      _ASSERT(associated(src_registry), 'Unknown source registry')
+!#
+!#      call this%connect_export_to_export(registry, src_registry, _RC)
         
       _RETURN(_SUCCESS)
    end subroutine connect

--- a/generic3g/registry/StateRegistry.F90
+++ b/generic3g/registry/StateRegistry.F90
@@ -488,6 +488,8 @@ contains
       type(VirtualConnectionPt), pointer :: virtual_pt
       type(VirtualConnectionPt) :: new_virtual_pt
       type(ExtensionFamily), pointer :: family
+      integer :: n
+      type(VirtualPtFamilyMapIterator) :: new_iter
 
       virtual_pt => iter%first()
       _RETURN_UNLESS(virtual_pt%is_export())
@@ -496,6 +498,16 @@ contains
       if (virtual_pt%get_comp_name() == '') then
          new_virtual_pt = VirtualConnectionPt(virtual_pt, comp_name=subregistry_name)
       end if
+
+      ! TODO: Better logic would be the following line.  But gFTL has
+      ! a missing TARGET attribute (bug)
+!# n = this%family_map%erase(new_virtual_pt)
+      ! instead we do this:
+      associate(e => this%family_map%end())
+        new_iter = this%family_map%find(new_virtual_pt)
+        new_iter = this%family_map%erase(new_iter, e)
+      end associate
+
       call this%add_virtual_pt(new_virtual_pt, _RC)
       family => iter%second()
       call this%family_map%insert(new_virtual_pt, family)

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -38,10 +38,26 @@ module mapl3g_FieldSpec
    public :: FieldSpec
    public :: new_FieldSpec_geom
 
+   ! Two FieldSpec's can be connected if:
+   !   1) They only differ in the following components:
+   !      - geom (couple with Regridder)
+   !      - vertical_regrid (couple with VerticalRegridder)
+   !      - typekind (Copy)
+   !      - units (Convert)
+   !      - frequency_spec (tbd)
+   !      - halo width (tbd)
+   !   2) They have the same values for
+   !      - ungridded_dims
+   !      - standard_name
+   !      - long_name
+   !      - regrid_param
+   !      - default_value
+   !   3) The attributes of destination spec are a subset of the
+   !      attributes of the source spec.
+
    type, extends(StateItemSpec) :: FieldSpec
 
       private
-
       type(ESMF_Geom), allocatable :: geom
       class(VerticalGrid), allocatable :: vertical_grid
       type(VerticalDimSpec) :: vertical_dim_spec = VERTICAL_DIM_UNKNOWN
@@ -62,6 +78,8 @@ module mapl3g_FieldSpec
       type(ESMF_Field) :: payload
       real, allocatable :: default_value
 
+      logical :: is_created = .false.
+
    contains
 
       procedure :: create
@@ -73,8 +91,6 @@ module mapl3g_FieldSpec
       procedure :: can_connect_to
       procedure :: add_to_state
       procedure :: add_to_bundle
-
-      procedure :: check_complete
 
       procedure :: extension_cost
       procedure :: make_extension
@@ -200,6 +216,7 @@ contains
       integer :: status
 
       this%payload = ESMF_FieldEmptyCreate(_RC)
+      this%is_created = .true.
 
       _RETURN(ESMF_SUCCESS)
    end subroutine create
@@ -584,18 +601,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
-
-   logical function check_complete(this, rc)
-      class(FieldSpec), intent(in) :: this
-      integer, intent(out), optional :: rc
-
-      integer :: status
-      type(ESMF_FieldStatus_Flag) :: fstatus
-
-      call ESMF_FieldGet(this%payload, status=fstatus, _RC)
-      check_complete = (fstatus == ESMF_FIELDSTATUS_COMPLETE)
-
-   end function check_complete
 
    integer function extension_cost(this, src_spec, rc) result(cost)
       class(FieldSpec), intent(in) :: this

--- a/generic3g/tests/scenarios/3d_specs/A.yaml
+++ b/generic3g/tests/scenarios/3d_specs/A.yaml
@@ -2,20 +2,20 @@ mapl:
   states:
     export:
       E_A1:
-        standard_name:  'A1 standard name'
+        standard_name: 'A1 standard name'
         units: 'barn'
         typekind: R4
         default_value: 1.
         vertical_dim_spec: NONE
       E_A3:
-        standard_name:  'A3 standard name'
+        standard_name: 'A3 standard name'
         units: 'barn'
         typekind: R4
         default_value: 7.
         vertical_dim_spec: NONE
     import:
       I_A2:
-        standard_name:  'B2 standard name'
+        standard_name: 'B2 standard name'
         units: 'barn'
         typekind: R4
         default_value: 3.

--- a/generic3g/tests/scenarios/3d_specs/B.yaml
+++ b/generic3g/tests/scenarios/3d_specs/B.yaml
@@ -2,7 +2,7 @@ mapl:
   states:
     export:
       E_B2:
-        standard_name:  'B2 standard name'
+        standard_name: 'B2 standard name'
         units: 'barn'
         typekind: R4
         default_value: 5.
@@ -10,15 +10,14 @@ mapl:
 
     import:
       I_B1:
-        standard_name:  'I_B1 standard name'
+        standard_name: 'I_B1 standard name'
         units: 'barn'
         typekind: R4
         default_value: 2. # expected to change
         vertical_dim_spec: NONE
       I_B3:
-        standard_name:  'I_B3 standard name'
+        standard_name: 'I_B3 standard name'
         units: 'barn'
         typekind: R4
         default_value: 2. # expected to change
         vertical_dim_spec: NONE
-

--- a/generic3g/tests/scenarios/precision_extension_3d/A.yaml
+++ b/generic3g/tests/scenarios/precision_extension_3d/A.yaml
@@ -2,20 +2,20 @@ mapl:
   states:
     export:
       E_A1:
-        standard_name:  'A1 standard name'
+        standard_name: 'A1 standard name'
         units: 'barn'
         typekind: R4
         default_value: 1.
         vertical_dim_spec: NONE
       E_A3:
-        standard_name:  'A3 standard name'
+        standard_name: 'A3 standard name'
         units: 'barn'
         typekind: R4
         default_value: 7.
         vertical_dim_spec: NONE
     import:
       I_A2:
-        standard_name:  'B2 standard name'
+        standard_name: 'B2 standard name'
         units: 'barn'
         typekind: R8
         default_value: 3.


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)
## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

More realignment of MAPL3 phases with NUOPC.

True connection of imports to exports (and creation of any needed couplers) is now delayed until modify_advertise().   Ordinary initialize() now only activates specs for which there are connections.

## Related Issue

