### PR TITLE
Update to ecbuild geos/v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - ExtDataDriver.x now uses ExtData2G by default
+- Update `components.yaml`
+  - ecbuild geos/v1.4.0
+    - Fixes bug between GCC, macOS, and the `-pipe` flag
 
 ### Fixed
 

--- a/components.yaml
+++ b/components.yaml
@@ -17,4 +17,4 @@ ESMA_cmake:
 ecbuild:
   local: ./ESMA_cmake/ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.3.0
+  tag: geos/v1.4.0


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

As found by @tclune and @gmao-ckung, XCode 16 on macOS has caused an issue where the `-pipe` GNU compiler flag causes errors in CMake builds.

It doesn't seem to be crucial and research online says the pipe flag isn't really that crucial for fast builds anymore. 

## Related Issue

