### PR TITLE
Separate out CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
             - build-and-test-MAPL-on-<< matrix.compiler >>-using-Unix Makefiles
           baselibs_version: *baselibs_version
 
-  build-and-run-GEOSgcm:
+  build-GEOSgcm:
     jobs:
       # Build GEOSgcm
       - ci/build:
@@ -99,6 +99,8 @@ workflows:
           checkout_mapl_branch: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra, retained for one day
 
+  run-GEOSgcm:
+    jobs:
       # Run GCM (1 hour, no ExtData)
       - ci/run_gcm:
           name: run-GCM-on-<< matrix.compiler >>
@@ -113,6 +115,8 @@ workflows:
           baselibs_version: *baselibs_version
           bcs_version: *bcs_version
 
+  run-GEOSgcm-coupled:
+    jobs:
       # Run Coupled GCM (1 hour, no ExtData)
       - ci/run_gcm:
           name: run-coupled-GCM-on-<< matrix.compiler >>


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

In talking with @tclune, he mentioned that the runs of GEOSgcm aren't really necessary for MAPL3 work, the nightly tests can handle that. So, this is a first step to see if I can separate out the build from the run. 

## Related Issue

