### PR TITLE
Update to ESMA_env v4.31.0 (ESMF 8.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Allow update offsets of &#177;timestep in ExtData2G
 
 ### Changed
 
 - Update ESMF version for Baselibs to match that of Spack for consistency
+- Update `components.yaml`
+  - ESMA_env v4.32.0
+    - Baselibs 7.27.0
+      - ESMF 8.7.0
+      - curl 8.10.1
+      - NCO 5.2.8
+      - CDO 2.4.4
+      - GSL 2.8
+      - jpeg 9f
+      - Various build fixes
+  - ESMA_cmake v3.52.0
+    - Fixes for using MAPL as a library in spack builds of GEOSgcm
+    - Various backports from v4
 
 ### Fixed
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.30.1
+  tag: v4.31.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.51.0
+  tag: v3.52.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates MAPL to use Baselibs 7.27.0 via `components.yaml`. This moves MAPL to use [ESMF 8.7.0](https://github.com/esmf-org/esmf/releases/tag/v8.7.0). Note I haven't changed the CMake ESMF required version yet because nothing in MAPL uses ESMF 8.7.0-specific things...yet. I believe @tclune et al do have plans for things in 8.7.0 though!

We also update ESMA_cmake to the latest v3 but this has little effect on MAPL.

## Related Issue

