### PR TITLE
Allow update offsets based on timestep for extdata2g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Allow update offsets of &#177;timestep in ExtData2G
 
 ### Changed
 

--- a/gridcomps/ExtData2G/CMakeLists.txt
+++ b/gridcomps/ExtData2G/CMakeLists.txt
@@ -36,3 +36,5 @@ set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${t
 if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
   set_source_files_properties(ExtDataGridCompNG.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
 endif ()
+
+add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -70,7 +70,7 @@ contains
       logical :: negative_offset
       type(ESMF_TimeInterval) :: timestep
       integer :: multiplier
-      integer :: i
+      integer :: i, j
       logical :: is_heartbeat
 
       this%last_checked = time
@@ -89,7 +89,10 @@ contains
          this%update_freq = string_to_esmf_timeinterval(update_freq,_RC)
       end if
       i = index(update_offset,"-") + 1
+      j = index(update_offset, '+') + 1
+      _ASSERT(i==1 .or. j==1, '"+" and "-" cannot both be present in update_offset string.')
       negative_offset = i > 1
+      if(.not. negative_offset) i = j
       call parse_heartbeat_timestring(update_offset(i:), is_heartbeat=is_heartbeat, multiplier=multiplier)
       if(is_heartbeat) then
          this%offset = multiplier * timestep

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -11,6 +11,7 @@ module MAPL_ExtDataPointerUpdate
    private
 
    public :: ExtDataPointerUpdate
+   public :: HEARTBEAT_STRING
 
    type :: ExtDataPointerUpdate
       private
@@ -32,7 +33,9 @@ module MAPL_ExtDataPointerUpdate
          procedure :: get_adjusted_time
    end type
 
-   contains
+   character(len=*), parameter :: HEARTBEAT_STRING = 'HEARTBEAT'
+   
+contains
 
    function get_adjusted_time(this,time,rc) result(adjusted_time)
       type(ESMF_Time) :: adjusted_time
@@ -94,13 +97,10 @@ module MAPL_ExtDataPointerUpdate
       character(len=*), intent(in) :: timestring
       logical, intent(out) :: is_heartbeat
       integer, intent(out) :: multiplier
-      character(len=*), parameter :: HEARTBEAT = 'HEARTBEAT'
-      character(len=:), allocatable :: uppercase
       integer :: i
 
       multiplier = 1
-      uppercase = to_upper(timestring)
-      i = index(uppercase, HEARTBEAT)
+      i = index(to_upper(timestring), HEARTBEAT_STRING)
       is_heartbeat = (i > 0)
 
    end subroutine parse_heartbeat_timestring

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -102,14 +102,18 @@ contains
 
    end subroutine create_from_parameters
 
-   subroutine parse_heartbeat_timestring(timestring, is_heartbeat, multiplier)
+   subroutine parse_heartbeat_timestring(timestring, is_heartbeat, multiplier, rc)
       character(len=*), intent(in) :: timestring
       logical, intent(out) :: is_heartbeat
       integer, intent(out) :: multiplier
       character(len=:), allocatable :: found_string
+      character(len=:), allocatable :: upper
+      integer, optional, intent(out) :: rc
+      integer :: status
 
       multiplier = 1
-      call split_on(to_upper(timestring), HEARTBEAT_STRING, found_string=found_string)
+      upper = ESMF_UtilStringUpperCase(timestring, _RC)
+      call split_on(upper, HEARTBEAT_STRING, found_string=found_string)
       is_heartbeat = len(found_string) > 0
       ! For now, multiplier is simply set to 1. In the future, as needed, the before_string
       ! and after_string arguments of split_on can be used to parse for a multiplier.
@@ -122,7 +126,7 @@ contains
       character(len=:), optional, allocatable, intent(out) :: before_string, after_string
       integer :: i
 
-      i = index(to_upper(string), substring)
+      i = index(string, substring)
       found_string = ''
       if(i > 0) found_string = string(i:i+len(substring)-1)
       if(present(before_string)) then

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -31,6 +31,7 @@ module MAPL_ExtDataPointerUpdate
          procedure :: is_single_shot
          procedure :: disable
          procedure :: get_adjusted_time
+         procedure :: get_offset
    end type
 
    character(len=*), parameter :: HEARTBEAT_STRING = 'HEARTBEAT'
@@ -48,6 +49,17 @@ contains
       _RETURN(_SUCCESS)
    end function
 
+   function get_offset(this, rc) result(offset)
+      type(ESMF_TimeInterval) :: offset
+      class(ExtDataPointerUpdate), intent(in) :: this
+      integer, optional, intent(out) :: rc
+      integer :: status
+
+      offset = this%offset
+      _RETURN(_SUCCESS)
+
+   end function get_offset
+      
    subroutine create_from_parameters(this,update_time,update_freq,update_offset,time,clock,rc)
       class(ExtDataPointerUpdate), intent(inout) :: this
       character(len=*), intent(in) :: update_time

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -37,10 +37,12 @@ module MAPL_ExtDataPointerUpdate
    function get_adjusted_time(this,time,rc) result(adjusted_time)
       type(ESMF_Time) :: adjusted_time
       class(ExtDataPointerUpdate), intent(inout) :: this
-      type(ESMF_Time), intent(in) :: time
+      type(ESMF_Time), optional, intent(in) :: time
       integer, optional, intent(out) :: rc
 
-      adjusted_time = time+this%offset
+      adjusted_time = this%last_ring
+      if(present(time)) adjusted_time = time
+      adjusted_time = adjusted_time+this%offset
 
       _RETURN(_SUCCESS)
    end function
@@ -141,7 +143,7 @@ module MAPL_ExtDataPointerUpdate
          if (first_time) then
             do_update = .true.
             this%first_time_updated = .true.
-            use_time = this%get_adjusted_time(last_ring)
+            use_time = this%get_adjusted_time(this%last_ring)
          else
             ! normal flow
             next_ring = this%last_ring
@@ -170,7 +172,7 @@ module MAPL_ExtDataPointerUpdate
                     if (this%first_time_updated) then
                        do_update=.true.
                        this%first_time_updated = .false.
-                       use_time = this%get_adjusted_time(last_ring)
+                       use_time = this%get_adjusted_time(this%last_ring)
                     end if
                ! otherwise we land on a time when the alarm would ring and we would update
                else if (this%last_ring == current_time) then

--- a/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
+++ b/gridcomps/ExtData2G/ExtDataUpdatePointer.F90
@@ -37,12 +37,10 @@ module MAPL_ExtDataPointerUpdate
    function get_adjusted_time(this,time,rc) result(adjusted_time)
       type(ESMF_Time) :: adjusted_time
       class(ExtDataPointerUpdate), intent(inout) :: this
-      type(ESMF_Time), optional, intent(in) :: time
+      type(ESMF_Time), intent(in) :: time
       integer, optional, intent(out) :: rc
 
-      adjusted_time = this%last_ring
-      if(present(time)) adjusted_time = time
-      adjusted_time = adjusted_time+this%offset
+      adjusted_time = time+this%offset
 
       _RETURN(_SUCCESS)
    end function

--- a/gridcomps/ExtData2G/tests/CMakeLists.txt
+++ b/gridcomps/ExtData2G/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/gridcomps/ExtData2G/ExtData2G/tests")
+set(MODULE_DIRECTORY "${esma_include}/gridcomps/ExtData2G/tests")
 
 set (test_srcs
   Test_ExtDataUpdatePointer.pf
@@ -14,7 +14,7 @@ set_tests_properties(MAPL.ExtData2G.tests PROPERTIES LABELS "ESSENTIAL")
 # With this test, it was shown that if you are building with the GNU Fortran
 # compiler and *not* on APPLE, then you need to link with the dl library.
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
-  target_link_libraries(ExtData2G.tests ${CMAKE_DL_LIBS})
+  target_link_libraries(MAPL.ExtData2G.tests ${CMAKE_DL_LIBS})
 endif ()
 
 add_dependencies(build-tests MAPL.ExtData2G.tests)

--- a/gridcomps/ExtData2G/tests/CMakeLists.txt
+++ b/gridcomps/ExtData2G/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(MODULE_DIRECTORY "${esma_include}/gridcomps/ExtData2G/ExtData2G/tests")
+
+set (test_srcs
+  Test_ExtDataUpdatePointer.pf
+  )
+
+add_pfunit_ctest(MAPL.ExtData2G.tests
+                TEST_SOURCES ${test_srcs}
+                LINK_LIBRARIES MAPL.ExtData2G
+                )
+set_target_properties(MAPL.ExtData2G.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.ExtData2G.tests PROPERTIES LABELS "ESSENTIAL")
+
+# With this test, it was shown that if you are building with the GNU Fortran
+# compiler and *not* on APPLE, then you need to link with the dl library.
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
+  target_link_libraries(ExtData2G.tests ${CMAKE_DL_LIBS})
+endif ()
+
+add_dependencies(build-tests MAPL.ExtData2G.tests)

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -97,7 +97,6 @@ contains
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       _VERIFY(ios)
       call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
-      !call ESMF_TimeSet(time, timeString=DEFAULT_TIMESTRING, _RC)
       call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
       actual_matches_expected = (ex%get_adjusted_time(time) == (time + offset))
       @assertTrue(actual_matches_expected, 'Adjusted time does match expected time.')
@@ -125,4 +124,64 @@ contains
       @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
 
    end subroutine test_create_from_parameters_string_positive
+
+   @Test
+   subroutine test_create_from_parameters_string_negative()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=32) :: offset_string
+      integer, parameter :: OFFSET_IN_SECONDS = 300
+      type(ESMF_TimeInterval) :: offset
+      integer :: ios
+      logical, parameter :: FIRST_TIME = .TRUE.
+      logical :: actual_matches_expected, do_update
+      type(ESMF_Time) :: use_time, current_time
+
+      write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
+      offset_string = '-' // offset_string
+      _VERIFY(ios)
+      call ESMF_TimeIntervalSet(offset, s=-OFFSET_IN_SECONDS, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
+      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      actual_matches_expected = (use_time == reference_time-offset)
+      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+
+   end subroutine test_create_from_parameters_string_negative
+
+   @Test
+   subroutine test_create_from_parameters_heartbeat_positive()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=*), parameter :: OFFSET_STRING = HEARTBEAT_STRING
+      type(ESMF_TimeInterval) :: offset
+      logical, parameter :: FIRST_TIME = .TRUE.
+      logical :: actual_matches_expected, do_update
+      type(ESMF_Time) :: use_time, current_time
+
+      offset = timestep
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, time, clock, _RC)
+      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      actual_matches_expected = (use_time == reference_time+offset)
+      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+
+   end subroutine test_create_from_parameters_heartbeat_positive
+
+   @Test
+   subroutine test_create_from_parameters_heartbeat_negative()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=*), parameter :: OFFSET_STRING = '-' // HEARTBEAT_STRING
+      type(ESMF_TimeInterval) :: offset
+      logical, parameter :: FIRST_TIME = .TRUE.
+      logical :: actual_matches_expected, do_update
+      type(ESMF_Time) :: use_time, current_time
+
+      offset = -timestep
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, time, clock, _RC)
+      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      actual_matches_expected = (use_time == reference_time+offset)
+      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+
+   end subroutine test_create_from_parameters_heartbeat_negative
+
 end module Test_ExtDataUpdatePointer

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -78,7 +78,7 @@ contains
       if(present(time_only)) then
          if(time_only) i = 4
          _HERE, 'time_only: ', time_only
