### PR TITLE
Add CMake to skip ExtData2G unit test if pfunit not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,21 @@ workflows:
           # ExtData1G tests were removed from ESSENTIAL, so we run them separately here as UFS might still use 1G?
           ctest_options: "-L 'ESSENTIAL|EXTDATA1G_SMALL_TESTS' --output-on-failure"
 
+      # Builds MAPL without pFUnit support
+      - ci/build:
+          name: build-MAPL-without-pFUnit-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [ifort]
+          baselibs_version: *baselibs_version
+          repo: MAPL
+          mepodevelop: false
+          remove_pfunit: true
+          run_unit_tests: true
+          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
+
       # Run MAPL Tutorials
       - ci/run_mapl_tutorial:
           name: run-<< matrix.tutorial_name >>-Tutorial-with-<< matrix.compiler >>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates to CI
   - Use v7.27.0 Baselibs
   - Use GCC 14 for GNU tests
+  - Add pFUnit-less build test
 
 ### Fixed
 

--- a/gridcomps/ExtData2G/CMakeLists.txt
+++ b/gridcomps/ExtData2G/CMakeLists.txt
@@ -37,4 +37,6 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release
   set_source_files_properties(ExtDataGridCompNG.F90 PROPERTIES COMPILE_OPTIONS ${FOPT1})
 endif ()
 
-add_subdirectory(tests EXCLUDE_FROM_ALL)
+if(PFUNIT_FOUND)
+  add_subdirectory(tests EXCLUDE_FROM_ALL)
+endif()


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

As found by Hoot Thompson, the ExtData2G Unit tests were not protected against pFUnit not being available (which is the default on spack, say). So we add a protection.

We also add a test in CI to build MAPL without pFUnit.

This is not yet in `main` so does not need a hotfix.

## Related Issue

