### PR TITLE
Fixed for NAG build issue - 

### DIFF
--- a/generic3g/vertical/FixedLevelsVerticalGrid.F90
+++ b/generic3g/vertical/FixedLevelsVerticalGrid.F90
@@ -110,12 +110,12 @@ contains
       integer, intent(out) :: iostat
       character(*), intent(inout) :: iomsg
 
-      write(unit, "(1x, a, a, 4x, a, a, a, 4x, a, a, a, 4x, a, *(g0, 1x), a, 1x, a)", iostat=iostat, iomsg=iomsg) &
+      write(unit, "(1x, a, a, 4x, a, a, a, 4x, a, a, a, 4x, a, *(g0, 1x))", iostat=iostat, iomsg=iomsg) &
            "FixedLevelsVerticalGrid(", new_line("a"), &
            "standard name: ", this%standard_name, new_line("a"), &
            "units: ", this%units, new_line("a"), &
-           "levels: ", this %levels, new_line("a"), &
-           ")"
+           "levels: ", this %levels
+      write(unit, "(a, 1x, a)", iostat=iostat, iomsg=iomsg) new_line("a"), ")"
 
       _UNUSED_DUMMY(iotype)
       _UNUSED_DUMMY(v_list)


### PR DESCRIPTION
NAG doesn't allow anything after an unlimited format item

Splitting the `write` statement
```Fortran
     write(unit, "(1x, a, a, 4x, a, a, a, 4x, a, a, a, 4x, a, *(g0, 1x), a, 1x, a)", iostat=iostat, iomsg=iomsg) &
           "FixedLevelsVerticalGrid(", new_line("a"), &
           "standard name: ", this%standard_name, new_line("a"), &
           "units: ", this%units, new_line("a"), &
           "levels: ", this %levels, new_line("a"), &
           ")"
```
into two `write`s
```Fortran
      write(unit, "(1x, a, a, 4x, a, a, a, 4x, a, a, a, 4x, a, *(g0, 1x))", iostat=iostat, iomsg=iomsg) &
           "FixedLevelsVerticalGrid(", new_line("a"), &
           "standard name: ", this%standard_name, new_line("a"), &
           "units: ", this%units, new_line("a"), &
           "levels: ", this %levels
      write(unit, "(a, 1x, a)", iostat=iostat, iomsg=iomsg) new_line("a"), ")"
```

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

