### PR TITLE
Fixes #3128 - support copy shared attrs

### DIFF
--- a/esmf_utils/InfoUtilities.F90
+++ b/esmf_utils/InfoUtilities.F90
@@ -36,9 +36,11 @@ module mapl3g_InfoUtilities
    public :: MAPL_InfoSet
 
    public :: MAPL_InfoCreateFromInternal
+   public :: MAPL_InfoCreateFromShared
    
    public :: MAPL_InfoGetShared
    public :: MAPL_InfoSetShared
+   public :: MAPL_InfoCopyShared
    public :: MAPL_InfoGetPrivate
    public :: MAPL_InfoSetPrivate
    public :: MAPL_InfoGetInternal
@@ -48,6 +50,10 @@ module mapl3g_InfoUtilities
    interface MAPL_InfoCreateFromInternal
       procedure :: info_field_create_from_internal
    end interface MAPL_InfoCreateFromInternal
+
+   interface MAPL_InfoCreateFromShared
+      procedure :: info_field_create_from_shared
+   end interface MAPL_InfoCreateFromShared
 
    ! Direct access through ESMF_Info object
    interface MAPL_InfoGet
@@ -61,7 +67,8 @@ module mapl3g_InfoUtilities
 
    ! Access info object from esmf stateitem
    interface MAPL_InfoGetShared
-      procedure :: info_get_state_shared_string
+      procedure :: info_state_get_shared_string
+      procedure :: info_field_get_shared_i4
       procedure :: info_stateitem_get_shared_string
       procedure :: info_stateitem_get_shared_logical
       procedure :: info_stateitem_get_shared_i4
@@ -71,7 +78,8 @@ module mapl3g_InfoUtilities
    end interface MAPL_InfoGetShared
 
    interface MAPL_InfoSetShared
-      procedure :: info_set_state_shared_string
+      procedure :: info_state_set_shared_string
+      procedure :: info_field_set_shared_i4
       procedure :: info_stateitem_set_shared_string
       procedure :: info_stateitem_set_shared_logical
       procedure :: info_stateitem_set_shared_i4
@@ -79,6 +87,10 @@ module mapl3g_InfoUtilities
       procedure :: info_stateitem_set_shared_r8
       procedure :: info_stateitem_set_shared_r4_1d
    end interface MAPL_InfoSetShared
+
+   interface MAPL_InfoCopyShared
+      procedure :: info_field_copy_shared
+   end interface MAPL_InfoCopyShared
 
    interface MAPL_InfoGetPrivate
       procedure :: info_stateitem_get_private_string
@@ -256,9 +268,23 @@ contains
       _RETURN(_SUCCESS)
    end function info_field_create_from_internal
 
-   ! MAPL_InfoGetShared
+   function info_field_create_from_shared(field, rc) result(info)
+      type(ESMF_Info) :: info
+      type(ESMF_Field), intent(in) :: field
+      integer, optional, intent(out) :: rc
 
