### PR TITLE
Remove the procedure process_connections from a module file.

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_modify_advertised2.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertised2.F90
@@ -31,24 +31,4 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_modify_advertised2
    
-   subroutine process_connections(this, rc)
-      class(OuterMetaComponent), intent(inout) :: this
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      type(ConnectionVectorIterator) :: iter
-      class(Connection), pointer :: c
-
-      associate (e => this%component_spec%connections%end())
-        iter = this%component_spec%connections%begin()
-        do while (iter /= e)
-           c => iter%of()
-           call c%connect(this%registry, _RC)
-           call iter%next()
-        end do
-      end associate
-
-      _RETURN(_SUCCESS)
-   end subroutine process_connections
-
 end submodule initialize_modify_advertised2_smod


### PR DESCRIPTION


## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
- Remove the procedure `process_connections` from the file `initialize_modify_advertised2.F90`. The procedure was not used.

## Related Issue

