### PR TITLE
Seek suggestions on mask sampler output with PFIO

### DIFF
--- a/gridcomps/History/CMakeLists.txt
+++ b/gridcomps/History/CMakeLists.txt
@@ -4,8 +4,8 @@ set (srcs
      MAPL_HistoryCollection.F90
      MAPL_HistoryGridComp.F90
      Sampler/MAPL_EpochSwathMod.F90
-     Sampler/MAPL_GeosatMaskMod.F90
-     Sampler/MAPL_GeosatMaskMod_smod.F90
+     Sampler/MAPL_MaskMod.F90
+     Sampler/MAPL_MaskMod_smod.F90
      Sampler/MAPL_StationSamplerMod.F90
      Sampler/MAPL_TrajectoryMod.F90
      Sampler/MAPL_TrajectoryMod_smod.F90

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -9,7 +9,7 @@ module MAPL_HistoryCollectionMod
   use MAPL_VerticalDataMod
   use MAPL_TimeDataMod
   use HistoryTrajectoryMod
-  use MaskSamplerGeosatMod
+  use MaskSamplerMod
   use StationSamplerMod
   use gFTL_StringStringMap
   use MAPL_EpochSwathMod
@@ -112,7 +112,7 @@ module MAPL_HistoryCollectionMod
      logical                            :: timeseries_output = .false.
      logical                            :: recycle_track = .false.
      type(HistoryTrajectory)            :: trajectory
-     type(MaskSamplerGeosat)            :: mask_sampler
+     type(MaskSampler)                  :: mask_sampler
      type(StationSampler)               :: station_sampler
      character(len=ESMF_MAXSTR)         :: sampler_spec = ""
      character(len=ESMF_MAXSTR)         :: positive

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -3778,6 +3778,9 @@ ENDDO PARSER
    if (any(writing)) then
       call o_Clients%done_collective_stage(_RC)
       call o_Clients%post_wait()
+      
+      write(6,*) ' list(1)%mask_sampler%this%array_scalar_1d',      list(1)%mask_sampler%array_scalar_1d
+      
    endif
    call MAPL_TimerOff(GENSTATE,"Done Wait")
 

--- a/gridcomps/History/Sampler/MAPL_MaskMod.F90
+++ b/gridcomps/History/Sampler/MAPL_MaskMod.F90
@@ -31,7 +31,8 @@ module MaskSamplerMod
 
   public :: MaskSampler
   type :: MaskSampler
-     private
+     !     private
+!!     public
      !     character(len=:), allocatable :: grid_file_name
      character(len=ESMF_MAXSTR) :: grid_file_name
      !     we need on each PET

--- a/gridcomps/History/Sampler/MAPL_MaskMod.F90
+++ b/gridcomps/History/Sampler/MAPL_MaskMod.F90
@@ -92,6 +92,7 @@ module MaskSamplerMod
      integer, allocatable :: global_count(:)
 
      !     real, target, allocatable :: array_scalar_2d(:,:,:)       ! (nx, nitem, ntime_seg)
+     real, allocatable :: array_scalar_1d(:)
      real, allocatable :: array_scalar_2d(:,:)
      real, allocatable :: array_scalar_3d(:,:,:)
 !     real, target, allocatable :: array_vector_2d(:,:,:)

--- a/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
@@ -1,14 +1,14 @@
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
-submodule (MaskSamplerGeosatMod)  MaskSamplerGeosat_implement
+submodule (MaskSamplerMod)  MaskSampler_implement
   implicit none
 contains
 
-module function MaskSamplerGeosat_from_config(config,string,clock,GENSTATE,rc) result(mask)
+module function MaskSampler_from_config(config,string,clock,GENSTATE,rc) result(mask)
   use BinIOMod
   use pflogger, only         :  Logger, logging
-  type(MaskSamplerGeosat) :: mask
+  type(MaskSampler) :: mask
   type(ESMF_Config), intent(inout)        :: config
   character(len=*),  intent(in)           :: string
   type(ESMF_Clock),  intent(in)           :: clock
@@ -39,7 +39,6 @@ module function MaskSamplerGeosat_from_config(config,string,clock,GENSTATE,rc) r
   call ESMF_ClockGet ( clock, CurrTime=currTime, _RC )
   if (mapl_am_I_root()) write(6,*) 'string', string
 
-
   call ESMF_ConfigGetAttribute(config, value=mask%grid_file_name,label=trim(string)//'obs_files:',    default="",  _RC)
   call ESMF_ConfigGetAttribute(config, value=mask%index_name_x,  label=trim(string)//'index_name_x:', default="x", _RC)
   call ESMF_ConfigGetAttribute(config, value=mask%index_name_y,  label=trim(string)//'index_name_y:', default="y", _RC)
@@ -48,7 +47,6 @@ module function MaskSamplerGeosat_from_config(config,string,clock,GENSTATE,rc) r
   call ESMF_ConfigGetAttribute(config, value=mask%var_name_proj, label=trim(string)//'var_name_proj:',default="",  _RC)
   call ESMF_ConfigGetAttribute(config, value=mask%att_name_proj, label=trim(string)//'att_name_proj:',default="",  _RC)
   call ESMF_ConfigGetAttribute(config, value=mask%thin_factor,   label=trim(string)//'thin_factor:',  default=-1,  _RC)
-
 
   if (mapl_am_I_root()) write(6,*) 'thin_factor:', mask%thin_factor
   call ESMF_ConfigGetAttribute(config, value=STR1, label=trim(string)//'obs_file_begin:', default="", _RC)
@@ -86,7 +84,6 @@ module function MaskSamplerGeosat_from_config(config,string,clock,GENSTATE,rc) r
   _ASSERT(STR1/='', 'fatal error: obs_file_interval not provided in RC file')
   if (mapl_am_I_root()) write(6,105) 'obs_file_interval:', trim(STR1)
 
-
   i= index( trim(STR1), ' ' )
   if (i>0) then
      symd=STR1(1:i-1)
@@ -98,19 +95,22 @@ module function MaskSamplerGeosat_from_config(config,string,clock,GENSTATE,rc) r
   call convert_twostring_2_esmfinterval (symd, shms,  mask%obsfile_interval, _RC)
 
   mask%is_valid = .true.
+  mask%call_count = 0
 
   _RETURN(_SUCCESS)
 
 105 format (1x,a,2x,a)
 106 format (1x,a,2x,i8)
-end function MaskSamplerGeosat_from_config
+end function MaskSampler_from_config
 
 
    !
    !-- integrate both initialize and reinitialize
    !
-module subroutine initialize_(this,items,bundle,timeInfo,vdata,reinitialize,rc)
-   class(MaskSamplerGeosat), intent(inout) :: this
+module subroutine initialize_(this,duration,frequency,items,bundle,timeInfo,vdata,reinitialize,rc)
+   class(MaskSampler), intent(inout) :: this
+   integer, intent(in) :: duration
+   integer, intent(in) :: frequency
    type(GriddedIOitemVector), optional, intent(inout) :: items
    type(ESMF_FieldBundle), optional, intent(inout)   :: bundle
    type(TimeData), optional, intent(inout)           :: timeInfo
@@ -124,13 +124,14 @@ module subroutine initialize_(this,items,bundle,timeInfo,vdata,reinitialize,rc)
    type(GriddedIOitemVectorIterator) :: iter
    type(GriddedIOitem), pointer :: item
    type(ESMF_Time)            :: currTime
-   integer :: k
+   integer :: n1, n2, k
+   integer :: nitem_scalar, nitem_vector
 
    if (.not. present(reinitialize)) then
       if(present(bundle))   this%bundle=bundle
       if(present(items))    this%items=items
-      if(present(timeInfo)) this%time_info=timeInfo
-      if (present(vdata)) then
+      if(present(timeInfo)) this%timeinfo=timeInfo
+      if(present(vdata)) then
          this%vdata=vdata
       else
          this%vdata=VerticalData(_RC)
@@ -140,22 +141,191 @@ module subroutine initialize_(this,items,bundle,timeInfo,vdata,reinitialize,rc)
 !   this%do_vertical_regrid = (this%vdata%regrid_type /= VERTICAL_METHOD_NONE)
 !   if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%bundle,_RC)
 
-   this%ofile = ''
    this%obs_written = 0
-
    call this%create_grid(_RC)
-   call this%add_metadata(_RC)
+   call this%create_metadata(_RC)
 
+   nitem_scalar = 0
+   nitem_vector = 0
+
+   iter = this%items%begin()
+   do while (iter /= this%items%end())
+      item => iter%get()
+      if (item%itemType == ItemTypeScalar) then
+         nitem_scalar = nitem_scalar + 1
+      else if (item%itemType == ItemTypeVector) then
+         nitem_vector = nitem_vector + 1
+      end if
+      call iter%next()
+   end do
+
+   n1 = MAPL_nsecf( duration )
+   n2 = MAPL_nsecf( frequency )
+   _ASSERT (n2>0, "list%frequency ==0, fail!")
+   this%tmax =  n1/n2
+
+   allocate ( this%array_scalar_2d (this%npt_mask_tot, nitem_scalar ) )
+   allocate ( this%array_scalar_3d (this%npt_mask_tot, this%vdata%lm, nitem_scalar) )
+   if (mapl_am_I_root()) then
+      write(6,*) 'ck count_scalar=',  nitem_scalar
+   end if
+   !
+   ! __ note thse large arrays should be deallocated in the future
+   !
+   
    _RETURN(_SUCCESS)
 
 end subroutine initialize_
+
+
+module subroutine set_param(this,deflation,quantize_algorithm,quantize_level,chunking,&
+     nbits_to_keep,regrid_method,itemOrder,write_collection_id,regrid_hints,rc)
+  class (MaskSampler), intent(inout) :: this
+  integer, optional, intent(in) :: deflation
+  integer, optional, intent(in) :: quantize_algorithm
+  integer, optional, intent(in) :: quantize_level
+  integer, optional, intent(in) :: chunking(:)
+  integer, optional, intent(in) :: nbits_to_keep
+  integer, optional, intent(in) :: regrid_method
+  logical, optional, intent(in) :: itemOrder
+  integer, optional, intent(in) :: write_collection_id
+  integer, optional, intent(in) :: regrid_hints
+  integer, optional, intent(out) :: rc
+  integer :: status
+
+  if (present(write_collection_id)) this%write_collection_id=write_collection_id
+!!  add later on
+!!        if (present(regrid_method)) this%regrid_method=regrid_method
+!!        if (present(nbits_to_keep)) this%nbits_to_keep=nbits_to_keep
+!!        if (present(deflation)) this%deflateLevel = deflation
+!!        if (present(quantize_algorithm)) this%quantizeAlgorithm = quantize_algorithm
+!!        if (present(quantize_level)) this%quantizeLevel = quantize_level
+!!        if (present(chunking)) then
+!!           allocate(this%chunking,source=chunking,stat=status)
+!!           _VERIFY(status)
+!!        end if
+!!        if (present(itemOrder)) this%itemOrderAlphabetical = itemOrder
+!!        if (present(regrid_hints)) this%regrid_hints = regrid_hints
+!!        _RETURN(ESMF_SUCCESS)
+
+end subroutine set_param
+
+
+module subroutine  create_metadata(this,rc)
+    class(MaskSampler), intent(inout) :: this
+    integer, optional, intent(out)          :: rc
+
+    type(variable)   :: v
+    type(ESMF_Field) :: field
+    integer          :: fieldCount
+    integer          :: field_rank
+    integer          :: nstation
+    logical          :: is_present
+    integer          :: ub(ESMF_MAXDIM)
+    integer          :: lb(ESMF_MAXDIM)
+    logical          :: do_vertical_regrid
+    integer          :: status
+    integer          :: i
+
+    character(len=ESMF_MAXSTR), allocatable ::  fieldNameList(:)
+    character(len=ESMF_MAXSTR) :: var_name, long_name, units, vdims
+    character(len=40) :: datetime_units
+
+
+    !__ 1. metadata add_dimension,
+    !     add_variable for time, mask_points, latlon,
+    !
+
+    if ( allocated (this%metadata) ) deallocate(this%metadata)
+    allocate(this%metadata)
+
+    call this%vdata%append_vertical_metadata(this%metadata,this%bundle,_RC) ! specify lev in fmd
+
+    call this%timeinfo%add_time_to_metadata(this%metadata,_RC)
+    call this%metadata%add_dimension('mask_index', this%npt_mask_tot)
+
+    v = Variable(type=pFIO_REAL64, dimensions='mask_index')
+    call v%add_attribute('long_name','longitude')
+    call v%add_attribute('unit','degree_east')
+    call this%metadata%add_variable('longitude',v)
+
+    v = Variable(type=pFIO_REAL64, dimensions='mask_index')
+    call v%add_attribute('long_name','latitude')
+    call v%add_attribute('unit','degree_north')
+    call this%metadata%add_variable('latitude',v)
+
+
+    ! To be added when values are available
+    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
+    !call v%add_attribute('long_name','The Cubed Sphere Global Face ID')
+    !call this%metadata%add_variable('mask_CS_Face_ID',v)
+    !
+    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
+    !call v%add_attribute('long_name','The Cubed Sphere Global Index I')
+    !call this%metadata%add_variable('mask_CS_global_index_I',v)
+    !
+    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
+    !call v%add_attribute('long_name','The Cubed Sphere Global Index J')
+    !call this%metadata%add_variable('mask_CS_global_index_J',v)
+
+
+    !__ 2. filemetadata: extract field from bundle, add_variable to metadata
+    !
+    call ESMF_FieldBundleGet(this%bundle, fieldCount=fieldCount, _RC)
+    allocate (fieldNameList(fieldCount), _STAT)
+    call ESMF_FieldBundleGet(this%bundle, fieldNameList=fieldNameList, _RC)
+    do i=1, fieldCount
+       var_name=trim(fieldNameList(i))
+       call ESMF_FieldBundleGet(this%bundle,var_name,field=field,_RC)
+       call ESMF_FieldGet(field,rank=field_rank,_RC)
+       call ESMF_AttributeGet(field,name="LONG_NAME",isPresent=is_present,_RC)
+       if ( is_present ) then
+          call ESMF_AttributeGet(field, NAME="LONG_NAME",VALUE=long_name, _RC)
+       else
+          long_name = var_name
+       endif
+       call ESMF_AttributeGet(field,name="UNITS",isPresent=is_present,_RC)
+       if ( is_present ) then
+          call ESMF_AttributeGet(field, NAME="UNITS",VALUE=units, _RC)
+       else
+          units = 'unknown'
+       endif
+
+!       if (this%timeInfo%is_initialized) then
+!          if (field_rank==2) then
+!             vdims = "mask_index,time"
+!             v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
+!          else if (field_rank==3) then
+!             vdims = "mask_index,lev,time"
+!             v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
+!          end if
+!       else
+          if (field_rank==2) then
+             vdims = "mask_index"
+             v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
+          else if (field_rank==3) then
+             vdims = "mask_index,lev"
+             v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
+          end if
+!       end if
+       call v%add_attribute('units',         trim(units))
+       call v%add_attribute('long_name',     trim(long_name))
+       call v%add_attribute('missing_value', MAPL_UNDEF)
+       call v%add_attribute('_FillValue',    MAPL_UNDEF)
+       call v%add_attribute('valid_range',   (/-MAPL_UNDEF,MAPL_UNDEF/))
+       call this%metadata%add_variable(trim(var_name),v,_RC)
+    end do
+    deallocate (fieldNameList, _STAT)
+
+    _RETURN(_SUCCESS)
+  end subroutine create_metadata
 
 
      module subroutine create_Geosat_grid_find_mask(this, rc)
        use pflogger, only: Logger, logging
        implicit none
 
-       class(MaskSamplerGeosat), intent(inout) :: this
+       class(MaskSampler), intent(inout) :: this
        integer, optional, intent(out)          :: rc
 
        type(Logger), pointer :: lgr
@@ -223,7 +393,7 @@ end subroutine initialize_
 
        real(ESMF_kind_R8), pointer :: lons_ptr(:,:), lats_ptr(:,:)
        integer :: nsend
-       integer, allocatable :: recvcounts_loc(:)
+       integer, allocatable :: recvcounts_loc(:), sendcounts_loc(:)
        integer, allocatable :: displs_loc(:)
 
        integer, allocatable :: sendcount(:), displs(:)
@@ -282,7 +452,7 @@ end subroutine initialize_
        ydim_red  = n2 / this%thin_factor
        _ASSERT ( xdim_red * ydim_red > M, 'mask reduced points after thin_factor is less than Nproc!')
 
-       ! get nx2
+       ! get nx2: local on each ip
        nx2=0
        k=0
        do i=1, xdim_red
@@ -342,6 +512,16 @@ end subroutine initialize_
             this%recvcounts, recvcounts_loc, displs_loc, MPI_INTEGER,&
             iroot, mpic, ierr )
        _VERIFY(ierr)
+
+       write(6,*) 'ip, nx2, this%recvcounts, recvcounts_loc, displs_loc'
+       write(6,'(200i5)')  ip, nx2
+       write(6,'(200i5)')  this%recvcounts
+       write(6,'(200i5)')  recvcounts_loc
+       write(6,'(200i5)')  displs_loc
+       call MPI_Barrier(mpic,ierr)
+       _VERIFY(ierr)
+
+
        if (.not. mapl_am_i_root()) then
           this%recvcounts(:) = 0
        end if
@@ -354,11 +534,11 @@ end subroutine initialize_
        call MPI_gatherv ( lons_chunk, nsend, MPI_REAL8, &
             lons, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
        call MPI_gatherv ( lats_chunk, nsend, MPI_REAL8, &
             lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
 
 
 !!       if (mapl_am_I_root()) write(6,*) 'nobs tot :', nx
@@ -393,13 +573,13 @@ end subroutine initialize_
        ptA(:) = lons_chunk(:)
        call ESMF_FieldRedistStore (fieldA, fieldB, RH, _RC)
        call MPI_Barrier(mpic,ierr)
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
        call ESMF_FieldRedist      (fieldA, fieldB, RH, _RC)
        lons_ds = ptB
 
        ptA(:) = lats_chunk(:)
        call MPI_Barrier(mpic,ierr)
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
        call ESMF_FieldRedist      (fieldA, fieldB, RH, _RC)
        lats_ds = ptB
 
@@ -410,7 +590,6 @@ end subroutine initialize_
        call ESMF_FieldRedistRelease(RH, noGarbage=.true., _RC)
 
        call MAPL_TimerOff(this%GENSTATE,"2_ABIgrid_LS")
-
 
        ! __ s3. find n.n. CS pts for LS_ds (halo)
        !
@@ -449,6 +628,14 @@ end subroutine initialize_
        call ESMF_FieldHaloStore (fieldI4, routehandle=RH_halo, _RC)
        call ESMF_FieldHalo (fieldI4, routehandle=RH_halo, _RC)
 
+!       !
+!       !-- print out eLB, eUB do they match 1:IM, JM?
+!       !
+!       write(6,*) 'IM,JM', IM,JM
+!       write(6,*) 'eLB(1), eUB(1)', eLB(1), eUB(1)
+!       write(6,*) 'eLB(2), eUB(2)', eLB(2), eUB(2)
+
+
        k=0
        do i=eLB(1), eUB(1)
           do j=eLB(2), eUB(2)
@@ -465,7 +652,7 @@ end subroutine initialize_
        allocate( mask(IM, JM), _STAT)
        mask(1:IM, 1:JM) = abs(farrayPtr(1:IM, 1:JM))
 
-       this%npt_mask = k
+       this%npt_mask = k    ! # of masked pts on CS grid
        allocate( this%index_mask(2,k), _STAT )
        arr(1)=k
        call ESMF_VMAllFullReduce(vm, sendData=arr, recvData=this%npt_mask_tot, &
@@ -507,7 +694,6 @@ end subroutine initialize_
           lats(i) = lats_ptr (ix, jx)
        end do
 
-
        iroot=0
        if (mapl_am_i_root()) then
           allocate (this%lons(this%npt_mask_tot), this%lats(this%npt_mask_tot), _STAT)
@@ -528,7 +714,9 @@ end subroutine initialize_
        call MPI_gatherv ( this%npt_mask, 1, MPI_INTEGER, &
             this%recvcounts, recvcounts_loc, displs_loc, MPI_INTEGER,&
             iroot, mpic, ierr )
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
+       !
+       ! set nonroot to zero for s4.3
        if (.not. mapl_am_i_root()) then
           this%recvcounts(:) = 0
        end if
@@ -544,126 +732,80 @@ end subroutine initialize_
        call MPI_gatherv ( lons, nsend, MPI_REAL8, &
             this%lons, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
        call MPI_gatherv ( lats, nsend, MPI_REAL8, &
             this%lats, this%recvcounts, this%displs, MPI_REAL8,&
             iroot, mpic, ierr )
-       _VERIFY(ierr) 
+       _VERIFY(ierr)
 
        call MAPL_TimerOff(this%GENSTATE,"4_gatherV")
+
+
+       ! __ s4.4  find (i1,in) for masked array
+       write(6,*) 'ip, this%npt_mask, this%recvcounts, this%displs'
+       write(6,'(200i10)')  ip, this%npt_mask
+       write(6,'(200i10)')  this%recvcounts
+       write(6,'(200i10)')  this%displs
+       call MPI_Barrier(mpic,ierr)
+       _VERIFY(ierr)
+
+
+       if (mapl_am_i_root()) then
+          print*, 'this%npt_mask_tot=', this%npt_mask_tot
+          allocate (this%lons_deg(this%npt_mask_tot), this%lats_deg(this%npt_mask_tot), _STAT)
+          this%lons_deg = this%lons * MAPL_RADIANS_TO_DEGREES
+          this%lats_deg = this%lats * MAPL_RADIANS_TO_DEGREES
+       else
+          allocate (this%lons_deg(0), this%lats_deg(0), _STAT)          
+       end if
+!!       write(6,'(2x,a,2x,i5,2x,1000f12.2)') 'ip, lons_deg', ip, this%lons_deg
+!!       write(6,'(2x,a,2x,i5,2x,1000f12.2)') 'ip, lats_deg', ip, this%lats_deg       
+
+!!       call MAPL_CommsBcast(vm, DATA=, N=1, ROOT=MAPL_Root, _RC)
+       allocate (sendcounts_loc(petcount))
+       do i=1, petcount
+          displs_loc(i)=i-1
+          sendcounts_loc(i)=1
+       enddo
+
+       call  MPI_Scatterv( this%displs, sendcounts_loc, displs_loc, MPI_INTEGER, &
+            this%i1, 1, MPI_INTEGER, iroot, mpic, ierr)
+       if (this%npt_mask > 0) then
+          this%i1 = this%i1 + 1       ! shift from 0 to 1
+          this%in =  this%i1 + this%npt_mask - 1
+       else
+          this%i1 = 0
+          this%in = 0
+       end if
+
+       write(6,'(2x,a,2x,200i10)')  'ip, this%npt_mask, this%i1, in:', &
+            ip, this%npt_mask, this%i1, this%in
+       call MPI_Barrier(mpic,ierr)
 
        _RETURN(_SUCCESS)
      end subroutine create_Geosat_grid_find_mask
 
 
-module subroutine  add_metadata(this,rc)
-    class(MaskSamplerGeosat), intent(inout) :: this
-    integer, optional, intent(out)          :: rc
 
-    type(variable)   :: v
-    type(ESMF_Field) :: field
-    integer          :: fieldCount
-    integer          :: field_rank
-    integer          :: nstation
-    logical          :: is_present
-    integer          :: ub(ESMF_MAXDIM)
-    integer          :: lb(ESMF_MAXDIM)
-    logical          :: do_vertical_regrid
-    integer          :: status
-    integer          :: i
-
-    character(len=ESMF_MAXSTR), allocatable ::  fieldNameList(:)
-    character(len=ESMF_MAXSTR) :: var_name, long_name, units, vdims
-    character(len=40) :: datetime_units
-
-    !__ 1. metadata add_dimension,
-    !     add_variable for time, latlon, mask_points
-    !
-    call this%vdata%append_vertical_metadata(this%metadata,this%bundle,_RC) ! specify lev in fmd
-    call this%time_info%add_time_to_metadata(this%metadata,_RC)
-    call this%metadata%add_dimension('mask_index', this%npt_mask_tot)
-
-    v = Variable(type=pFIO_REAL64, dimensions='mask_index')
-    call v%add_attribute('long_name','longitude')
-    call v%add_attribute('unit','degree_east')
-    call this%metadata%add_variable('longitude',v)
-
-    v = Variable(type=pFIO_REAL64, dimensions='mask_index')
-    call v%add_attribute('long_name','latitude')
-    call v%add_attribute('unit','degree_north')
-    call this%metadata%add_variable('latitude',v)
-
-    ! To be added when values are available
-    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
-    !call v%add_attribute('long_name','The Cubed Sphere Global Face ID')
-    !call this%metadata%add_variable('mask_CS_Face_ID',v)
-    !
-    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
-    !call v%add_attribute('long_name','The Cubed Sphere Global Index I')
-    !call this%metadata%add_variable('mask_CS_global_index_I',v)
-    !
-    !v = Variable(type=pFIO_INT32, dimensions='mask_index')
-    !call v%add_attribute('long_name','The Cubed Sphere Global Index J')
-    !call this%metadata%add_variable('mask_CS_global_index_J',v)
-
-
-    !__ 2. filemetadata: extract field from bundle, add_variable to metadata
-    !
-    call ESMF_FieldBundleGet(this%bundle, fieldCount=fieldCount, _RC)
-    allocate (fieldNameList(fieldCount), _STAT)
-    call ESMF_FieldBundleGet(this%bundle, fieldNameList=fieldNameList, _RC)
-    do i=1, fieldCount
-       var_name=trim(fieldNameList(i))
-       call ESMF_FieldBundleGet(this%bundle,var_name,field=field,_RC)
-       call ESMF_FieldGet(field,rank=field_rank,_RC)
-       call ESMF_AttributeGet(field,name="LONG_NAME",isPresent=is_present,_RC)
-       if ( is_present ) then
-          call ESMF_AttributeGet(field, NAME="LONG_NAME",VALUE=long_name, _RC)
-       else
-          long_name = var_name
-       endif
-       call ESMF_AttributeGet(field,name="UNITS",isPresent=is_present,_RC)
-       if ( is_present ) then
-          call ESMF_AttributeGet(field, NAME="UNITS",VALUE=units, _RC)
-       else
-          units = 'unknown'
-       endif
-       if (field_rank==2) then
-          vdims = "mask_index,time"
-          v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
-       else if (field_rank==3) then
-          vdims = "lev,mask_index,time"
-          call ESMF_FieldGet(field,ungriddedLBound=lb,ungriddedUBound=ub,_RC)
-          v = variable(type=PFIO_REAL32,dimensions=trim(vdims))
-       end if
-       call v%add_attribute('units',         trim(units))
-       call v%add_attribute('long_name',     trim(long_name))
-       call v%add_attribute('missing_value', MAPL_UNDEF)
-       call v%add_attribute('_FillValue',    MAPL_UNDEF)
-       call v%add_attribute('valid_range',   (/-MAPL_UNDEF,MAPL_UNDEF/))
-       call this%metadata%add_variable(trim(var_name),v,_RC)
-    end do
-    deallocate (fieldNameList, _STAT)
-
-    _RETURN(_SUCCESS)
-  end subroutine add_metadata
-
-
- module subroutine regrid_append_file(this,current_time,rc)
+ module subroutine output_to_server(this,current_time,filename,oClients,rc)
     implicit none
 
-    class(MaskSamplerGeosat), intent(inout) :: this
+    class(MaskSampler), target, intent(inout) :: this
     type(ESMF_Time), intent(inout)          :: current_time
+    character(len=*), intent(in) :: filename
+    type (ClientManager), target, optional, intent(inout) :: oClients
     integer, optional, intent(out)          :: rc
     !
     integer :: status
     integer :: fieldCount
     integer :: ub(1), lb(1)
     type(ESMF_Field) :: src_field,dst_field
-    real(kind=REAL32), pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
-    real(kind=REAL32), allocatable :: p_dst_3d(:),p_dst_2d(:)
-    real(kind=REAL32), allocatable :: p_dst_3d_full(:),p_dst_2d_full(:)
-    real(kind=REAL32), allocatable :: arr(:,:)
+    real, pointer :: p_src_3d(:,:,:),p_src_2d(:,:)
+    real, pointer :: ptr1d(:) => null()
+    real, pointer :: ptr2d(:,:) => null()
+    
+    real, allocatable :: p_dst_3d_full(:),p_dst_2d_full(:)
+    real, allocatable :: arr(:,:)
     character(len=ESMF_MAXSTR), allocatable ::  fieldNameList(:)
     character(len=ESMF_MAXSTR) :: xname
     real(kind=ESMF_KIND_R8), allocatable :: rtimes(:)
@@ -678,8 +820,21 @@ module subroutine  add_metadata(this,rc)
     type(GriddedIOitemVectorIterator) :: iter
     type(GriddedIOitem), pointer :: item
     type(ESMF_VM) :: vm
+    type(ArrayReference), target :: ref
+    integer, allocatable :: local_start(:)
+    integer, allocatable :: global_start(:)
+    integer, allocatable :: global_count(:)
+    integer, allocatable :: gridLocalStart(:)
+    integer, allocatable :: gridGlobalStart(:)
+    integer, allocatable :: gridGlobalCount(:)
 
-    this%obs_written=this%obs_written+1
+    logical :: have_time
+    integer :: tindex, nset
+    integer :: count_scalar, count_vector
+
+    ! __ s1. find local_start, global_start, etc.
+    this%obs_written=1
+    this%call_count = this%call_count + 1
 
     ! -- fixed for all fields
     call ESMF_VMGetCurrent(vm,_RC)
@@ -687,8 +842,7 @@ module subroutine  add_metadata(this,rc)
     iroot=0
     nx = this%npt_mask
     nz = this%vdata%lm
-    allocate(p_dst_2d (nx), _STAT)
-    allocate(p_dst_3d (nx * nz), _STAT)
+
     if (mapl_am_i_root()) then
        allocate ( p_dst_2d_full (this%npt_mask_tot), _STAT )
        allocate ( p_dst_3d_full (this%npt_mask_tot * nz), _STAT )
@@ -701,15 +855,28 @@ module subroutine  add_metadata(this,rc)
     displs_3d(:)     = nz * this%displs(:)
 
 
-    !__ 1. put_var: time variable
+    !   use griddedio logic
+    !__ 1. stage data :  time variable, lat/lon
     !
-    allocate( rtimes(1), _STAT )
-    rtimes(1) = this%compute_time_for_current(current_time,_RC) ! rtimes: seconds since opening file
-    if (mapl_am_i_root()) then
-       call this%formatter%put_var('time',rtimes(1:1),&
-            start=[this%obs_written],count=[1],_RC)
+    Have_time = this%timeInfo%am_i_initialized()
+
+    if (have_time) then
+       this%times = this%timeInfo%compute_time_vector(this%metadata,_RC)
+       write(6,*)  'this%times=', this%times
+
+       ref = ArrayReference(this%times)
+
+       call oClients%stage_nondistributed_data(this%write_collection_id,trim(filename),'time',ref)
+       tindex = size(this%times)
+       if (tindex==1) then
+          call this%stage2DLatLon(filename,oClients=oClients,_RC)
+        end if
+    else
+       tindex = -1
+       call this%stage2DLatLon(filename,oClients=oClients,_RC)
     end if
 
+    write(6,*) 'tindex=', tindex
 
     !__ 2. put_var: ungridded_dim from src to dst [use index_mask]
     !
@@ -720,10 +887,25 @@ module subroutine  add_metadata(this,rc)
     !   call this%vdata%setup_eta_to_pressure(_RC)
     !endif
 
+
+
+!!    if ( nx>0 ) then
+!!       allocate ( gridLocalStart,  source=[this%i1] )
+!!       allocate ( gridGlobalStart, source=[1] )
+!!       allocate ( gridGlobalCount, source=[this%npt_mask_tot] )
+!!    else
+!!       allocate ( gridLocalStart,  source=[0] )
+!!       allocate ( gridGlobalStart, source=[0] )
+!!       allocate ( gridGlobalCount, source=[0] )
+!!    end if
+
+    count_scalar = 0
+    count_vector = 0
     iter = this%items%begin()
     do while (iter /= this%items%end())
        item => iter%get()
        if (item%itemType == ItemTypeScalar) then
+          count_scalar = count_scalar + 1
           call ESMF_FieldBundleGet(this%bundle,trim(item%xname),field=src_field,_RC)
           call ESMF_FieldGet(src_field,rank=rank,_RC)
           if (rank==2) then
@@ -731,112 +913,101 @@ module subroutine  add_metadata(this,rc)
              do j=1, nx
                 ix = this%index_mask(1,j)
                 iy = this%index_mask(2,j)
-                p_dst_2d(j) = p_src_2d(ix, iy)
+                this%array_scalar_2d(j, count_scalar) = p_src_2d(ix, iy)
              end do
-             nsend = nx
-             call MPI_gatherv ( p_dst_2d, nsend, MPI_REAL, &
-                  p_dst_2d_full, this%recvcounts, this%displs, MPI_REAL,&
-                  iroot, mpic, status )
-             _VERIFY(status)
-             call MAPL_TimerOn(this%GENSTATE,"put2D")
-             if (mapl_am_i_root()) then
-                call this%formatter%put_var(item%xname,p_dst_2d_full,&
-                     start=[1,this%obs_written],count=[this%npt_mask_tot,1],_RC)
+             if (nx>0) then
+                ptr1d(1:nx) => this%array_scalar_2d(1:nx, count_scalar)
+             else
+                allocate (ptr1d(0))
              end if
-             call MAPL_TimerOff(this%GENSTATE,"put2D")
+             ref = ArrayReference(ptr1d)
+
+             if (mapl_am_I_root()) then
+                write(6,*) ' count_scalar=',  count_scalar
+             end if
+
+!                write(6,*) 'ip, nx, this%npt_mask_tot, i1, in=', &
+!                     mypet, nx, this%npt_mask_tot, this%i1, this%in
+             write(6,*) 'ip, this%p1d', mypet, ptr1d
+                
+
+             if (nx>0) then
+                allocate(local_start,source=[this%i1])
+                allocate(global_start,source=[1])
+                allocate(global_count,source=[this%npt_mask_tot])
+                print*, 'mypet, local_start, global_start, global_count', &
+                     mypet, local_start, global_start, global_count
+             else
+                allocate(local_start,source=[0])
+                allocate(global_start,source=[0])
+                allocate(global_count,source=[0])
+             end if
+             print*, 'ck ip, this%npt_mask_tot = ', mypet, this%npt_mask_tot
+
+
+             call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(item%xname), &
+                  ref,start=local_start, global_start=global_start, global_count=global_count)
+             deallocate (local_start, global_start, global_count)
+
+
           else if (rank==3) then
+             stop -3
+
              call ESMF_FieldGet(src_field,farrayptr=p_src_3d,_RC)
              call ESMF_FieldGet(src_field,ungriddedLBound=lb,ungriddedUBound=ub,_RC)
              _ASSERT (this%vdata%lm == (ub(1)-lb(1)+1), 'vertical level is different from CS grid')
-             m=0
-             do j=1, nx
-                ix = this%index_mask(1,j)
-                iy = this%index_mask(2,j)
-                do k= lb(1), ub(1)
-                   m = m + 1
-                   p_dst_3d(m) = p_src_3d(ix, iy, k)
+
+             allocate(arr(nx, lb(1):ub(1)))
+             if (tindex > -1) then
+                allocate(local_start,source=[1,1,1])
+                allocate(global_start,source=[1,1,tindex])
+                allocate(global_count,source=[this%npt_mask_tot,nz,1])
+             else
+                allocate(local_start,source=[1,1])
+                allocate(global_start,source=[1,1])
+                allocate(global_count,source=[this%npt_mask_tot,nz])
+             end if
+
+             do k= lb(1), ub(1)
+                do j=1, nx
+                   ix = this%index_mask(1,j)
+                   iy = this%index_mask(2,j)
+                   arr(j,k) = p_src_3d(ix, iy, k)
                 end do
              end do
              !! write(6,'(2x,a,2x,i5,3x,10f8.1)') 'pet, p_dst_3d(j)', mypet, p_dst_3d(::10)
-             nsend = nx * nz
-             call MPI_gatherv ( p_dst_3d, nsend, MPI_REAL, &
-                  p_dst_3d_full, recvcounts_3d, displs_3d, MPI_REAL,&
-                  iroot, mpic, status )
-             _VERIFY(status)
-             call MAPL_TimerOn(this%GENSTATE,"put3D")
-             if (mapl_am_i_root()) then
-                allocate(arr(nz, this%npt_mask_tot), _STAT)
-                arr=reshape(p_dst_3d_full,[nz,this%npt_mask_tot],order=[1,2])
-                call this%formatter%put_var(item%xname,arr,&
-                     start=[1,1,this%obs_written],count=[nz,this%npt_mask_tot,1],_RC)
-                !note:     lev,station,time
-                deallocate(arr, _STAT)
-             end if
-             call MAPL_TimerOff(this%GENSTATE,"put3D")
+
+             ref = ArrayReference(arr)
+             write(6,*) 'end collective_stage_data p_dst_3d'
+
+             call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(item%xname), &
+                  ref,start=local_start, global_start=global_start, global_count=global_count)
+          deallocate (local_start, global_start, global_count)
+
+
           else
              _FAIL('grid2LS regridder: rank > 3 not implemented')
           end if
+
+
+          !! if (present(local_start,))  deallocate(local_start)
+
        end if
+
 
        call iter%next()
     end do
 
-    _RETURN(_SUCCESS)
-  end subroutine regrid_append_file
-
-
-
-  module subroutine create_file_handle(this,filename,rc)
-    class(MaskSamplerGeosat), intent(inout) :: this
-    character(len=*), intent(in)            :: filename
-    integer, optional, intent(out)          :: rc
-    type(variable) :: v
-    integer :: status, j
-    real(kind=REAL64), allocatable :: x(:)
-    integer :: nx
-
-    this%ofile = trim(filename)
-    v = this%time_info%define_time_variable(_RC)
-    call this%metadata%modify_variable('time',v,_RC)
-    this%obs_written = 0
-
-    if (.not. mapl_am_I_root()) then
-       _RETURN(_SUCCESS)
-    end if
-
-    call this%formatter%create(trim(filename),_RC)
-    call this%formatter%write(this%metadata,_RC)
-
-    nx = size (this%lons)
-    allocate ( x(nx), _STAT )
-    x(:) = this%lons(:) * MAPL_RADIANS_TO_DEGREES
-    call this%formatter%put_var('longitude',x,_RC)
-    x(:) = this%lats(:) * MAPL_RADIANS_TO_DEGREES
-    call this%formatter%put_var('latitude',x,_RC)
-!    call this%formatter%put_var('mask_id',this%mask_id,_RC)
-!    call this%formatter%put_var('mask_name',this%mask_name,_RC)
+    nset = mod (this%call_count, this%tmax) + 1
+    if (nset == this%tmax) this%call_count = 0
 
     _RETURN(_SUCCESS)
-  end subroutine create_file_handle
-
-
-   module subroutine close_file_handle(this,rc)
-    class(MaskSamplerGeosat), intent(inout) :: this
-    integer, optional, intent(out)          :: rc
-
-    integer :: status
-    if (trim(this%ofile) /= '') then
-       if (mapl_am_i_root()) then
-          call this%formatter%close(_RC)
-       end if
-    end if
-    _RETURN(_SUCCESS)
-  end subroutine close_file_handle
+  end subroutine output_to_server
 
 
   module function compute_time_for_current(this,current_time,rc) result(rtime)
     use  MAPL_NetCDF, only : convert_NetCDF_DateTime_to_ESMF
-    class(MaskSamplerGeosat), intent(inout) :: this
+    class(MaskSampler), intent(inout) :: this
     type(ESMF_Time), intent(in) :: current_time
     integer, optional, intent(out) :: rc
     real(kind=ESMF_KIND_R8) :: rtime
@@ -868,6 +1039,72 @@ module subroutine  add_metadata(this,rc)
     _RETURN(_SUCCESS)
   end function compute_time_for_current
 
+  module subroutine stage2dlatlon(this,filename,oClients,rc)
+    implicit none
+
+    class(MaskSampler), intent(inout) :: this
+    character(len=*), intent(in) :: fileName
+    type (ClientManager), optional, target, intent(inout) :: oClients
+    integer, optional, intent(out) :: rc
+
+    integer, allocatable :: local_start(:)
+    integer, allocatable :: global_start(:)
+    integer, allocatable :: global_count(:)
+    integer :: nx
+    real, allocatable :: lons(:), lats(:)
+    type(ArrayReference), target :: ref
+    integer :: status
+
+    ! Note: we have already gatherV to root the lon/lat
+    !       in sub. create_Geosat_grid_find_mask
+    !
+    if (mapl_am_i_root()) then
+       allocate(local_start,source=[1])
+       allocate(global_start,source=[1])
+       allocate(global_count,source=[this%npt_mask_tot])
+       write(6,*) 'this%lons_deg  root',     this%lons_deg
+    else
+       allocate(local_start,source=[0])
+       allocate(global_start,source=[0])
+       allocate(global_count,source=[0])
+       write(6,*) 'this%lons_deg else',     this%lons_deg       
+    end if
+    
+    ref = ArrayReference(this%lons_deg)
+    call oClients%collective_stage_data(this%write_collection_id,trim(filename),'longitude', &
+         ref,start=local_start, global_start=global_start, global_count=global_count)
+
+    ref = ArrayReference(this%lats_deg)
+    call oClients%collective_stage_data(this%write_collection_id,trim(filename),'latitude', &
+         ref,start=local_start, global_start=global_start, global_count=global_count)
+
+    _RETURN(_SUCCESS)
+ end subroutine stage2dlatlon
 
 
-end submodule MaskSamplerGeosat_implement
+     module subroutine modifyTime(this, oClients, rc)
+        class(MaskSampler), intent(inout) :: this
+        type (ClientManager), optional, intent(inout) :: oClients
+        integer, optional, intent(out) :: rc
+
+        type(Variable) :: v
+        type(StringVariableMap) :: var_map
+        integer :: status
+
+        if (this%timeInfo%is_initialized) then
+           v = this%timeInfo%define_time_variable(_RC)
+           call this%metadata%modify_variable('time',v,rc=status)
+           _VERIFY(status)
+           if (present(oClients)) then
+              call var_map%insert('time',v)
+              call oClients%modify_metadata(this%write_collection_id, var_map=var_map, rc=status)
+              _VERIFY(status)
+           end if
+        else
+           _FAIL("Time was not initialized for the GriddedIO class instance")
+        end if
+        _RETURN(ESMF_SUCCESS)
+
+     end subroutine modifyTime
+
+   end submodule MaskSampler_implement

--- a/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
@@ -939,9 +939,12 @@ module subroutine  create_metadata(this,rc)
                 print*, 'mypet, local_start, global_start, global_count', &
                      mypet, local_start, global_start, global_count
              else
-                allocate(local_start,source=[0])
-                allocate(global_start,source=[0])
-                allocate(global_count,source=[0])
+                allocate(local_start,source=[this%i1])
+                allocate(global_start,source=[1])
+                allocate(global_count,source=[this%npt_mask_tot])
+!                allocate(local_start,source=[0])
+!                allocate(global_start,source=[0])
+!                allocate(global_count,source=[0])
              end if
              print*, 'ck ip, this%npt_mask_tot = ', mypet, this%npt_mask_tot
 

--- a/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_MaskMod_smod.F90
@@ -164,8 +164,9 @@ module subroutine initialize_(this,duration,frequency,items,bundle,timeInfo,vdat
    _ASSERT (n2>0, "list%frequency ==0, fail!")
    this%tmax =  n1/n2
 
-   allocate ( this%array_scalar_2d (this%npt_mask_tot, nitem_scalar ) )
-   allocate ( this%array_scalar_3d (this%npt_mask_tot, this%vdata%lm, nitem_scalar) )
+   allocate ( this%array_scalar_1d (this%npt_mask))
+   allocate ( this%array_scalar_2d (this%npt_mask, nitem_scalar ) )
+   allocate ( this%array_scalar_3d (this%npt_mask, this%vdata%lm, nitem_scalar) )
    if (mapl_am_I_root()) then
       write(6,*) 'ck count_scalar=',  nitem_scalar
    end if
@@ -862,7 +863,6 @@ module subroutine  create_metadata(this,rc)
 
     if (have_time) then
        this%times = this%timeInfo%compute_time_vector(this%metadata,_RC)
-       write(6,*)  'this%times=', this%times
 
        ref = ArrayReference(this%times)
 
@@ -876,7 +876,6 @@ module subroutine  create_metadata(this,rc)
        call this%stage2DLatLon(filename,oClients=oClients,_RC)
     end if
 
-    write(6,*) 'tindex=', tindex
 
     !__ 2. put_var: ungridded_dim from src to dst [use index_mask]
     !
@@ -914,9 +913,11 @@ module subroutine  create_metadata(this,rc)
                 ix = this%index_mask(1,j)
                 iy = this%index_mask(2,j)
                 this%array_scalar_2d(j, count_scalar) = p_src_2d(ix, iy)
+                this%array_scalar_1d(j) = 1.d0                
              end do
              if (nx>0) then
-                ptr1d(1:nx) => this%array_scalar_2d(1:nx, count_scalar)
+                !                ptr1d(1:nx) => this%array_scalar_2d(1:nx, count_scalar)
+                ptr1d => this%array_scalar_1d
              else
                 allocate (ptr1d(0))
              end if
@@ -1062,12 +1063,10 @@ module subroutine  create_metadata(this,rc)
        allocate(local_start,source=[1])
        allocate(global_start,source=[1])
        allocate(global_count,source=[this%npt_mask_tot])
-       write(6,*) 'this%lons_deg  root',     this%lons_deg
     else
        allocate(local_start,source=[0])
        allocate(global_start,source=[0])
        allocate(global_count,source=[0])
-       write(6,*) 'this%lons_deg else',     this%lons_deg       
     end if
     
     ref = ArrayReference(this%lons_deg)

--- a/gridcomps/History/Sampler/MAPL_StationSamplerMod.F90
+++ b/gridcomps/History/Sampler/MAPL_StationSamplerMod.F90
@@ -47,7 +47,7 @@ module StationSamplerMod
      type(FileMetadata)             :: metadata
      type(NetCDF4_FileFormatter)    :: formatter
      type(VerticalData)             :: vdata
-     type(TimeData)                 :: time_info
+     type(TimeData)                 :: timeinfo
      character(LEN=ESMF_MAXPATHLEN) :: ofile
      integer                        :: obs_written
 
@@ -351,7 +351,7 @@ contains
     !
     if(present(bundle))   this%bundle=bundle
     if(present(items))    this%items=items
-    if(present(timeInfo)) this%time_info=timeInfo
+    if(present(timeInfo)) this%timeinfo=timeInfo
     if (present(vdata)) then
        this%vdata = vdata
     else
@@ -366,7 +366,7 @@ contains
     endif
 
     call timeInfo%add_time_to_metadata(this%metadata,_RC) ! specify time in fmd
-    this%time_info = timeInfo
+    this%timeinfo = timeInfo
 
     call this%metadata%add_dimension('station_index',nstation)
 
@@ -712,7 +712,7 @@ contains
     integer :: status, j
 
     this%ofile = trim(filename)
-    v = this%time_info%define_time_variable(_RC)
+    v = this%timeinfo%define_time_variable(_RC)
     call this%metadata%modify_variable('time',v,_RC)
     this%obs_written = 0
 

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -41,7 +41,7 @@ module HistoryTrajectoryMod
      logical :: do_vertical_regrid
 
      type(LocstreamRegridder) :: regridder
-     type(TimeData)           :: time_info
+     type(TimeData)           :: timeinfo
      type(ESMF_Clock)         :: clock
      type(ESMF_Alarm), public :: alarm
      type(ESMF_Time)          :: RingTime

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -278,7 +278,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          if (.not. present(reinitialize)) then
             if(present(bundle))   this%bundle=bundle
             if(present(items))    this%items=items
-            if(present(timeInfo)) this%time_info=timeInfo
+            if(present(timeInfo)) this%timeinfo=timeInfo
             if (present(vdata)) then
                this%vdata=vdata
             else
@@ -326,7 +326,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
 
          do k=1, this%nobs_type
             call this%obs(k)%metadata%add_dimension(this%index_name_x, this%obs(k)%nobs_epoch)
-            if (this%time_info%integer_time) then
+            if (this%timeinfo%integer_time) then
                v = Variable(type=PFIO_INT32,dimensions=this%index_name_x)
             else
                v = Variable(type=PFIO_REAL64,dimensions=this%index_name_x)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

I am seeking help for this piece of code to dispatch output, 1d array selected from a 2D array:
I am missing all the data from non-root processors. 
This is the confusing part, for pointer, array and allocated variables. 

```
After allocate in  mask init:
  allocate ( this%array_scalar_2d (this%npt_mask_tot, nitem_scalar ) )
  allocate ( this%array_scalar_3d (this%npt_mask_tot, this%vdata%lm, nitem_scalar) )

I added the oclients stage data:

             call ESMF_FieldGet(src_field,farrayptr=p_src_2d,_RC)
             do j=1, nx
                ix = this%index_mask(1,j)
                iy = this%index_mask(2,j)
                this%array_scalar_2d(j, count_scalar) = p_src_2d(ix, iy)
             end do
             if (nx>0) then
                ptr1d(1:nx) => this%array_scalar_2d(1:nx, count_scalar)
             else
                allocate (ptr1d(0))
             end if
             ref = ArrayReference(ptr1d)

             if (mapl_am_I_root()) then
                write(6,*) ' count_scalar=',  count_scalar
             end if

!                write(6,*) 'ip, nx, this%npt_mask_tot, i1, in=', &
!                     mypet, nx, this%npt_mask_tot, this%i1, this%in
             write(6,*) 'ip, this%p1d', mypet, ptr1d


             if (nx>0) then
                allocate(local_start,source=[this%i1])
                allocate(global_start,source=[1])
                allocate(global_count,source=[this%npt_mask_tot])
                print*, 'mypet, local_start, global_start, global_count', &
                     mypet, local_start, global_start, global_count
             else
                allocate(local_start,source=[0])
                allocate(global_start,source=[0])
                allocate(global_count,source=[0])
             end if
             print*, 'ck ip, this%npt_mask_tot = ', mypet, this%npt_mask_tot


             call oClients%collective_stage_data(this%write_collection_id,trim(filename),trim(item%xname), &
                  ref,start=local_start, global_start=global_start, global_count=global_count)
             deallocate (local_start, global_start, global_count)
```

The output shows:

```

 ck ip, this%npt_mask_tot =  4 65
 ck ip, this%npt_mask_tot =  2 65
 ck ip, this%npt_mask_tot =  0 65
 ck ip, this%npt_mask_tot =  5 65
 ck ip, this%npt_mask_tot =  1 65
 ck ip, this%npt_mask_tot =  3 65

 ip, this%npt_mask, this%i1, in:           0        18         1        18
  ip, this%npt_mask, this%i1, in:           4        42        19        60
  ip, this%npt_mask, this%i1, in:           2         0         0         0
  ip, this%npt_mask, this%i1, in:           5         5        61        65
  ip, this%npt_mask, this%i1, in:           1         0         0         0

 ip, this%p1d 4 -34.2816315  24.5193481 -11.7045240 -28.7434216 -36.4769363  35.3333778  26.3994541  16.8893108  -2.8508387 -12.5388012 -21.7820663 -38.2840652  27.9462414 -13.2156935  18.6562767 -13.6949644 -40.6111794  29.6331234  19.0445766   7.9561124  -3.1845305 -13.9438419 -23.9748096 -33.0550804 -41.0861626  19.0445766 -13.9438419 -41.0861626  18.6562767 -13.6949644 -40.6111794  27.9462414  17.9166775   7.4805627  -3.0111017 -13.2156935 -22.8467579 -31.7024555 -39.6709099  16.8893108 -12.5388012 -38.2840652

 ip, this%p1d 2

 ip, this%p1d 0 -46.6035919 -48.2927628 -42.8012505 -58.5990944 -61.5401497 -60.4166603 -63.7372818 -66.0939713 -67.3196945 -67.3196945 -66.0939713 -67.9778214 -72.1054001 -59.6047211 -67.0103073 -62.0779228 -56.5859642 -63.6863976

 ip, this%p1d 5 -27.7251472 -23.4788818 -31.6026516 -39.1352425 -35.1871452

 ip, this%p1d 1

 ip, this%p1d 3


ncdump output shows:
 longitude = 308.22040481638, 308.231351085531, 308.19711927854, ...
 latitude = -15.4538198001052, 3.09841504273754, 27.6667346534551, ...

 var2 = -46.60359, -48.29276, -42.80125, -58.59909, -61.54015, -60.41666,
    -63.73728, -66.09397, -67.31969, -67.31969, -66.09397, -67.97782,
    -72.1054, -59.60472, -67.01031, -62.07792, -56.58596, -63.6864, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
```


## Related Issue

