### PR TITLE
Update stale action to remove stale label when unstale

### DIFF
--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -45,3 +45,7 @@ jobs:
           stale-pr-label: ':snowflake: Stale'
           exempt-pr-labels: ':hourglass: Long Term,:exclamation: High Priority'
 
+          labels-to-remove-when-unstale: ':snowflake: Stale'
+          remove-stale-when-updated: true
+
+


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This should have the stale action remove the stale label when an issue or PR is unstaled.

## Related Issue

