### PR TITLE
Add Time Accumulation for ESMF_Field objects to MAPL3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability for HistoryCollectionGridComp to extract multiple field names from expressions
 - Added vertical and ungridded dimensions to output for History3G
 - Create rank-agnostic representation of `ESMF_Field` objects as rank-3 array pointers.
+- Add time accumulation for output from ESMF_Field objects.
 
 ### Changed
 

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -1,0 +1,193 @@
+#include "MAPL_Generic.h"
+module mapl3g_AccumulatorAction
+   use mapl3g_ExtensionAction
+   use MAPL_InternalConstantsMod, only: MAPL_UNDEFINED_REAL, MAPL_UNDEFINED_REAL64
+   use MAPL_FieldUtilities, only: FieldSet 
+   use MAPL_FieldPointerUtilities
+   use MAPL_ExceptionHandling
+   use ESMF
+   implicit none
+   private
+   public :: AccumulatorAction
+
+   type, extends(ExtensionAction) :: AccumulatorAction
+      type(ESMF_Field) :: accumulation_field
+      type(ESMF_Field) :: result_field
+      real(kind=ESMF_KIND_R4) :: CLEAR_VALUE_R4 = 0.0_ESMF_KIND_R4
+      logical :: update_calculated = .FALSE.
+   contains
+      ! Implementations of deferred procedures
+      procedure :: invalidate
+      procedure :: initialize
+      procedure :: update
+      ! Helpers
+      procedure :: accumulate
+      procedure :: initialized
+      procedure :: clear_accumulator
+      procedure :: accumulate_R4
+   end type AccumulatorAction
+
+contains
+
+   logical function initialized(this) result(lval)
+      class(AccumulatorAction), intent(in) :: this
+
+      lval = ESMF_FieldIsCreated(this%accumulation_field) 
+
+   end function initialized
+
+   subroutine clear_accumulator(this, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      type(ESMF_TypeKind_Flag) :: tk
+
+      call ESMF_FieldGet(this%accumulation_field, typekind=tk, _RC)
+      if(tk == ESMF_TYPEKIND_R4) then
+         call FieldSet(this%accumulation_field, this%CLEAR_VALUE_R4, _RC)
+      else
+         _FAIL('Unsupported typekind')
+      end if
+      _RETURN(_SUCCESS)
+
+   end subroutine clear_accumulator
+
+   subroutine initialize(this, importState, exportState, clock, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: import_field, export_field
+      logical :: fields_are_conformable
+
+      call get_field(importState, import_field, _RC)
+      call get_field(exportState, export_field, _RC)
+      fields_are_conformable = FieldsAreConformable(import_field, export_field, _RC)
+      _ASSERT(fields_are_conformable, 'Import field and export field are not conformable.')
+
+      if(this%initialized()) then
+         call ESMF_FieldDestroy(this%accumulation_field, _RC)
+         call ESMF_FieldDestroy(this%result_field, _RC)
+      end if
+      this%accumulation_field = ESMF_FieldCreate(import_field, _RC)
+      this%result_field = ESMF_FieldCreate(export_field, _RC)
+
+      call this%clear_accumulator(_RC)
+      _UNUSED_DUMMY(clock)
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize
+
+   subroutine update(this, importState, exportState, clock, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: export_field
+      
+      _ASSERT(this%initialized(), 'Accumulator has not been initialized.')
+      if(.not. this%update_calculated) then
+         call FieldCopy(this%accumulation_field, this%result_field, _RC)
+         this%update_calculated = .TRUE.
+      end if
+      call get_field(exportState, export_field, _RC)
+      call FieldCopy(this%result_field, export_field, _RC)
+
+      call this%clear_accumulator(_RC)
+      _UNUSED_DUMMY(clock)
+      _UNUSED_DUMMY(importState)
+      _RETURN(_SUCCESS)
+
+   end subroutine update
+
+   subroutine invalidate(this, importState, exportState, clock, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: import_field
+      
+      _ASSERT(this%initialized(), 'Accumulator has not been initialized.')
+      this%update_calculated = .FALSE.
+      call get_field(importState, import_field, _RC)
+      call this%accumulate(import_field, _RC)
+      _UNUSED_DUMMY(clock)
+      _UNUSED_DUMMY(exportState)
+      _RETURN(_SUCCESS)
+
+   end subroutine invalidate
+
+   subroutine get_field(state, field, rc)
+      type(ESMF_State), intent(inout) :: state
+      type(ESMF_Field), intent(inout) :: field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: itemCount
+      integer, parameter :: N = 1
+      character(len=ESMF_MAXSTR) :: itemNameList(N)
+      type(ESMF_StateItem_Flag) :: itemTypeList(N)
+
+      call ESMF_StateGet(state, itemCount=itemCount, _RC)
+      _ASSERT(itemCount == N, 'itemCount does not equal the expected value.')
+      call ESMF_StateGet(state, itemNameList=itemNameList, itemTypeList=itemTypeList, _RC)
+      _ASSERT(itemTypeList(N) == ESMF_STATEITEM_FIELD, 'State item is the wrong type.')
+      call ESMF_StateGet(state, itemName=itemNameList(N), field=field, _RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine get_field
+
+   subroutine accumulate(this, update_field, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: update_field
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      type(ESMF_TypeKind_Flag) :: tk, tk_field
+
+      call ESMF_FieldGet(this%accumulation_field, typekind=tk, _RC)
+      call ESMF_FieldGet(update_field, typekind=tk_field, _RC)
+      _ASSERT(tk == tk_field, 'Update field must be the same typekind as the accumulation field.')
+      if(tk == ESMF_TYPEKIND_R4) then
+         call this%accumulate_R4(update_field, _RC)
+      else
+         _FAIL('Unsupported typekind value')
+      end if
+
+      _RETURN(_SUCCESS)
+
+   end subroutine accumulate
+
+   subroutine accumulate_R4(this, update_field, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: update_field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real(kind=ESMF_KIND_R4), pointer :: current(:)
+      real(kind=ESMF_KIND_R4), pointer :: latest(:)
+      real(kind=ESMF_KIND_R4) :: undef
+
+      undef = MAPL_UNDEFINED_REAL
+      call assign_fptr(this%accumulation_field, current, _RC)
+      call assign_fptr(update_field, latest, _RC)
+      where(current /= undef .and. latest /= undef)
+        current = current + latest
+      elsewhere(latest == undef)
+        current = undef
+      end where
+      _RETURN(_SUCCESS)
+
+   end subroutine accumulate_R4
+
+end module mapl3g_AccumulatorAction

--- a/generic3g/actions/CMakeLists.txt
+++ b/generic3g/actions/CMakeLists.txt
@@ -13,4 +13,5 @@ target_sources(MAPL.generic3g PRIVATE
   AccumulatorAction.F90
   MeanAccumulator.F90
   MaxAccumulator.F90
+  MinAccumulator.F90
 )

--- a/generic3g/actions/CMakeLists.txt
+++ b/generic3g/actions/CMakeLists.txt
@@ -10,4 +10,7 @@ target_sources(MAPL.generic3g PRIVATE
   ConvertUnitsAction.F90
 
   TimeInterpolateAction.F90
+  AccumulatorAction.F90
+  MeanAccumulator.F90
+  MaxAccumulator.F90
 )

--- a/generic3g/actions/MaxAccumulator.F90
+++ b/generic3g/actions/MaxAccumulator.F90
@@ -1,0 +1,52 @@
+#include "MAPL_Generic.h"
+module mapl3g_MaxAccumulator
+   use mapl3g_AccumulatorAction
+   use MAPL_ExceptionHandling
+   use MAPL_InternalConstantsMod, only: MAPL_UNDEFINED_REAL, MAPL_UNDEFINED_REAL64
+   use MAPL_FieldPointerUtilities, only: assign_fptr
+   use ESMF
+   implicit none
+   private
+   public :: AccumulatorAction
+
+   type, extends(AccumulatorAction) :: MaxAccumulator
+      private
+   contains
+      procedure :: accumulate_R4 => max_accumulate_R4
+   end type MaxAccumulator
+
+   interface MaxAccumulator
+      module procedure :: construct_MaxAccumulator
+   end interface MaxAccumulator
+
+contains
+
+   function construct_MaxAccumulator() result(acc)
+      type(MaxAccumulator) :: acc
+
+      acc%CLEAR_VALUE_R4 = MAPL_UNDEFINED_REAL
+
+   end function construct_MaxAccumulator
+
+   subroutine max_accumulate_R4(this, update_field, rc)
+      class(MaxAccumulator), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: update_field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real(kind=ESMF_KIND_R4), pointer :: current(:)
+      real(kind=ESMF_KIND_R4), pointer :: latest(:)
+      real(kind=ESMF_KIND_R4), parameter :: UNDEF = MAPL_UNDEFINED_REAL
+
+      call assign_fptr(this%accumulation_field, current, _RC)
+      call assign_fptr(update_field, latest, _RC)
+      where(current == UNDEF)
+         current = latest
+      elsewhere(latest /= UNDEF)
+         current = max(current, latest)
+      end where
+      _RETURN(_SUCCESS)
+
+   end subroutine max_accumulate_R4
+
+end module mapl3g_MaxAccumulator

--- a/generic3g/actions/MeanAccumulator.F90
+++ b/generic3g/actions/MeanAccumulator.F90
@@ -1,0 +1,147 @@
+#include "MAPL_Generic.h"
+module mapl3g_MeanAccumulator
+   use mapl3g_AccumulatorAction
+   use MAPL_InternalConstantsMod, only: MAPL_UNDEFINED_REAL, MAPL_UNDEFINED_REAL64
+   use MAPL_ExceptionHandling
+   use MAPL_FieldPointerUtilities
+   use ESMF
+   implicit none
+   private
+   public :: MeanAccumulator
+
+   type, extends(AccumulatorAction) :: MeanAccumulator
+      !private
+      integer(ESMF_KIND_R8) :: counter_scalar = 0_ESMF_KIND_I8
+      logical, allocatable :: valid_mean(:)
+   contains
+      procedure :: invalidate => invalidate_mean_accumulator
+      procedure :: clear_accumulator => clear_mean_accumulator
+      procedure :: update => update_mean_accumulator
+      procedure :: calculate_mean
+      procedure :: calculate_mean_R4
+      procedure :: clear_valid_mean
+      procedure :: accumulate_R4 => accumulate_mean_R4
+   end type MeanAccumulator
+
+contains
+
+   subroutine clear_mean_accumulator(this, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      this%counter_scalar = 0_ESMF_KIND_R8
+      call this%clear_valid_mean(_RC)
+      call this%AccumulatorAction%clear_accumulator(_RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine clear_mean_accumulator
+
+   subroutine clear_valid_mean(this, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: local_size
+
+      if(allocated(this%valid_mean)) deallocate(this%valid_mean)
+      local_size = FieldGetLocalSize(this%accumulation_field, _RC)
+      allocate(this%valid_mean(local_size), source = .FALSE.)
+      _RETURN(_SUCCESS)
+
+   end subroutine clear_valid_mean
+
+   subroutine calculate_mean(this, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_TypeKind_Flag) :: tk
+
+      _ASSERT(this%counter_scalar > 0, 'Cannot calculate mean for zero steps')
+      call ESMF_FieldGet(this%accumulation_field, typekind=tk, _RC)
+      if(tk == ESMF_TypeKind_R4) then
+         call this%calculate_mean_R4(_RC)
+      else
+         _FAIL('Unsupported typekind')
+      end if
+      _RETURN(_SUCCESS)
+
+   end subroutine calculate_mean
+
+   subroutine update_mean_accumulator(this, importState, exportState, clock, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      
+      _ASSERT(this%initialized(), 'Accumulator has not been initialized.')
+      if(.not. this%update_calculated) then
+         call this%calculate_mean(_RC)
+      end if
+      call this%AccumulatorAction%update(importState, exportState, clock, _RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine update_mean_accumulator
+
+   subroutine invalidate_mean_accumulator(this, importState, exportState, clock, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      
+      call this%AccumulatorAction%invalidate(importState, exportState, clock, _RC)
+      this%counter_scalar = this%counter_scalar + 1
+      _RETURN(_SUCCESS)
+
+   end subroutine invalidate_mean_accumulator
+
+   subroutine calculate_mean_R4(this, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real(kind=ESMF_KIND_R4), pointer :: current_ptr(:) => null()
+      real(kind=ESMF_KIND_R4), parameter :: UNDEF = MAPL_UNDEFINED_REAL
+
+      call assign_fptr(this%accumulation_field, current_ptr, _RC)
+      where(current_ptr /= UNDEF .and. this%valid_mean)
+         current_ptr = current_ptr / this%counter_scalar
+      elsewhere
+         current_ptr = UNDEF
+      end where
+      _RETURN(_SUCCESS)
+
+   end subroutine calculate_mean_R4
+
+   subroutine accumulate_mean_R4(this, update_field, rc)
+      class(MeanAccumulator), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: update_field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real(kind=ESMF_KIND_R4), pointer :: current(:)
+      real(kind=ESMF_KIND_R4), pointer :: latest(:)
+      real(kind=ESMF_KIND_R4) :: undef
+
+      undef = MAPL_UNDEFINED_REAL
+      call assign_fptr(this%accumulation_field, current, _RC)
+      call assign_fptr(update_field, latest, _RC)
+      where(current /= undef .and. latest /= undef)
+        current = current + latest
+        this%valid_mean = .TRUE.
+      elsewhere(latest == undef)
+        current = undef
+      end where
+      _RETURN(_SUCCESS)
+
+   end subroutine accumulate_mean_R4
+
+end module mapl3g_MeanAccumulator

--- a/generic3g/actions/MinAccumulator.F90
+++ b/generic3g/actions/MinAccumulator.F90
@@ -1,0 +1,52 @@
+#include "MAPL_Generic.h"
+module mapl3g_MinAccumulator
+   use mapl3g_AccumulatorAction
+   use MAPL_ExceptionHandling
+   use MAPL_InternalConstantsMod, only: MAPL_UNDEFINED_REAL, MAPL_UNDEFINED_REAL64
+   use MAPL_FieldPointerUtilities, only: assign_fptr
+   use ESMF
+   implicit none
+   private
+   public :: AccumulatorAction
+
+   type, extends(AccumulatorAction) :: MinAccumulator
+      private
+   contains
+      procedure :: accumulate_R4 => min_accumulate_R4
+   end type MinAccumulator
+
+   interface MinAccumulator
+      module procedure :: construct_MinAccumulator
+   end interface MinAccumulator
+
+contains
+
+   function construct_MinAccumulator() result(acc)
+      type(MinAccumulator) :: acc
+
+      acc%CLEAR_VALUE_R4 = MAPL_UNDEFINED_REAL
+
+   end function construct_MinAccumulator
+
+   subroutine min_accumulate_R4(this, update_field, rc)
+      class(MinAccumulator), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: update_field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real(kind=ESMF_KIND_R4), pointer :: current(:)
+      real(kind=ESMF_KIND_R4), pointer :: latest(:)
+      real(kind=ESMF_KIND_R4), parameter :: UNDEF = MAPL_UNDEFINED_REAL
+
+      call assign_fptr(this%accumulation_field, current, _RC)
+      call assign_fptr(update_field, latest, _RC)
+      where(current == UNDEF)
+         current = latest
+      elsewhere(latest /= UNDEF)
+         current = min(current, latest)
+      end where
+      _RETURN(_SUCCESS)
+
+   end subroutine min_accumulate_R4
+
+end module mapl3g_MinAccumulator

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set (test_srcs
   Test_VerticalLinearMap.pf
 
   Test_CSR_SparseMatrix.pf
+  Test_AccumulatorAction.pf
   )
 
 

--- a/generic3g/tests/Test_AccumulatorAction.pf
+++ b/generic3g/tests/Test_AccumulatorAction.pf
@@ -1,0 +1,395 @@
+#define _RETURN_(R, S) if(present(R)) R = S; return
+#define _RETURN(S) _RETURN_(rc, S)
+#define _SUCCESS 0
+#include "MAPL_TestErr.h"
+#include "unused_dummy.H"
+module Test_AccumulatorAction
+   use mapl3g_AccumulatorAction
+   use mapl3g_MeanAccumulator
+   use esmf
+   use funit
+   use MAPL_FieldUtils
+   implicit none
+
+   integer(kind=ESMF_KIND_I4), parameter :: TIME_STEP = 1
+   integer(kind=ESMF_KIND_I4), parameter :: START_TIME = 3000
+   integer, parameter :: MAX_INDEX(2) = [4, 4]
+   real(kind=ESMF_KIND_R8), parameter :: MIN_CORNER_COORD(2) = [0.0_ESMF_KIND_R8, 0.0_ESMF_KIND_R8]
+   real(kind=ESMF_KIND_R8), parameter :: MAX_CORNER_COORD(2) = [4.0_ESMF_KIND_R8, 4.0_ESMF_KIND_R8]
+   type(ESMF_TypeKind_Flag), parameter :: typekind = ESMF_TYPEKIND_R4
+   integer, parameter :: R4 = ESMF_KIND_R4
+   integer, parameter :: R8 = ESMF_KIND_R8
+
+contains
+
+   @Test
+   subroutine test_construct_AccumulatorAction()
+      type(AccumulatorAction) :: acc
+
+      @assert_that(acc%update_calculated, is(false()))
+
+   end subroutine test_construct_AccumulatorAction
+
+   @Test
+   subroutine test_initialize()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      type(ESMF_Field) :: import_field
+      integer :: status
+      real(kind=R4), parameter :: TEST_VALUE = 1.0_R4
+      real(kind=R4) :: clear_value
+      logical :: equals_expected_value 
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      @assert_that(acc%initialized(), is(false()))
+
+      call get_field(importState, import_field, _RC)
+      call FieldSet(import_field, TEST_VALUE, _RC)
+
+      equals_expected_value = FieldIsConstant(import_field, TEST_VALUE, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      call acc%initialize(importState, exportState, clock, _RC)
+      @assert_that(acc%initialized(), is(true()))
+
+      clear_value = acc%CLEAR_VALUE_R4
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, clear_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      call destroy_objects(importState, exportState, clock, _RC)
+
+   end subroutine test_initialize
+
+   @Test
+   subroutine test_invalidate()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      type(ESMF_Field) :: import_field
+      real(kind=R4), parameter :: invalidate_value = 4.0_R4
+      logical :: equals_expected_value
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call get_field(importState, import_field, _RC)
+      call FieldSet(import_field, invalidate_value, _RC)
+
+      call acc%invalidate(importState, exportState, clock, _RC)
+      @assert_that(acc%update_calculated, is(false()))
+
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, invalidate_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      call acc%invalidate(importState, exportState, clock, _RC)
+      @assert_that(acc%update_calculated, is(false()))
+
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, 2*invalidate_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      call destroy_objects(importState, exportState, clock, _RC)
+
+   end subroutine test_invalidate
+
+   @Test
+   subroutine test_update()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      type(ESMF_Field) :: import_field, export_field
+      real(kind=R4), parameter :: invalidate_value = 4.0_R4
+      real(kind=R4) :: update_value
+      logical :: equals_expected_value
+
+      ! Set up
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+
+      ! Initialize
+      call acc%initialize(importState, exportState, clock, _RC)
+
+      ! Set import_field for invalidate step.
+      call get_field(importState, import_field, _RC)
+      call FieldSet(import_field, invalidate_value, _RC)
+
+      ! Invalidate.
+      call acc%invalidate(importState, exportState, clock, _RC)
+      
+      ! Check invalidate.
+      @assert_that(acc%update_calculated, is(false()))
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, invalidate_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+      
+      ! Set expected value for update.
+      update_value = invalidate_value
+      ! Update.
+      call acc%update(importState, exportState, clock, _RC)
+
+      ! Check update.
+      @assert_that(acc%update_calculated, is(true()))
+      ! Check that accumulation_field is cleared.
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, acc%CLEAR_VALUE_R4, _RC)
+      @assert_that(equals_expected_value, is(true()))
+      ! Check result_field
+      equals_expected_value = FieldIsConstant(acc%result_field, update_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+      ! Check export_field.
+      call get_field(exportState, export_field, _RC)
+      equals_expected_value = FieldIsConstant(export_field, update_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      ! Invalidate
+      call acc%invalidate(importState, exportState, clock, _RC)
+
+      ! Check invalidate.
+      @assert_that(acc%update_calculated, is(false()))
+
+      ! Invalidate again.
+      call acc%invalidate(importState, exportState, clock, _RC)
+
+      ! Check invalidate, again.
+      @assert_that(acc%update_calculated, is(false()))
+      ! This time accumulation_field should show true accumulation.
+      update_value = 2 * invalidate_value
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, update_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      ! Update
+      call acc%update(importState, exportState, clock, _RC)
+
+      ! Check update.
+      @assert_that(acc%update_calculated, is(true()))
+      ! Check that accumulation_field is cleared.
+      equals_expected_value = FieldIsConstant(acc%accumulation_field, acc%CLEAR_VALUE_R4, _RC)
+      @assert_that(equals_expected_value, is(true()))
+      ! This time result_field should show true accumulation.
+      equals_expected_value = FieldIsConstant(acc%result_field, update_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+      ! This time export_field should show true accumulation.
+      call get_field(exportState, export_field, _RC)
+      equals_expected_value = FieldIsConstant(export_field, update_value, _RC)
+      @assert_that(equals_expected_value, is(true()))
+
+      ! Tear down.
+      call destroy_objects(importState, exportState, clock, _RC)
+
+   end subroutine test_update
+
+   @Test
+   subroutine test_accumulate()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      type(ESMF_Field) :: update_field, import_field
+      type(ESMF_Grid) :: grid
+      type(ESMF_TypeKind_Flag) :: typekind
+      logical :: matches_expected
+      real(kind=ESMF_KIND_R4), parameter :: value_r4 = 3.0_ESMF_KIND_R4
+
+      typekind = ESMF_TYPEKIND_R4
+      call initialize_objects(importState, exportState, clock, typekind, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call get_field(importState, import_field, _RC)
+      call ESMF_FieldGet(import_field, grid=grid, _RC)
+      call initialize_field(update_field, typekind=typekind, grid=grid, _RC)
+      call FieldSet(update_field, value_r4, _RC)
+
+      call acc%accumulate(update_field, _RC)
+      matches_expected = FieldIsConstant(acc%accumulation_field, value_r4, _RC)
+      @assert_that(matches_expected, is(true()))
+      call ESMF_FieldDestroy(update_field, _RC)
+
+      typekind = ESMF_TYPEKIND_R8
+      call initialize_field(update_field, typekind=typekind, grid=grid, _RC)
+      call FieldSet(update_field, 3.0_ESMF_KIND_R8, _RC)
+      call acc%accumulate(update_field)
+      @assertExceptionRaised()
+      call ESMF_FieldDestroy(update_field, _RC)
+
+   end subroutine test_accumulate
+
+   @Test
+   subroutine test_clear_accumulator()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      logical :: is_expected_value
+      real(kind=ESMF_KIND_R4), parameter :: TEST_VALUE = 2.0_ESMF_KIND_R4
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call FieldSet(acc%accumulation_field, TEST_VALUE, _RC)
+      is_expected_value = FieldIsConstant(acc%accumulation_field, TEST_VALUE, _RC)
+      call acc%clear_accumulator(_RC)
+      is_expected_value = FieldIsConstant(acc%accumulation_field, acc%CLEAR_VALUE_R4, _RC)
+      @assert_that(is_expected_value, is(true()))
+
+   end subroutine test_clear_accumulator
+
+   @Test
+   subroutine test_accumulate_R4()
+      type(AccumulatorAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      real(kind=R4), parameter :: INITIAL_VALUE = 2.0_R4
+      real(kind=R4) :: update_value = 3.0_R4
+      real(kind=R4) :: expected_value
+      type(ESMF_Field) :: import_field, update_field
+      logical :: field_is_expected_value
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call get_field(importState, import_field, _RC)
+      call FieldClone(import_field, update_field, _RC)
+      call FieldSet(update_field, update_value, _RC)
+      call FieldSet(acc%accumulation_field, INITIAL_VALUE, _RC)
+      expected_value = INITIAL_VALUE
+      call acc%accumulate_R4(update_field, _RC)
+      expected_value = expected_value + update_value
+      field_is_expected_value = FieldIsConstant(acc%accumulation_field, expected_value, _RC)
+      @assert_that(field_is_expected_value, is(true()))
+
+      update_value = INITIAL_VALUE
+      call FieldSet(update_field, update_value, _RC)
+      call acc%accumulate_R4(update_field, _RC)
+      expected_value = expected_value + update_value
+      field_is_expected_value = FieldIsConstant(acc%accumulation_field, expected_value, _RC)
+      @assert_that(field_is_expected_value, is(true()))
+
+   end subroutine test_accumulate_R4
+
+   @Test
+   subroutine test_calculate_mean_R4()
+      type(MeanAccumulator) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      integer(kind=ESMF_KIND_I8), parameter :: COUNTER = 4
+      real(kind=ESMF_KIND_R4), parameter :: MEAN = 4.0_R4
+      logical :: matches_expected
+      
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
+      acc%counter_scalar = 4
+      acc%valid_mean = .TRUE.
+
+      call acc%calculate_mean_R4(_RC)
+      matches_expected = FieldIsConstant(acc%accumulation_field, MEAN, _RC)
+      @assert_that(matches_expected, is(true()))
+
+   end subroutine test_calculate_mean_R4
+
+! HELPER PROCEDURES
+
+   logical function is_initialized(rc) result(lval)
+      integer, optional, intent(out) :: rc
+      integer :: status
+
+      lval = ESMF_IsInitialized(_RC)
+      _RETURN(_SUCCESS)
+
+   end function is_initialized
+
+   subroutine initialize_field(field, typekind, grid, rc)
+      type(ESMF_Field), intent(inout) :: field
+      type(ESMF_TypeKind_Flag), intent(in) :: typekind
+      type(ESMF_Grid), optional, intent(inout) :: grid
+      integer, optional, intent(out) :: rc
+      type(ESMF_Grid) :: grid_
+      logical :: grid_created
+
+      integer :: status
+      
+      grid_created = .FALSE.
+      if(present(grid)) then
+         grid_created = ESMF_GridIsCreated(grid, _RC)
+         if(grid_created) grid_ = grid
+      end if
+
+      if(.not. grid_created) then
+         grid_ = ESMF_GridCreateNoPeriDimUfrm(maxIndex=MAX_INDEX, &
+            & minCornerCoord=MIN_CORNER_COORD, maxCornerCoord=MAX_CORNER_COORD, _RC)
+      end if
+
+      field = ESMF_FieldCreate(grid=grid_, typekind=typekind, _RC)
+      
+      if(present(grid)) grid = grid_
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize_field
+
+   subroutine initialize_objects(importState, exportState, clock, typekind, rc) 
+      type(ESMF_State), intent(inout) :: importState, exportState
+      type(ESMF_Clock), intent(inout) :: clock
+      type(ESMF_TypeKind_Flag), intent(in) :: typekind
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: importField, exportField
+      type(ESMF_Time) :: startTime
+      type(ESMF_TimeInterval) :: timeStep
+      type(ESMF_Grid) :: grid
+
+      call ESMF_TimeIntervalSet(timeStep, s=TIME_STEP, _RC)
+      call ESMF_TimeSet(startTime, yy=START_TIME, _RC)
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=startTime, _RC)
+      grid = ESMF_GridCreateNoPeriDimUfrm(maxIndex=MAX_INDEX, minCornerCoord=MIN_CORNER_COORD, maxCornerCoord=MAX_CORNER_COORD, _RC)
+      importField = ESMF_FieldCreate(grid=grid, typekind=typekind, _RC)
+      exportField = ESMF_FieldCreate(grid=grid, typekind=typekind, _RC)
+      importState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_IMPORT, fieldList=[importField], name='import', _RC)
+      exportState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_EXPORT, fieldList=[exportField], name='export', _RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize_objects
+
+   subroutine get_field(state, field, rc)
+      type(ESMF_State), intent(inout) :: state
+      type(ESMF_Field), intent(inout) :: field
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      character(len=ESMF_MAXSTR) :: itemNameList(1)
+
+      call ESMF_StateGet(state, itemNameList=itemNameList, _RC)
+      call ESMF_StateGet(state, itemName=itemNameList(1), field=field, _RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine get_field
+   
+   subroutine destroy_objects(importState, exportState, clock, rc)
+      type(ESMF_State), intent(inout) :: importState, exportState
+      type(ESMF_Clock), intent(inout) :: clock
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Field) :: importField, exportField
+      type(ESMF_Grid) :: grid
+
+      call get_field(importState, importField, _RC)
+      call get_field(exportState, exportField, _RC)
+      call ESMF_StateDestroy(importState, _RC)
+      call ESMF_StateDestroy(exportState, _RC)
+      call ESMF_FieldGet(importField, grid=grid, _RC)
+      call ESMF_FieldDestroy(importField, _RC)
+      call ESMF_FieldDestroy(exportField, _RC)
+      call ESMF_GridDestroy(grid, _RC)
+      call ESMF_ClockDestroy(clock, _RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine destroy_objects
+
+   @Before
+   subroutine set_up()
+      integer :: status
+
+      if(is_initialized()) return
+      call ESMF_Initialize(_RC)
+
+   end subroutine set_up
+
+end module Test_AccumulatorAction


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This PR adds a mechanism to MAPL3 to accumulate field data in time for ESMF_TYPEKIND_R4 fields. The three accumulations are MeanAccumulator, MaxAccumulator, and MinAccumulator. The common procedures have passed tests. The calculation for the mean has also been tested. The other procedures for the individual accumulators have not been tested. They will be tested with fixes in a future PR. Also, in future PR, the mechanism will be extended to ESMF_TYPEKIND_R8 fields.

## Related Issue
#3027

