### PR TITLE
Refactor name change.

### DIFF
--- a/generic3g/registry/ExtensionFamily.F90
+++ b/generic3g/registry/ExtensionFamily.F90
@@ -117,7 +117,7 @@ contains
       type(StateItemExtensionPtrVector) :: subgroup, new_subgroup
       class(StateItemSpec), pointer :: archetype
       integer :: i, j
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       integer :: status
       type(StateItemExtensionPtr) :: extension_ptr
       type(StateItemExtension), pointer :: primary
@@ -127,15 +127,15 @@ contains
       subgroup = family%get_extensions()
       primary => family%get_primary()  ! archetype defines the rules
       archetype => primary%get_spec()
-      filters = archetype%make_filters(goal_spec, _RC)
+      adapters = archetype%make_adapters(goal_spec, _RC)
 
-      do i = 1, size(filters)
+      do i = 1, size(adapters)
          new_subgroup = StateItemExtensionPtrVector()
          do j = 1, subgroup%size()
             extension_ptr = subgroup%of(j)
             spec => extension_ptr%ptr%get_spec()
-            associate (f => filters(i)%filter)
-              if (f%apply(spec)) then
+            associate (adapter => adapters(i)%adapter)
+              if (adapter%apply(spec)) then
                  call new_subgroup%push_back(extension_ptr)
               end if
             end associate

--- a/generic3g/specs/BracketSpec.F90
+++ b/generic3g/specs/BracketSpec.F90
@@ -46,7 +46,7 @@ module mapl3g_BracketSpec
 
       procedure :: extension_cost
       procedure :: make_extension
-      procedure :: make_filters
+      procedure :: make_adapters
       procedure :: set_geometry
    end type BracketSpec
 
