### PR TITLE
Fixes #3075 - propagate time-varying aspects of fields

### DIFF
--- a/GeomIO/SharedIO.F90
+++ b/GeomIO/SharedIO.F90
@@ -1,7 +1,7 @@
 #include "MAPL_Generic.h"
 module mapl3g_SharedIO
    use mapl_ErrorHandlingMod
-   use esmf
+   use mapl3g_InfoUtilities
    use pfio
    use gFTL2_StringVector
    use mapl3g_geom_mgr
@@ -9,6 +9,7 @@ module mapl3g_SharedIO
    use mapl3g_UngriddedDims
    use mapl3g_UngriddedDim
    use mapl3g_FieldDimensionInfo
+   use esmf
 
    implicit none
 
@@ -89,7 +90,6 @@ contains
       character(len=:), allocatable :: dims
       type(ESMF_TYPEKIND_FLAG) :: typekind
       integer :: pfio_type
-      type(ESMF_Info) :: info
       character(len=:), allocatable :: char
       character(len=ESMF_MAXSTR) :: fname
       type(MAPLGeom), pointer :: mapl_geom
@@ -112,10 +112,9 @@ contains
       dims = dims//",time"
       pfio_type = esmf_to_pfio_type(typekind ,_RC)
       v = Variable(type=pfio_type, dimensions=dims)
-      call ESMF_InfoGetFromHost(field, info, _RC)
-      call ESMF_InfoGetCharAlloc(info, 'MAPL/units', char, _RC)
+      call MAPL_InfoGetInternal(field, 'units', char, _RC)
       call v%add_attribute('units',char)
-      call ESMF_InfoGetCharAlloc(info, 'MAPL/standard_name', char, _RC)
+      call MAPL_InfoGetInternal(field, 'standard_name', char, _RC)
       call v%add_attribute('long_name',char)
       call metadata%add_variable(trim(fname), v, _RC)
       _RETURN(_SUCCESS)