-         _HERE, 'i, i+k-1, k, size(n), size(fields): ', i, i+k-1, k, size(n)
+         _HERE, 'i, i+k-1, k, size(n): ', i, i+k-1, k, size(n)
          _HERE, 'n = ', n
       end if
       n(i:i+k-1) = fields(1:k)

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -12,41 +12,23 @@ module Test_ExtDataUpdatePointer
    implicit none
 
 
-   integer, parameter :: TIME_STEP_IN_SECONDS = 500
-   character(len=*), parameter :: START_TIME_STRING = '2024-12-31T12:30:00'
-   integer, parameter :: YY=2024, MM=12, DD=31, H=12, M=30, S=0
-   character(len=*), parameter :: TIME_STRING = '2024-12-31T12:40:00'
-   character(len=*), parameter :: UPDATE_TIME = 'T20:00:00'
-   character(len=*), parameter :: UPDATE_FREQ = '-'
-   character(len=*), parameter :: DEFAULT_UPDATE_OFFSET = 'PT300S'
+   integer, parameter :: TIME_STEP_IN_SECONDS = 1
+   integer, parameter :: REFERENCE_TIME_FIELDS(*) = [2024, 12, 31, 20]
+   integer, parameter :: START_TIME_FIELDS(*) = [2024, 01, 01] 
+   integer, parameter :: DEFAULT_TIME_FIELDS(*) = REFERENCE_TIME_FIELDS(1:3)
+   integer, parameter :: UPDATE_TIME_FIELDS(*) = REFERENCE_TIME_FIELDS(4:)
+   character(len=*), parameter :: UPDATE_TIMESTRING = 'T20:00:00'
+   character(len=*), parameter :: UPDATE_FREQ_STRING = '-'
    type(ESMF_Time) :: start_time
    type(ESMF_TimeInterval) :: timestep
-   type(ESMF_Time) :: time
    type(ESMF_Clock) :: clock
+   type(ESMF_Time) :: time
+   type(ESMF_TimeInterval) :: time_interval
+   type(ESMF_Time) :: update_time
+   type(ESMF_Time) :: reference_time
    integer, parameter :: SUCCESS = 0
 
 contains
-
-   @Test
-   subroutine test_get_adjusted_time_without_time_argument()
-      type(ExtDataPointerUpdate) :: ex
-      integer :: status, rc
-      type(ESMF_Time) :: adjusted_time
-      type(ESMF_Time) :: expected_time
-
-      call ex%create_from_parameters(UPDATE_TIME, UPDATE_FREQ, DEFAULT_UPDATE_OFFSET, time, clock, _RC)
-      adjusted_time = ex%get_adjusted_time()
-      @assertTrue(.TRUE.)
-
-   end subroutine test_get_adjusted_time_without_time_argument
-
-   @Test
-   subroutine test_get_adjusted_time_with_time_argument()
-!      type(ExtDataPointerUpdate) :: ex
-
-      @assertTrue(.TRUE.)
-
-   end subroutine test_get_adjusted_time_with_time_argument
 
    @Before
    subroutine set_up()
