### PR TITLE
Fix bug from dev-to-mapl3 merge 2024-Aug-27

### DIFF
--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -652,7 +652,7 @@ contains
        do while(iter /= cap_exports_vec%end())
           component_name = iter%of()
           component_name = trim(component_name(index(component_name, ",")+1:))
-          field_name = iter%get()
+          field_name = iter%of()
           field_name = trim(field_name(1:index(field_name, ",")-1))
           call MAPL_ExportStateGet([cap%child_exports(cap%root_id)], component_name, &
                component_state, status)
@@ -666,7 +666,7 @@ contains
     if (extdata_imports_vec%size() /= 0) then
        iter = extdata_imports_vec%begin()
        do while(iter /= extdata_imports_vec%end())
-          component_name = iter%get()
+          component_name = iter%of()
           component_name = trim(component_name(index(component_name, ",")+1:))
 
           field_name = iter%of()


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Mea culpa. Yesterday I merged in the updates from #2994 to `develop` into `release/MAPL-v3` and the merge looked simple enough, I just pushed it up. Turns out, nope. There was a gFTL v1 to gFTL v2 difference I missed.

So we fix it here.

## Related Issue

