### PR TITLE
Turn off zstandard with Baselibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update ESMF version for Baselibs to match that of Spack for consistency
+
 ### Fixed
 
 - Fixed issue of some Baselibs builds appearing to support zstandard. This is not possible due to Baselibs building HDF5 and netCDF as static libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed issue of some Baselibs builds appearing to support zstandard. This is not possible due to Baselibs building HDF5 and netCDF as static libraries
+
 ### Removed
 
 ### Deprecated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,8 @@ else ()
   # This is an ESMF version test when using Baselibs which doesn't use the
   # same find_package internally in ESMA_cmake as used above (with a version
   # number) so this lets us at least trap use of old Baselibs here.
-  if (ESMF_VERSION VERSION_LESS 8.6.0)
-    message(FATAL_ERROR "ESMF must be at least 8.6.0")
+  if (ESMF_VERSION VERSION_LESS 8.6.1)
+    message(FATAL_ERROR "ESMF must be at least 8.6.1")
   endif ()
 endif ()
 

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -109,7 +109,7 @@ check_c_source_compiles("
   NETCDF_HAS_QUANTIZE)
 if (NETCDF_HAS_QUANTIZE)
   message(STATUS "netCDF has quantize capability")
-  add_definitions(-DNF_HAS_QUANTIZE)
+  target_compile_definitions(${this} PRIVATE NF_HAS_QUANTIZE)
 else ()
   message(STATUS "netCDF does not have quantize capability")
 endif ()
@@ -128,9 +128,19 @@ check_c_source_compiles("
   }
   "
   NETCDF_HAS_ZSTD)
+
+# NOTE: Even if the check above succeeds, zstandard is *not*
+# possible with Baselibs (builds HDF5, netCDF as static)
+# so we want to check for Baselibs first.
+
+if (Baselibs_FOUND)
+  message(STATUS "Baselibs found, zstandard capability not possible")
+  set(NETCDF_HAS_ZSTD FALSE)
+endif ()
+
 if (NETCDF_HAS_ZSTD)
   message(STATUS "netCDF has zstandard capability")
-  add_definitions(-DNF_HAS_ZSTD)
+  target_compile_definitions(${this} PRIVATE NF_HAS_ZSTD)
 else ()
   message(STATUS "netCDF does not have zstandard capability")
 endif ()

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -91,6 +91,26 @@ set (srcs
   StringVectorUtil.F90
   )
 
+if (BUILD_WITH_PFLOGGER)
+  find_package (PFLOGGER REQUIRED)
+endif ()
+
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
+
+target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
+target_include_directories (${this} PUBLIC
+          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
+
+set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
+# Kludge for OSX security and DYLD_LIBRARY_PATH ...
+foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
+  target_link_libraries(${this} PRIVATE "-Xlinker -rpath -Xlinker ${dir}")
+endforeach()
+
+if (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
+  target_compile_definitions(${this} PRIVATE SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
+endif ()
+
 ###############################################################
 # Check to see if quantize capability is present in netcdf-c. #
 ###############################################################
@@ -143,26 +163,6 @@ if (NETCDF_HAS_ZSTD)
   target_compile_definitions(${this} PRIVATE NF_HAS_ZSTD)
 else ()
   message(STATUS "netCDF does not have zstandard capability")
-endif ()
-
-if (BUILD_WITH_PFLOGGER)
-  find_package (PFLOGGER REQUIRED)
-endif ()
-
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
-
-target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
-target_include_directories (${this} PUBLIC
-          $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
-
-set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
-# Kludge for OSX security and DYLD_LIBRARY_PATH ...
-foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
-  target_link_libraries(${this} PRIVATE "-Xlinker -rpath -Xlinker ${dir}")
-endforeach()
-
-if (SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
-  target_compile_definitions(${this} PRIVATE SUPPORT_FOR_MPI_ALLOC_MEM_CPTR)
 endif ()
 
 ecbuild_add_executable (

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -155,7 +155,7 @@ check_c_source_compiles("
 
 if (Baselibs_FOUND)
   message(STATUS "Baselibs found, zstandard capability not possible")
-  set(NETCDF_HAS_ZSTD FALSE)
+  set(NETCDF_HAS_ZSTD FALSE CACHE BOOL "netCDF has zstandard capability" FORCE)
 endif ()
 
 if (NETCDF_HAS_ZSTD)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

As found by @bena-nasa, Bucy is showing Baselibs supports zstandard compression because, I guess, HDF5 or netCDF or something found it. But, since Baselibs builds HDF5 and netCDF as static libraries, Baselibs can never *run* zstandard code. So, by fiat, if Baselibs is used, we just turn off zstandard.

Also, for consistency, set the ESMF required version in Baselibs builds to match that of Spack.

## Related Issue