@@ -54,15 +36,13 @@ contains
 
       status = SUCCESS
       call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, _RC)
-!      call ESMF_TimeSet(start_time, timeString=START_TIME_STRING, _RC)
-      call ESMF_TimeSet(start_time, yy=YY, _RC)
-      call ESMF_TimeSet(start_time, mm=MM, _RC)
-      call ESMF_TimeSet(start_time, dd=DD, _RC)
-      call ESMF_TimeSet(start_time, h=H, _RC)
-      call ESMF_TimeSet(start_time, m=M, _RC)
-      call ESMF_TimeSet(start_time, s=S, _RC)
+      call ESMF_TimeIntervalSet(time_interval, _RC)
+      call ESMF_TimeIntervalSet(timestep, s=TIME_STEP_IN_SECONDS, _RC)
+      call make_esmf_time(START_TIME_FIELDS, start_time, _RC)
+      call make_esmf_time(DEFAULT_TIME_FIELDS, time, _RC)
+      call make_esmf_time(UPDATE_TIME_FIELDS, update_time, time_only=.TRUE., _RC)
+      call make_esmf_time(REFERENCE_TIME_FIELDS, reference_time, _RC)
       clock = ESMF_ClockCreate(timestep=timestep, startTime=start_time, _RC)
-      call ESMF_TimeSet(time, timeString=TIME_STRING, _RC)
       
    end subroutine set_up
 
@@ -70,9 +50,79 @@ contains
    subroutine tear_down()
       integer :: status, rc
 
+      call ESMF_TimeSet(start_time, _RC)
+      call ESMF_TimeIntervalSet(timestep, _RC)
       call ESMF_ClockDestroy(clock, _RC)
+      call ESMF_TimeSet(time, _RC)
+      call ESMF_TimeIntervalSet(time_interval, _RC)
+      call ESMF_TimeSet(time, _RC)
+      call ESMF_TimeSet(update_time, _RC)
+      call ESMF_TimeSet(reference_time, _RC)
       call ESMF_Finalize(_RC)
 
    end subroutine tear_down
 
+   subroutine make_esmf_time(fields, time, time_only, rc)
+      integer, intent(in) :: fields(:)
+      type(ESMF_Time), intent(inout) :: time
+      logical, optional, intent(in) :: time_only
+      integer, optional, intent(out) :: rc
+      integer :: status, n(6), i, k
+
+      status = 0
+      k = size(fields)
+      if(k == 0 .or. k > size(n)) status = -1
+      _VERIFY(status)
+      n = 0
+      i = 1
+      if(present(time_only)) then
+         if(time_only) i = 4
+      end if
+      n(i:i+k-1) = fields(1:k)
+      call ESMF_TimeSet(time, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
+      _RETURN(_SUCCESS)
+         
+   end subroutine make_esmf_time
+
+   @Test
+   subroutine test_get_adjusted_time
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=32) :: offset_string
+      type(ESMF_TimeInterval) :: offset
+      integer :: ios
+      integer, parameter :: OFFSET_IN_SECONDS = 300
+      logical :: actual_matches_expected
+
+      write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
+      _VERIFY(ios)
+      call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
+      !call ESMF_TimeSet(time, timeString=DEFAULT_TIMESTRING, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
+      actual_matches_expected = (ex%get_adjusted_time(time) == (time + offset))
+      @assertTrue(actual_matches_expected, 'Adjusted time does match expected time.')
+
+   end subroutine test_get_adjusted_time
+
+   @Test
+   subroutine test_create_from_parameters_string_positive()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=32) :: offset_string
+      integer, parameter :: OFFSET_IN_SECONDS = 300
+      type(ESMF_TimeInterval) :: offset
+      integer :: ios
+      logical, parameter :: FIRST_TIME = .TRUE.
+      logical :: actual_matches_expected, do_update
+      type(ESMF_Time) :: use_time, current_time
+
+      write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
+      _VERIFY(ios)
+      call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
+      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      actual_matches_expected = (use_time == reference_time+offset)
+      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+
+   end subroutine test_create_from_parameters_string_positive
 end module Test_ExtDataUpdatePointer

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -18,6 +18,7 @@ module Test_ExtDataUpdatePointer
    integer, parameter :: START_TIME_FIELDS(*) = [2024, 01, 01, 0, 0, 0] 
    integer, parameter :: DEFAULT_TIME_FIELDS(*) = [REFERENCE_TIME_FIELDS(1:3), 0, 0, 0]
    integer, parameter :: UPDATE_TIME_FIELDS(*) = [0, 1, 1, REFERENCE_TIME_FIELDS(4:)]
+   integer, parameter :: STRLEN = 32
    character(len=*), parameter :: UPDATE_TIMESTRING = 'T20:00:00'
    character(len=*), parameter :: UPDATE_FREQ_STRING = '-'
    character(len=*), parameter :: ERR_MSG = 'Actual offset does match expected offset.'
@@ -93,11 +94,22 @@ contains
 
    end subroutine get_int_time
 
+   subroutine make_offset_string(offset, offset_string, rc)
+      integer, intent(in) :: offset
+      character(len=*), intent(out) :: offset_string
+      integer, optional, intent(out) :: rc
+      integer :: status
+
+      write(offset_string, fmt='("PT", I03, "S")', iostat=status) offset
+      _VERIFY(status)
+
+   end subroutine make_offset_string
+      
    @Test
    subroutine test_get_adjusted_time
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
-      character(len=32) :: offset_string
+      character(len=STRLEN) :: offset_string
       type(ESMF_TimeInterval) :: offset
       integer :: ios
       integer, parameter :: OFFSET_IN_SECONDS = 300
@@ -113,19 +125,16 @@ contains
 
    end subroutine test_get_adjusted_time
 
-   
    @Test
    subroutine test_create_from_parameters_string_positive()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
-      character(len=32) :: offset_string
+      character(len=STRLEN) :: offset_string
       integer, parameter :: OFFSET_IN_SECONDS = 300
-      integer :: ios
       integer :: expected, actual
       type(ESMF_TimeInterval) :: interval
 
-      write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
-      _VERIFY(ios)
+      call make_offset_string(OFFSET_IN_SECONDS, offset_string, _RC)
       expected = OFFSET_IN_SECONDS
       call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
       interval = ex%get_offset()
@@ -133,19 +142,17 @@ contains
       @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_string_positive
-
+     
    @Test
    subroutine test_create_from_parameters_string_negative()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
-      character(len=32) :: offset_string
+      character(len=STRLEN) :: offset_string
       integer, parameter :: OFFSET_IN_SECONDS = 300
-      integer :: ios
       integer :: expected, actual
       type(ESMF_TimeInterval) :: interval
 
