### PR TITLE
check tableEnd efficiently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- refactored tableEnd check
 - Added commandline options to `checkpoint_benchmark.x` and `restart_benchmark.x` to allow for easier testing of different configurations. Note that the old configuration file style of input is allowed via the `--config_file` option (which overrides any other command line options)
 - Update ESMF version for Baselibs to match that of Spack for consistency
 - Update `components.yaml`

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -979,12 +979,11 @@ contains
 
     cap_import = ""
     if (present) then
-
-       do while(trim(cap_import) /= "::")
+       do while( .true.)
           call ESMF_ConfigNextLine(config, tableEnd=tableEnd, _RC)
           if (tableEnd) exit
           call ESMF_ConfigGetAttribute(config, cap_import, _RC)
-          if (trim(cap_import) /= "::") call vec%push_back(trim(cap_import))
+          call vec%push_back(trim(cap_import))
        end do
     end if
     _RETURN(_SUCCESS)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
The "::" will not be returned so it is not necessary to check it every time
## Related Issue

