### PR TITLE
Adapter adapts.

### DIFF
--- a/generic3g/connection/SimpleConnection.F90
+++ b/generic3g/connection/SimpleConnection.F90
@@ -138,23 +138,16 @@ contains
       integer, optional, intent(out) :: rc
 
 
-      type(StateItemExtensionPtr), target, allocatable :: src_extensions(:), dst_extensions(:)
-      type(StateItemExtension), pointer :: src_extension, dst_extension
-      class(StateItemSpec), pointer :: src_spec, dst_spec
+      type(StateItemExtensionPtr), target, allocatable :: dst_extensions(:)
+      type(StateItemExtension), pointer :: dst_extension
+      class(StateItemSpec), pointer :: dst_spec
       integer :: i
       integer :: status
       type(ConnectionPt) :: src_pt, dst_pt
-      integer :: i_extension
-      integer :: lowest_cost
-      type(StateItemExtension), pointer :: best_extension
       type(StateItemExtension), pointer :: last_extension
-      type(StateItemExtension) :: extension
       type(StateItemExtension), pointer :: new_extension
-      class(StateItemSpec), pointer :: last_spec
       class(StateItemSpec), pointer :: new_spec
-      class(StateItemSpec), pointer :: best_spec
       type(ActualConnectionPt) :: effective_pt
-
       type(GriddedComponentDriver), pointer :: coupler
       type(ActualConnectionPt) :: a_pt
       type(MultiState) :: coupler_states
@@ -168,55 +161,14 @@ contains
          dst_extension => dst_extensions(i)%ptr
          dst_spec => dst_extension%get_spec()
 