-      write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
-      _VERIFY(ios)
+      call make_offset_string(OFFSET_IN_SECONDS, offset_string, _RC)
       offset_string = '-' // offset_string
       expected = -OFFSET_IN_SECONDS
       call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
@@ -188,5 +195,51 @@ contains
       @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_heartbeat_negative
+
+   @Test
+   subroutine test_compare_positive_string_to_positive_heartbeat()
+      type(ExtDataPointerUpdate) :: ex_str, ex_hb
+      integer :: status, rc
+      type(ESMF_TimeInterval) :: intv_str, intv_hb
+      integer :: expected, actual
+      character(len=STRLEN) :: offset_string
+
+      call make_offset_string(TIME_STEP_IN_SECONDS, offset_string, _RC)
+
+      call ex_str%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
+      intv_str = ex_str%get_offset()
+      call ESMF_TimeIntervalGet(intv_str, s=expected, _RC)
+
+      call ex_hb%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, HEARTBEAT_STRING, default_time, clock, _RC)
+      intv_hb = ex_hb%get_offset()
+      call ESMF_TimeIntervalGet(intv_hb, s=actual, _RC)
+
+      @assertEqual(expected, actual, ERR_MSG)
+
+   end subroutine test_compare_positive_string_to_positive_heartbeat
+
+   @Test
+   subroutine test_compare_negative_string_to_negative_heartbeat()
+      type(ExtDataPointerUpdate) :: ex_str, ex_hb
+      integer :: status, rc
+      type(ESMF_TimeInterval) :: intv_str, intv_hb
+      integer :: expected, actual
+      character(len=STRLEN) :: offset_string
+
+      call make_offset_string(TIME_STEP_IN_SECONDS, offset_string, _RC)
+      offset_string = '-' // offset_string
+
+      call ex_str%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
+      intv_str = ex_str%get_offset()
+      call ESMF_TimeIntervalGet(intv_str, s=expected, _RC)
+
+      call ex_hb%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, '-' // HEARTBEAT_STRING, default_time, clock, _RC)
+      intv_hb = ex_hb%get_offset()
+      call ESMF_TimeIntervalGet(intv_hb, s=actual, _RC)
+
+      @assertEqual(expected, actual, ERR_MSG)
+
+   end subroutine test_compare_negative_string_to_negative_heartbeat
+
 
 end module Test_ExtDataUpdatePointer

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -11,7 +11,6 @@ module Test_ExtDataUpdatePointer
    use MAPL_ExceptionHandling
    implicit none
 
-
    integer, parameter :: SUCCESS = 0
    integer, parameter :: TIME_STEP_IN_SECONDS = 1
    integer, parameter :: REFERENCE_TIME_FIELDS(*) = [2024, 12, 31, 20, 0, 0]
@@ -19,13 +18,13 @@ module Test_ExtDataUpdatePointer
    integer, parameter :: START_TIME_FIELDS(*) = [2024, 01, 01, 0, 0, 0] 
    integer, parameter :: DEFAULT_TIME_FIELDS(*) = [REFERENCE_TIME_FIELDS(1:3), 0, 0, 0]
    integer, parameter :: UPDATE_TIME_FIELDS(*) = [0, 1, 1, REFERENCE_TIME_FIELDS(4:)]
-   integer :: actual(NF), expected(NF)
    character(len=*), parameter :: UPDATE_TIMESTRING = 'T20:00:00'
    character(len=*), parameter :: UPDATE_FREQ_STRING = '-'
+   character(len=*), parameter :: ERR_MSG = 'Actual offset does match expected offset.'
    type(ESMF_Time) :: start_time
    type(ESMF_TimeInterval) :: timestep
    type(ESMF_Clock) :: clock
-   type(ESMF_Time) :: previous_time
+   type(ESMF_Time) :: default_time
    type(ESMF_TimeInterval) :: time_interval
    type(ESMF_Time) :: update_time
    type(ESMF_Time) :: reference_time
@@ -39,33 +38,18 @@ contains
 
       status = SUCCESS
       uninitialized = .not. ESMF_IsInitialized(_RC)
-!      if(uninitialized) call set_up_initial(REFERENCE_TIME_FIELDS, DEFAULT_TIME_FIELDS, UPDATE_TIME_FIELDS, _RC)
       if(uninitialized) then
          call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, logKindFlag=ESMF_LOGKIND_NONE, defaultLogKindFlag=ESMF_LOGKIND_NONE, _RC)
       end if
       call ESMF_TimeIntervalSet(time_interval, _RC)
       call ESMF_TimeIntervalSet(timestep, s=TIME_STEP_IN_SECONDS, _RC)
       call make_esmf_time(START_TIME_FIELDS, start_time, _RC)
-      call make_esmf_time(DEFAULT_TIME_FIELDS, previous_time, _RC)
+      call make_esmf_time(DEFAULT_TIME_FIELDS, default_time, _RC)
       call make_esmf_time(UPDATE_TIME_FIELDS, update_time, _RC)
       call make_esmf_time(REFERENCE_TIME_FIELDS, reference_time, _RC)
       clock = ESMF_ClockCreate(timestep=timestep, startTime=start_time, _RC)
 
    end subroutine set_up
-
-   subroutine set_up_initial(reference, default, update, rc)
-      integer, intent(in) :: reference(NF)
-      integer, intent(inout) :: default(NF)
-      integer, intent(inout) :: update(NF)
-      integer, optional, intent(out) :: rc
-      integer :: status
-      
-      status = SUCCESS
-      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, logKindFlag=ESMF_LOGKIND_NONE, defaultLogKindFlag=ESMF_LOGKIND_NONE, _RC)
-      default = [reference(1:3), 0, 0, 0]
-      update = [0, 1, 1, reference(4:)]
-      _RETURN(_SUCCESS)
-   end subroutine set_up_initial
 
    @After
    subroutine tear_down()
@@ -74,13 +58,14 @@ contains
       call ESMF_TimeSet(start_time, _RC)
       call ESMF_TimeIntervalSet(timestep, _RC)
       call ESMF_ClockDestroy(clock, _RC)
-      call ESMF_TimeSet(previous_time, _RC)
+      call ESMF_TimeSet(default_time, _RC)
       call ESMF_TimeIntervalSet(time_interval, _RC)
       call ESMF_TimeSet(update_time, _RC)
       call ESMF_TimeSet(reference_time, _RC)
 
    end subroutine tear_down
 
+   ! Set ESMF_Time using an integer array of datetime fields.
    subroutine make_esmf_time(f, datetime, rc)
       integer, intent(in) :: f(NF)
       type(ESMF_Time), intent(inout) :: datetime
@@ -93,6 +78,7 @@ contains
          
    end subroutine make_esmf_time
 
+   ! Put ESMF_Time output args into an integer array.
    subroutine get_int_time(datetime, n, rc)
       type(ESMF_Time), intent(in) :: datetime
       integer, intent(inout) :: n(NF)
@@ -107,20 +93,6 @@ contains
 
    end subroutine get_int_time
 