@@ -302,20 +302,20 @@ contains
       _UNUSED_DUMMY(vertical_grid)
    end subroutine set_geometry
 
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(BracketSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
 
-      allocate(filters(0))
+      allocate(adapters(0))
       _FAIL('unimplemented')
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(goal_spec)
-   end function make_filters
+   end function make_adapters
 
  
 end module mapl3g_BracketSpec

--- a/generic3g/specs/InvalidSpec.F90
+++ b/generic3g/specs/InvalidSpec.F90
@@ -38,7 +38,7 @@ module mapl3g_InvalidSpec
       procedure :: extension_cost
       procedure :: set_geometry => set_geometry
 
-      procedure :: make_filters
+      procedure :: make_adapters
    end type InvalidSpec
 
 
@@ -182,18 +182,18 @@ contains
    end subroutine set_geometry
 
    ! Stub implementation
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(InvalidSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
-      allocate(filters(0))
+      allocate(adapters(0))
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(goal_spec)
-   end function make_filters
+   end function make_adapters
 
 
 end module mapl3g_InvalidSpec

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -42,7 +42,7 @@ module mapl3g_ServiceSpec
       procedure :: can_connect_to
       procedure :: make_extension
       procedure :: extension_cost
-      procedure :: make_filters
+      procedure :: make_adapters
 
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -237,18 +237,18 @@ contains
       _RETURN(_SUCCESS)
    end subroutine set_geometry
 
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(ServiceSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
 
-      allocate(filters(0))
+      allocate(adapters(0))
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(goal_spec)
-   end function make_filters
+   end function make_adapters
 
 end module mapl3g_ServiceSpec

--- a/generic3g/specs/StateItemSpec.F90
+++ b/generic3g/specs/StateItemSpec.F90
@@ -9,24 +9,24 @@ module mapl3g_StateItemSpec
 
    public :: StateItemSpec
    public :: StateItemSpecPtr
-   public :: StateItemFilter
-   public :: StateItemFilterWrapper
+   public :: StateItemAdapter
+   public :: StateItemAdapterWrapper
 
-   ! Concrete filter subclasses are used to identify members of an
-   ! ExtensionFamily that match some aspect of a "goal" spec.
-   ! A sequence of filters can then be used.
-   ! Note that to avoid circularity, Filters actually act on
-   ! an array of ptr wrappers of StateItemSpecs.
-   type, abstract :: StateItemFilter
+   ! Concrete adapter subclasses are used to identify members of an
+   ! ExtensionFamily that match some aspect of a "goal" spec.  A
+   ! sequence of adapters can then be used.  Note that to avoid
+   ! circularity, Adapters actually act on an array of ptr wrappers of
+   ! StateItemSpecs.
+   type, abstract :: StateItemAdapter
    contains
       procedure(I_apply_one), deferred :: apply_one
       procedure :: apply_ptr
       generic :: apply => apply_one, apply_ptr
-   end type StateItemFilter
+   end type StateItemAdapter
 
-   type :: StateItemFilterWrapper
-      class(StateItemFilter), allocatable :: filter
-   end type StateItemFilterWrapper
+   type :: StateItemAdapterWrapper
+      class(StateItemAdapter), allocatable :: adapter
+   end type StateItemAdapterWrapper
 
    type, abstract :: StateItemSpec
       private
@@ -47,7 +47,7 @@ module mapl3g_StateItemSpec
       procedure(I_make_extension), deferred :: make_extension
       procedure(I_extension_cost), deferred :: extension_cost
 
-      procedure(I_make_filters), deferred :: make_filters
+      procedure(I_make_adapters), deferred :: make_adapters
 
       procedure(I_add_to_state), deferred :: add_to_state
       procedure(I_add_to_bundle), deferred :: add_to_bundle
@@ -71,9 +71,9 @@ module mapl3g_StateItemSpec
    abstract interface
 
       logical function I_apply_one(this, spec)
-         import StateItemFilter
+         import StateItemAdapter
          import StateItemSpec
-         class(StateItemFilter), intent(in) :: this
+         class(StateItemAdapter), intent(in) :: this
          class(StateItemSpec), intent(in) :: spec
       end function I_apply_one
 
@@ -160,21 +160,21 @@ module mapl3g_StateItemSpec
       end subroutine I_set_geometry
 
 
-      ! Returns an ordered list of filters that priorities matching
+      ! Returns an ordered list of adapters that priorities matching
       ! rules for connecting a family of extension to a goal spec.
-      ! The intent is that the filters are ordered to prioritize
+      ! The intent is that the adapters are ordered to prioritize
       ! coupling to avoid more expensive and/or diffusive couplers.
-      ! E.g., The first filter for a FieldSpec is expected to be
-      ! a GeomFilter so that a new RegridAction is only needed when
+      ! E.g., The first adapter for a FieldSpec is expected to be
+      ! a GeomAdapter so that a new RegridAction is only needed when
       ! no existing extensions match the geom of the goal_spec.
-      function I_make_filters(this, goal_spec, rc) result(filters)
+      function I_make_adapters(this, goal_spec, rc) result(adapters)
          import StateItemSpec
-         import StateItemFilterWrapper
-         type(StateItemFilterWrapper), allocatable :: filters(:)
+         import StateItemAdapterWrapper
+         type(StateItemAdapterWrapper), allocatable :: adapters(:)
          class(StateItemSpec), intent(in) :: this
          class(StateItemSpec), intent(in) :: goal_spec
          integer, optional, intent(out) :: rc
-      end function I_make_filters
+      end function I_make_adapters
    end interface
 
 contains
@@ -247,7 +247,7 @@ contains
    end subroutine set_raw_dependencies
 
    logical function apply_ptr(this, spec_ptr) result(match)
-      class(StateItemFilter), intent(in) :: this
+      class(StateItemAdapter), intent(in) :: this
       type(StateItemSpecPtr), intent(in) :: spec_ptr
       match = this%apply(spec_ptr%ptr)
    end function apply_ptr

--- a/generic3g/specs/StateSpec.F90
+++ b/generic3g/specs/StateSpec.F90
@@ -35,7 +35,7 @@ module mapl3g_StateSpec
       procedure :: can_connect_to
       procedure :: make_extension
       procedure :: extension_cost
-      procedure :: make_filters
+      procedure :: make_adapters
 
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -199,19 +199,19 @@ contains
    end function extension_cost
 
 
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(StateSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
 
-      allocate(filters(0))
+      allocate(adapters(0))
       _FAIL('unimplemented')
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(goal_spec)
-   end function make_filters
+   end function make_adapters
 
 end module mapl3g_StateSpec

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -33,7 +33,7 @@ module mapl3g_WildcardSpec
       procedure :: can_connect_to
       procedure :: make_extension
       procedure :: extension_cost
-      procedure :: make_filters
+      procedure :: make_adapters
       procedure :: add_to_state
       procedure :: add_to_bundle
       procedure :: set_geometry
@@ -239,19 +239,19 @@ contains
       _RETURN(_SUCCESS)
    end subroutine set_geometry
 
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(WildcardSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
       integer :: status
       associate (field_spec => this%reference_spec)
-        filters = field_spec%make_filters(field_spec, _RC)
+        adapters = field_spec%make_adapters(field_spec, _RC)
       end associate
 
       _RETURN(_SUCCESS)
-   end function make_filters
+   end function make_adapters
 
    function get_reference_spec(this) result(reference_spec)
       class(WildcardSpec), target, intent(in) :: this

--- a/generic3g/tests/MockItemSpec.F90
+++ b/generic3g/tests/MockItemSpec.F90
@@ -23,7 +23,7 @@ module MockItemSpecMod
    type, extends(StateItemSpec) :: MockItemSpec
       character(len=:), allocatable :: name
       character(len=:), allocatable :: subtype
-      character(len=:), allocatable :: filter_type
+      character(len=:), allocatable :: adapter_type
    contains
       procedure :: create
       procedure :: destroy
@@ -34,7 +34,7 @@ module MockItemSpecMod
       procedure :: can_connect_to
       procedure :: make_extension
       procedure :: extension_cost
-      procedure :: make_filters
+      procedure :: make_adapters
       procedure :: add_to_state
       procedure :: add_to_bundle
    end type MockItemSpec
@@ -54,38 +54,38 @@ module MockItemSpecMod
       module procedure new_MockAction
    end interface MockAction
 
-   type, extends(StateItemFilter) :: SubtypeFilter
+   type, extends(StateItemAdapter) :: SubtypeAdapter
       character(:), allocatable :: subtype
    contains
       procedure :: apply_one => match_subtype
-   end type SubtypeFilter
+   end type SubtypeAdapter
 
-   interface SubtypeFilter
-      procedure :: new_SubtypeFilter
-   end interface SubtypeFilter
+   interface SubtypeAdapter
+      procedure :: new_SubtypeAdapter
+   end interface SubtypeAdapter
       
 
-   type, extends(StateItemFilter) :: NameFilter
+   type, extends(StateItemAdapter) :: NameAdapter
       character(:), allocatable :: name
    contains
       procedure :: apply_one => match_name
-   end type NameFilter
+   end type NameAdapter
 
-   interface NameFilter
-      procedure :: new_NameFilter
-   end interface NameFilter
+   interface NameAdapter
+      procedure :: new_NameAdapter
+   end interface NameAdapter
       
 contains
 
-   function new_MockItemSpec(name, subtype, filter_type) result(spec)
+   function new_MockItemSpec(name, subtype, adapter_type) result(spec)
       type(MockItemSpec) :: spec
       character(*), intent(in) :: name
       character(*), optional, intent(in) :: subtype
-      character(*), optional, intent(in) :: filter_type
+      character(*), optional, intent(in) :: adapter_type
 
       spec%name = name
       if (present(subtype)) spec%subtype = subtype
-      if (present(filter_type)) spec%filter_type = filter_type
+      if (present(adapter_type)) spec%adapter_type = adapter_type
 
    end function new_MockItemSpec
 
@@ -301,52 +301,52 @@ contains
       _FAIL('This procedure should not be called.')
    end subroutine run
    
-   function make_filters(this, goal_spec, rc) result(filters)
-      type(StateItemFilterWrapper), allocatable :: filters(:)
+   function make_adapters(this, goal_spec, rc) result(adapters)
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
       class(MockItemSpec), intent(in) :: this
       class(StateItemSpec), intent(in) :: goal_spec
       integer, optional, intent(out) :: rc
 
-      type(SubtypeFilter) :: subtype_filter
-      type(NameFilter) :: name_filter
-      allocate(filters(0)) ! just in case
+      type(SubtypeAdapter) :: subtype_adapter
+      type(NameAdapter) :: name_adapter
+      allocate(adapters(0)) ! just in case
 
       select type (goal_spec)
       type is (MockItemSpec)
 
          
-         if (allocated(this%filter_type)) then
-            select case (this%filter_type)
+         if (allocated(this%adapter_type)) then
+            select case (this%adapter_type)
             case ('subtype')
-               deallocate(filters)
-               allocate(filters(1))
-               subtype_filter = SubtypeFilter(goal_spec%subtype)
-               allocate(filters(1)%filter, source=subtype_filter)
+               deallocate(adapters)
+               allocate(adapters(1))
+               subtype_adapter = SubtypeAdapter(goal_spec%subtype)
+               allocate(adapters(1)%adapter, source=subtype_adapter)
             case ('name')
-               deallocate(filters)
-               allocate(filters(1))
-               name_filter = NameFilter(goal_spec%name)
-               allocate(filters(1)%filter, source=name_filter)
+               deallocate(adapters)
+               allocate(adapters(1))
+               name_adapter = NameAdapter(goal_spec%name)
+               allocate(adapters(1)%adapter, source=name_adapter)
             case default
-               _FAIL('unsupported filter type')
+               _FAIL('unsupported adapter type')
             end select
          else
-            deallocate(filters)
-            allocate(filters(2))
-            subtype_filter = SubtypeFilter(goal_spec%subtype)
-            name_filter = NameFilter(goal_spec%name)
-            allocate(filters(1)%filter, source=name_filter)
-            allocate(filters(2)%filter, source=subtype_filter)
+            deallocate(adapters)
+            allocate(adapters(2))
+            subtype_adapter = SubtypeAdapter(goal_spec%subtype)
+            name_adapter = NameAdapter(goal_spec%name)
+            allocate(adapters(1)%adapter, source=name_adapter)
+            allocate(adapters(2)%adapter, source=subtype_adapter)
          end if
       end select
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(goal_spec)
-   end function make_filters
+   end function make_adapters
 
    logical function match_subtype(this, spec) result(match)
-      class(SubtypeFilter), intent(in) :: this
+      class(SubtypeAdapter), intent(in) :: this
       class(StateItemSpec), intent(in) :: spec
 
       match = .false.
@@ -366,7 +366,7 @@ contains
    end function match_subtype
 
    logical function match_name(this, spec) result(match)
-      class(NameFilter), intent(in) :: this
+      class(NameAdapter), intent(in) :: this
       class(StateItemSpec), intent(in) :: spec
 
 
@@ -386,20 +386,20 @@ contains
       
    end function match_name
 
-   function new_SubtypeFilter(subtype) result(filter)
-     type(SubtypeFilter) :: filter
+   function new_SubtypeAdapter(subtype) result(adapter)
+     type(SubtypeAdapter) :: adapter
      character(*), optional, intent(in) :: subtype
      if (present(subtype)) then
-        filter%subtype=subtype
+        adapter%subtype=subtype
      end if
-   end function new_SubtypeFilter
+   end function new_SubtypeAdapter
      
-   function new_NameFilter(name) result(filter)
-     type(NameFilter) :: filter
+   function new_NameAdapter(name) result(adapter)
+     type(NameAdapter) :: adapter
      character(*), optional, intent(in) :: name
      if (present(name)) then
-        filter%name=name
+        adapter%name=name
      end if
-   end function new_NameFilter
+   end function new_NameAdapter
      
 end module MockItemSpecMod

--- a/generic3g/tests/Test_ExtensionFamily.pf
+++ b/generic3g/tests/Test_ExtensionFamily.pf
@@ -53,7 +53,7 @@ contains
       r = StateRegistry('A')
       v_pt = VirtualConnectionPt(state_intent='export', short_name='E1')
 
-      call r%add_primary_spec(v_pt, MockItemSpec('E', subtype='A', filter_type='subtype'))
+      call r%add_primary_spec(v_pt, MockItemSpec('E', subtype='A', adapter_type='subtype'))
 
       extension = StateItemExtension(MockItemSpec('E',subtype='B'))
       ext_1 => r%add_extension(v_pt, extension, _RC)
@@ -86,7 +86,7 @@ contains
       r = StateRegistry('A')
       v_pt = VirtualConnectionPt(state_intent='export', short_name='E1')
 
-      call r%add_primary_spec(v_pt, MockItemSpec('E', subtype='A', filter_type='name'))
+      call r%add_primary_spec(v_pt, MockItemSpec('E', subtype='A', adapter_type='name'))
 
       extension = StateItemExtension(MockItemSpec('E',subtype='B'))
       ext_1 => r%add_extension(v_pt, extension, _RC)

--- a/generic3g/vertical/BasicVerticalGrid.F90
+++ b/generic3g/vertical/BasicVerticalGrid.F90
@@ -18,7 +18,6 @@ module mapl3g_BasicVerticalGrid
       procedure :: get_num_levels
       procedure :: get_coordinate_field
       procedure :: can_connect_to
-!#      procedure :: make_filters
    end type BasicVerticalGrid
 
    interface operator(==)
@@ -86,15 +85,5 @@ contains
       not_equal_to = .not. (a == b)
    end function not_equal_to
 
-
-!#   function make_filters(this, goal_grid, rc) result(filters)
-!#      type(StateItemFilterWrapper), allocatable :: filters(:)
-!#      class(BasicVerticalGrid), intent(in) :: this
-!#      class(VerticalGrid), intent(in) :: goal_grid
-!#      integer, optional, intent(out) :: rc
-!#
-!#      filters = 
-!#      select
-!#   end function make_filters
 
 end module mapl3g_BasicVerticalGrid

--- a/generic3g/vertical/VerticalGrid.F90
+++ b/generic3g/vertical/VerticalGrid.F90
@@ -15,8 +15,6 @@ module mapl3g_VerticalGrid
       procedure(I_get_coordinate_field), deferred :: get_coordinate_field
       procedure(I_can_connect_to), deferred :: can_connect_to
 
-!#      procedure(I_make_filters), deferred :: make_filters
-
       procedure :: set_id
       procedure :: get_id
       procedure :: same_id
@@ -53,14 +51,6 @@ module mapl3g_VerticalGrid
          integer, optional, intent(out) :: rc
       end function I_can_connect_to
 
-!#      function I_make_filters(this, goal_spec, rc) result(filters)
-!#         import StateItemSpec
-!#         import StateItemFilterWrapper
-!#         type(StateItemFilterWrapper), allocatable :: filters(:)
-!#         class(StateItemSpec), intent(in) :: this
-!#         class(StateItemSpec), intent(in) :: goal_spec
-!#         integer, optional, intent(out) :: rc
-!#      end function I_make_filters
    end interface
 
 contains


### PR DESCRIPTION
Filter classes are now Adapter classes in anticipation of new responsibilities.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Simple name change  *Filter --> *Adapter

## Related Issue

