### PR TITLE
Fixes #3169 - handle duplicate dimensions

### DIFF
--- a/pfio/FileMetadata.F90
+++ b/pfio/FileMetadata.F90
@@ -123,11 +123,20 @@ contains
       class (FileMetadata), target, intent(inout) :: this
       character(len=*), intent(in) :: dim_name
       integer, intent(in) :: extent
-
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
-      call this%dimensions%insert(dim_name, extent)
+      integer :: existing_extent
+
+      if (.not. this%has_dimension(dim_name)) then
+         call this%dimensions%insert(dim_name, extent)
+         _RETURN(_SUCCESS)
+      end if
+
+      ! Otherwise verify consistency
+      existing_extent = this%get_dimension(dim_name)
+      _ASSERT(extent == existing_extent,'FileMetadata::add_dimension() - dimension already exists with different extent.')
+
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine add_dimension

--- a/pfio/tests/Test_FileMetadata.pf
+++ b/pfio/tests/Test_FileMetadata.pf
@@ -50,6 +50,26 @@ contains
    end subroutine test_get_dimension
 
    @test
+   subroutine test_fail_add_existing_dim_with_mismatch()
+      type (FileMetadata) :: cf
+
+      call cf%add_dimension('x', 10)
+      call cf%add_dimension('x', 11)
+
+      @assertExceptionRaised('FileMetadata::add_dimension() - dimension already exists with different extent.')
+
+   end subroutine test_fail_add_existing_dim_with_mismatch
+
+   @test
+   subroutine test_add_duplicate_dimension()
+      type (FileMetadata) :: cf
+
+      call cf%add_dimension('x', 10)
+      call cf%add_dimension('x', 10)
+
+   end subroutine test_add_duplicate_dimension
+
+   @test
    subroutine test_get_dimensions()
       type (FileMetadata), target :: cf
       type (StringIntegerMap), pointer :: dimensions


### PR DESCRIPTION
Issue #3169 was incorrect - code was not trapping duplicate dimensions
at all.   Now throws exception if duplicate dim name has different
extent.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