-   subroutine get_int_time_interval(interval, n, rc)
-      type(ESMF_TimeInterval), intent(in) :: interval
-      integer, intent(inout) :: n(NF)
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      status = 0
-      n = 0
-      !call ESMF_TimeIntervalGet(interval, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
-
-      _RETURN(_SUCCESS)
-
-   end subroutine get_int_time_interval
-
    @Test
    subroutine test_get_adjusted_time
       type(ExtDataPointerUpdate) :: ex
@@ -129,13 +101,14 @@ contains
       type(ESMF_TimeInterval) :: offset
       integer :: ios
       integer, parameter :: OFFSET_IN_SECONDS = 300
+      integer :: expected(NF), actual(NF)
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       _VERIFY(ios)
       call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
-      call get_int_time(previous_time+offset, expected, _RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
-      call get_int_time(ex%get_adjusted_time(previous_time), actual, _RC)
+      call get_int_time(default_time+offset, expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
+      call get_int_time(ex%get_adjusted_time(default_time), actual, _RC)
       @assertEqual(expected, actual, 'Adjusted time does match expected time.')
 
    end subroutine test_get_adjusted_time
@@ -147,87 +120,72 @@ contains
       integer :: status, rc
       character(len=32) :: offset_string
       integer, parameter :: OFFSET_IN_SECONDS = 300
-      type(ESMF_TimeInterval) :: offset
       integer :: ios
       integer :: expected, actual
-!      logical, parameter :: FIRST_TIME = .TRUE.
-!      logical :: do_update
       type(ESMF_TimeInterval) :: interval
-!      type(ESMF_Time) :: use_time, current_time
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       _VERIFY(ios)
-      call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
-      !call get_int_time_interval(offset, expected, _RC)
       expected = OFFSET_IN_SECONDS
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
-      !call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
       interval = ex%get_offset()
       call ESMF_TimeIntervalGet(interval, s=actual, _RC)
-!      call get_int_time_interval(interval, actual, _RC)
-      @assertEqual(expected, actual, 'Updated time interval does match expected time interval.')
+      @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_string_positive
 
-   !@Test
+   @Test
    subroutine test_create_from_parameters_string_negative()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
       character(len=32) :: offset_string
       integer, parameter :: OFFSET_IN_SECONDS = 300
-      type(ESMF_TimeInterval) :: offset
       integer :: ios
-      logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: do_update
-      type(ESMF_Time) :: use_time, current_time
+      integer :: expected, actual
+      type(ESMF_TimeInterval) :: interval
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
-      offset_string = '-' // offset_string
       _VERIFY(ios)
-      call ESMF_TimeIntervalSet(offset, s=-OFFSET_IN_SECONDS, _RC)
-!      call get_int_time(reference_time+offset, expected, _RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
-      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-!      call get_int_time(use_time, actual, _RC)
-      @assertEqual(expected, actual, 'Updated time does match expected time.')
+      offset_string = '-' // offset_string
+      expected = -OFFSET_IN_SECONDS
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, default_time, clock, _RC)
+      interval = ex%get_offset()
+      call ESMF_TimeIntervalGet(interval, s=actual, _RC)
+      @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_string_negative
 
-   !@Test
+   @Test
    subroutine test_create_from_parameters_heartbeat_positive()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
       character(len=*), parameter :: OFFSET_STRING = HEARTBEAT_STRING
-      type(ESMF_TimeInterval) :: offset
-      logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: do_update
-      type(ESMF_Time) :: use_time, current_time
+      type(ESMF_TimeInterval) :: offset, interval
+      integer :: expected, actual
 
       offset = timestep
-!      call get_int_time(reference_time + offset, expected,_RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, previous_time, clock, _RC)
-      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-!      call get_int_time(use_time, actual, _RC)
-      @assertEqual(expected, actual, 'Updated time does match expected time.')
+      call ESMF_TimeIntervalGet(offset, s=expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, default_time, clock, _RC)
+      interval = ex%get_offset()
+      call ESMF_TimeIntervalGet(interval, s=actual, _RC)
+      @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_heartbeat_positive
 
-   !@Test
+   @Test
    subroutine test_create_from_parameters_heartbeat_negative()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
       character(len=*), parameter :: OFFSET_STRING = '-' // HEARTBEAT_STRING
-      type(ESMF_TimeInterval) :: offset
-      logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: do_update
-      type(ESMF_Time) :: use_time, current_time
+      type(ESMF_TimeInterval) :: offset, interval
+      integer :: expected, actual
 
       offset = -timestep
-!      call get_int_time(reference_time + offset, expected,_RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, previous_time, clock, _RC)
-      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-!      call get_int_time(use_time, actual, _RC)
-      @assertEqual(expected, actual, 'Updated time does match expected time.')
+      call ESMF_TimeIntervalGet(offset, s=expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, default_time, clock, _RC)
+      interval = ex%get_offset()
+      call ESMF_TimeIntervalGet(interval, s=actual, _RC)
+      @assertEqual(expected, actual, ERR_MSG)
 
    end subroutine test_create_from_parameters_heartbeat_negative
 

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -241,5 +241,51 @@ contains
 
    end subroutine test_compare_negative_string_to_negative_heartbeat
 
+   @Test
+   subroutine test_create_from_parameters_heartbeat_positive_explicit()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=*), parameter :: OFFSET_STRING = '+' // HEARTBEAT_STRING
+      type(ESMF_TimeInterval) :: offset, interval
+      integer :: expected, actual
+
+      offset = timestep
+      call ESMF_TimeIntervalGet(offset, s=expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, default_time, clock, _RC)
+      interval = ex%get_offset()
+      call ESMF_TimeIntervalGet(interval, s=actual, _RC)
+      @assertEqual(expected, actual, ERR_MSG)
+
+   end subroutine test_create_from_parameters_heartbeat_positive_explicit
+
+   @Test
+   subroutine test_create_from_parameters_heartbeat_positive_negative()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=*), parameter :: OFFSET_STRING = '+-' // HEARTBEAT_STRING
+      type(ESMF_TimeInterval) :: offset, interval
+      integer :: expected, actual
+
+      offset = timestep
+      call ESMF_TimeIntervalGet(offset, s=expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, default_time, clock, rc=status)
+      @assertFalse(status == 0, 'An exception should have been thrown.')
+
+   end subroutine test_create_from_parameters_heartbeat_positive_negative
+
+   @Test
+   subroutine test_create_from_parameters_heartbeat_negative_positive()
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      character(len=*), parameter :: OFFSET_STRING = '-+' // HEARTBEAT_STRING
+      type(ESMF_TimeInterval) :: offset, interval
+      integer :: expected, actual
+
+      offset = timestep
+      call ESMF_TimeIntervalGet(offset, s=expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, default_time, clock, rc=status)
+      @assertFalse(status == 0, 'An exception should have been thrown.')
+
+   end subroutine test_create_from_parameters_heartbeat_negative_positive
 
 end module Test_ExtDataUpdatePointer

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -1,0 +1,84 @@
+module Test_ExtDataUpdatePointer
+   use MAPL_ExtDataPointerUpdate
+   use funit
+   use esmf
+   implicit none
+
+   type(ExtDataPointerUpdate) :: ex
+
+   integer, parameter :: TIME_STEP_IN_SECONDS = 500
+   character(len=*), parameter :: START_TIME_STRING = '20241231T123000'
+   character(len=*), parameter :: TIME_STRING = '20241231T124000'
+   character(len=*), parameter :: UPDATE_TIME = 'T200000'
+   character(len=*), parameter :: UPDATE_FREQ = '-'
+   character(len=*), parameter :: DEFAULT_UPDATE_OFFSET = 'PT900H'
+   integer :: status_stack(1024)
+   integer :: status_stack_size = 0
+   type(ESMF_Time) :: start_time
+   type(ESMF_TimeInterval) :: timestep
+   type(ESMF_Time) :: time
+   type(ESMF_Clock) :: clock
+   integer :: status
+   integer, parameter :: SUCCESS = 0
+   integer, parameter :: FAIL = -1
+   integer :: past_status
+
+contains
+
+   @Test
+   subroutine test_get_adjusted_time_without_time_argument()
+      @assertTrue(.FALSE.)
+   end subroutine test_get_adjusted_time_without_time_argument
+
+   @Test
+   subroutine test_get_adjusted_time_with_time_argument()
+      @assertTrue(.FALSE.)
+   end subroutine test_get_adjusted_time_with_time_argument
+
+   @Before
+   subroutine set_up()
+      status = SUCCESS
+      status_stack = status
+      status_stack_size = 0
+      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+      call ESMF_TimeIntervalSet(timestep, s=TIME_STEP_IN_SECONDS, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+      call ESMF_TimeSet(start_time, timeString=START_TIME_STRING, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+!      call ESMF_TimeSet(start_time, yy=START_YY, mm=START_MM, dd=START_DD, rc=status) 
+!      call ESMF_TimeSet(start_time, h=START_H, m=START_M, s=START_S, rc=status)
+      clock = call ESMF_ClockCreate(timestep=timestep, startTime=start_time, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+      call ESMF_TimeSet(time, timeString=TIME_STRING, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+      ex = ExtDataUpdatePointer()
+   end subroutine set_up
+
+   @After
+   subroutine tear_down()
+      call ESMF_ClockDestroy(clock, rc=status)
+      call add_status(status_stack, status_stack_size, status)
+      call ESMF_Finalize(rc=status)
+      call add_status(status_stack, status_stack_size, status)
+   end subroutine tear_down
+
+   logical function os_true(intval) result(lval)
+      integer, intent(in) :: intval
+
+      lval = (intval == 0)
+
+   end function os_true
+
+   subroutine add_status(status_stack, size_ss, status) result(sz)
+      integer, intent(inout) :: status_stack(:)
+      integer, intent(inout) :: size_ss
+      integer, intent(in) :: status
+      
+      size_ss = min(ss_size+1, size(status_stack))
+      status_stack(2:size_ss) = status_stack(1:size(status_stack)-1)
+      status_stack(1) = status
+
+   end subroutine add_status
+
+end module Test_ExtDataUpdatePointer

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -77,8 +77,12 @@ contains
       i = 1
       if(present(time_only)) then
          if(time_only) i = 4
+         _HERE, 'time_only: ', time_only
+         _HERE, 'i, i+k-1, k, size(n), size(fields): ', i, i+k-1, k, size(n)
+         _HERE, 'n = ', n
       end if
       n(i:i+k-1) = fields(1:k)
+      _HERE, 'n = ', n
       call ESMF_TimeSet(time, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
       _RETURN(_SUCCESS)
          

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -12,39 +12,60 @@ module Test_ExtDataUpdatePointer
    implicit none
 
 
+   integer, parameter :: SUCCESS = 0
    integer, parameter :: TIME_STEP_IN_SECONDS = 1
-   integer, parameter :: REFERENCE_TIME_FIELDS(*) = [2024, 12, 31, 20]
-   integer, parameter :: START_TIME_FIELDS(*) = [2024, 01, 01] 
-   integer, parameter :: DEFAULT_TIME_FIELDS(*) = REFERENCE_TIME_FIELDS(1:3)
-   integer, parameter :: UPDATE_TIME_FIELDS(*) = REFERENCE_TIME_FIELDS(4:)
+   integer, parameter :: REFERENCE_TIME_FIELDS(*) = [2024, 12, 31, 20, 0, 0]
+   integer, parameter :: NF = size(REFERENCE_TIME_FIELDS)
+   integer, parameter :: START_TIME_FIELDS(*) = [2024, 01, 01, 0, 0, 0] 
+   integer, parameter :: DEFAULT_TIME_FIELDS(*) = [REFERENCE_TIME_FIELDS(1:3), 0, 0, 0]
+   integer, parameter :: UPDATE_TIME_FIELDS(*) = [0, 1, 1, REFERENCE_TIME_FIELDS(4:)]
+   integer :: actual(NF), expected(NF)
    character(len=*), parameter :: UPDATE_TIMESTRING = 'T20:00:00'
    character(len=*), parameter :: UPDATE_FREQ_STRING = '-'
    type(ESMF_Time) :: start_time
    type(ESMF_TimeInterval) :: timestep
    type(ESMF_Clock) :: clock
-   type(ESMF_Time) :: time
+   type(ESMF_Time) :: previous_time
    type(ESMF_TimeInterval) :: time_interval
    type(ESMF_Time) :: update_time
    type(ESMF_Time) :: reference_time
-   integer, parameter :: SUCCESS = 0
 
 contains
 
    @Before
    subroutine set_up()
       integer :: status, rc
+      logical :: uninitialized
 
       status = SUCCESS
-      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, _RC)
+      uninitialized = .not. ESMF_IsInitialized(_RC)
+!      if(uninitialized) call set_up_initial(REFERENCE_TIME_FIELDS, DEFAULT_TIME_FIELDS, UPDATE_TIME_FIELDS, _RC)
+      if(uninitialized) then
+         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, logKindFlag=ESMF_LOGKIND_NONE, defaultLogKindFlag=ESMF_LOGKIND_NONE, _RC)
+      end if
       call ESMF_TimeIntervalSet(time_interval, _RC)
       call ESMF_TimeIntervalSet(timestep, s=TIME_STEP_IN_SECONDS, _RC)
       call make_esmf_time(START_TIME_FIELDS, start_time, _RC)
-      call make_esmf_time(DEFAULT_TIME_FIELDS, time, _RC)
-      call make_esmf_time(UPDATE_TIME_FIELDS, update_time, time_only=.TRUE., _RC)
+      call make_esmf_time(DEFAULT_TIME_FIELDS, previous_time, _RC)
+      call make_esmf_time(UPDATE_TIME_FIELDS, update_time, _RC)
       call make_esmf_time(REFERENCE_TIME_FIELDS, reference_time, _RC)
       clock = ESMF_ClockCreate(timestep=timestep, startTime=start_time, _RC)
-      
+
    end subroutine set_up
+
+   subroutine set_up_initial(reference, default, update, rc)
+      integer, intent(in) :: reference(NF)
+      integer, intent(inout) :: default(NF)
+      integer, intent(inout) :: update(NF)
+      integer, optional, intent(out) :: rc
+      integer :: status
+      
+      status = SUCCESS
+      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, logKindFlag=ESMF_LOGKIND_NONE, defaultLogKindFlag=ESMF_LOGKIND_NONE, _RC)
+      default = [reference(1:3), 0, 0, 0]
+      update = [0, 1, 1, reference(4:)]
+      _RETURN(_SUCCESS)
+   end subroutine set_up_initial
 
    @After
    subroutine tear_down()
@@ -53,40 +74,52 @@ contains
       call ESMF_TimeSet(start_time, _RC)
       call ESMF_TimeIntervalSet(timestep, _RC)
       call ESMF_ClockDestroy(clock, _RC)
-      call ESMF_TimeSet(time, _RC)
+      call ESMF_TimeSet(previous_time, _RC)
       call ESMF_TimeIntervalSet(time_interval, _RC)
-      call ESMF_TimeSet(time, _RC)
       call ESMF_TimeSet(update_time, _RC)
       call ESMF_TimeSet(reference_time, _RC)
-      call ESMF_Finalize(_RC)
 
    end subroutine tear_down
 
-   subroutine make_esmf_time(fields, time, time_only, rc)
-      integer, intent(in) :: fields(:)
-      type(ESMF_Time), intent(inout) :: time
-      logical, optional, intent(in) :: time_only
+   subroutine make_esmf_time(f, datetime, rc)
+      integer, intent(in) :: f(NF)
+      type(ESMF_Time), intent(inout) :: datetime
       integer, optional, intent(out) :: rc
-      integer :: status, n(6), i, k
+      integer :: status
 
       status = 0
-      k = size(fields)
-      if(k == 0 .or. k > size(n)) status = -1
-      _VERIFY(status)
-      n = 0
-      i = 1
-      if(present(time_only)) then
-         if(time_only) i = 4
-         _HERE, 'time_only: ', time_only
-         _HERE, 'i, i+k-1, k, size(n): ', i, i+k-1, k, size(n)
-         _HERE, 'n = ', n
-      end if
-      n(i:i+k-1) = fields(1:k)
-      _HERE, 'n = ', n
-      call ESMF_TimeSet(time, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
+      call ESMF_TimeSet(datetime, yy=f(1), mm=f(2), dd=f(3), h=f(4), m=f(5), s=f(6), _RC)
       _RETURN(_SUCCESS)
          
    end subroutine make_esmf_time
+
+   subroutine get_int_time(datetime, n, rc)
+      type(ESMF_Time), intent(in) :: datetime
+      integer, intent(inout) :: n(NF)
+      integer, optional, intent(out) :: rc
+      integer :: status
+
+      status = 0
+      n = -1
+      call ESMF_TimeGet(datetime, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine get_int_time
+
+   subroutine get_int_time_interval(interval, n, rc)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      integer, intent(inout) :: n(NF)
+      integer, optional, intent(out) :: rc
+      integer :: status
+
+      status = 0
+      n = 0
+      !call ESMF_TimeIntervalGet(interval, yy=n(1), mm=n(2), dd=n(3), h=n(4), m=n(5), s=n(6), _RC)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine get_int_time_interval
 
    @Test
    subroutine test_get_adjusted_time
@@ -96,17 +129,18 @@ contains
       type(ESMF_TimeInterval) :: offset
       integer :: ios
       integer, parameter :: OFFSET_IN_SECONDS = 300
-      logical :: actual_matches_expected
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       _VERIFY(ios)
       call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
-      actual_matches_expected = (ex%get_adjusted_time(time) == (time + offset))
-      @assertTrue(actual_matches_expected, 'Adjusted time does match expected time.')
+      call get_int_time(previous_time+offset, expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
+      call get_int_time(ex%get_adjusted_time(previous_time), actual, _RC)
+      @assertEqual(expected, actual, 'Adjusted time does match expected time.')
 
    end subroutine test_get_adjusted_time
 
+   
    @Test
    subroutine test_create_from_parameters_string_positive()
       type(ExtDataPointerUpdate) :: ex
@@ -115,21 +149,27 @@ contains
       integer, parameter :: OFFSET_IN_SECONDS = 300
       type(ESMF_TimeInterval) :: offset
       integer :: ios
-      logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: actual_matches_expected, do_update
-      type(ESMF_Time) :: use_time, current_time
+      integer :: expected, actual
+!      logical, parameter :: FIRST_TIME = .TRUE.
+!      logical :: do_update
+      type(ESMF_TimeInterval) :: interval
+!      type(ESMF_Time) :: use_time, current_time
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       _VERIFY(ios)
       call ESMF_TimeIntervalSet(offset, s=OFFSET_IN_SECONDS, _RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
-      call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-      actual_matches_expected = (use_time == reference_time+offset)
-      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+      !call get_int_time_interval(offset, expected, _RC)
+      expected = OFFSET_IN_SECONDS
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
+      !call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
+      interval = ex%get_offset()
+      call ESMF_TimeIntervalGet(interval, s=actual, _RC)
+!      call get_int_time_interval(interval, actual, _RC)
+      @assertEqual(expected, actual, 'Updated time interval does match expected time interval.')
 
    end subroutine test_create_from_parameters_string_positive
 
-   @Test
+   !@Test
    subroutine test_create_from_parameters_string_negative()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
@@ -138,53 +178,56 @@ contains
       type(ESMF_TimeInterval) :: offset
       integer :: ios
       logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: actual_matches_expected, do_update
+      logical :: do_update
       type(ESMF_Time) :: use_time, current_time
 
       write(offset_string, fmt='("PT", I03, "S")', iostat=ios) OFFSET_IN_SECONDS
       offset_string = '-' // offset_string
       _VERIFY(ios)
       call ESMF_TimeIntervalSet(offset, s=-OFFSET_IN_SECONDS, _RC)
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, time, clock, _RC)
+!      call get_int_time(reference_time+offset, expected, _RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, offset_string, previous_time, clock, _RC)
       call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-      actual_matches_expected = (use_time == reference_time-offset)
-      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+!      call get_int_time(use_time, actual, _RC)
+      @assertEqual(expected, actual, 'Updated time does match expected time.')
 
    end subroutine test_create_from_parameters_string_negative
 
-   @Test
+   !@Test
    subroutine test_create_from_parameters_heartbeat_positive()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
       character(len=*), parameter :: OFFSET_STRING = HEARTBEAT_STRING
       type(ESMF_TimeInterval) :: offset
       logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: actual_matches_expected, do_update
+      logical :: do_update
       type(ESMF_Time) :: use_time, current_time
 
       offset = timestep
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, time, clock, _RC)
+!      call get_int_time(reference_time + offset, expected,_RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, previous_time, clock, _RC)
       call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-      actual_matches_expected = (use_time == reference_time+offset)
-      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+!      call get_int_time(use_time, actual, _RC)
+      @assertEqual(expected, actual, 'Updated time does match expected time.')
 
    end subroutine test_create_from_parameters_heartbeat_positive
 
-   @Test
+   !@Test
    subroutine test_create_from_parameters_heartbeat_negative()
       type(ExtDataPointerUpdate) :: ex
       integer :: status, rc
       character(len=*), parameter :: OFFSET_STRING = '-' // HEARTBEAT_STRING
       type(ESMF_TimeInterval) :: offset
       logical, parameter :: FIRST_TIME = .TRUE.
-      logical :: actual_matches_expected, do_update
+      logical :: do_update
       type(ESMF_Time) :: use_time, current_time
 
       offset = -timestep
-      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, time, clock, _RC)
+!      call get_int_time(reference_time + offset, expected,_RC)
+      call ex%create_from_parameters(UPDATE_TIMESTRING, UPDATE_FREQ_STRING, OFFSET_STRING, previous_time, clock, _RC)
       call ex%check_update(do_update, use_time, current_time, FIRST_TIME, _RC)
-      actual_matches_expected = (use_time == reference_time+offset)
-      @assertTrue(actual_matches_expected, 'use_time does not match expected time.')
+!      call get_int_time(use_time, actual, _RC)
+      @assertEqual(expected, actual, 'Updated time does match expected time.')
 
    end subroutine test_create_from_parameters_heartbeat_negative
 

--- a/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
+++ b/gridcomps/ExtData2G/tests/Test_ExtDataUpdatePointer.pf
@@ -1,84 +1,78 @@
+#include "MAPL_Generic.h"
+#if defined(I_AM_PFUNIT)
+#  undef I_AM_PFUNIT
+#endif
+#define I_AM_PFUNIT
+
 module Test_ExtDataUpdatePointer
    use MAPL_ExtDataPointerUpdate
    use funit
    use esmf
+   use MAPL_ExceptionHandling
    implicit none
 
-   type(ExtDataPointerUpdate) :: ex
 
    integer, parameter :: TIME_STEP_IN_SECONDS = 500
-   character(len=*), parameter :: START_TIME_STRING = '20241231T123000'
-   character(len=*), parameter :: TIME_STRING = '20241231T124000'
-   character(len=*), parameter :: UPDATE_TIME = 'T200000'
+   character(len=*), parameter :: START_TIME_STRING = '2024-12-31T12:30:00'
+   integer, parameter :: YY=2024, MM=12, DD=31, H=12, M=30, S=0
+   character(len=*), parameter :: TIME_STRING = '2024-12-31T12:40:00'
+   character(len=*), parameter :: UPDATE_TIME = 'T20:00:00'
    character(len=*), parameter :: UPDATE_FREQ = '-'
-   character(len=*), parameter :: DEFAULT_UPDATE_OFFSET = 'PT900H'
-   integer :: status_stack(1024)
-   integer :: status_stack_size = 0
+   character(len=*), parameter :: DEFAULT_UPDATE_OFFSET = 'PT300S'
    type(ESMF_Time) :: start_time
    type(ESMF_TimeInterval) :: timestep
    type(ESMF_Time) :: time
    type(ESMF_Clock) :: clock
-   integer :: status
    integer, parameter :: SUCCESS = 0
-   integer, parameter :: FAIL = -1
-   integer :: past_status
 
 contains
 
    @Test
    subroutine test_get_adjusted_time_without_time_argument()
-      @assertTrue(.FALSE.)
+      type(ExtDataPointerUpdate) :: ex
+      integer :: status, rc
+      type(ESMF_Time) :: adjusted_time
+      type(ESMF_Time) :: expected_time
+
+      call ex%create_from_parameters(UPDATE_TIME, UPDATE_FREQ, DEFAULT_UPDATE_OFFSET, time, clock, _RC)
+      adjusted_time = ex%get_adjusted_time()
+      @assertTrue(.TRUE.)
+
    end subroutine test_get_adjusted_time_without_time_argument
 
    @Test
    subroutine test_get_adjusted_time_with_time_argument()
-      @assertTrue(.FALSE.)
+!      type(ExtDataPointerUpdate) :: ex
+
+      @assertTrue(.TRUE.)
+
    end subroutine test_get_adjusted_time_with_time_argument
 
    @Before
    subroutine set_up()
+      integer :: status, rc
+
       status = SUCCESS
-      status_stack = status
-      status_stack_size = 0
-      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-      call ESMF_TimeIntervalSet(timestep, s=TIME_STEP_IN_SECONDS, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-      call ESMF_TimeSet(start_time, timeString=START_TIME_STRING, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-!      call ESMF_TimeSet(start_time, yy=START_YY, mm=START_MM, dd=START_DD, rc=status) 
-!      call ESMF_TimeSet(start_time, h=START_H, m=START_M, s=START_S, rc=status)
-      clock = call ESMF_ClockCreate(timestep=timestep, startTime=start_time, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-      call ESMF_TimeSet(time, timeString=TIME_STRING, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-      ex = ExtDataUpdatePointer()
+      call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN, _RC)
+!      call ESMF_TimeSet(start_time, timeString=START_TIME_STRING, _RC)
+      call ESMF_TimeSet(start_time, yy=YY, _RC)
+      call ESMF_TimeSet(start_time, mm=MM, _RC)
+      call ESMF_TimeSet(start_time, dd=DD, _RC)
+      call ESMF_TimeSet(start_time, h=H, _RC)
+      call ESMF_TimeSet(start_time, m=M, _RC)
+      call ESMF_TimeSet(start_time, s=S, _RC)
+      clock = ESMF_ClockCreate(timestep=timestep, startTime=start_time, _RC)
+      call ESMF_TimeSet(time, timeString=TIME_STRING, _RC)
+      
    end subroutine set_up
 
    @After
    subroutine tear_down()
-      call ESMF_ClockDestroy(clock, rc=status)
-      call add_status(status_stack, status_stack_size, status)
-      call ESMF_Finalize(rc=status)
-      call add_status(status_stack, status_stack_size, status)
+      integer :: status, rc
+
+      call ESMF_ClockDestroy(clock, _RC)
+      call ESMF_Finalize(_RC)
+
    end subroutine tear_down
-
-   logical function os_true(intval) result(lval)
-      integer, intent(in) :: intval
-
-      lval = (intval == 0)
-
-   end function os_true
-
-   subroutine add_status(status_stack, size_ss, status) result(sz)
-      integer, intent(inout) :: status_stack(:)
-      integer, intent(inout) :: size_ss
-      integer, intent(in) :: status
-      
-      size_ss = min(ss_size+1, size(status_stack))
-      status_stack(2:size_ss) = status_stack(1:size(status_stack)-1)
-      status_stack(1) = status
-
-   end subroutine add_status
 
 end module Test_ExtDataUpdatePointer


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Currently, the YAML configuration file for ExtData2 allows an offset for updates using an ISO8601 time duration string, such at `T09:00:00`. A user requested the capability to specify the offset as (+/-) timestep. This PR implements that capability. If map value for the `update_offset` is `HEARTBEAT`, the offset is set to an `ESMF_TimeInterval` equal to 1 timestep. If the map value is `-HEARTBEAT`, the offset is set to an `ESMF_TimeInterval` equal to -1 timestep. This may be extended to allow offsets of &#177;`n timestep`, where is a natural number.

## Related Issue
resolve #3064
