### PR TITLE
GitFlow: Merge 2.46.4 hotfix into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.49.1] - 2024-10-07
+
+### Fixed
+
+- Removed erroneous asserts that blocked some use cases in creating route handles
+
 ## [2.49.0] - 2024-10-04
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.49.0
+  VERSION 2.49.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/base/MAPL_EsmfRegridder.F90
+++ b/base/MAPL_EsmfRegridder.F90
@@ -1530,9 +1530,9 @@ contains
               _VERIFY(status)
            case (REGRID_METHOD_PATCH)
 
-              _ASSERT(.not.has_mask, "destination masking with this regrid type is unsupported")
               call ESMF_FieldRegridStore(src_field, dst_field, &
                    & regridmethod=ESMF_REGRIDMETHOD_PATCH, &
+                   & dstMaskValues = dstMaskValues, &
                    & linetype=ESMF_LINETYPE_GREAT_CIRCLE, & ! closer to SJ Lin interpolation weights?
                    & srcTermProcessing = srcTermProcessing, &
                    & factorList=factorList, factorIndexList=factorIndexList, &
@@ -1540,26 +1540,28 @@ contains
               _VERIFY(status)
            case (REGRID_METHOD_CONSERVE_2ND)
 
-              _ASSERT(.not.has_mask, "destination masking with this regrid type is unsupported")
               call ESMF_FieldRegridStore(src_field, dst_field, &
                    & regridmethod=ESMF_REGRIDMETHOD_CONSERVE_2ND, &
+                   & dstMaskValues = dstMaskValues, &
                    & linetype=ESMF_LINETYPE_GREAT_CIRCLE, & ! closer to SJ Lin interpolation weights?
                    & srcTermProcessing = srcTermProcessing, &
                    & factorList=factorList, factorIndexList=factorIndexList, &
                    & routehandle=route_handle, unmappedaction=unmappedaction, rc=status)
               _VERIFY(status)
            case (REGRID_METHOD_CONSERVE, REGRID_METHOD_CONSERVE_MONOTONIC, REGRID_METHOD_VOTE, REGRID_METHOD_FRACTION)
-              _ASSERT(.not.has_mask, "destination masking with this regrid type is unsupported")
+
               call ESMF_FieldRegridStore(src_field, dst_field, &
                    & regridmethod=ESMF_REGRIDMETHOD_CONSERVE, &
+                   & dstMaskValues = dstMaskValues, &
                    & srcTermProcessing = srcTermProcessing, &
                    & factorList=factorList, factorIndexList=factorIndexList, &
                    & routehandle=route_handle, unmappedaction=unmappedaction, rc=status)
               _VERIFY(status)
            case (REGRID_METHOD_NEAREST_STOD)
-              _ASSERT(.not.has_mask, "destination masking with this regrid type is unsupported")
+
               call ESMF_FieldRegridStore(src_field, dst_field, &
                    & regridmethod=ESMF_REGRIDMETHOD_NEAREST_STOD, &
+                   & dstMaskValues = dstMaskValues, &
                    & factorList=factorList, factorIndexList=factorIndexList, &
                    & routehandle=route_handle, unmappedaction=unmappedaction, rc=status)
               _VERIFY(status)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is a gitflow hotfix onto `main` bringing in the changes from [MAPL 2.46.4](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.46.4) (see https://github.com/ufs-community/ufs-weather-model/pull/2406#issuecomment-2386741453 for more info)

These changes fix erroneous asserts that blocked some use cases when creating route handles.

Testing with GEOS show this as zero-diff.

## Related Issue

