### PR TITLE
Fixes #3062 - mapl accessors for ESMF info object

### DIFF
--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -35,6 +35,7 @@ set(srcs
   # ComponentSpecBuilder.F90
 
   ESMF_Utilities.F90
+  InfoUtilities.F90
   ESMF_HConfigUtilities.F90
   RestartHandler.F90
   )

--- a/generic3g/InfoUtilities.F90
+++ b/generic3g/InfoUtilities.F90
@@ -1,0 +1,275 @@
+#include "MAPL_Generic.h"
+
+! This module is intended to manage user-level access to ESMF info
+! objects and thereby ensure consistent support for namespace
+! management and such.
+
+module mapl3g_InfoUtilities
+   use mapl_ErrorHandling
+   use mapl_KeywordEnforcer
+
+   use mapl3g_esmf_info_keys
+   use esmf, only: ESMF_StateItem_Flag
+   use esmf, only: ESMF_STATEITEM_FIELD
+   use esmf, only: operator(==), operator(/=)
+   use esmf, only: ESMF_Info
+   use esmf, only: ESMF_InfoGetFromHost
+   use esmf, only: ESMF_InfoGet
+   use esmf, only: ESMF_InfoGetCharAlloc
+   use esmf, only: ESMF_InfoSet
+   use esmf, only: ESMF_State
+   use esmf, only: ESMF_StateGet
+   use esmf, only: ESMF_Field
+   use esmf, only: ESMF_KIND_I4
+
+   implicit none
+   private
+
+   public :: MAPL_InfoGetShared
+   public :: MAPL_InfoSetShared
+   public :: MAPL_InfoGetPrivate
+   public :: MAPL_InfoSetPrivate
+
+   interface MAPL_InfoGetShared
+      procedure :: info_get_shared_string
+      procedure :: info_get_shared_i4
+      procedure :: info_get_state_shared_string
+      procedure :: info_get_stateitem_shared_i4
+   end interface MAPL_InfoGetShared
+
+   interface MAPL_InfoSetShared
+      procedure :: info_set_shared_string
+      procedure :: info_set_shared_i4
+      procedure :: info_set_state_shared_string
+      procedure :: info_set_stateitem_shared_i4
+   end interface MAPL_InfoSetShared
+   
+   interface MAPL_InfoGetPrivate
+      procedure :: info_get_private_i4
+      procedure :: info_get_stateitem_private_i4
+   end interface MAPL_InfoGetPrivate
+   
+   interface MAPL_InfoSetPrivate
+      procedure :: info_set_private_i4
+       procedure :: info_set_stateitem_private_i4
+   end interface MAPL_InfoSetPrivate
+
+
+contains
+
+   subroutine info_get_shared_string(info, key, value, unusable, rc)
+      type(ESMF_Info), intent(in) :: info
+      character(*), intent(in) :: key
+      character(:), allocatable :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoGetCharAlloc(info, key=KEY_SHARED//key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_get_shared_string
+
+   subroutine info_get_shared_i4(info, key, value, rc)
+      type(ESMF_Info), intent(in) :: info
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine info_get_shared_i4
+
+   subroutine info_get_state_shared_string(state, key, value, unusable, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: key
+      character(:), allocatable :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: state_info
+
+      call ESMF_InfoGetFromHost(state, state_info, _RC)
+      call MAPL_InfoGetShared(state_info, key=key, value=value, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine info_get_state_shared_string
+
+
+   subroutine info_get_stateitem_shared_i4(state, short_name, key, value, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: short_name
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: info
+
+      call info_get_stateitem_info(state, short_name, info, _RC)
+      call MAPL_InfoGetShared(info, key=key, value=value, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine info_get_stateitem_shared_i4
+
+   subroutine info_set_shared_string(info, key, value, unusable, rc)
+      type(ESMF_Info), intent(inout) :: info
+      character(*), intent(in) :: key
+      character(*), intent(in) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoSet(info, key=KEY_SHARED // key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_shared_string
+
+   subroutine info_set_shared_i4(info, key, value, unusable, rc)
+      type(ESMF_Info), intent(inout) :: info
+      character(*), intent(in) :: key
+      integer(ESMF_KIND_I4), intent(in) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoSet(info, key=KEY_SHARED // key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_shared_i4
+
+   subroutine info_set_state_shared_string(state, key, value, unusable, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: key
+      character(*), intent(in) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: state_info
+
+      call ESMF_InfoGetFromHost(state, state_info, _RC)
+      call MAPL_InfoSetShared(state_info, key=key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_state_shared_string
+
+   subroutine info_set_stateitem_shared_i4(state, short_name, key, value, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: short_name
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(in) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: info
+
+      call info_get_stateitem_info(state, short_name, info, _RC)
+      call MAPL_InfoSetShared(info, key=key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_stateitem_shared_i4
+
+   subroutine info_get_private_i4(info, key, value, unusable, rc)
+      type(ESMF_Info), intent(in) :: info
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoGet(info, key=KEY_PRIVATE//key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_get_private_i4
+
+
+   subroutine info_get_stateitem_private_i4(state, short_name, key, value, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: short_name
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: item_info
+      character(:), allocatable :: namespace
+
+      call MAPL_InfoGetShared(state, key='gridcomp', value=namespace, _RC)
+      
+      call info_get_stateitem_info(state, short_name, item_info, _RC)
+      associate (private_key => namespace // '/' // key )
+        call MAPL_InfoGetPrivate(item_info, key=private_key, value=value, _RC)
+      end associate
+      
+      _RETURN(_SUCCESS)
+   end subroutine info_get_stateitem_private_i4
+
+   subroutine info_set_private_i4(info, key, value, unusable, rc)
+      type(ESMF_Info), intent(inout) :: info
+      character(*), intent(in) :: key
+      integer(ESMF_KIND_I4), intent(in) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      call ESMF_InfoSet(info, key=KEY_PRIVATE//key, value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_private_i4
+
+
+   subroutine info_set_stateitem_private_i4(state, short_name, key, value, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: short_name
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(in) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      type(ESMF_Info) :: item_info
+      character(:), allocatable :: namespace
+
+      call MAPL_InfoGetShared(state, key='gridcomp', value=namespace, _RC)
+      
+      call info_get_stateitem_info(state, short_name, item_info, _RC)
+      associate (private_key => namespace // '/' // key )
+        call MAPL_InfoSetPrivate(item_info, key=private_key, value=value, _RC)
+      end associate
+
+      _RETURN(_SUCCESS)
+   end subroutine info_set_stateitem_private_i4
+
+   ! private helper procedure
+   subroutine info_get_stateitem_info(state, short_name, info, rc)
+      type(ESMF_State), intent(in) :: state
+      character(*), intent(in) :: short_name
+      type(ESMF_Info), intent(out) :: info
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_StateItem_Flag) :: itemType
+      type(ESMF_Field) :: field
+
+      call ESMF_StateGet(state, itemName=short_name, itemType=itemType, _RC)
+      if (itemType == ESMF_STATEITEM_FIELD) then
+         call ESMF_StateGet(state, itemName=short_name, field=field, _RC)
+         call ESMF_InfoGetFromHost(field, info, _RC)
+      else
+         _FAIL('unsupported state item type')
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine info_get_stateitem_info
+
+end module mapl3g_InfoUtilities

--- a/generic3g/actions/NullAction.F90
+++ b/generic3g/actions/NullAction.F90
@@ -1,7 +1,7 @@
 #include "MAPL_Generic.h"
 
 ! A NullAction object is just used so that a function that returns an
-! ExtensionAction can allocate its return value in the presenc of
+! ExtensionAction can allocate its return value in the presence of
 ! error conditions.
 
 module mapl3g_NullAction

--- a/generic3g/registry/StateItemExtension.F90
+++ b/generic3g/registry/StateItemExtension.F90
@@ -104,7 +104,6 @@ contains
    ! gains it as a reference (pointer).
 
    function make_extension(this, goal, rc) result(extension)
-      use mapl3g_NullAction
       type(StateItemExtension), target :: extension
       class(StateItemExtension), target, intent(inout) :: this
       class(StateItemSpec), target, intent(in) :: goal

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(gridcomps)
 
 set (test_srcs
 
+  Test_InfoUtilities.F90
   Test_VirtualConnectionPt.pf
 
   Test_SimpleLeafGridComp.pf

--- a/generic3g/tests/Test_InfoUtilities.F90
+++ b/generic3g/tests/Test_InfoUtilities.F90
@@ -5,7 +5,8 @@ module Test_InfoUtilities
    use mapl3g_InfoUtilities, only: MAPL_InfoGetShared
    use mapl3g_InfoUtilities, only: MAPL_InfosetShared
    use mapl3g_InfoUtilities, only: MAPL_InfoGetPrivate
-   use mapl3g_InfoUtilities, only: MAPL_InfosetPrivate
+   use mapl3g_InfoUtilities, only: MAPL_InfoSetPrivate
+   use mapl3g_InfoUtilities, only: MAPL_InfoSetNamespace
    use esmf
    use funit
 
@@ -58,7 +59,7 @@ contains
       integer :: i
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetShared(state, key='gridcomp', value='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -83,10 +84,10 @@ contains
       integer :: i_a, i_b
 
       state_a = ESMF_StateCreate(name='import', _RC)
-       call MAPL_InfoSetShared(state_a, key='gridcomp', value='compA', _RC)
+      call MAPL_InfoSetNameSpace(state_a, namespace='compA', _RC)
 
       state_b = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetShared(state_b, key='gridcomp', value='compB', _RC)
+      call MAPL_InfoSetNameSpace(state_b, namespace='compB', _RC)
 
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)

--- a/generic3g/tests/Test_InfoUtilities.F90
+++ b/generic3g/tests/Test_InfoUtilities.F90
@@ -1,0 +1,111 @@
+#include "MAPL_TestErr.h"
+
+module Test_InfoUtilities
+   use mapl3g_ESMF_info_keys
+   use mapl3g_InfoUtilities, only: MAPL_InfoGetShared
+   use mapl3g_InfoUtilities, only: MAPL_InfosetShared
+   use mapl3g_InfoUtilities, only: MAPL_InfoGetPrivate
+   use mapl3g_InfoUtilities, only: MAPL_InfosetPrivate
+   use esmf
+   use funit
+
+   implicit none
+
+contains
+
+   @test
+   subroutine test_set_state()
+      type(ESMF_State) :: state
+      integer :: status
+      character(:), allocatable :: name
+
+      state = ESMF_StateCreate(name='export', _RC)
+      call MAPL_InfoSetShared(state, key='component', value='comp_A', _RC)
+      call MAPL_InfoGetShared(state, key='component', value=name, _RC)
+
+      @assertEqual('comp_A', name)
+
+      call ESMF_StateDestroy(state, _RC)
+   end subroutine test_set_state
+
+   @test
+   subroutine test_setShared()
+      type(ESMF_State) :: state
+      type(ESMF_Field) :: field
+      integer :: status
+      integer :: i
+
+      state = ESMF_StateCreate(name='export', _RC)
+
+      field = ESMF_FieldEmptyCreate(name='f', _RC)
+      call ESMF_StateAdd(state, [field], _RC)
+
+      call MAPL_InfoSetShared(state, short_name='f', key='a', value=1, _RC)
+      call MAPL_InfoGetShared(state, short_name='f', key='a', value=i, _RC)
+
+      @assert_that(i, is(1))
+
+      call ESMF_FieldDestroy(field, _RC)
+      call ESMF_StateDestroy(state, _RC)
+
+   end subroutine test_setShared
+
+   @test
+   subroutine test_setPrivate()
+      type(ESMF_State) :: state
+      type(ESMF_Field) :: field
+      integer :: status
+      integer :: i
+
+      state = ESMF_StateCreate(name='import', _RC)
+      call MAPL_InfoSetShared(state, key='gridcomp', value='compA', _RC)
+
+      field = ESMF_FieldEmptyCreate(name='f', _RC)
+      call ESMF_StateAdd(state, [field], _RC)
+
+      call MAPL_InfoSetPrivate(state, short_name='f', key='a', value=1, _RC)
+      call MAPL_InfoGetPrivate(state, short_name='f', key='a', value=i, _RC)
+
+      @assert_that(i, is(1))
+
+      call ESMF_FieldDestroy(field, _RC)
+      call ESMF_StateDestroy(state, _RC)
+
+   end subroutine test_setPrivate
+
+   @test
+   ! Check that field shared in 2 states does not overwrite info between gridcomps.
+   subroutine test_setPrivate_is_private()
+      type(ESMF_State) :: state_a
+      type(ESMF_State) :: state_b
+      type(ESMF_Field) :: field
+      integer :: status
+      integer :: i_a, i_b
+
+      state_a = ESMF_StateCreate(name='import', _RC)
+       call MAPL_InfoSetShared(state_a, key='gridcomp', value='compA', _RC)
+
+      state_b = ESMF_StateCreate(name='import', _RC)
+      call MAPL_InfoSetShared(state_b, key='gridcomp', value='compB', _RC)
+
+
+      field = ESMF_FieldEmptyCreate(name='f', _RC)
+      call ESMF_StateAdd(state_a, [field], _RC)
+      call ESMF_StateAdd(state_b, [field], _RC)
+
+      call MAPL_InfoSetPrivate(state_a, short_name='f', key='a', value=1, _RC)
+      call MAPL_InfoSetPrivate(state_b, short_name='f', key='a', value=2, _RC)
+
+      call MAPL_InfoGetPrivate(state_a, short_name='f', key='a', value=i_a, _RC)
+      call MAPL_InfoGetPrivate(state_b, short_name='f', key='a', value=i_b, _RC)
+
+      @assert_that(i_a, is(1))
+      @assert_that(i_b, is(2))
+
+      call ESMF_FieldDestroy(field, _RC)
+      call ESMF_StateDestroy(state_a, _RC)
+      call ESMF_StateDestroy(state_b, _RC)
+
+   end subroutine test_setPrivate_is_private
+
+end module Test_InfoUtilities

--- a/shared/MAPL_ESMF_InfoKeys.F90
+++ b/shared/MAPL_ESMF_InfoKeys.F90
@@ -5,6 +5,9 @@ module mapl3g_esmf_info_keys
 
    implicit none
 
+   public :: KEY_SHARED
+   public :: KEY_PRIVATE
+   public :: KEY_INTERNAL
    public :: KEY_UNGRIDDED_DIMS
    public :: KEY_VERT_DIM
    public :: KEY_VERT_GEOM
@@ -24,6 +27,10 @@ module mapl3g_esmf_info_keys
 
    ! FieldSpec info keys
    character(len=*), parameter :: PREFIX = 'MAPL/'
+   character(len=*), parameter :: KEY_SHARED = PREFIX // 'shared/'
+   character(len=*), parameter :: KEY_PRIVATE = PREFIX // 'private/'
+   character(len=*), parameter :: KEY_INTERNAL = PREFIX // 'internal/'
+
    character(len=*), parameter :: KEY_UNGRIDDED_DIMS = PREFIX // 'ungridded_dims/'
    character(len=*), parameter :: KEY_VERT_DIM = PREFIX // 'vertical_dim/'
    character(len=*), parameter :: KEY_VERT_GEOM = PREFIX // 'vertical_geom/'


### PR DESCRIPTION
 - eventually needs more overloads for other types

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

