### PR TITLE
candidate for a v2.35.2+R21C_v1.3.0

### DIFF
--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -21,6 +21,7 @@ module MAPL_ESMFFieldBundleRead
    use MAPL_SimpleAlarm
    use MAPL_StringTemplate
    use gFTL_StringVector
+   use MAPL_CommsMod
    use, intrinsic :: iso_fortran_env, only: REAL32
    implicit none
    private
@@ -175,6 +176,7 @@ module MAPL_ESMFFieldBundleRead
 
          call fill_grads_template(file_name,file_tmpl,time=time,rc=status)
          _VERIFY(status)
+         if (mapl_am_I_root()) write(*,*)"MAPL_read_bundle reading: ",trim(file_name)
 
          collection_id=i_clients%add_ext_collection(trim(file_tmpl))
 

--- a/griddedio/FieldBundleWrite.F90
+++ b/griddedio/FieldBundleWrite.F90
@@ -9,6 +9,7 @@ module MAPL_ESMFFieldBundleWrite
    use MAPL_VerticalDataMod
    use pFIO_ClientManagerMod, only: o_Clients
    use MAPL_ExceptionHandling
+   use MAPL_CommsMod
    implicit none
    private
 
@@ -120,6 +121,7 @@ module MAPL_ESMFFieldBundleWrite
 
          call this%cfio%bundlepost(this%file_name,oClients=o_clients,rc=status)
          _VERIFY(status)
+         if (mapl_am_I_root()) write(*,*)"MAPL_write_bundle writing: ",trim(this%file_name)
          call o_Clients%done_collective_stage(_RC)
          call o_Clients%wait()
          _RETURN(_SUCCESS)


### PR DESCRIPTION
Requested for R21C so they know when a file is read with this layer used by Surface to read some sort of precipitation correction being done.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

