### PR TITLE
Trajectory sampler: minor bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow update offsets of &#177;timestep in ExtData2G
 - Minor revision (and generalization) of grid-def for GSI purposes
+- Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
 
 ### Changed
 

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -221,13 +221,13 @@ contains
     integer :: ncid, varid, ncid2
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
-    if(present(group_name)) then
+    if(present(group_name) .AND. group_name/='') then
        ncid2= ncid
        call check_nc_status(nf90_inq_ncid(ncid2, group_name, ncid), _RC)
     end if
     call check_nc_status(nf90_inq_varid(ncid, name, varid), _RC)
     call check_nc_status(nf90_get_var(ncid, varid, array), _RC)
-    if(present(group_name)) then
+    if(present(group_name) .AND. group_name/='') then
        call check_nc_status(nf90_close(ncid2), _RC)
     else
        call check_nc_status(nf90_close(ncid), _RC)
@@ -255,7 +255,7 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name)) then
+    if(present(group_name) .AND. group_name/='') then
        call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
        ! mod
        ncid = ncid_grp
@@ -295,7 +295,7 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name)) then
+    if(present(group_name) .AND. group_name/='') then
        call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
        ! overwrite
        ncid = ncid_grp
@@ -323,7 +323,7 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name)) then
+    if(present(group_name) .AND. group_name/='') then
        call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
        ! overwrite
        ncid = ncid_grp

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -218,20 +218,21 @@ contains
     real(REAL64), dimension(Xdim), intent(out) :: array
     integer, optional, intent(out) :: rc
     integer :: status
-    integer :: ncid, varid, ncid2
+    integer :: ncid, varid, ncid2, ncid_sv
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
-    if(present(group_name) .AND. group_name/='') then
-       ncid2= ncid
-       call check_nc_status(nf90_inq_ncid(ncid2, group_name, ncid), _RC)
+    ncid_sv = ncid
+
+    if(present(group_name)) then
+       if(group_name/='') then
+          ncid2= ncid
+          call check_nc_status(nf90_inq_ncid(ncid2, group_name, ncid), _RC)
+       end if
     end if
     call check_nc_status(nf90_inq_varid(ncid, name, varid), _RC)
     call check_nc_status(nf90_get_var(ncid, varid, array), _RC)
-    if(present(group_name) .AND. group_name/='') then
-       call check_nc_status(nf90_close(ncid2), _RC)
-    else
-       call check_nc_status(nf90_close(ncid), _RC)
-    end if
+
+    call check_nc_status(nf90_close(ncid_sv), _RC)
     _RETURN(_SUCCESS)
 
   end subroutine get_v1d_netcdf_R8
@@ -255,10 +256,12 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name) .AND. group_name/='') then
-       call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
-       ! mod
-       ncid = ncid_grp
+    if(present(group_name)) then
+       if(group_name/='') then
+          call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
+          ! mod
+          ncid = ncid_grp
+       end if
     end if
     call check_nc_status(nf90_inq_varid(ncid, varname, varid), _RC)
     call check_nc_status(nf90_get_var(ncid, varid, array), _RC)
@@ -295,10 +298,12 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name) .AND. group_name/='') then
-       call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
-       ! overwrite
-       ncid = ncid_grp
+    if(present(group_name)) then
+       if(group_name/='') then
+          call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
+          ! overwrite
+          ncid = ncid_grp
+       end if
     end if
     call check_nc_status(nf90_inq_varid(ncid, varname, varid), _RC)
     call check_nc_status(nf90_get_att(ncid, varid, att_name, att_value), _RC)
@@ -323,10 +328,12 @@ contains
 
     call check_nc_status(nf90_open(trim(fileName), NF90_NOWRITE, ncid), _RC)
     ncid_sv = ncid
-    if(present(group_name) .AND. group_name/='') then
-       call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
-       ! overwrite
-       ncid = ncid_grp
+    if(present(group_name)) then
+       if(group_name/='') then
+          call check_nc_status(nf90_inq_ncid(ncid, group_name, ncid_grp), _RC)
+          ! overwrite
+          ncid = ncid_grp
+       end if
     end if
     call check_nc_status(nf90_inq_varid(ncid, varname, varid), _RC)
     call check_nc_status(nf90_get_att(ncid, varid, att_name, att_value), _RC)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -732,22 +732,11 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                  times_R8_full(1), times_R8_full(nend))
             call lgr%debug ('%a %i20 %i20', 'jt1, jt2 [final intercepted position]', jt1, jt2)
 
-
-!            if (jt1==jt2) then
-!               _FAIL('Epoch Time is too small, empty grid is generated, increase Epoch')
-!            endif
-
-            !-- shift the zero item to index 1
-            zero_obs = .false.
             if (jt1/=jt2) then
                zero_obs = .false.
-               !-- YGYU: 8-Nov-2024 :
-               !   this fix bug, otherwise, the first time point is missing in ARGOS_geolocation
-               !!if (jt1==0) jt1=1
             else
                ! at most one obs point exist, set it .true.
                zero_obs = .true.
-               !!  if (jt1==0) jt1=1
             end if
 
             !

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -741,7 +741,9 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             zero_obs = .false.
             if (jt1/=jt2) then
                zero_obs = .false.
-               if (jt1==0) jt1=1
+               !-- YGYU: 8-Nov-2024 :
+               !   this fix bug, otherwise, the first time point is missing in ARGOS_geolocation
+               !!if (jt1==0) jt1=1
             else
                ! at most one obs point exist, set it .true.
                zero_obs = .true.


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)


## Description
This modification affects only the sampler code, especially the trajectory sampler. It fixes the following bugs:
- When group_name does not exist in netCDF file, the sampler code complains.
- The first time point was omitted when the model start time falls outside the time range for the trajectory. It is a valid setup.

## Related Issue
I left some comments in the code, because I want to further test sampler code.  More clean up will be performed afterwards.
