### PR TITLE
Cleanup/refactor.

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
@@ -60,7 +60,7 @@ contains
       
       integer :: status
 
-      call this%registry%initialize_specs(this%geom, this%vertical_grid, _RC)
+      call this%registry%set_blanket_geometry(this%geom, this%vertical_grid, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)

--- a/generic3g/OuterMetaComponent/initialize_modify_advertised2.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertised2.F90
@@ -31,19 +31,6 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_modify_advertised2
    
-   subroutine self_advertise(this, unusable, rc)
-      class(OuterMetaComponent), target, intent(inout) :: this
-      class(KE), optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-      
-      integer :: status
-
-      call this%registry%initialize_specs(this%geom, this%vertical_grid, _RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine self_advertise
-
    subroutine process_connections(this, rc)
       class(OuterMetaComponent), intent(inout) :: this
       integer, optional, intent(out) :: rc

--- a/generic3g/registry/StateRegistry.F90
+++ b/generic3g/registry/StateRegistry.F90
@@ -78,7 +78,7 @@ module mapl3g_StateRegistry
 
       ! Actions on specs
       procedure :: allocate
-      procedure :: initialize_specs
+      procedure :: set_blanket_geometry
       procedure :: add_to_states
 
       procedure :: filter ! for MatchConnection
@@ -625,7 +625,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine allocate
 
-   subroutine initialize_specs(this, geom, vertical_grid, rc)
+   subroutine set_blanket_geometry(this, geom, vertical_grid, rc)
       class(StateRegistry), target, intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -643,13 +643,13 @@ contains
            extension => iter%of()
            spec => extension%get_spec()
            if (spec%is_active()) then
-              call spec%initialize(geom, vertical_grid, _RC)
+              call spec%set_geometry(geom, vertical_grid, _RC)
            end if
         end do
       end associate
       
       _RETURN(_SUCCESS)
-   end subroutine initialize_specs
+   end subroutine set_blanket_geometry
 
   subroutine add_to_states(this, multi_state, mode, rc)
       use esmf

--- a/generic3g/specs/BracketSpec.F90
+++ b/generic3g/specs/BracketSpec.F90
@@ -46,7 +46,7 @@ module mapl3g_BracketSpec
 
       procedure :: extension_cost
       procedure :: make_extension
-      procedure :: initialize => initialize_bracket_spec
+      procedure :: set_geometry
    end type BracketSpec
 
    interface BracketSpec
@@ -292,7 +292,7 @@ contains
       _FAIL('not implemented')
    end subroutine make_extension
 
-   subroutine initialize_bracket_spec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(BracketSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -300,6 +300,6 @@ contains
       integer :: status
 
       _RETURN(_SUCCESS)
-   end subroutine initialize_bracket_spec
+   end subroutine set_geometry
 
 end module mapl3g_BracketSpec

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -108,7 +108,7 @@ module mapl3g_FieldSpec
       procedure :: make_extension
 
       procedure :: set_info
-      procedure :: initialize => initialize_field_spec
+      procedure :: set_geometry
 
    end type FieldSpec
 
@@ -234,7 +234,7 @@ contains
       _RETURN(_SUCCESS)
    end function get_regrid_method_
 
-   subroutine initialize_field_spec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(FieldSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -259,7 +259,7 @@ contains
       
       _RETURN(_SUCCESS)
       
-   end subroutine initialize_field_spec
+   end subroutine set_geometry
 
 !#   function new_FieldSpec_defaults(ungridded_dims, geom, units) result(field_spec)
 !#      type(FieldSpec) :: field_spec

--- a/generic3g/specs/InvalidSpec.F90
+++ b/generic3g/specs/InvalidSpec.F90
@@ -36,7 +36,7 @@ module mapl3g_InvalidSpec
 
       procedure :: make_extension
       procedure :: extension_cost
-      procedure :: initialize => initialize_invalid_spec
+      procedure :: set_geometry => set_geometry
    end type InvalidSpec
 
 
@@ -156,7 +156,7 @@ contains
 
    end function extension_cost
 
-   subroutine initialize_invalid_spec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(InvalidSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -166,6 +166,6 @@ contains
 
       _FAIL('Attempt to initialize item of type InvalidSpec')
 
-   end subroutine initialize_invalid_spec
+   end subroutine set_geometry
 
 end module mapl3g_InvalidSpec

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -44,7 +44,7 @@ module mapl3g_ServiceSpec
       procedure :: extension_cost
       procedure :: add_to_state
       procedure :: add_to_bundle
-      procedure :: initialize => initialize_service_spec
+      procedure :: set_geometry
 !!$      procedure :: check_complete
    end type ServiceSpec
 
@@ -205,7 +205,7 @@ contains
       _RETURN(_SUCCESS)
    end function extension_cost
 
-   subroutine initialize_service_spec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(ServiceSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -231,6 +231,6 @@ contains
       this%dependency_specs = specs
 
       _RETURN(_SUCCESS)
-   end subroutine initialize_service_spec
+   end subroutine set_geometry
 
 end module mapl3g_ServiceSpec

--- a/generic3g/specs/StateItemSpec.F90
+++ b/generic3g/specs/StateItemSpec.F90
@@ -31,7 +31,7 @@ module mapl3g_StateItemSpec
 
       procedure(I_add_to_state), deferred :: add_to_state
       procedure(I_add_to_bundle), deferred :: add_to_bundle
-      procedure(I_initialize), deferred :: initialize
+      procedure(I_set_geometry), deferred :: set_geometry
 
       procedure, non_overridable :: set_allocated
       procedure, non_overridable :: is_allocated
@@ -122,7 +122,7 @@ module mapl3g_StateItemSpec
          integer, optional, intent(out) :: rc
       end subroutine I_add_to_bundle
 
-      subroutine I_initialize(this, geom, vertical_grid, rc)
+      subroutine I_set_geometry(this, geom, vertical_grid, rc)
          use esmf, only: ESMF_Geom
          use mapl3g_VerticalGrid, only: VerticalGrid
          import StateItemSpec
@@ -130,7 +130,7 @@ module mapl3g_StateItemSpec
          type(ESMF_Geom), optional, intent(in) :: geom
          class(VerticalGrid), optional, intent(in) :: vertical_grid
          integer, optional, intent(out) :: rc
-      end subroutine I_initialize
+      end subroutine I_set_geometry
 
    end interface
 

--- a/generic3g/specs/StateSpec.F90
+++ b/generic3g/specs/StateSpec.F90
@@ -23,7 +23,7 @@ module mapl3g_StateSpec
       type(ESMF_State) :: payload
       type(StateItemSpecMap) :: item_specs
    contains
-      procedure :: initialize
+      procedure :: set_geometry
       procedure :: add_item
       procedure :: get_item
 
@@ -44,7 +44,7 @@ module mapl3g_StateSpec
 contains
 
    ! Nothing defined at this time.
-   subroutine initialize(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(StateSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -54,7 +54,7 @@ contains
       integer :: status
 
       _RETURN(_SUCCESS)
-   end subroutine initialize
+   end subroutine set_geometry
 
    subroutine add_item(this, name, item)
       class(StateSpec), target, intent(inout) :: this

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -35,7 +35,7 @@ module mapl3g_WildcardSpec
       procedure :: add_to_state
       procedure :: add_to_bundle
       procedure :: extension_cost
-      procedure :: initialize => initialize_wildcard_spec
+      procedure :: set_geometry
 
    end type WildcardSpec
 
@@ -236,7 +236,7 @@ contains
       _RETURN(_SUCCESS)
    end function extension_cost
 
-   subroutine initialize_wildcard_spec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(WildcardSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
@@ -244,9 +244,9 @@ contains
 
       integer :: status
 
-      call this%reference_spec%initialize(geom, vertical_grid, _RC)
+      call this%reference_spec%set_geometry(geom, vertical_grid, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine initialize_wildcard_spec
+   end subroutine set_geometry
 
 end module mapl3g_WildcardSpec

--- a/generic3g/tests/MockItemSpec.F90
+++ b/generic3g/tests/MockItemSpec.F90
@@ -27,7 +27,7 @@ module MockItemSpecMod
       procedure :: create
       procedure :: destroy
       procedure :: allocate
-      procedure :: initialize => initialize_mockspec
+      procedure :: set_geometry
 
       procedure :: connect_to
       procedure :: can_connect_to
@@ -64,14 +64,14 @@ contains
 
    end function new_MockItemSpec
 
-   subroutine initialize_mockspec(this, geom, vertical_grid, rc)
+   subroutine set_geometry(this, geom, vertical_grid, rc)
       class(MockItemSpec), intent(inout) :: this
       type(ESMF_Geom), optional, intent(in) :: geom
       class(VerticalGrid), optional, intent(in) :: vertical_grid
       integer, optional, intent(out) :: rc
 
       _RETURN(_SUCCESS)
-   end subroutine initialize_mockspec
+   end subroutine set_geometry
 
    subroutine create(this, rc)
       class(MockItemSpec), intent(inout) :: this

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -67,7 +67,7 @@ contains
            default_value=3.)
      allocate(ple_spec, source=make_itemSpec(var_spec, r, rc=status))
      _VERIFY(status)
-     call ple_spec%initialize(geom=geom, vertical_grid=vgrid, _RC)
+     call ple_spec%set_geometry(geom=geom, vertical_grid=vgrid, _RC)
 
       call r%add_primary_spec(ple_pt, ple_spec)
 


### PR DESCRIPTION
 - initialize() was a bit vague of a name for the StateItemSpec classes. Renamed to `set_geometry`
 - Add (as-yet-unused) interface in MAPL_Generic.F90 to allow gridcomps to set a different geometry for each variable.  This will be needed for the envisioned design of ExtData, and allow the logic to be expressed at a higher level.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Introduced simple high level procedure to set geometry on specs.

## Related Issue

