### PR TITLE
Change '_FUNCN' to '_FUNC' which is the correct macro appearing in files in field subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented workaround for NAG related to ArrayReference use in GriddedIO.
 - Implemented workarounds to avoid needing `-dusty` for NAG.  (Related PR in ESMA_CMake.)
 - Added constructor for DSO_SetServicesWrapper
+- Change macro in field/undo_function_overload.macro
 
 ## [Unreleased]
 

--- a/field/undo_function_overload.macro
+++ b/field/undo_function_overload.macro
@@ -1,4 +1,4 @@
-#undef _FUNCN
+#undef _FUNC
 #undef _IDENTITY
 #undef _SUB
 #undef __SUB


### PR DESCRIPTION
in field

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
This PR fixes a typo in a `#undef` statement in `field/undo_function_overload.macro`. It was `_FUNCN`. It should be `_FUNC`, which what appears in the files that include it.

## Related Issue

