### PR TITLE
Select short name of variable defining ModelVerticalGrid

### DIFF
--- a/generic3g/ComponentSpecParser/parse_geometry_spec.F90
+++ b/generic3g/ComponentSpecParser/parse_geometry_spec.F90
@@ -107,13 +107,12 @@ contains
             levels = ESMF_HConfigAsR4Seq(vertical_grid_cfg, keyString='levels' ,_RC)
             vertical_grid = FixedLevelsVerticalGrid(standard_name, levels, units)
          case('model')
-            num_levels = ESMF_HConfigAsI4(vertical_grid_cfg, keyString='num_levels', _RC)
+            standard_name = ESMF_HConfigAsString(vertical_grid_cfg, keyString='standard_name', _RC)
             units = ESMF_HConfigAsString(vertical_grid_cfg, keyString='units', _RC)
-            vertical_grid = ModelVerticalGrid(num_levels=num_levels, units=units)
-            short_name = ESMF_HConfigAsString(vertical_grid_cfg, keyString='short_name', _RC)
+            num_levels = ESMF_HConfigAsI4(vertical_grid_cfg, keyString='num_levels', _RC)
+            vertical_grid = ModelVerticalGrid(standard_name=standard_name, units=units, num_levels=num_levels)
             select type(vertical_grid)
             type is(ModelVerticalGrid)
-               call vertical_grid%add_variant(short_name=short_name)
                call vertical_grid%set_registry(registry)
             end select
          case default

--- a/generic3g/ComponentSpecParser/parse_geometry_spec.F90
+++ b/generic3g/ComponentSpecParser/parse_geometry_spec.F90
@@ -33,7 +33,7 @@ contains
       type(GeomManager), pointer :: geom_mgr
       class(GeomSpec), allocatable :: geom_spec
       integer :: num_levels
-      character(:), allocatable :: vertical_grid_class, standard_name, units, short_name
+      character(:), allocatable :: vertical_grid_class, standard_name, units
       class(VerticalGrid), allocatable :: vertical_grid
       real, allocatable :: levels(:)
 
@@ -114,6 +114,7 @@ contains
             select type(vertical_grid)
             type is(ModelVerticalGrid)
                call vertical_grid%set_registry(registry)
