### PR TITLE
Make `get_fptr_shape` public and a bug fix

### DIFF
--- a/field_utils/FieldCondensedArray.F90
+++ b/field_utils/FieldCondensedArray.F90
@@ -56,13 +56,13 @@ contains
       logical :: has_vertical
       character(len=:), allocatable :: spec_name
       character(len=*), parameter :: VERTICAL_DIM_NONE_NAME = 'VERTICAL_DIM_NONE'
-      integer :: dimCount
+      integer :: geomDimCount
 
-      call ESMF_FieldGet(f, dimCount=dimCount, rank=rank, _RC)
+      call ESMF_FieldGet(f, geomDimCount=geomDimCount, rank=rank, _RC)
       _ASSERT(.not. rank < 0, 'rank cannot be negative.')
-      _ASSERT(.not. dimCount < 0, 'dimCount cannot be negative.')
+      _ASSERT(.not. geomDimCount < 0, 'geomDimCount cannot be negative.')
       allocate(localElementCount(rank))
-      allocate(gridToFieldMap(dimCount))
+      allocate(gridToFieldMap(geomDimCount))
       call ESMF_FieldGet(f, gridToFieldMap=gridToFieldMap, _RC) 
       !  Due to an ESMF bug, getting the localElementCount must use the module function.
       !  See FieldGetLocalElementCount (specific function) comments.

--- a/field_utils/FieldCondensedArray.F90
+++ b/field_utils/FieldCondensedArray.F90
@@ -11,7 +11,6 @@ module mapl3g_FieldCondensedArray
    implicit none
    private
    public :: assign_fptr_condensed_array
-   public :: get_fptr_shape
 
    interface assign_fptr_condensed_array
       module procedure :: assign_fptr_condensed_array_r4
@@ -72,6 +71,7 @@ contains
       has_vertical = spec_name /= VERTICAL_DIM_NONE_NAME
       fptr_shape = get_fptr_shape_private(gridToFieldMap, localElementCount, has_vertical, _RC)
 
+      _RETURN(_SUCCESS)
    end function get_fptr_shape
 
 end module mapl3g_FieldCondensedArray

--- a/field_utils/FieldCondensedArray.F90
+++ b/field_utils/FieldCondensedArray.F90
@@ -11,6 +11,7 @@ module mapl3g_FieldCondensedArray
    implicit none
    private
    public :: assign_fptr_condensed_array
+   public :: get_fptr_shape
 
    interface assign_fptr_condensed_array
       module procedure :: assign_fptr_condensed_array_r4

--- a/field_utils/FieldCondensedArray_private.F90
+++ b/field_utils/FieldCondensedArray_private.F90
@@ -26,9 +26,9 @@ contains
       
       vert_dim = 0
       vert_size = 1
-      
+
       rank = size(localElementCount)
-      grid_dims = pack(gridToFieldMap, gridToFieldMap /= 0)
+      grid_dims = pack(gridToFieldMap, gridToFieldMap > 0)
       _ASSERT(all(grid_dims <= size(grid_dims)), 'MAPL expects geom dims before ungridded.')
       if(has_vertical) vert_dim = 1 
       if(size(grid_dims) > 0) vert_dim = maxval(grid_dims) + vert_dim

--- a/field_utils/FieldCondensedArray_private.F90
+++ b/field_utils/FieldCondensedArray_private.F90
@@ -28,7 +28,7 @@ contains
       vert_size = 1
 
       rank = size(localElementCount)
-      grid_dims = pack(gridToFieldMap, gridToFieldMap > 0)
+      grid_dims = pack(gridToFieldMap, gridToFieldMap /= 0)
       _ASSERT(all(grid_dims <= size(grid_dims)), 'MAPL expects geom dims before ungridded.')
       if(has_vertical) vert_dim = 1 
       if(size(grid_dims) > 0) vert_dim = maxval(grid_dims) + vert_dim


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
- Excluding negative values of gridToFieldMap
- Making `mapl3g_FieldCondensedArray::get_fptr_shape` public

## Related Issue