-   subroutine info_get_state_shared_string(state, key, value, unusable, rc)
+      type(ESMF_Info) :: host_info
+      integer :: status
+
+      call ESMF_InfoGetFromHost(field, host_info, _RC)
+      info = ESMF_InfoCreate(host_info, key=INFO_SHARED_NAMESPACE, _RC)
+
+      _RETURN(_SUCCESS)
+   end function info_field_create_from_shared
+
+
+   ! MAPL_InfoGetShared
+   subroutine info_state_get_shared_string(state, key, value, unusable, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: key
       character(:), allocatable, intent(out) :: value
@@ -272,7 +298,23 @@ contains
       call MAPL_InfoGet(state_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_get_state_shared_string
+   end subroutine info_state_get_shared_string
+
+   subroutine info_field_get_shared_i4(field, key, value, unusable, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(out) :: value
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: field_info
+
+      call ESMF_InfoGetFromHost(field, field_info, _RC)
+      call MAPL_InfoGet(field_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_get_shared_i4
 
    subroutine info_stateitem_get_shared_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
@@ -373,7 +415,7 @@ contains
 
    ! MAPL_InfoSetShared
 
-   subroutine info_set_state_shared_string(state, key, value, unusable, rc)
+   subroutine info_state_set_shared_string(state, key, value, unusable, rc)
       type(ESMF_State), intent(in) :: state
       character(*), intent(in) :: key
       character(*), intent(in) :: value
@@ -387,7 +429,22 @@ contains
       call MAPL_InfoSet(state_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
 
       _RETURN(_SUCCESS)
-   end subroutine info_set_state_shared_string
+   end subroutine info_state_set_shared_string
+
+   subroutine info_field_set_shared_i4(field, key, value, rc)
+      type(ESMF_Field), intent(in) :: field
+      character(*), intent(in) :: key
+      integer(kind=ESMF_KIND_I4), intent(in) :: value
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: field_info
+
+      call ESMF_InfoGetFromHost(field, field_info, _RC)
+      call MAPL_InfoSet(field_info, key=concat(INFO_SHARED_NAMESPACE,key), value=value, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_set_shared_i4
 
    subroutine info_stateitem_set_shared_string(state, short_name, key, value, rc)
       type(ESMF_State), intent(in) :: state
@@ -1078,6 +1135,23 @@ contains
       full_key = namespace // '/' //key
 
    end function concat
+
+   subroutine info_field_copy_shared(field_in, field_out, rc)
+      type(ESMF_Field), intent(in) :: field_in
+      type(ESMF_Field), intent(inout) :: field_out
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: shared_info, info_out
+
+      shared_info = MAPL_InfoCreateFromShared(field_in, _RC)
+      call ESMF_InfoGetFromHost(field_out, info_out, _RC)
+      ! 'force' may be needed in next, but ideally the import field will not yet have an shared space
+      call MAPL_InfoSet(info_out, INFO_SHARED_NAMESPACE, shared_info, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine info_field_copy_shared
+      
    
 end module mapl3g_InfoUtilities
 

--- a/esmf_utils/tests/Test_InfoUtilities.pf
+++ b/esmf_utils/tests/Test_InfoUtilities.pf
@@ -28,7 +28,6 @@ contains
 
    @test
    subroutine test_info_get_internal_info()
-      type(ESMF_Info) :: info
       type(ESMF_Info) :: subinfo
       integer :: status
       type(ESMF_Field) :: field
@@ -350,6 +349,10 @@ contains
       call MAPL_InfoSetNameSpace(state_b, namespace='/compB', _RC)
 
 
+      ! Same field goes in multiple states.  Accesses to private
+      ! attributes first retrieves the namespace from state.
+      ! Note that this means "raw" access to private attributes is
+      ! not supported as the context in not available.
       field = ESMF_FieldEmptyCreate(name='f', _RC)
       call ESMF_StateAdd(state_a, [field], _RC)
       call ESMF_StateAdd(state_b, [field], _RC)
@@ -549,6 +552,28 @@ contains
       call ESMF_StateDestroy(state, _RC)
 
    end subroutine test_setInternal_bundle
+
+   @test
+   subroutine test_copy_shared_field()
+      type(ESMF_Field) :: f_in, f_out
+      integer :: status
+      integer :: ia, ib
+
+      f_in = ESMF_FieldEmptyCreate(name='f_in', _RC)
+      f_out= ESMF_FieldEmptyCreate(name='f_out', _RC)
+
+      call MAPL_InfoSetShared(f_in, key='a', value=1, _RC)
+      call MAPL_InfoSetShared(f_in, key='b', value=2, _RC)
+
+      call MAPL_InfoCopyShared(f_in, f_out, _RC)
+
+      call MAPL_InfoGetShared(f_out, key='a', value=ia, _RC)
+      call MAPL_InfoGetShared(f_out, key='b', value=ib, _RC)
+
+      @assert_that(ia, is(1))
+      @assert_that(ib, is(2))
+
+   end subroutine test_copy_shared_field
 
 end module Test_InfoUtilities
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Added interface to copy all shared attributes in one info into the shared address space of another.   Current implementation assumes that the target info object does not have a shared space already.   If that assumption is later shown to be invalid, we must instead loop over each item in shared space and then copy.

## Related Issue

