### PR TITLE
Better Grid naming util used in GSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Minor revision (and generalization) of grid-def for GSI purposes
+
 ### Fixed
 
 ### Removed

--- a/base/MAPL_DefGridName.F90
+++ b/base/MAPL_DefGridName.F90
@@ -5,38 +5,17 @@ logical,intent(in)::iamroot
 character(len=*),intent(out)::gridname
 character(len=2) poletype
 character(len=3) llcb
-character(len=30) myfmt
+character(len=30) imstr,jmstr
 poletype='PC'
 if(mod(jm,2)==0) poletype='PE'
 
 llcb='-DC' ! lat-lon
 if(6*im==jm) llcb='-CF' ! cubed
 
-! there has to be a smarter way to do this format 
-if(im>10.and.im<100.and.&
-   jm>10.and.jm<100) then
-   myfmt='(a,i2,a,i2,a)'
-endif
-if(im>100.and.im<1000.and.&
-   jm>10.and.jm<100) then
-   myfmt='(a,i3,a,i2,a)'
-endif
-if(im>100.and.im<1000.and.&
-   jm>100.and.jm<1000) then
-   myfmt='(a,i3,a,i3,a)'
-endif
-if(im>1000.and.im<10000.and.&
-   jm>100 .and.jm<1000) then
-   myfmt='(a,i4,a,i3,a)'
-endif
-if(im>100 .and.im<1000.and.&
-   jm>1000.and.jm<100) then
-   myfmt='(a,i3,a,i4,a)'
-endif
-if(im>1000.and.im<10000.and.&
-   jm>1000.and.jm<10000) then
-   myfmt='(a,i4,a,i4,a)'
-endif
-write(gridname,fmt=trim(myfmt)) trim(poletype),im,'x',jm,trim(llcb)
-if(iamroot)print*,'MAPL_DefGridName: ',trim(gridname)
+write(imstr,*) im
+write(jmstr,*) jm
+
+gridname=trim(poletype)//trim(adjustl(imstr))//'x'//&
+                         trim(adjustl(jmstr))//trim(llcb)
+
 end subroutine MAPL_DefGridName

--- a/base/MAPL_DefGridName.F90
+++ b/base/MAPL_DefGridName.F90
@@ -12,10 +12,9 @@ if(mod(jm,2)==0) poletype='PE'
 llcb='-DC' ! lat-lon
 if(6*im==jm) llcb='-CF' ! cubed
 
-write(imstr,*) im
-write(jmstr,*) jm
+write(imstr,'(I0)' im
+write(jmstr,'(I0)') jm
 
-gridname=trim(poletype)//trim(adjustl(imstr))//'x'//&
-                         trim(adjustl(jmstr))//trim(llcb)
+gridname=trim(poletype)//trim(imstr) / / 'x' // & trim(jmstr) // trim(llcb)
 
 end subroutine MAPL_DefGridName


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This cleans up and generalizes the gridname definition used in GSI.

**This change is being placed on top of v2.47.1  - it would be nice to have a v2.47.x issues for this.**

I see there is already a v2.47.2 ... i compared 47.1 w/ 2 and that seems to involve a baselibs  change not sure I want to inherit that!
 
## Related Issue

