### PR TITLE
Update to use GCC 14 in CI GNU runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@4
+  ci: geos-esm/circleci-tools@dev:0a07ff6bfd3c3f40cfa5aa80d8622be79f9e1615
 
 workflows:
   build-and-test-MAPL:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.27.0-openmpi_5.0.2-gcc_13.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.27.0-openmpi_5.0.5-gcc_14.2.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v3.52.0
     - Fixes for using MAPL as a library in spack builds of GEOSgcm
     - Various backports from v4
-- Update CI to use v7.27.0 Baselibs
+- Updates to CI
+  - Use v7.27.0 Baselibs
+  - Use GCC 14 for GNU tests
 
 ### Fixed
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR updates the CI in MAPL to use GCC 14. This matches what is currently run in testing at NCCS and NAS for GNU runs.

## Related Issue

