### PR TITLE
Fixes #2845. Allow ESMF_CONFIG_FILE to specify ESMF control file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,8 @@ workflows:
           fixture_branch: feature/mathomp4/mapldevelop
           checkout_mapl_branch: true
           mepodevelop: false
-          rebuild_procs: 1
+          rebuild_procs: 4
+          build_type: Release
 
   build-and-publish-docker:
     when:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow update offsets of &#177;timestep in ExtData2G
 - Minor revision (and generalization) of grid-def for GSI purposes
-- Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
+- Add ability to use an `ESMF_CONFIG_FILE` environment variable to specify name of file to pass in pre-`ESMF_Initialize` options to ESMF (see [ESMF Docs](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node4.html#SECTION04024000000000000000) for allowed flags.
 
 ### Changed
 
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue of some Baselibs builds appearing to support zstandard. This is not possible due to Baselibs building HDF5 and netCDF as static libraries
+- Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added macro _RETURN(_SUCCESS) to fetch_data
+- Added macro `_RETURN(_SUCCESS)` to fetch_data
 - Allow update offsets of &#177;timestep in ExtData2G
 - Minor revision (and generalization) of grid-def for GSI purposes
 - Add ability to use an `ESMF_CONFIG_FILE` environment variable to specify name of file to pass in pre-`ESMF_Initialize` options to ESMF (see [ESMF Docs](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node4.html#SECTION04024000000000000000) for allowed flags.
-- Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
 - Allow lat-lon grid factory to detect and use CF compliant lat-lon bounds in a file when making a grid
 - PFIO/Variable class, new procedures to retrieve string/reals/int attributes from a variable
 
@@ -51,11 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue of some Baselibs builds appearing to support zstandard. This is not possible due to Baselibs building HDF5 and netCDF as static libraries
-<<<<<<< HEAD
 - Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
-=======
 - Fixed a bug where the periodicity around the earth of the lat-lon grid was not being set properly when grid did not span from pole to pole
->>>>>>> develop
 
 ### Removed
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -301,11 +301,12 @@ contains
       ! Step two: get the length of the environment variable
       call get_environment_variable('ESMF_CONFIG_FILE', length=esmfConfigFileLen, status=status)
       ! Step three: if the environment variable exists, get the value of the environment variable
-      if (status == 0) then
+      if (status == 0) then ! variable exists
          ! We need to deallocate so we can reallocate
          deallocate(esmfConfigFile)
          allocate(character(len = esmfConfigFileLen) :: esmfConfigFile)
          call get_environment_variable('ESMF_CONFIG_FILE', value=esmfConfigFile, status=status)
+         _VERIFY(status)
       end if
 
       if (rank == 0) then

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -308,7 +308,7 @@ contains
 
       ! If the file exists, we pass it into ESMF_Initialize, else, we
       ! use the one from the command line arguments
-      if (esmf_config_file_exists) then
+      if (esmfConfigFileExists) then
          call ESMF_Initialize (configFileName=esmfConfig_file, mpiCommunicator=comm, vm=vm, _RC)
       else
          call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, vm=vm, _RC)

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -316,9 +316,12 @@ contains
       call MPI_BCAST(esmfConfigFile, esmfConfigFileLen, MPI_CHARACTER, 0, comm, status)
       _VERIFY(status)
 
+      lgr => logging%get_logger('MAPL')
+
       ! If the file exists, we pass it into ESMF_Initialize, else, we
       ! use the one from the command line arguments
       if (esmfConfigFileExists) then
+         call lgr%info("Using ESMF configuration file: %a", esmfConfigFile)
          call ESMF_Initialize (configFileName=esmfConfigFile, mpiCommunicator=comm, vm=vm, _RC)
       else
          call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, vm=vm, _RC)
@@ -334,7 +337,6 @@ contains
       call ESMF_MeshSetMOAB(this%cap_options%with_esmf_moab, rc=status)
       _VERIFY(status)
 
-      lgr => logging%get_logger('MAPL')
       call lgr%info("Running with MOAB library for ESMF Mesh: %l1", this%cap_options%with_esmf_moab)
 
       call this%initialize_cap_gc(rc=status)

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -309,7 +309,7 @@ contains
       ! If the file exists, we pass it into ESMF_Initialize, else, we
       ! use the one from the command line arguments
       if (esmfConfigFileExists) then
-         call ESMF_Initialize (configFileName=esmfConfig_file, mpiCommunicator=comm, vm=vm, _RC)
+         call ESMF_Initialize (configFileName=esmfConfigFile, mpiCommunicator=comm, vm=vm, _RC)
       else
          call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, vm=vm, _RC)
       end if

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -292,10 +292,20 @@ contains
       ! We look to see if the user has set an environment variable for the
       ! name of the ESMF configuration file. If they have, we use that. If not,
       ! we use the default of "ESMF.rc" for backward compatibility
-      call get_environment_variable('ESMF_CONFIG_FILE', value=esmfConfigFile, length=esmfConfigFileLen, status=status)
-      if (status /= 0) then
-         esmfConfigFile = 'ESMF.rc'
-         esmfConfigFileLen = len_trim(esmfConfigFile)
+
+      ! Step one: default to ESMF.rc
+
+      esmfConfigFile = 'ESMF.rc'
+      esmfConfigFileLen = len(esmfConfigFile)
+
+      ! Step two: get the length of the environment variable
+      call get_environment_variable('ESMF_CONFIG_FILE', length=esmfConfigFileLen, status=status)
+      ! Step three: if the environment variable exists, get the value of the environment variable
+      if (status == 0) then
+         ! We need to deallocate so we can reallocate
+         deallocate(esmfConfigFile)
+         allocate(character(len = esmfConfigFileLen) :: esmfConfigFile)
+         call get_environment_variable('ESMF_CONFIG_FILE', value=esmfConfigFile, status=status)
       end if
 
       if (rank == 0) then


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR adds the ability for users to set an environment variable, `ESMF_CONFIG_FILE`, that can point to a file where pre `ESMF_Initialize` values can be set. Previously, the file *had* to be called `ESMF.rc`. Now, it looks at `ESMF_CONFIG_FILE` and if that isn't set, it then looks for `ESMF.rc` (for backwards compatibility).

I have tested this with GEOS and it works as expected.

@tclune if you have time, let me know if you have preferences for what to call the environment variable, etc.

## Related Issue

Closes #2845 