+               call vertical_grid%add_short_names(edge="PLE", center="PL")
             end select
          case default
             _FAIL('vertical grid class '//vertical_grid_class//' not supported')

--- a/generic3g/ComponentSpecParser/parse_geometry_spec.F90
+++ b/generic3g/ComponentSpecParser/parse_geometry_spec.F90
@@ -114,7 +114,13 @@ contains
             select type(vertical_grid)
             type is(ModelVerticalGrid)
                call vertical_grid%set_registry(registry)
-               call vertical_grid%add_short_names(edge="PLE", center="PL")
+               if (standard_name == "air_pressure") then
+                  call vertical_grid%add_short_names(edge="PLE", center="PL")
+               else if (standard_name == "height") then
+                  call vertical_grid%add_short_names(edge="ZLE", center="ZL")
+               else
+                  _FAIL("unsupported standard name ["//standard_name//"]")
+               end if
             end select
          case default
             _FAIL('vertical grid class '//vertical_grid_class//' not supported')

--- a/generic3g/ComponentSpecParser/parse_geometry_spec.F90
+++ b/generic3g/ComponentSpecParser/parse_geometry_spec.F90
@@ -115,9 +115,9 @@ contains
             type is(ModelVerticalGrid)
                call vertical_grid%set_registry(registry)
                if (standard_name == "air_pressure") then
-                  call vertical_grid%add_short_names(edge="PLE", center="PL")
+                  call vertical_grid%add_short_name(edge="PLE", center="PL")
                else if (standard_name == "height") then
-                  call vertical_grid%add_short_names(edge="ZLE", center="ZL")
+                  call vertical_grid%add_short_name(edge="ZLE", center="ZL")
                else
                   _FAIL("unsupported standard name ["//standard_name//"]")
                end if

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -65,8 +65,8 @@ contains
       rc = 0
       ! Inside user "set_geom" phase.
       geom = make_geom(_RC)
-      vgrid = ModelVerticalGrid(num_levels=LM, units="hPa")
-      call vgrid%add_variant(short_name=var_name)
+      vgrid = ModelVerticalGrid(standard_name="air_pressure", units="hPa", num_levels=LM)
+      call vgrid%add_short_names(edge="PLE", center="PL")
 
       ! inside OuterMeta
       r = StateRegistry("dyn")
@@ -114,21 +114,9 @@ contains
       integer :: num_levels
 
       num_levels = 10
-      vgrid = ModelVerticalGrid(num_levels=num_levels, units="hPa")
+      vgrid = ModelVerticalGrid(standard_name="height", units="m", num_levels=num_levels)
       @assert_that(vgrid%get_num_levels(), is(num_levels))
    end subroutine test_num_levels
-
-   @test
-   subroutine test_num_variants()
-      type(ModelVerticalGrid) :: vgrid
-
-      vgrid = ModelVerticalGrid(num_levels=3, units="hPa")
-      @assert_that(vgrid%get_num_variants(), is(0))
-      call vgrid%add_variant(short_name="PLE")
-      @assert_that(vgrid%get_num_variants(), is(1))
-      call vgrid%add_variant(short_name="ZLE")
-      @assert_that(vgrid%get_num_variants(), is(2))
-   end subroutine test_num_variants
 
    @test(type=ESMF_TestMethod, npes=[1])
    subroutine test_created_fields_have_num_levels(this)

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -66,7 +66,7 @@ contains
       ! Inside user "set_geom" phase.
       geom = make_geom(_RC)
       vgrid = ModelVerticalGrid(standard_name="air_pressure", units="hPa", num_levels=LM)
-      call vgrid%add_short_names(edge="PLE", center="PL")
+      call vgrid%add_short_name(edge="PLE", center="PL")
 
       ! inside OuterMeta
       r = StateRegistry("dyn")

--- a/generic3g/tests/scenarios/vertical_regridding_2/A.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/A.yaml
@@ -9,14 +9,14 @@ mapl:
       dateline: DC
     vertical_grid:
       class: model
-      short_name: PLE
+      standard_name: air_pressure
       units: hPa
       num_levels: 4
 
   states:
     import: {}
     export:
-      PLE:
+      PL:
         standard_name: air_pressure
         units: hPa
         default_value: 17.

--- a/generic3g/tests/scenarios/vertical_regridding_2/C.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/C.yaml
@@ -9,14 +9,14 @@ mapl:
       dateline: DC
     vertical_grid:
       class: model
-      short_name: ZLE
+      standard_name: height
       units: m
       num_levels: 4
 
   states:
     import: {}
     export:
-      ZLE:
+      ZL:
         standard_name: height
         units: m
         default_value: 23.

--- a/generic3g/tests/scenarios/vertical_regridding_2/expectations.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/expectations.yaml
@@ -5,7 +5,7 @@
 
 - component: A
   export:
-    PLE: {status: complete}
+    PL: {status: complete}
 
 - component: B
   import:
@@ -13,7 +13,7 @@
 
 - component: C
   export:
-    ZLE: {status: complete}
+    ZL: {status: complete}
 
 - component: D
   import:

--- a/generic3g/tests/scenarios/vertical_regridding_2/parent.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/parent.yaml
@@ -21,11 +21,11 @@ mapl:
   states: {}
 
   connections:
-    - src_name: PLE
+    - src_name: PL
       dst_name: I_B
       src_comp: A
       dst_comp: B
-    - src_name: ZLE
+    - src_name: ZL
       dst_name: I_D
       src_comp: C
       dst_comp: D

--- a/generic3g/tests/scenarios/vertical_regridding_3/DYN.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_3/DYN.yaml
@@ -9,7 +9,7 @@ mapl:
       dateline: DC
     vertical_grid:
       class: model
-      short_name: PL
+      standard_name: air_pressure
       units: hPa
       num_levels: 4
 

--- a/generic3g/vertical/FixedLevelsVerticalGrid.F90
+++ b/generic3g/vertical/FixedLevelsVerticalGrid.F90
@@ -8,6 +8,7 @@ module mapl3g_FixedLevelsVerticalGrid
    use mapl3g_FieldCreate
    use mapl3g_GriddedComponentDriver
    use mapl3g_VerticalDimSpec
+   use mapl3g_FieldCondensedArray, only: assign_fptr_condensed_array
    use esmf
 
    implicit none
@@ -71,23 +72,19 @@ contains
       integer, optional, intent(out) :: rc
 
       real(kind=ESMF_KIND_R4), pointer :: farray3d(:, :, :)
-      integer, allocatable :: local_cell_count(:)
-      integer :: i, j, IM, JM, status
+      integer :: shape_(3), horz, ungrd, status
 
-      ! _HERE
-      ! print *, "units: ", units
       field = MAPL_FieldCreate( &
            geom=geom, &
            typekind=ESMF_TYPEKIND_R4, &
            num_levels=size(this%levels), &
            vert_staggerloc=VERTICAL_STAGGER_CENTER, &
            _RC)
-      ! Copy the 1D array, levels(:), to each point on the horz grid
-      call ESMF_FieldGet(field, fArrayPtr=farray3d, _RC)
-      call MAPL_GeomGet_(geom, localCellCount=local_cell_count, _RC)
-      IM = local_cell_count(1); JM = local_cell_count(2)
-      do concurrent (i=1:IM, j=1:JM)
-         farray3d(i, j, :) = this%levels(:)
+      ! Copy the 1D array, levels(:), to each point of the horz grid
+      call assign_fptr_condensed_array(field, farray3d, _RC)
+      shape_ = shape(farray3d)
+      do concurrent (horz=1:shape_(1), ungrd=1:shape_(3))
+         farray3d(horz, :, ungrd) = this%levels(:)
       end do
 
       _RETURN(_SUCCESS)
@@ -145,62 +142,5 @@ contains
 
       not_equal = .not. (a==b)
    end function not_equal_FixedLevelsVerticalGrid
-
-   ! Create an ESMF_Field containing a 3D array that is replicated from
-   ! a 1D array at each point of the horizontal grid
-   function esmf_field_create_(geom, farray1d, rc) result(field)
-      type(ESMF_Field) :: field ! result
-      type(ESMF_Geom), intent(in) :: geom
-      real(kind=ESMF_KIND_R4), intent(in) :: farray1d(:)
-!#      character(len=*), intent(in) :: vloc
-      integer, optional, intent(out) :: rc
-
-      integer, allocatable :: local_cell_count(:)
-      real(kind=ESMF_KIND_R4), pointer :: farray3d(:, :, :)
-      integer :: i, j, IM, JM, status
-
-!#      ! First, copy the 1D array, farray1d, to each point on the horz grid
-!#      allocate(farray3d(IM, JM, size(farray1d)))
-!#      do concurrent (i=1:IM, j=1:JM)
-!#         farray3d(i, j, :) = farray1d(:)
-!#      end do
-
-      ! Create an ESMF_Field containing farray3d
-      field = MAPL_FieldCreate( &
-           geom=geom, typekind=ESMF_TYPEKIND_R4, &
-           num_levels=size(farray1d), &
-           vert_staggerloc=VERTICAL_STAGGER_CENTER, &
-           _RC)
-
-!#      ! First, copy the 1D array, farray1d, to each point on the horz grid
-      call ESMF_FieldGet(field, fArrayPtr=farray3d, _RC)
-      call MAPL_GeomGet_(geom, localCellCount=local_cell_count, _RC)
-      IM = local_cell_count(1); JM = local_cell_count(2)
-      do concurrent (i=1:IM, j=1:JM)
-         farray3d(i, j, :) = farray1d(:)
-      end do
-
-
-      _RETURN(_SUCCESS)
-   end function esmf_field_create_
-
-   ! Temporary version here while the detailed MAPL_GeomGet utility gets developed
-   subroutine MAPL_GeomGet_(geom, localCellCount, rc)
-      use MAPLBase_Mod
-      type(ESMF_Geom), intent(in) :: geom
-      integer, allocatable, intent(out), optional :: localCellCount(:)
-      integer, intent(out), optional :: rc
-
-      type(ESMF_Grid) :: grid
-      integer :: status
-
-      if (present(localCellCount)) then
-         call ESMF_GeomGet(geom, grid=grid)
-         allocate(localCellCount(3), source=-1)
-         call MAPL_GridGet(grid, localCellCountPerDim=localCellCount, _RC)
-      end if
-
-      _RETURN(_SUCCESS)
-   end subroutine MAPL_GeomGet_
 
 end module mapl3g_FixedLevelsVerticalGrid

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -5,19 +5,15 @@ module mapl3g_ModelVerticalGrid
    use mapl_ErrorHandling
    use mapl3g_VerticalGrid
    use mapl3g_StateRegistry
-   use mapl3g_MultiState
    use mapl3g_VirtualConnectionPt
-   use mapl3g_ActualConnectionPt
    use mapl3g_StateItemSpec
    use mapl3g_FieldSpec
    use mapl3g_UngriddedDims
    use mapl3g_StateItemExtension
    use mapl3g_ExtensionFamily
    use mapl3g_ExtensionAction
-   use mapl3g_StateItemExtensionPtrVector
    use mapl3g_GriddedComponentDriver
    use mapl3g_VerticalDimSpec
-   use gftl2_StringVector
    use esmf
 
    implicit none

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -14,6 +14,7 @@ module mapl3g_ModelVerticalGrid
    use mapl3g_ExtensionAction
    use mapl3g_GriddedComponentDriver
    use mapl3g_VerticalDimSpec
+   use mapl_KeywordEnforcer
    use esmf
 
    implicit none
@@ -35,7 +36,7 @@ module mapl3g_ModelVerticalGrid
       procedure :: write_formatted
 
       ! subclass-specific methods
-      procedure :: add_short_names
+      procedure :: add_short_name
       procedure :: get_short_name
       procedure :: set_registry
       procedure :: get_registry
@@ -76,14 +77,16 @@ contains
       num_levels = this%num_levels
    end function get_num_levels
 
-   subroutine add_short_names(this, edge, center)
+   subroutine add_short_name(this, unusable, edge, center)
       class(ModelVerticalGrid), intent(inout) :: this
+      class(KeywordEnforcer), optional, intent(in) :: unusable
       character(*), optional, intent(in) :: edge
       character(*), optional, intent(in) :: center
 
       if (present(edge)) this%short_name_edge = edge
       if (present(center)) this%short_name_center = center
-   end subroutine add_short_names
+      _UNUSED_DUMMY(unusable)
+   end subroutine add_short_name
 
    function get_short_name(this, vertical_dim_spec, rc) result(short_name)
       character(:), allocatable :: short_name

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -17,7 +17,6 @@ module mapl3g_ModelVerticalGrid
    use mapl3g_StateItemExtensionPtrVector
    use mapl3g_GriddedComponentDriver
    use mapl3g_VerticalDimSpec
-   use gftl2_StringVector
    use esmf
 
    implicit none
@@ -25,14 +24,20 @@ module mapl3g_ModelVerticalGrid
 
    public :: ModelVerticalGrid
 
+   type :: Pair
+      type(VerticalDimSpec) :: vertical_dim_spec = VERTICAL_DIM_UNKNOWN
+      character(:), allocatable :: short_name
+   end type Pair
+
+   interface Pair
+      module procedure new_Pair
+   end interface Pair
+
    type, extends(VerticalGrid) :: ModelVerticalGrid
       private
+      character(:), allocatable :: standard_name
       integer :: num_levels = -1
-      type(StringVector) :: variants
-
-      !# character(:), allocatable :: short_name
-      !# character(:), allocatable :: standard_name
-      !# type(ESMF_Field) :: reference_field
+      type(Pair) :: variants(2)
       type(StateRegistry), pointer :: registry => null()
    contains
       procedure :: get_num_levels
@@ -41,8 +46,7 @@ module mapl3g_ModelVerticalGrid
       procedure :: write_formatted
 
       ! subclass-specific methods
-      procedure :: add_variant
-      procedure :: get_num_variants
+      procedure :: get_short_name
       procedure :: set_registry
       procedure :: get_registry
    end type ModelVerticalGrid
@@ -65,20 +69,27 @@ module mapl3g_ModelVerticalGrid
 
 contains
 
-   function new_ModelVerticalGrid_basic(num_levels, units) result(vgrid)
+   function new_Pair(vertical_dim_spec, short_name) result(pair)
+      type(Pair) :: pair
+      type(VerticalDimSpec), intent(in) :: vertical_dim_spec
+      character(*), intent(in) :: short_name
+
+      pair%vertical_dim_spec = vertical_dim_spec
+      pair%short_name = short_name
+   end function new_Pair
+
+   function new_ModelVerticalGrid_basic(standard_name, units, num_levels) result(vgrid)
       type(ModelVerticalGrid) :: vgrid
-      integer, intent(in) :: num_levels
+      character(*), intent(in) :: standard_name
       character(*) , intent(in) :: units
-      !# character(*), intent(in) :: short_name
-      !# character(*), intent(in) :: standard_name
-      !# type(StateRegistry), pointer, intent(in) :: registry
+      integer, intent(in) :: num_levels
 
       call vgrid%set_id()
+      vgrid%standard_name = standard_name
       call vgrid%set_units(units)
       vgrid%num_levels = num_levels
-      !# vgrid%short_name = short_name
-      !# vgrid%standard_name = standard_name
-      !# vgrid%registry => registry
+      vgrid%variants(1) = Pair(VERTICAL_DIM_EDGE, "PLE")
+      vgrid%variants(2) = Pair(VERTICAL_DIM_CENTER, "PL")
    end function new_ModelVerticalGrid_basic
 
    integer function get_num_levels(this) result(num_levels)
@@ -86,68 +97,76 @@ contains
       num_levels = this%num_levels
    end function get_num_levels
 
-   subroutine add_variant(this, short_name)
-      class(ModelVerticalGrid), intent(inout) :: this
-      character(*), intent(in) :: short_name
-
-      call this%variants%push_back(short_name)
-   end subroutine add_variant
-
-   integer function get_num_variants(this) result(num_variants)
+   function get_short_name(this, vertical_dim_spec, rc) result(short_name)
+      character(:), allocatable :: short_name
       class(ModelVerticalGrid), intent(in) :: this
-      num_variants = this%variants%size()
-   end function get_num_variants
+      type(VerticalDimSpec), intent(in) :: vertical_dim_spec
+      integer, optional :: rc
 
-    subroutine set_registry(this, registry)
-       class(ModelVerticalGrid), intent(inout) :: this
-       type(StateRegistry), target, intent(in) :: registry
+      integer :: i
 
-       this%registry => registry
-    end subroutine set_registry
+      do i = 1, 2
+         if (this%variants(i)%vertical_dim_spec == vertical_dim_spec) then
+            short_name = this%variants(i)%short_name
+         end if
+      end do
+      if (.not. allocated(short_name)) then
+         _FAIL("unsupported vertical_dim_spec")
+      end if
 
-    function get_registry(this) result(registry)
-       class(ModelVerticalGrid), intent(in) :: this
-       type(StateRegistry), pointer :: registry
-       registry => this%registry
-    end function get_registry
+      _RETURN(_SUCCESS)
+   end function get_short_name
 
-    subroutine get_coordinate_field(this, field, coupler, standard_name, geom, typekind, units, vertical_dim_spec, rc)
-       class(ModelVerticalGrid), intent(in) :: this
-       type(ESMF_Field), intent(out) :: field
-       type(GriddedComponentDriver), pointer, intent(out) :: coupler
-       character(*), intent(in) :: standard_name
-       type(ESMF_Geom), intent(in) :: geom
-       type(ESMF_TypeKind_Flag), intent(in) :: typekind
-       character(*), intent(in) :: units
-       type(VerticalDimSpec), intent(in) :: vertical_dim_spec
-       integer, optional, intent(out) :: rc
+   subroutine set_registry(this, registry)
+      class(ModelVerticalGrid), intent(inout) :: this
+      type(StateRegistry), target, intent(in) :: registry
 
-       integer :: status
-       character(:), allocatable :: short_name
-       type(VirtualConnectionPt) :: v_pt
-       type(StateItemExtension), pointer :: new_extension
-       class(StateItemSpec), pointer :: new_spec
-       type(FieldSpec) :: goal_spec
+      this%registry => registry
+   end subroutine set_registry
 
-       short_name = this%variants%of(1)
-       v_pt = VirtualConnectionPt(state_intent="export", short_name=short_name)
-       
-       goal_spec = FieldSpec( &
-            geom=geom, vertical_grid=this, vertical_dim_spec=vertical_dim_spec, &
-            typekind=typekind, standard_name=standard_name, units=units, ungridded_dims=UngriddedDims())
+   function get_registry(this) result(registry)
+      class(ModelVerticalGrid), intent(in) :: this
+      type(StateRegistry), pointer :: registry
+      registry => this%registry
+   end function get_registry
 
-       new_extension => this%registry%extend(v_pt, goal_spec, _RC)
-       coupler => new_extension%get_producer()
-       new_spec => new_extension%get_spec()
-       select type (new_spec)
-       type is (FieldSpec)
-          field = new_spec%get_payload()
-       class default
-          _FAIL("unsupported spec type; must be FieldSpec")
-       end select
+   subroutine get_coordinate_field(this, field, coupler, standard_name, geom, typekind, units, vertical_dim_spec, rc)
+      class(ModelVerticalGrid), intent(in) :: this
+      type(ESMF_Field), intent(out) :: field
+      type(GriddedComponentDriver), pointer, intent(out) :: coupler
+      character(*), intent(in) :: standard_name
+      type(ESMF_Geom), intent(in) :: geom
+      type(ESMF_TypeKind_Flag), intent(in) :: typekind
+      character(*), intent(in) :: units
+      type(VerticalDimSpec), intent(in) :: vertical_dim_spec
+      integer, optional, intent(out) :: rc
 
-       _RETURN(_SUCCESS)
-    end subroutine get_coordinate_field
+      integer :: status
+      character(:), allocatable :: short_name
+      type(VirtualConnectionPt) :: v_pt
+      type(StateItemExtension), pointer :: new_extension
+      class(StateItemSpec), pointer :: new_spec
+      type(FieldSpec) :: goal_spec
+
+      short_name = this%get_short_name(vertical_dim_spec)
+      v_pt = VirtualConnectionPt(state_intent="export", short_name=short_name)
+
+      goal_spec = FieldSpec( &
+           geom=geom, vertical_grid=this, vertical_dim_spec=vertical_dim_spec, &
+           typekind=typekind, standard_name=standard_name, units=units, ungridded_dims=UngriddedDims())
+
+      new_extension => this%registry%extend(v_pt, goal_spec, _RC)
+      coupler => new_extension%get_producer()
+      new_spec => new_extension%get_spec()
+      select type (new_spec)
+      type is (FieldSpec)
+         field = new_spec%get_payload()
+      class default
+         _FAIL("unsupported spec type; must be FieldSpec")
+      end select
+
+      _RETURN(_SUCCESS)
+   end subroutine get_coordinate_field
 
    subroutine write_formatted(this, unit, iotype, v_list, iostat, iomsg)
       class(ModelVerticalGrid), intent(in) :: this

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -93,13 +93,13 @@ contains
 
       if (vertical_dim_spec == VERTICAL_DIM_EDGE) then
          short_name = this%short_name_edge
-         _RETURN(_SUCCESS)
       else if (vertical_dim_spec == VERTICAL_DIM_CENTER) then
          short_name = this%short_name_center
-         _RETURN(_SUCCESS)
       else
          _FAIL("unsupported vertical_dim_spec")
       end if
+
+      _RETURN(_SUCCESS)
    end function get_short_name
 
    subroutine set_registry(this, registry)

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -58,8 +58,6 @@ module mapl3g_ModelVerticalGrid
       end function
    end interface
 
-   integer, parameter :: NDX_EDGE=1, NDX_CENTER=2
-
    ! TODO:
    ! - Ensure that there really is a vertical dimension
 

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -29,7 +29,8 @@ module mapl3g_ModelVerticalGrid
       private
       character(:), allocatable :: standard_name
       integer :: num_levels = -1
-      character(len=ESMF_MAXSTR) :: variants(2) = ["UNDEFINED", "UNDEFINED"]
+      character(:), allocatable :: short_name_edge
+      character(:), allocatable :: short_name_center
       type(StateRegistry), pointer :: registry => null()
    contains
       procedure :: get_num_levels
@@ -83,11 +84,11 @@ contains
 
    subroutine add_short_names(this, edge, center)
       class(ModelVerticalGrid), intent(inout) :: this
-      character(*), intent(in) :: edge
-      character(*), intent(in) :: center
+      character(*), optional, intent(in) :: edge
+      character(*), optional, intent(in) :: center
 
-      this%variants(NDX_EDGE) = edge
-      this%variants(NDX_CENTER) = center
+      if (present(edge)) this%short_name_edge = edge
+      if (present(center)) this%short_name_center = center
    end subroutine add_short_names
 
    function get_short_name(this, vertical_dim_spec, rc) result(short_name)
@@ -97,10 +98,10 @@ contains
       integer, optional :: rc
 
       if (vertical_dim_spec == VERTICAL_DIM_EDGE) then
-         short_name = trim(this%variants(NDX_EDGE))
+         short_name = this%short_name_edge
          _RETURN(_SUCCESS)
       else if (vertical_dim_spec == VERTICAL_DIM_CENTER) then
-         short_name = trim(this%variants(NDX_CENTER))
+         short_name = this%short_name_center
          _RETURN(_SUCCESS)
       else
          _FAIL("unsupported vertical_dim_spec")


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

- A Model VerticalGrid is now instantiated with `standard_name`, `units` and `num_levels`. The method `add_short_name` is used to specify variable short names corresponding to edge and center vertical staggerings, which is selected at runtime using the method `get_short_name`.
- Updated `ComponentSpecParse::parse_geometry_spec` to use the new interface.
- Updated `Test_ModelVerticalGrid.pf` to use the new interface.
- Updated vertical regridding tests to specify `standard_name` instead of `short_name` for Model VerticalGrids.
- Cleanup of FixedLevels VerticalGrid - we didn't need `MAPL_BaseMod::MAPL_GridGet` after all.

## Related Issue