--- a/esmf_utils/CMakeLists.txt
+++ b/esmf_utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 esma_set_this (OVERRIDE MAPL.esmf_utils)
 
 set(srcs
+  InfoUtilities.F90
   FieldDimensionInfo.F90
   UngriddedDim.F90
   UngriddedDims.F90

--- a/esmf_utils/InfoUtilities.F90
+++ b/esmf_utils/InfoUtilities.F90
@@ -14,6 +14,7 @@ module mapl3g_InfoUtilities
    use esmf, only: ESMF_STATEITEM_FIELDBundle
    use esmf, only: operator(==), operator(/=)
    use esmf, only: ESMF_Info
+   use esmf, only: ESMF_InfoCreate
    use esmf, only: ESMF_InfoIsPresent
    use esmf, only: ESMF_InfoGetFromHost
    use esmf, only: ESMF_InfoGet
@@ -34,6 +35,8 @@ module mapl3g_InfoUtilities
    public :: MAPL_InfoGet
    public :: MAPL_InfoSet
 
+   public :: MAPL_InfoCreateFromInternal
+   
    public :: MAPL_InfoGetShared
    public :: MAPL_InfoSetShared
    public :: MAPL_InfoGetPrivate
@@ -41,6 +44,10 @@ module mapl3g_InfoUtilities
    public :: MAPL_InfoGetInternal
    public :: MAPL_InfoSetInternal
    public :: MAPL_InfoSetNamespace
+
+   interface MAPL_InfoCreateFromInternal
+      procedure :: info_field_create_from_internal
+   end interface MAPL_InfoCreateFromInternal
 
    ! Direct access through ESMF_Info object
    interface MAPL_InfoGet
@@ -55,59 +62,63 @@ module mapl3g_InfoUtilities
    ! Access info object from esmf stateitem
    interface MAPL_InfoGetShared
       procedure :: info_get_state_shared_string
-      procedure :: info_get_stateitem_shared_string
-      procedure :: info_get_stateitem_shared_logical
-      procedure :: info_get_stateitem_shared_i4
-      procedure :: info_get_stateitem_shared_r4
-      procedure :: info_get_stateitem_shared_r8
-      procedure :: info_get_stateitem_shared_r4_1d
+      procedure :: info_stateitem_get_shared_string
+      procedure :: info_stateitem_get_shared_logical
+      procedure :: info_stateitem_get_shared_i4
+      procedure :: info_stateitem_get_shared_r4
+      procedure :: info_stateitem_get_shared_r8
+      procedure :: info_stateitem_get_shared_r4_1d
    end interface MAPL_InfoGetShared
 
    interface MAPL_InfoSetShared
       procedure :: info_set_state_shared_string
-      procedure :: info_set_stateitem_shared_string
-      procedure :: info_set_stateitem_shared_logical
-      procedure :: info_set_stateitem_shared_i4
-      procedure :: info_set_stateitem_shared_r4
-      procedure :: info_set_stateitem_shared_r8
-      procedure :: info_set_stateitem_shared_r4_1d
+      procedure :: info_stateitem_set_shared_string
+      procedure :: info_stateitem_set_shared_logical
+      procedure :: info_stateitem_set_shared_i4
+      procedure :: info_stateitem_set_shared_r4
+      procedure :: info_stateitem_set_shared_r8
+      procedure :: info_stateitem_set_shared_r4_1d
    end interface MAPL_InfoSetShared
 
    interface MAPL_InfoGetPrivate
-      procedure :: info_get_stateitem_private_string
-      procedure :: info_get_stateitem_private_logical
-      procedure :: info_get_stateitem_private_i4
-      procedure :: info_get_stateitem_private_r4
-      procedure :: info_get_stateitem_private_r8
-      procedure :: info_get_stateitem_private_r4_1d
+      procedure :: info_stateitem_get_private_string
+      procedure :: info_stateitem_get_private_logical
+      procedure :: info_stateitem_get_private_i4
+      procedure :: info_stateitem_get_private_r4
+      procedure :: info_stateitem_get_private_r8
+      procedure :: info_stateitem_get_private_r4_1d
    end interface MAPL_InfoGetPrivate
 
    interface MAPL_InfoSetPrivate
-      procedure :: info_set_stateitem_private_string
-      procedure :: info_set_stateitem_private_logical
-      procedure :: info_set_stateitem_private_i4
-      procedure :: info_set_stateitem_private_r4
-      procedure :: info_set_stateitem_private_r8
-      procedure :: info_set_stateitem_private_r4_1d
+      procedure :: info_stateitem_set_private_string
+      procedure :: info_stateitem_set_private_logical
+      procedure :: info_stateitem_set_private_i4
+      procedure :: info_stateitem_set_private_r4
+      procedure :: info_stateitem_set_private_r8
+      procedure :: info_stateitem_set_private_r4_1d
    end interface MAPL_InfoSetPrivate
 
    interface MAPL_InfoGetInternal
+      procedure :: info_field_get_internal_string
+      procedure :: info_field_get_internal_i4
       procedure :: info_get_bundle_internal_r4_1d
-      procedure :: info_get_stateitem_internal_string
-      procedure :: info_get_stateitem_internal_logical
-      procedure :: info_get_stateitem_internal_i4
-      procedure :: info_get_stateitem_internal_r4
-      procedure :: info_get_stateitem_internal_r8
-      procedure :: info_get_stateitem_internal_r4_1d
+      procedure :: info_stateitem_get_internal_string
+      procedure :: info_stateitem_get_internal_logical
+      procedure :: info_stateitem_get_internal_i4
+      procedure :: info_stateitem_get_internal_r4
+      procedure :: info_stateitem_get_internal_r8
+      procedure :: info_stateitem_get_internal_r4_1d
    end interface MAPL_InfoGetInternal
 
    interface MAPL_InfoSetInternal
-      procedure :: info_set_stateitem_internal_string
-      procedure :: info_set_stateitem_internal_logical
-      procedure :: info_set_stateitem_internal_i4
-      procedure :: info_set_stateitem_internal_r4
-      procedure :: info_set_stateitem_internal_r8
-      procedure :: info_set_stateitem_internal_r4_1d
+      procedure :: info_field_set_internal_string
+      procedure :: info_field_set_internal_i4
+      procedure :: info_stateitem_set_internal_string
+      procedure :: info_stateitem_set_internal_logical
+      procedure :: info_stateitem_set_internal_i4
+      procedure :: info_stateitem_set_internal_r4
+      procedure :: info_stateitem_set_internal_r8
+      procedure :: info_stateitem_set_internal_r4_1d
    end interface MAPL_InfoSetInternal
 
    ! Control namespace in state
@@ -119,6 +130,7 @@ contains
 
 
    ! MAPL_InfoGet
+
    subroutine info_get_string(info, key, value, unusable, rc)
       type(ESMF_Info), intent(in) :: info
       character(*), intent(in) :: key
@@ -228,6 +240,22 @@ contains
    end subroutine info_get_r4_1d
 
 
+   ! MAPL_InfoCreateFromInternal
+
+   function info_field_create_from_internal(field, rc) result(info)
+      type(ESMF_Info) :: info
+      type(ESMF_Field), intent(in) :: field
+      integer, optional, intent(out) :: rc
+
+      type(ESMF_Info) :: host_info
+      integer :: status
+
+      call ESMF_InfoGetFromHost(field, host_info, _RC)
+      info = ESMF_InfoCreate(host_info, key=INFO_INTERNAL_NAMESPACE, _RC)
+
+      _RETURN(_SUCCESS)
+   end function info_field_create_from_internal
+
    ! MAPL_InfoGetShared
 
    subroutine info_get_state_shared_string(state, key, value, unusable, rc)
@@ -241,12 +269,12 @@ contains
       type(ESMF_Info) :: state_info
 
       call ESMF_InfoGetFromHost(state, state_info, _RC)
-      call MAPL_InfoGet(state_info, key=KEY_SHARED//key, value=value, _RC)
+      call MAPL_InfoGet(state_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine info_get_state_shared_string
 
-   subroutine info_get_stateitem_shared_string(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_shared_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -256,14 +284,14 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_string
+   end subroutine info_stateitem_get_shared_string
 
 
-   subroutine info_get_stateitem_shared_logical(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_shared_logical(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -273,13 +301,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_logical
+   end subroutine info_stateitem_get_shared_logical
 
-   subroutine info_get_stateitem_shared_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_shared_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -289,13 +317,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_i4
+   end subroutine info_stateitem_get_shared_i4
 
-   subroutine info_get_stateitem_shared_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_shared_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -305,13 +333,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_r4
+   end subroutine info_stateitem_get_shared_r4
 
-   subroutine info_get_stateitem_shared_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_shared_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -321,13 +349,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_r8
+   end subroutine info_stateitem_get_shared_r8
 
-   subroutine info_get_stateitem_shared_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_get_shared_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -337,11 +365,11 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_SHARED//key, values=values, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_SHARED_NAMESPACE,key), values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_shared_r4_1d
+   end subroutine info_stateitem_get_shared_r4_1d
 
    ! MAPL_InfoSetShared
 
@@ -356,12 +384,12 @@ contains
       type(ESMF_Info) :: state_info
 
       call ESMF_InfoGetFromHost(state, state_info, _RC)
-      call MAPL_InfoSet(state_info, key=KEY_SHARED//key, value=value, _RC)
+      call MAPL_InfoSet(state_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine info_set_state_shared_string
 
-   subroutine info_set_stateitem_shared_string(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_shared_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -371,13 +399,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_string
+   end subroutine info_stateitem_set_shared_string
 
-   subroutine info_set_stateitem_shared_logical(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_shared_logical(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -387,13 +415,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_logical
+   end subroutine info_stateitem_set_shared_logical
 
-   subroutine info_set_stateitem_shared_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_shared_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -403,13 +431,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_i4
+   end subroutine info_stateitem_set_shared_i4
 
-   subroutine info_set_stateitem_shared_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_shared_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -419,13 +447,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_r4
+   end subroutine info_stateitem_set_shared_r4
 
-   subroutine info_set_stateitem_shared_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_shared_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -435,13 +463,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_r8
+   end subroutine info_stateitem_set_shared_r8
 
-   subroutine info_set_stateitem_shared_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_set_shared_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -451,15 +479,15 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_SHARED//key, values=values, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_SHARED_NAMESPACE,key), values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_shared_r4_1d
+   end subroutine info_stateitem_set_shared_r4_1d
    
    ! MAPL_InfoGetPrivate
 
-   subroutine info_get_stateitem_private_string(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_private_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -473,14 +501,14 @@ contains
 
       call get_namespace(state, namespace, _RC)
 
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key 
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_string
+   end subroutine info_stateitem_get_private_string
 
-   subroutine info_get_stateitem_private_logical(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_private_logical(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -494,14 +522,14 @@ contains
 
       call get_namespace(state, namespace, _RC)
 
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key 
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_logical
+   end subroutine info_stateitem_get_private_logical
 
-   subroutine info_get_stateitem_private_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_private_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -515,14 +543,14 @@ contains
 
       call get_namespace(state, namespace, _RC)
 
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key 
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_i4
+   end subroutine info_stateitem_get_private_i4
 
-   subroutine info_get_stateitem_private_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_private_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -535,14 +563,14 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_r4
+   end subroutine info_stateitem_get_private_r4
 
-   subroutine info_get_stateitem_private_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_private_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -555,14 +583,14 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_r8
+   end subroutine info_stateitem_get_private_r8
 
-   subroutine info_get_stateitem_private_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_get_private_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -575,16 +603,16 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoGet(item_info, key=private_key, values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_private_r4_1d
+   end subroutine info_stateitem_get_private_r4_1d
 
    ! MAPL_InfoGetPrivate
 
-   subroutine info_set_stateitem_private_string(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_private_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -598,15 +626,15 @@ contains
 
       call get_namespace(state, namespace, _RC)
 
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key 
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_string
+   end subroutine info_stateitem_set_private_string
       
 
-  subroutine info_set_stateitem_private_logical(state, short_name, key, value, rc)
+  subroutine info_stateitem_set_private_logical(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -620,14 +648,14 @@ contains
 
       call get_namespace(state, namespace, _RC)
 
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key 
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_logical
+   end subroutine info_stateitem_set_private_logical
 
-   subroutine info_set_stateitem_private_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_private_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -641,14 +669,14 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_i4
+   end subroutine info_stateitem_set_private_i4
 
-   subroutine info_set_stateitem_private_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_private_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -662,14 +690,14 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_r4
+   end subroutine info_stateitem_set_private_r4
 
-   subroutine info_set_stateitem_private_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_private_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -683,14 +711,14 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_r8
+   end subroutine info_stateitem_set_private_r8
 
-   subroutine info_set_stateitem_private_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_set_private_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -704,14 +732,44 @@ contains
       character(:), allocatable :: private_key
 
       call get_namespace(state, namespace, _RC)
-      call info_get_stateitem_info(state, short_name, item_info, _RC)
-      private_key = KEY_PRIVATE // namespace // '/' // key
+      call info_stateitem_get_info(state, short_name, item_info, _RC)
+      private_key = concat(INFO_PRIVATE_NAMESPACE // namespace, key)
       call MAPL_InfoSet(item_info, key=private_key, values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_private_r4_1d
+   end subroutine info_stateitem_set_private_r4_1d
 
    ! MAPL_InfoGetInternal
+
+   subroutine info_field_get_internal_string(field, key, value, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      character(:), allocatable, intent(out) :: value
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      type(ESMF_Info) :: info
+      
+      call ESMF_InfoGetFromHost(field, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine info_field_get_internal_string
+
+   subroutine info_field_get_internal_i4(field, key, value, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: info
+
+      call ESMF_InfoGetFromHost(field, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_get_internal_i4
 
    subroutine info_get_bundle_internal_r4_1d(bundle, key, values, rc)
       type(ESMF_FieldBundle), intent(in) :: bundle
@@ -722,13 +780,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call ESMF_InfoGetFromHost(bundle,info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, values=values, _RC)
+      call ESMF_InfoGetFromHost(bundle, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), values=values, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine info_get_bundle_internal_r4_1d
 
-   subroutine info_get_stateitem_internal_string(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_internal_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -738,13 +796,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_string
+   end subroutine info_stateitem_get_internal_string
 
-   subroutine info_get_stateitem_internal_logical(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_internal_logical(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -754,13 +812,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_logical
+   end subroutine info_stateitem_get_internal_logical
 
-   subroutine info_get_stateitem_internal_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_internal_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -770,13 +828,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_i4
+   end subroutine info_stateitem_get_internal_i4
 
-   subroutine info_get_stateitem_internal_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_internal_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -786,13 +844,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_r4
+   end subroutine info_stateitem_get_internal_r4
 
-   subroutine info_get_stateitem_internal_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_get_internal_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -802,13 +860,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_r8
+   end subroutine info_stateitem_get_internal_r8
 
-   subroutine info_get_stateitem_internal_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_get_internal_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -818,15 +876,45 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoGet(info, key=KEY_INTERNAL//key, values=values, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoGet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_internal_r4_1d
+   end subroutine info_stateitem_get_internal_r4_1d
 
    ! MAPL_InfoSetInternal
 
-   subroutine info_set_stateitem_internal_string(state, short_name, key, value, rc)
+   subroutine info_field_set_internal_string(field, key, value, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      character(*), intent(in) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: info
+
+      call ESMF_InfoGetFromHost(field, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_set_internal_string
+
+   subroutine info_field_set_internal_i4(field, key, value, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      integer, intent(in) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: info
+
+      call ESMF_InfoGetFromHost(field, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_set_internal_i4
+
+   subroutine info_stateitem_set_internal_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -836,13 +924,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_internal_string
+   end subroutine info_stateitem_set_internal_string
 
-    subroutine info_set_stateitem_internal_logical(state, short_name, key, value, rc)
+    subroutine info_stateitem_set_internal_logical(state, short_name, key, value, rc)
         type(ESMF_State), intent(in) :: state
         character(*), intent(in) :: short_name
         character(*), intent(in) :: key
@@ -852,13 +940,13 @@ contains
         integer :: status
         type(ESMF_Info) :: info
   
-        call info_get_stateitem_info(state, short_name, info, _RC)
-        call MAPL_InfoSet(info, key=KEY_INTERNAL//key, value=value, _RC)
+        call info_stateitem_get_info(state, short_name, info, _RC)
+        call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
   
         _RETURN(_SUCCESS)
-    end subroutine info_set_stateitem_internal_logical
+    end subroutine info_stateitem_set_internal_logical
 
-   subroutine info_set_stateitem_internal_i4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_internal_i4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -868,13 +956,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_internal_i4
+   end subroutine info_stateitem_set_internal_i4
 
-   subroutine info_set_stateitem_internal_r4(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_internal_r4(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -884,13 +972,13 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_internal_r4
+   end subroutine info_stateitem_set_internal_r4
 
-   subroutine info_set_stateitem_internal_r8(state, short_name, key, value, rc)
+   subroutine info_stateitem_set_internal_r8(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -900,14 +988,14 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_INTERNAL//key, value=value, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_internal_r8
+   end subroutine info_stateitem_set_internal_r8
 
 
-   subroutine info_set_stateitem_internal_r4_1d(state, short_name, key, values, rc)
+   subroutine info_stateitem_set_internal_r4_1d(state, short_name, key, values, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       character(*), intent(in) :: key
@@ -917,15 +1005,15 @@ contains
       integer :: status
       type(ESMF_Info) :: info
 
-      call info_get_stateitem_info(state, short_name, info, _RC)
-      call MAPL_InfoSet(info, key=KEY_INTERNAL//key, values=values, _RC)
+      call info_stateitem_get_info(state, short_name, info, _RC)
+      call MAPL_InfoSet(info, key=concat(INFO_INTERNAL_NAMESPACE,key), values=values, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_stateitem_internal_r4_1d
+   end subroutine info_stateitem_set_internal_r4_1d
 
 
    ! private helper procedure
-   subroutine info_get_stateitem_info(state, short_name, info, rc)
+   subroutine info_stateitem_get_info(state, short_name, info, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: short_name
       type(ESMF_Info), intent(out) :: info
@@ -950,7 +1038,7 @@ contains
       _FAIL('Unsupported state item type.')
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_stateitem_info
+   end subroutine info_stateitem_get_info
 
 
    subroutine get_namespace(state, namespace, rc)
@@ -977,6 +1065,20 @@ contains
       _RETURN(_SUCCESS)
    end subroutine set_namespace
 
+
+   function concat(namespace, key) result(full_key)
+      character(*), intent(in) :: namespace
+      character(*), intent(in) :: key
+      character(len(namespace)+len(key)+1) :: full_key
+
+      if (key(1:1) == '/') then
+         full_key = namespace // key
+         return
+      end if
+      full_key = namespace // '/' //key
+
+   end function concat
+   
 end module mapl3g_InfoUtilities
 
 

--- a/esmf_utils/tests/CMakeLists.txt
+++ b/esmf_utils/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_DIRECTORY "${esma_include}/MAPL.esmf_utils.tests")
 
 set (test_srcs
   Test_FieldDimensionInfo.pf
+  Test_InfoUtilities.pf
   )
 
 add_pfunit_ctest(MAPL.esmf_utils.tests

--- a/esmf_utils/tests/Test_FieldDimensionInfo.pf
+++ b/esmf_utils/tests/Test_FieldDimensionInfo.pf
@@ -209,7 +209,7 @@ contains
          coordinates_ = coordinates
       end if
 
-      call ESMF_InfoSet(info, KEY_NUM_UNGRID_DIMS, num_ungridded, _RC)
+      call ESMF_InfoSet(info, KEY_NUM_UNGRIDDED_DIMS, num_ungridded, _RC)
 
       do i=1, num_ungridded
          key = make_dim_key(i, _RC)

--- a/esmf_utils/tests/Test_InfoUtilities.pf
+++ b/esmf_utils/tests/Test_InfoUtilities.pf
@@ -15,7 +15,7 @@ contains
       type(ESMF_State) :: state
       integer :: status
       character(:), allocatable :: name
-      character(*), parameter :: expected = 'comp_A'
+      character(*), parameter :: expected = '/comp_A'
 
       state = ESMF_StateCreate(name='export', _RC)
       call MAPL_InfoSetNamespace(state, namespace=expected, _RC)
@@ -25,6 +25,28 @@ contains
 
       call ESMF_StateDestroy(state, _RC)
    end subroutine test_set_namespace
+
+   @test
+   subroutine test_info_get_internal_info()
+      type(ESMF_Info) :: info
+      type(ESMF_Info) :: subinfo
+      integer :: status
+      type(ESMF_Field) :: field
+      integer, parameter :: expected = 1
+      integer :: found
+
+      field = ESMF_FieldEmptyCreate(name='f', _RC)
+      call MAPL_InfoSetInternal(field, key='d', value=expected, _RC)
+      call MAPL_InfoSetInternal(field, key='a', value=2, _RC)
+
+      subinfo = MAPL_InfoCreateFromInternal(field, _RC)
+      call ESMF_InfoGet(subinfo, key='d', value=found, _RC)
+      @assert_that(found, is(expected))
+
+      call ESMF_InfoDestroy(subinfo)
+      call ESMF_FieldDestroy(field)
+      
+   end subroutine test_info_get_internal_info
 
    @test
    subroutine test_set_stateitem_shared_string()
@@ -175,7 +197,7 @@ contains
       character(*), parameter :: expected = 'hello'
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -199,7 +221,7 @@ contains
       logical, parameter :: expected = .true.
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -224,7 +246,7 @@ contains
       integer(kind=ESMF_KIND_I4), parameter :: expected = 1
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -249,7 +271,7 @@ contains
       real(kind=ESMF_KIND_R4), parameter :: expected = 1.0
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -273,7 +295,7 @@ contains
       real(kind=ESMF_KIND_R8), parameter :: expected = 1.0
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -297,7 +319,7 @@ contains
       real(kind=ESMF_KIND_R4), parameter :: expected(*) = [1.0, 3.0, 7.0]
 
       state = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state, namespace='/compA', _RC)
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state, [field], _RC)
@@ -322,10 +344,10 @@ contains
       integer :: i_a, i_b
 
       state_a = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state_a, namespace='compA', _RC)
+      call MAPL_InfoSetNameSpace(state_a, namespace='/compA', _RC)
 
       state_b = ESMF_StateCreate(name='import', _RC)
-      call MAPL_InfoSetNameSpace(state_b, namespace='compB', _RC)
+      call MAPL_InfoSetNameSpace(state_b, namespace='/compB', _RC)
 
 
       field = ESMF_FieldEmptyCreate(name='f', _RC)
@@ -347,6 +369,24 @@ contains
 
    end subroutine test_setPrivate_is_private
 
+
+   @test
+   subroutine test_field_set_string()
+      type(ESMF_Field) :: field
+      integer :: status
+      character(len=:), allocatable :: s
+      character(len=*), parameter :: expected = 'hello'
+
+      field = ESMF_FieldEmptyCreate(name='f', _RC)
+
+      call MAPL_InfoSetInternal(field, key='a', value=expected, _RC)
+      call MAPL_InfoGetInternal(field, key='a', value=s, _RC)
+
+      @assert_that(s, is(expected))
+
+      call ESMF_FieldDestroy(field, _RC)
+
+   end subroutine test_field_set_string
 
    @test
    subroutine test_set_stateitem_internal_string()

--- a/field_utils/tests/Test_FieldUtilities.pf
+++ b/field_utils/tests/Test_FieldUtilities.pf
@@ -2,11 +2,18 @@
 #include "unused_dummy.H"
 module Test_FieldUtilities
    use mapl_FieldUtilities
+   use mapl3g_ESMF_Info_Keys
+   use mapl3g_InfoUtilities
    use esmf
    use ESMF_TestMethod_mod
    use funit
    implicit none
 
+   integer, parameter :: ORIGINAL_NUM_LEVELS = 5
+   real, parameter :: FILL_VALUE = 99.
+   character(*), parameter :: ORIGINAL_UNITS = 'm'
+   character(*), parameter :: REFERENCE_UNITS = 'km'
+   
 contains
 
    @test(type=ESMF_TestMethod, npes=[1])
@@ -24,6 +31,9 @@ contains
       geom = ESMF_GeomCreate(grid, _RC)
 
       f = ESMF_FieldCreate(geom, typekind=ESMF_TYPEKIND_R4, name='in', _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
       call FieldReallocate(f, typekind=ESMF_TYPEKIND_R8, _RC)
 
       call ESMF_FieldGet(f, status=field_status, typekind=typekind, _RC)
@@ -42,7 +52,7 @@ contains
       class(ESMF_TestMethod), intent(inout) :: this
       type(ESMF_Field) :: f
       type(ESMF_Grid) :: grid
-      type(ESMF_Geom) :: geom
+      type(ESMF_Geom) :: geom, other_geom
 
       integer :: status
       type(ESMF_FieldStatus_Flag) :: field_status
@@ -52,17 +62,21 @@ contains
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom = ESMF_GeomCreate(grid, _RC)
       f = ESMF_FieldCreate(geom, typekind=ESMF_TYPEKIND_R4, name='in', _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      x = 99
+      x = FILL_VALUE
 
       call FieldReallocate(f, typekind=ESMF_TYPEKIND_R4, _RC)
 
-      call ESMF_FieldGet(f, status=field_status, typekind=typekind, _RC)
+      call ESMF_FieldGet(f, status=field_status, typekind=typekind, geom=other_geom, _RC)
       @assert_that(field_status == ESMF_FIELDSTATUS_COMPLETE, is(true()))
       @assert_that(typekind == ESMF_TYPEKIND_R4, is(true()))
+      @assert_that(other_geom == geom, is(true()))
 
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      @assert_that(all(x == 99), is(true()))
+      @assert_that(all(x == FILL_VALUE), is(true()))
 
       call ESMF_FieldDestroy(f, _RC)
       call ESMF_GridDestroy(grid, _RC)
@@ -86,6 +100,8 @@ contains
       grid1 = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom1 = ESMF_GeomCreate(grid1, _RC)
       f = ESMF_FieldCreate(geom1, typekind=ESMF_TYPEKIND_R4, name='in', _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
 
       grid2 = ESMF_GridCreateNoPeriDim(maxIndex=[3,5], name='I_AM_GROOT', _RC)
       geom2 = ESMF_GeomCreate(grid2, _RC)
@@ -122,8 +138,17 @@ contains
       grid1 = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom1 = ESMF_GeomCreate(grid1, _RC)
       f = ESMF_FieldCreate(geom1, typekind=ESMF_TYPEKIND_R4, name='in', _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
+
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      x = 99
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+      x = FILL_VALUE
 
       geom2 = geom1
       call FieldReallocate(f, geom=geom2, _RC) ! same geom
@@ -133,7 +158,7 @@ contains
       @assert_that(typekind == ESMF_TYPEKIND_R4, is(true()))
 
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      @assert_that(all(x == 99), is(true()))
+      @assert_that(all(x == FILL_VALUE), is(true()))
 
       call ESMF_FieldDestroy(f, _RC)
       call ESMF_GridDestroy(grid1, _RC)
@@ -142,10 +167,11 @@ contains
       _UNUSED_DUMMY(this)
    end subroutine test_same_geom_do_not_reallocate
 
+
     @test(type=ESMF_TestMethod, npes=[1])
    ! Probably exceedingly rare, but MAPL3 allows the vertical grid to change with time
    ! which could change the number of levels ...
-   subroutine test_change_ungridded_bounds(this)
+   subroutine test_change_n_levels(this)
       class(ESMF_TestMethod), intent(inout) :: this
       type(ESMF_Field) :: f
       type(ESMF_Grid) :: grid
@@ -153,15 +179,19 @@ contains
 
       integer :: status
       type(ESMF_FieldStatus_Flag) :: field_status
-      real(ESMF_KIND_R4), pointer :: x(:,:,:,:)
       type(ESMF_TypeKind_Flag) :: typekind
+      real(ESMF_KIND_R4), pointer :: x(:,:,:,:)
 
       grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
       geom = ESMF_GeomCreate(grid, _RC)
 
       f = ESMF_FieldCreate(geom, typekind=ESMF_TYPEKIND_R4, name='in', &
-           ungriddedLbound=[1,1], ungriddedUbound=[5,3], _RC)
-      call FieldReallocate(f, ungriddedUbound=[4,3], _RC)
+           ungriddedLbound=[1,1], ungriddedUbound=[ORIGINAL_NUM_LEVELS,3], _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
+
+      call FieldReallocate(f, num_levels=4, _RC)
 
       call ESMF_FieldGet(f, status=field_status, typekind=typekind, _RC)
       @assert_that(field_status == ESMF_FIELDSTATUS_COMPLETE, is(true()))
@@ -175,16 +205,15 @@ contains
       call ESMF_GeomDestroy(geom, _RC)
 
       _UNUSED_DUMMY(this)
-   end subroutine test_change_ungridded_bounds
+   end subroutine test_change_n_levels
+
 
     @test(type=ESMF_TestMethod, npes=[1])
-   ! Probably exceedingly rare, but MAPL3 allows the vertical grid to change with time
-   ! which could change the number of levels ...
-   subroutine test_same_ungridded_bounds_do_not_allocate(this)
+   subroutine test_same_n_levels_do_not_reallocate(this)
       class(ESMF_TestMethod), intent(inout) :: this
       type(ESMF_Field) :: f
       type(ESMF_Grid) :: grid
-      type(ESMF_Geom) :: geom
+      type(ESMF_Geom) :: geom, other_geom
 
       integer :: status
       type(ESMF_FieldStatus_Flag) :: field_status
@@ -195,25 +224,85 @@ contains
       geom = ESMF_GeomCreate(grid, _RC)
 
       f = ESMF_FieldCreate(geom, typekind=ESMF_TYPEKIND_R4, name='in', &
-           ungriddedLbound=[1,1], ungriddedUbound=[5,3], _RC)
+           ungriddedLbound=[1,1], ungriddedUbound=[ORIGINAL_NUM_LEVELS,3], _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      x = 99
+      x = FILL_VALUE
 
-      call FieldReallocate(f, ungriddedUbound=[5,3], _RC)
+      call FieldReallocate(f, num_levels=ORIGINAL_NUM_LEVELS, _RC)
 
-      call ESMF_FieldGet(f, status=field_status, typekind=typekind, _RC)
+      call ESMF_FieldGet(f, status=field_status, typekind=typekind, geom=other_geom, _RC)
       @assert_that(field_status == ESMF_FIELDSTATUS_COMPLETE, is(true()))
       @assert_that(typekind == ESMF_TYPEKIND_R4, is(true()))
+      @assert_that(other_geom == geom, is(true()))
 
+      ! Check that Field data is unchanged
       call ESMF_FieldGet(f, fArrayPtr=x, _RC)
-      @assert_that(all(x == 99), is(true()))
-      @assert_that(shape(x), is(equal_to([4,4,5,3])))
+      @assert_that(all(x == FILL_VALUE), is(true()))
 
       call ESMF_FieldDestroy(f, _RC)
       call ESMF_GridDestroy(grid, _RC)
       call ESMF_GeomDestroy(geom, _RC)
 
       _UNUSED_DUMMY(this)
-   end subroutine test_same_ungridded_bounds_do_not_allocate
+   end subroutine test_same_n_levels_do_not_reallocate
+
+
+    @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_field_update_from_field_ignore_geom(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(ESMF_Field) :: f, f_ref
+      type(ESMF_Grid) :: grid, grid_ref
+      type(ESMF_Geom) :: geom, geom_ref, new_geom
+      character(:), allocatable :: new_units
+
+      integer :: status
+      type(ESMF_FieldStatus_Flag) :: field_status
+      real(ESMF_KIND_R8), pointer :: x8(:,:,:,:)
+      type(ESMF_TypeKind_Flag) :: typekind
+
+      grid = ESMF_GridCreateNoPeriDim(maxIndex=[4,4], name='I_AM_GROOT', _RC)
+      geom = ESMF_GeomCreate(grid, _RC)
+
+      grid_ref = ESMF_GridCreateNoPeriDim(maxIndex=[7,7], name='I_AM_GROOT', _RC)
+      geom_ref = ESMF_GeomCreate(grid_ref, _RC)
+
+      f = ESMF_FieldCreate(geom, typekind=ESMF_TYPEKIND_R4, name='in', &
+           ungriddedLbound=[1,1], ungriddedUbound=[ORIGINAL_NUM_LEVELS+1,3], _RC)
+
+      f_ref = ESMF_FieldCreate(geom_ref, typekind=ESMF_TYPEKIND_R8, name='in', &
+           ungriddedLbound=[1,1], ungriddedUbound=[ORIGINAL_NUM_LEVELS,3], _RC)
+
+      call MAPL_InfoSetInternal(f, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS+1, _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+      call MAPL_InfoSetInternal(f, key=KEY_UNITS, value=ORIGINAL_UNITS)
+
+      call MAPL_InfoSetInternal(f_ref, key=KEY_NUM_LEVELS, value=ORIGINAL_NUM_LEVELS, _RC)
+      call MAPL_InfoSetInternal(f_ref, key=KEY_VLOC, value='VERTICAL_DIM_EDGE', _RC)
+      call MAPL_InfoSetInternal(f_ref, key=KEY_UNITS, value=REFERENCE_UNITS)
+
+      call FieldUpdate(f, f_ref, ignore='geom', _RC)
+
+      call ESMF_FieldGet(f, status=field_status, typekind=typekind, geom=new_geom, _RC)
+      @assert_that(field_status == ESMF_FIELDSTATUS_COMPLETE, is(true()))
+      @assert_that(typekind == ESMF_TYPEKIND_R8, is(true()))
+      @assert_that(new_geom == geom, is(true()))
+
+      call MAPL_InfoGetInternal(f, key=KEY_UNITS, value=new_units, _RC)
+      @assertEqual(REFERENCE_UNITS, new_units)
+
+      ! check that field shape is changed due to new num levels
+      call ESMF_FieldGet(f, fArrayPtr=x8, _RC)
+      @assert_that(shape(x8),is(equal_to([4,4,ORIGINAL_NUM_LEVELS,3])))
+
+      call ESMF_FieldDestroy(f, _RC)
+      call ESMF_GridDestroy(grid, _RC)
+      call ESMF_GeomDestroy(geom, _RC)
+
+      _UNUSED_DUMMY(this)
+   end subroutine test_field_update_from_field_ignore_geom
+
 
 end module Test_FieldUtilities

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -35,7 +35,6 @@ set(srcs
   # ComponentSpecBuilder.F90
 
   ESMF_Utilities.F90
-  InfoUtilities.F90
 
   ESMF_HConfigUtilities.F90
   RestartHandler.F90

--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -23,6 +23,8 @@ module mapl3g_FieldSpec
    use mapl3g_ActualConnectionPt
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
+   use mapl3g_esmf_info_keys
+   use mapl3g_InfoUtilities
    use mapl3g_ExtensionAction
    use mapl3g_VerticalGrid
    use mapl3g_VerticalRegridAction
@@ -801,25 +803,25 @@ contains
       call ESMF_InfoGetFromHost(field, field_info, _RC)
 
       ungridded_dims_info = this%ungridded_dims%make_info(_RC)
-      call ESMF_InfoSet(field_info, key='MAPL/ungridded_dims', value=ungridded_dims_info, _RC)
+      call ESMF_InfoSet(field_info, key=INFO_INTERNAL_NAMESPACE//KEY_UNGRIDDED_DIMS, value=ungridded_dims_info, _RC)
       call ESMF_InfoDestroy(ungridded_dims_info, _RC)
 
       vertical_dim_info = this%vertical_dim_spec%make_info(_RC)
-      call ESMF_InfoSet(field_info, key='MAPL/vertical_dim', value=vertical_dim_info, _RC)
+      call ESMF_InfoSet(field_info, key=INFO_INTERNAL_NAMESPACE//KEY_VERT_DIM, value=vertical_dim_info, _RC)
       call ESMF_InfoDestroy(vertical_dim_info, _RC)
 
       vertical_grid_info = this%vertical_grid%make_info(_RC)
-      call ESMF_InfoSet(field_info, key='MAPL/vertical_grid', value=vertical_grid_info, _RC)
+      call ESMF_InfoSet(field_info, key=INFO_INTERNAL_NAMESPACE//KEY_VERT_GRID, value=vertical_grid_info, _RC)
       call ESMF_InfoDestroy(vertical_grid_info, _RC)
 
       if (allocated(this%units)) then
-         call ESMF_InfoSet(field_info, key='MAPL/units', value=this%units, _RC)
+         call MAPL_InfoSetInternal(field,key='/units', value= this%units, _RC)
       end if
       if (allocated(this%long_name)) then
-         call ESMF_InfoSet(field_info, key='MAPL/long_name', value=this%long_name, _RC)
+         call MAPL_InfoSetInternal(field,key='/long_name', value=this%long_name, _RC)
       end if
       if (allocated(this%standard_name)) then
-         call ESMF_InfoSet(field_info, key='MAPL/standard_name', value=this%standard_name, _RC)
+         call MAPL_InfoSetInternal(field,key='/standard_name', value=this%standard_name, _RC)
       end if
 
       _RETURN(_SUCCESS)

--- a/generic3g/specs/VerticalDimSpec.F90
+++ b/generic3g/specs/VerticalDimSpec.F90
@@ -1,7 +1,7 @@
 #include "MAPL_Generic.h"
 
 module mapl3g_VerticalDimSpec
-   !use mapl3g_UngriddedDimSpec
+   use mapl3g_esmf_info_keys
    use esmf, only: ESMF_Info
    use esmf, only: ESMF_InfoCreate
    use esmf, only: ESMF_InfoSet

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -6,7 +6,6 @@ add_subdirectory(gridcomps)
 
 set (test_srcs
 
-  Test_InfoUtilities.pf
   Test_VirtualConnectionPt.pf
 
   Test_SimpleLeafGridComp.pf

--- a/generic3g/tests/Test_FieldInfo.pf
+++ b/generic3g/tests/Test_FieldInfo.pf
@@ -5,6 +5,8 @@ module Test_FieldInfo
    use mapl3g_BasicVerticalGrid
    use mapl3g_UngriddedDims
    use mapl3g_UngriddedDim
+   use mapl3g_esmf_info_keys
+   use mapl3g_InfoUtilities
    use esmf
    use funit
    implicit none
@@ -41,59 +43,60 @@ contains
       f = ESMF_FieldCreate(geom, ESMF_TYPEKIND_R4, ungriddedLbound=[1,1], ungriddedUbound=[2,3], _RC)
       call spec%set_info(f, _RC)
 
-      call ESMF_InfoGetFromHost(f, info, _RC)
+      info = MAPL_InfoCreateFromInternal(f, _RC)
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_dim', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_VERT_DIM, _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_dim/vloc', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_VLOC, _RC)
       @assert_that(found, is(true()))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_grid', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_VERT_GRID, _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/vertical_grid/num_levels', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_NUM_LEVELS, _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGet(info, 'MAPL/vertical_grid/num_levels',temp_int , _RC)
+      call MAPL_InfoGet(info, KEY_NUM_LEVELS, temp_int, _RC)
       @assert_that(temp_int, equal_to(4))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS, _RC)
       @assert_that(found, is(true()))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_1', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_1', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_1/name', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_1/name', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_1/units', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_1/units', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_1/coordinates', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_1/coordinates', _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGetAlloc(info, 'MAPL/ungridded_dims/dim_1/coordinates', coords, _RC)
+      call MAPL_InfoGet(info, KEY_UNGRIDDED_DIMS//'/dim_1/coordinates', coords, _RC)
       @assert_that(coords, equal_to([1.,2.]))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_2', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_2', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_2/name', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_2/name', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_2/units', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_2/units', _RC)
       @assert_that(found, is(true()))
-      found = ESMF_InfoIsPresent(info, key='MAPL/ungridded_dims/dim_2/coordinates', _RC)
+      found = ESMF_InfoIsPresent(info, key=KEY_UNGRIDDED_DIMS//'/dim_2/coordinates', _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGetAlloc(info, 'MAPL/ungridded_dims/dim_2/coordinates', coords, _RC)
+      call MAPL_InfoGet(info, KEY_UNGRIDDED_DIMS//'/dim_2/coordinates', coords, _RC)
       @assert_that(coords, equal_to([1.,2.,3.]))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/standard_name', _RC)
+      found = ESMF_InfoIsPresent(info, key='/standard_name', _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGetCharAlloc(info, 'MAPL/standard_name', temp_string, _RC)
+      call MAPL_InfoGet(info, '/standard_name', temp_string, _RC)
       @assert_that(temp_string, equal_to("t"))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/long_name', _RC)
+      found = ESMF_InfoIsPresent(info, key='/long_name', _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGetCharAlloc(info, 'MAPL/long_name', temp_string, _RC)
+      call MAPL_InfoGet(info, '/long_name', temp_string, _RC)
       @assert_that(temp_string, equal_to("p"))
 
-      found = ESMF_InfoIsPresent(info, key='MAPL/units', _RC)
+      found = ESMF_InfoIsPresent(info, key='/units', _RC)
       @assert_that(found, is(true()))
-      call ESMF_InfoGetCharAlloc(info, 'MAPL/units', temp_string, _RC)
+      call MAPL_InfoGet(info, '/units', temp_string, _RC)
       @assert_that(temp_string, equal_to("unknown"))
 
+      call ESMF_InfoDestroy(info)
    end subroutine test_field_set_info
 end module Test_FieldInfo

--- a/shared/MAPL_ESMF_InfoKeys.F90
+++ b/shared/MAPL_ESMF_InfoKeys.F90
@@ -5,18 +5,18 @@ module mapl3g_esmf_info_keys
 
    implicit none
 
-   public :: KEY_SHARED
-   public :: KEY_PRIVATE
-   public :: KEY_INTERNAL
+   public :: INFO_SHARED_NAMESPACE
+   public :: INFO_PRIVATE_NAMESPACE
+   public :: INFO_INTERNAL_NAMESPACE
    public :: KEY_UNGRIDDED_DIMS
    public :: KEY_VERT_DIM
-   public :: KEY_VERT_GEOM
+   public :: KEY_VERT_GRID
    public :: KEY_UNITS
    public :: KEY_LONG_NAME
    public :: KEY_STANDARD_NAME
    public :: KEY_NUM_LEVELS
    public :: KEY_VLOC
-   public :: KEY_NUM_UNGRID_DIMS
+   public :: KEY_NUM_UNGRIDDED_DIMS
    public :: KEYSTUB_DIM
    public :: KEY_UNGRIDDED_NAME
    public :: KEY_UNGRIDDED_UNITS
@@ -26,27 +26,27 @@ module mapl3g_esmf_info_keys
    private
 
    ! FieldSpec info keys
-   character(len=*), parameter :: PREFIX = 'MAPL/'
-   character(len=*), parameter :: KEY_SHARED = PREFIX // 'shared/'
-   character(len=*), parameter :: KEY_PRIVATE = PREFIX // 'private/'
-   character(len=*), parameter :: KEY_INTERNAL = PREFIX // 'internal/'
+   character(len=*), parameter :: PREFIX = '/MAPL'
+   character(len=*), parameter :: INFO_SHARED_NAMESPACE   = PREFIX // '/shared'
+   character(len=*), parameter :: INFO_PRIVATE_NAMESPACE  = PREFIX // '/private'
+   character(len=*), parameter :: INFO_INTERNAL_NAMESPACE = PREFIX // '/internal'
 
-   character(len=*), parameter :: KEY_UNGRIDDED_DIMS = PREFIX // 'ungridded_dims/'
-   character(len=*), parameter :: KEY_VERT_DIM = PREFIX // 'vertical_dim/'
-   character(len=*), parameter :: KEY_VERT_GEOM = PREFIX // 'vertical_geom/'
-   character(len=*), parameter :: KEY_UNITS = PREFIX // 'units'
-   character(len=*), parameter :: KEY_LONG_NAME = PREFIX // 'long_name'
-   character(len=*), parameter :: KEY_STANDARD_NAME = PREFIX // 'standard_name'
+   character(len=*), parameter :: KEY_UNGRIDDED_DIMS = '/ungridded_dims'
+   character(len=*), parameter :: KEY_VERT_DIM = '/vertical_dim'
+   character(len=*), parameter :: KEY_VERT_GRID = '/vertical_grid'
+   character(len=*), parameter :: KEY_UNITS = '/units'
+   character(len=*), parameter :: KEY_LONG_NAME = '/long_name'
+   character(len=*), parameter :: KEY_STANDARD_NAME = '/standard_name'
 
    ! VerticalGeom info keys
-   character(len=*), parameter :: KEY_NUM_LEVELS = KEY_VERT_GEOM // 'num_levels'
+   character(len=*), parameter :: KEY_NUM_LEVELS = KEY_VERT_GRID // '/num_levels'
 
    ! VerticalDimSpec info keys
-   character(len=*), parameter :: KEY_VLOC = KEY_VERT_DIM // 'vloc'
+   character(len=*), parameter :: KEY_VLOC = KEY_VERT_DIM // '/vloc'
 
    ! UngriddedDims info keys
-   character(len=*), parameter :: KEY_NUM_UNGRID_DIMS = KEY_UNGRIDDED_DIMS // 'num_ungridded_dimensions'
-   character(len=*), parameter :: KEYSTUB_DIM = KEY_UNGRIDDED_DIMS // 'dim_'
+   character(len=*), parameter :: KEY_NUM_UNGRIDDED_DIMS = KEY_UNGRIDDED_DIMS // '/num_ungridded_dimensions'
+   character(len=*), parameter :: KEYSTUB_DIM = KEY_UNGRIDDED_DIMS // '/dim_'
 
    ! UngriddedDim info keys
    character(len=*), parameter :: KEY_UNGRIDDED_NAME = 'name'
@@ -54,9 +54,9 @@ module mapl3g_esmf_info_keys
    character(len=*), parameter :: KEY_UNGRIDDED_COORD = 'coordinates'
 
    character(len=*), parameter :: KEY_DIM_STRINGS(9) = [ &
-      KEYSTUB_DIM // '1', KEYSTUB_DIM // '2', KEYSTUB_DIM // '3', &
-      KEYSTUB_DIM // '4', KEYSTUB_DIM // '5', KEYSTUB_DIM // '6', &
-      KEYSTUB_DIM // '7', KEYSTUB_DIM // '8', KEYSTUB_DIM // '9']
+      KEYSTUB_DIM // '/1', KEYSTUB_DIM // '/2', KEYSTUB_DIM // '/3', &
+      KEYSTUB_DIM // '/4', KEYSTUB_DIM // '/5', KEYSTUB_DIM // '/6', &
+      KEYSTUB_DIM // '/7', KEYSTUB_DIM // '/8', KEYSTUB_DIM // '/9']
 
 contains
 


### PR DESCRIPTION
Required updating various things to use new MAPL_Info interfaces.

Need to be careful that keys sent to ESMF do not end in "/" and yet we don't want users to have to prepend their keys with "/".  Fix for now is to check and prepend with "/" if not present.

If performance is found to be inadequate the issue will be revisited.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