-         last_extension => src_registry%extend(src_pt%v_pt, dst_spec, _RC)
-
-!#         src_extensions = src_registry%get_extensions(src_pt%v_pt, _RC)
-!#
-!#
-!#         ! Connection is transitive -- if any src_specs can connect, all can connect.
-!#         ! So we can just check this property on the 1st item.
-!#         src_extension => src_extensions(1)%ptr
-!#         src_spec => src_extension%get_spec()
-!#         if (.not. dst_spec%can_connect_to(src_spec)) then
-!#            _HERE, 'cannot connect: ', src_pt%v_pt, ' --> ', dst_pt%v_pt
-!#         end if
-!#
-!#         call find_closest_extension(dst_extension, src_extensions, closest_extension=best_extension, lowest_cost=lowest_cost, _RC)
-!#         best_spec => best_extension%get_spec()
-!#         call best_spec%set_active()
-!#
-!#         last_extension => best_extension
-!#
-!#
-!#         do i_extension = 1, lowest_cost
-!#
-!#            extension = last_extension%make_extension(dst_spec, _RC)
-!#                 
-!#            new_extension => src_registry%add_extension(src_pt%v_pt, extension, _RC)
-!#            coupler => new_extension%get_producer()
-!#
-!#            ! WARNING TO FUTURE DEVELOPERS: There may be issues if
-!#            ! some spec needs to be a bit different in import and
-!#            ! export roles.  Here we use "last_extension" as an export
-!#            ! of src and an import of coupler.
-!#            coupler_states = coupler%get_states()
-!#            a_pt = ActualConnectionPt(VirtualConnectionPt(state_intent='import', short_name='import[1]'))
-!#            last_spec => last_extension%get_spec()
-!#            call last_spec%add_to_state(coupler_states, a_pt, _RC)
-!#            a_pt = ActualConnectionPt(VirtualConnectionPt(state_intent='export', short_name='export[1]'))
-!#            new_spec => new_extension%get_spec()
-!#            call new_spec%add_to_state(coupler_states, a_pt, _RC)
-!#            
-!#            call last_extension%add_consumer(coupler)
-!#            last_extension => new_extension
-!#         end do
+         new_extension => src_registry%extend(src_pt%v_pt, dst_spec, _RC)
 
          ! In the case of wildcard specs, we need to pass an actual_pt to
          ! the dst_spec to support multiple matches.  A bit of a kludge.
          effective_pt = ActualConnectionPt(VirtualConnectionPt(ESMF_STATEINTENT_IMPORT, &
               src_pt%v_pt%get_comp_name()//'/'//src_pt%v_pt%get_esmf_name()))
-         last_spec => last_extension%get_spec()
-         call dst_spec%connect_to(last_spec, effective_pt, _RC)
+         new_spec => new_extension%get_spec()
+         call dst_spec%connect_to(new_spec, effective_pt, _RC)
          call dst_spec%set_active()
             
       end do
@@ -253,40 +205,40 @@ contains
       _RETURN(_SUCCESS)
    end subroutine activate_dependencies
 
-   subroutine find_closest_extension(goal_extension, candidate_extensions, closest_extension, lowest_cost, rc)
-      type(StateItemExtension), intent(in) :: goal_extension
-      type(StateItemExtensionPtr), target, intent(in) :: candidate_extensions(:)
-      type(StateItemExtension), pointer :: closest_extension
-      integer, intent(out) :: lowest_cost
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      type(StateItemExtension), pointer :: extension
-      class(StateItemSpec), pointer :: spec
-      class(StateItemSpec), pointer :: goal_spec
-      integer :: cost
-      integer :: j
-      
-      _ASSERT(size(candidate_extensions) > 0, 'no candidates found')
-
-      goal_spec => goal_extension%get_spec()
-      closest_extension => candidate_extensions(1)%ptr
-      spec => closest_extension%get_spec()
-      lowest_cost = goal_spec%extension_cost(spec, _RC)
-      do j = 2, size(candidate_extensions)
-         if (lowest_cost == 0) exit
-
-         extension => candidate_extensions(j)%ptr
-         spec => extension%get_spec()
-         cost = goal_spec%extension_cost(spec)
-         if (cost < lowest_cost) then
-            lowest_cost = cost
-            closest_extension => extension
-         end if
-
-      end do
-
-   end subroutine find_closest_extension
+!#   subroutine find_closest_extension(goal_extension, candidate_extensions, closest_extension, lowest_cost, rc)
+!#      type(StateItemExtension), intent(in) :: goal_extension
+!#      type(StateItemExtensionPtr), target, intent(in) :: candidate_extensions(:)
+!#      type(StateItemExtension), pointer :: closest_extension
+!#      integer, intent(out) :: lowest_cost
+!#      integer, optional, intent(out) :: rc
+!#
+!#      integer :: status
+!#      type(StateItemExtension), pointer :: extension
+!#      class(StateItemSpec), pointer :: spec
+!#      class(StateItemSpec), pointer :: goal_spec
+!#      integer :: cost
+!#      integer :: j
+!#      
+!#      _ASSERT(size(candidate_extensions) > 0, 'no candidates found')
+!#
+!#      goal_spec => goal_extension%get_spec()
+!#      closest_extension => candidate_extensions(1)%ptr
+!#      spec => closest_extension%get_spec()
+!#      lowest_cost = goal_spec%extension_cost(spec, _RC)
+!#      do j = 2, size(candidate_extensions)
+!#         if (lowest_cost == 0) exit
+!#
+!#         extension => candidate_extensions(j)%ptr
+!#         spec => extension%get_spec()
+!#         cost = goal_spec%extension_cost(spec)
+!#         if (cost < lowest_cost) then
+!#            lowest_cost = cost
+!#            closest_extension => extension
+!#         end if
+!#
+!#      end do
+!#
+!#   end subroutine find_closest_extension
 
 end module mapl3g_SimpleConnection
 

--- a/generic3g/registry/ExtensionFamily.F90
+++ b/generic3g/registry/ExtensionFamily.F90
@@ -135,7 +135,7 @@ contains
             extension_ptr = subgroup%of(j)
             spec => extension_ptr%ptr%get_spec()
             associate (adapter => adapters(i)%adapter)
-              if (adapter%apply(spec)) then
+              if (adapter%match(spec)) then
                  call new_subgroup%push_back(extension_ptr)
               end if
             end associate

--- a/generic3g/specs/BracketSpec.F90
+++ b/generic3g/specs/BracketSpec.F90
@@ -44,7 +44,6 @@ module mapl3g_BracketSpec
       procedure :: add_to_state
       procedure :: add_to_bundle
 
-      procedure :: extension_cost
       procedure :: make_extension
       procedure :: make_adapters
       procedure :: set_geometry
@@ -255,24 +254,6 @@ contains
       _UNUSED_DUMMY(this)
       _UNUSED_DUMMY(bundle)
    end subroutine add_to_bundle
-
-
-   integer function extension_cost(this, src_spec, rc) result(cost)
-      class(BracketSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: src_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      select type (src_spec)
-      type is (BracketSpec)
-         cost = this%reference_spec%extension_cost(src_spec%reference_spec, _RC)
-      class default
-         _FAIL('Cannot extend BracketSpec with non BracketSpec.')
-      end select
-
-      _RETURN(_SUCCESS)
-   end function extension_cost
 
    recursive subroutine make_extension(this, dst_spec, new_spec, action, rc)
       class(BracketSpec), intent(in) :: this

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -69,7 +69,6 @@ module mapl3g_FieldSpec
 
    type, extends(StateItemSpec) :: FieldSpec
 
-!#      private
       type(ESMF_Geom), allocatable :: geom
       class(VerticalGrid), allocatable :: vertical_grid
       type(VerticalDimSpec) :: vertical_dim_spec = VERTICAL_DIM_UNKNOWN
@@ -105,7 +104,6 @@ module mapl3g_FieldSpec
       procedure :: add_to_state
       procedure :: add_to_bundle
 
-      procedure :: extension_cost
       procedure :: make_extension
       procedure :: make_adapters
 
@@ -117,12 +115,10 @@ module mapl3g_FieldSpec
    interface FieldSpec
       module procedure new_FieldSpec_geom
       module procedure new_FieldSpec_varspec
-!#      module procedure new_FieldSpec_defaults
    end interface FieldSpec
 
    interface match
       procedure :: match_geom
-      procedure :: match_typekind
       procedure :: match_string
       procedure :: match_vertical_dim_spec
       procedure :: match_ungridded_dims
@@ -133,23 +129,13 @@ module mapl3g_FieldSpec
       procedure :: can_match_vertical_grid
    end interface can_match
 
-   interface get_cost
-      procedure :: get_cost_geom
-      procedure :: get_cost_typekind
-      procedure :: get_cost_string
-   end interface get_cost
-
-   interface update_item
-      procedure update_item_geom
-      procedure update_item_typekind
-      procedure update_item_string
-   end interface update_item
-
    type, extends(StateItemAdapter) :: GeomAdapter
       private
-      type(ESMF_Geom) :: geom
+      type(ESMF_Geom), allocatable :: geom
+      type(EsmfRegridderParam) :: regrid_param
    contains
-      procedure :: apply_one => adapter_match_geom
+      procedure :: adapt_one => adapt_geom
+      procedure :: match_one => adapter_match_geom
    end type GeomAdapter
 
    interface GeomAdapter
@@ -160,7 +146,8 @@ module mapl3g_FieldSpec
       private
       type(ESMF_Typekind_Flag) :: typekind
    contains
-      procedure :: apply_one => adapter_match_typekind
+      procedure :: adapt_one => adapt_typekind
+      procedure :: match_one => adapter_match_typekind
    end type TypeKindAdapter
 
    interface TypeKindAdapter
@@ -171,7 +158,8 @@ module mapl3g_FieldSpec
       private
       character(:), allocatable :: units
    contains
-      procedure :: apply_one => adapter_match_units
+      procedure :: adapt_one => adapt_units
+      procedure :: match_one => adapter_match_units
    end type UnitsAdapter
 
    interface UnitsAdapter
@@ -283,17 +271,6 @@ contains
       _RETURN(_SUCCESS)
       
    end subroutine set_geometry
-
-!#   function new_FieldSpec_defaults(ungridded_dims, geom, units) result(field_spec)
-!#      type(FieldSpec) :: field_spec
-!#      type(ExtraDimsSpec), intent(in) :: ungridded_dims
-!#      type(ESMF_Geom), intent(in) :: geom
-!#      character(*), intent(in) :: units
-!#
-!#      field_spec = FieldSpec(ungridded_dims, ESMF_TYPEKIND_R4, geom, units)
-!#
-!#   end function new_FieldSpec_defaults
-!#
 
    subroutine create(this, rc)
       class(FieldSpec), intent(inout) :: this
@@ -645,12 +622,6 @@ contains
    end function can_connect_to
 
 
-   logical function same_typekind(a, b)
-      class(FieldSpec), intent(in) :: a
-      class(FieldSpec), intent(in) :: b
-      same_typekind = (a%typekind == b%typekind)
-   end function same_typekind
-
    subroutine add_to_state(this, multi_state, actual_pt, rc)
       class(FieldSpec), intent(in) :: this
       type(MultiState), intent(inout) :: multi_state
@@ -687,27 +658,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine add_to_bundle
-
-   integer function extension_cost(this, src_spec, rc) result(cost)
-      class(FieldSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: src_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      cost = 0
-      select type (src_spec)
-      type is (FieldSpec)
-         cost = cost + get_cost(this%geom, src_spec%geom)
-         cost = cost + get_cost(this%typekind, src_spec%typekind)
-         cost = cost + get_cost(this%units, src_spec%units)
-      class default
-         _FAIL('Cannot extend to this StateItemSpec subclass.')
-      end select
-
-      _RETURN(_SUCCESS)
-   end function extension_cost
-
 
 
 
@@ -832,68 +782,7 @@ contains
       _RETURN(_SUCCESS)
    end function can_connect_units
 
-   integer function get_cost_geom(a, b) result(cost)
-      type(ESMF_GEOM), allocatable, intent(in) :: a, b
-      cost = 0
-      if (.not. match(a,b)) cost = 1
-   end function get_cost_geom
-
-   integer function get_cost_typekind(a, b) result(cost)
-      type(ESMF_TypeKind_Flag), intent(in) :: a, b
-      cost = 0
-      if (.not. match(a,b)) cost = 1
-   end function get_cost_typekind
-
-   integer function get_cost_string(a, b) result(cost)
-      character(:), allocatable, intent(in) :: a, b
-      cost = 0
-      if (.not. match(a,b)) cost = 1
-   end function get_cost_string
-
-   logical function update_item_geom(a, b)
-      type(ESMF_GEOM), allocatable, intent(inout) :: a
-      type(ESMF_GEOM), allocatable, intent(in) :: b
-
-      update_item_geom = .false.
-
-      if (.not. allocated(b)) return ! nothing to do (no coupler)
-
-      if (.not. allocated(a)) then ! Fill-in ExtData (no coupler)
-         a = b
-         return
-      end if
-
-      if (MAPL_SameGeom(a,b)) return
-      update_item_geom = .true.
-      a = b
-
-
-   end function update_item_geom
-
-   logical function update_item_typekind(a, b)
-      type(ESMF_TypeKind_Flag), intent(inout) :: a
-      type(ESMF_TypeKind_Flag), intent(in) :: b
-
-      update_item_typekind = .false.
-      if (.not. match(a, b)) then
-         a = b
-         update_item_typekind = .true.
-      end if
-
-   end function update_item_typekind
-
-   logical function update_item_string(a, b)
-      character(:), allocatable, intent(inout) :: a
-      character(:), allocatable, intent(in) :: b
-
-      update_item_string = .false.
-      if (.not. match(a, b)) then
-         a = b
-         update_item_string = .true.
-      end if
-   end function update_item_string
-
-   function get_payload(this) result(payload)
+  function get_payload(this) result(payload)
       type(ESMF_Field) :: payload
       class(FieldSpec), intent(in) :: this
       payload = this%payload
@@ -938,12 +827,30 @@ contains
       _RETURN(_SUCCESS)
    end subroutine set_info
 
-   function new_GeomAdapter(geom) result(geom_adapter)
+   function new_GeomAdapter(geom, regrid_param) result(geom_adapter)
       type(GeomAdapter) :: geom_adapter
       type(ESMF_Geom), optional, intent(in) :: geom
+      type(EsmfRegridderParam), optional, intent(in) :: regrid_param
 
       if (present(geom)) geom_adapter%geom = geom
+
+      geom_adapter%regrid_param = EsmfRegridderParam()
+      if (present(regrid_param)) geom_adapter%regrid_param = regrid_param
+
    end function new_GeomAdapter
+
+   subroutine adapt_geom(this, spec, action)
+      class(GeomAdapter), intent(in) :: this
+      class(StateItemSpec), intent(inout) :: spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+
+      select type (spec)
+      type is (FieldSpec)
+         action = RegridAction(spec%geom, this%geom, this%regrid_param)
+         spec%geom = this%geom
+      end select
+
+   end subroutine adapt_geom
 
    logical function adapter_match_geom(this, spec) result(match)
       class(GeomAdapter), intent(in) :: this
@@ -952,8 +859,9 @@ contains
       match = .false.
       select type (spec)
       type is (FieldSpec)
-         match = match_geom(spec%geom, spec%geom)
+         match = match_geom(spec%geom, this%geom)
       end select
+
    end function adapter_match_geom
 
 
@@ -964,6 +872,18 @@ contains
       typekind_adapter%typekind = typekind
    end function new_TypekindAdapter
 
+   subroutine adapt_typekind(this, spec, action)
+      class(TypekindAdapter), intent(in) :: this
+      class(StateItemSpec), intent(inout) :: spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+
+      select type (spec)
+      type is (FieldSpec)
+         spec%typekind = this%typekind
+         action = CopyAction(spec%typekind, this%typekind)
+      end select
+   end subroutine adapt_typekind
+
    logical function adapter_match_typekind(this, spec) result(match)
       class(TypekindAdapter), intent(in) :: this
       class(StateItemSpec), intent(in) :: spec
@@ -971,7 +891,7 @@ contains
       match = .false.
       select type (spec)
       type is (FieldSpec)
-         match = match_typekind(this%typekind, spec%typekind)
+         match = any(this%typekind == [spec%typekind,MAPL_TYPEKIND_MIRROR])
       end select
    end function adapter_match_typekind
 
@@ -982,14 +902,28 @@ contains
       if (present(units)) units_adapter%units = units
    end function new_UnitsAdapter
 
-   logical function adapter_match_units(this, spec) result(match)
+   subroutine adapt_units(this, spec, action)
+      class(UnitsAdapter), intent(in) :: this
+      class(StateItemSpec), intent(inout) :: spec
+      class(ExtensionAction), allocatable, intent(out) :: action
+
+      select type (spec)
+      type is (FieldSpec)
+         action = ConvertUnitsAction(spec%units, this%units)
+         spec%units = this%units
+      end select
+   end subroutine adapt_units
+
+  logical function adapter_match_units(this, spec) result(match)
       class(UnitsAdapter), intent(in) :: this
       class(StateItemSpec), intent(in) :: spec
 
       match = .false.
       select type (spec)
       type is (FieldSpec)
-         match = match_string(spec%units, spec%units)
+         match = .true.
+         if (.not. allocated(this%units)) return
+         match = (this%units == spec%units)
       end select
    end function adapter_match_units
 
@@ -1004,18 +938,9 @@ contains
       select type (goal_spec)
       type is (FieldSpec)
          allocate(adapters(3))
-!#         adapters(1)%adapter = GeomAdapter(goal_spec%geom)
-         allocate(adapters(1)%adapter, source=GeomAdapter(goal_spec%geom))
-!#         adapters(2)%adapter = TypeKindAdapter(goal_spec%typekind)
+         allocate(adapters(1)%adapter, source=GeomAdapter(goal_spec%geom, goal_spec%regrid_param))
          allocate(adapters(2)%adapter, source=TypeKindAdapter(goal_spec%typekind))
-!#         adapters(3)%adapter = UnitsAdapter(goal_spec%units)
          allocate(adapters(3)%adapter, source=UnitsAdapter(goal_spec%units))
-         ! GFortran 13.3 chokes on thecode below
-!#         adapters = [ &
-!#              StateItemAdapterWrapper(GeomAdapter(goal_spec%geom)), &
-!#   !#              this%vertical_grid%make_adapters(goal_spec%vertical_grid), &
-!#              StateItemAdapterWrapper(TypeKindAdapter(goal_spec%typekind)), &
-!#              StateItemAdapterWrapper(UnitsAdapter(goal_spec%units))]
       type is (WildCardSpec)
          adapters = goal_spec%make_adapters(goal_spec, _RC)
       class default
@@ -1039,7 +964,7 @@ contains
 
       select type(dst_spec)
       type is (FieldSpec)
-         call make_extension_safely(this, dst_spec, tmp_spec, action, _RC)
+      call make_extension_safely(this, dst_spec, tmp_spec, action, _RC)
          allocate(new_spec, source=tmp_spec)
       type is (WildCardSpec)
          call this%make_extension(dst_spec%get_reference_spec(), new_spec, action, _RC)
@@ -1061,16 +986,19 @@ contains
       type(GriddedComponentDriver), pointer :: v_in_coupler
       type(GriddedComponentDriver), pointer :: v_out_coupler
       type(ESMF_Field) :: v_in_coord, v_out_coord
+      type(StateItemAdapterWrapper), allocatable :: adapters(:)
+      integer :: i
 
       new_spec = this ! plus one modification from below
+      adapters = this%make_adapters(dst_spec, _RC)
 
-      _ASSERT(allocated(this%geom), 'Source spec must specify a valid geom.')
-      if (.not. same_geom(this%geom, dst_spec%geom)) then
-         action = RegridAction(this%geom, dst_spec%geom, dst_spec%regrid_param)
-         new_spec%geom = dst_spec%geom
-         _RETURN(_SUCCESS)
-      end if
-
+      do i = 1, size(adapters)
+         if (adapters(i)%adapter%match(new_spec)) cycle
+         call adapters(i)%adapter%adapt(new_spec, action)
+         exit
+      end do
+      _RETURN_IF(allocated(action))
+      
       _ASSERT(allocated(this%vertical_grid), 'Source spec must specify a valid vertical grid.')
       if (.not. same_vertical_grid(this%vertical_grid, dst_spec%vertical_grid)) then
          call this%vertical_grid%get_coordinate_field(v_in_coord, v_in_coupler, &
@@ -1078,24 +1006,6 @@ contains
          call this%vertical_grid%get_coordinate_field(v_out_coord, v_out_coupler, &
               'ignore', dst_spec%geom, dst_spec%typekind, dst_spec%units, _RC)
          action = VerticalRegridAction(v_in_coord, v_out_coupler, v_out_coord, v_out_coupler, VERTICAL_REGRID_LINEAR)
-         _RETURN(_SUCCESS)
-      end if
-      
-!#   if (.not. same_freq_spec(this%freq_spec, dst_spec%freq_spec)) then
-!#      action = VerticalRegridAction(this%freq_spec, dst_spec%freq_spec
-!#      new_spec%freq_spec = dst_spec%freq_spec
-!!$         _RETURN(_SUCCESS)
-!#   end if
-      
-      if (.not. match(this%typekind, dst_spec%typekind)) then
-         action = CopyAction(this%typekind, dst_spec%typekind)
-         new_spec%typekind = dst_spec%typekind
-         _RETURN(_SUCCESS)
-      end if
-      
-      if (.not. same_units(this%units, dst_spec%units)) then
-         action = ConvertUnitsAction(this%units, dst_spec%units)
-         new_spec%units = dst_spec%units
          _RETURN(_SUCCESS)
       end if
 
@@ -1106,18 +1016,6 @@ contains
 
    contains
 
-      
-      logical function same_geom(src_geom, dst_geom)
-         type(ESMF_Geom), intent(in) :: src_geom
-         type(ESMF_Geom), allocatable, intent(in) :: dst_geom
-         
-         same_geom = .true.
-         if (.not. allocated(dst_geom)) return ! mirror geom
-         
-         same_geom = MAPL_SameGeom(src_geom, dst_geom)
-         
-      end function same_geom
- 
      logical function same_vertical_grid(src_grid, dst_grid)
         class(VerticalGrid), intent(in) :: src_grid
         class(VerticalGrid), allocatable, intent(in) :: dst_grid
@@ -1143,17 +1041,6 @@ contains
 
       end function same_vertical_grid
       
-      logical function same_units(src_units, dst_units)
-         character(*), intent(in) :: src_units
-         character(:), allocatable, intent(in) :: dst_units
-         
-         same_units = .true.
-         if (.not. allocated(dst_units)) return ! mirror units
-      
-         same_units = (src_units == dst_units)
-         
-      end function same_units
-      
    end subroutine make_extension_safely
 
 
@@ -1162,3 +1049,4 @@ end module mapl3g_FieldSpec
 
 #undef _SET_FIELD
 #undef _SET_ALLOCATED_FIELD
+

--- a/generic3g/specs/ServiceSpec.F90
+++ b/generic3g/specs/ServiceSpec.F90
@@ -41,7 +41,6 @@ module mapl3g_ServiceSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
-      procedure :: extension_cost
       procedure :: make_adapters
 
       procedure :: add_to_state
@@ -200,14 +199,6 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine make_extension
-
-   integer function extension_cost(this, src_spec, rc) result(cost)
-      class(ServiceSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: src_spec
-      integer, optional, intent(out) :: rc
-      cost = 0
-      _RETURN(_SUCCESS)
-   end function extension_cost
 
    subroutine set_geometry(this, geom, vertical_grid, rc)
       class(ServiceSpec), intent(inout) :: this

--- a/generic3g/specs/WildcardSpec.F90
+++ b/generic3g/specs/WildcardSpec.F90
@@ -32,7 +32,6 @@ module mapl3g_WildcardSpec
       procedure :: connect_to
       procedure :: can_connect_to
       procedure :: make_extension
-      procedure :: extension_cost
       procedure :: make_adapters
       procedure :: add_to_state
       procedure :: add_to_bundle
@@ -213,18 +212,6 @@ contains
 
       _FAIL('not implemented')
    end subroutine make_extension
-
-   integer function extension_cost(this, src_spec, rc) result(cost)
-      class(WildcardSpec), intent(in) :: this
-      class(StateItemSpec), intent(in) :: src_spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      cost = this%reference_spec%extension_cost(src_spec, _RC)
-
-      _RETURN(_SUCCESS)
-   end function extension_cost
 
    subroutine set_geometry(this, geom, vertical_grid, rc)
       class(WildcardSpec), intent(inout) :: this

--- a/generic3g/tests/Test_FieldSpec.pf
+++ b/generic3g/tests/Test_FieldSpec.pf
@@ -268,29 +268,6 @@ contains
 
    end subroutine test_mirror_geom
 
-   @test
-   subroutine test_mirror_geom_cost()
-      type(FieldSpec) :: import_spec
-      type(FieldSpec) :: export_spec
-
-      
-      import_spec = FieldSpec( &
-           vertical_grid=BasicVerticalGrid(1), vertical_dim_spec=VerticalDimSpec(), &
-           typekind=ESMF_TYPEKIND_R4, &
-           ungridded_dims = UngriddedDims(), &
-           standard_name='A', long_name='AA', attributes=StringVector())
-
-      export_spec = FieldSpec( &
-           geom=geom, vertical_grid=BasicVerticalGrid(1), vertical_dim_spec=VerticalDimSpec(), &
-           typekind=ESMF_TYPEKIND_R4, &
-           ungridded_dims = UngriddedDims(), &
-           standard_name='A', long_name='AA', attributes=StringVector(), &
-           units='m')
-
-      @assert_that(export_spec%extension_cost(import_spec), is(0))
-
-   end subroutine test_mirror_geom_cost
-
    subroutine test_mirror_ungridded_dims()
       type(FieldSpec) :: import_spec
       type(FieldSpec) :: export_spec

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -53,12 +53,12 @@ contains
       vgrid = ModelVerticalGrid(num_levels=LM)
       call vgrid%add_variant(short_name='PLE')
 
-      ! inside OuterMeta
+     ! inside OuterMeta
       r = StateRegistry('dyn')
       call vgrid%set_registry(r) ! MAPL_SetVerticalGrid(...)
 
       ple_pt = VirtualConnectionPt(state_intent='export', short_name='PLE')
-     var_spec = VariableSpec(&
+      var_spec = VariableSpec(&
            short_name='PLE', &
            state_intent=ESMF_STATEINTENT_EXPORT, &
            standard_name='air_pressure', &

--- a/generic3g/tests/scenarios/extdata_1/expectations.yaml
+++ b/generic3g/tests/scenarios/extdata_1/expectations.yaml
@@ -17,15 +17,15 @@
 - component: extdata/collection_1
   export:
     E1: {status: complete, typekind: R8, value: 7.}
-    E1(1): {status: complete, typekind: R4}
+#    E1(1): {status: complete, typekind: R4}
     E2: {status: complete, typekind: R4}
 
 - component: extdata/<user>
   export:
-    E1: {status: complete, typekind: R4}
+    E1: {status: complete, typekind: R8}
     E2: {status: complete, typekind: R4}
   import:
-    E1: {status: complete, typekind: R4}
+    E1: {status: complete, typekind: R8}
     E2: {status: complete, typekind: R4}
 
 # Because collection_1 is added _after_ the usual advertise phase some

--- a/generic3g/tests/scenarios/extdata_1/extdata.yaml
+++ b/generic3g/tests/scenarios/extdata_1/extdata.yaml
@@ -17,12 +17,13 @@ mapl:
       E1:
         standard_name: 'T1'
         units: none
-        typekind: mirror
+        typekind: R8 # must match collection for now
         vertical_dim_spec: NONE
+        default_value: 7
       E2:
         standard_name: 'T1'
         units: none
-        typekind: mirror
+        typekind: R4 # must match collection for now
         vertical_dim_spec: NONE
 
   children:


### PR DESCRIPTION
 - introduced adapt() method on Adapters that modifes a targeted attribute of a StateItemSpec.
 - modified FieldSpec to use adapter loop in make_extension()
   - soon this can be moved into StateItemExtension I think.
 - eliminated vestiges of the "cost" mechanism in the previous extension mechanism.
 - eliminated lots of procedures that are no longer used due to these changes
 - eliminated commented out code from previous refactoring.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Introduced adapt() method on the new StateItemAdapter family of classes.   This make it possible to write a generic algorithm to iteratively extend a src spec to a dst spec.    VerticalGrid still not handled the new way.


## Related Issue

