### PR TITLE
Update MAPL3 time averaging to use a pointwise counter

### DIFF
--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -33,6 +33,8 @@ module MAPL_FieldPointerUtilities
       module procedure assign_fptr_r8_rank2
       module procedure assign_fptr_r4_rank3
       module procedure assign_fptr_r8_rank3
+      module procedure assign_fptr_i4_rank1
+      module procedure assign_fptr_i8_rank1
    end interface assign_fptr
 
    interface FieldGetCptr
@@ -989,5 +991,43 @@ contains
       _RETURN(ESMF_SUCCESS)
 
    end subroutine Destroy
+
+   subroutine assign_fptr_i4_rank1(x, fptr, rc)
+      type(ESMF_Field), intent(inout) :: x
+      integer(kind=ESMF_KIND_I4), pointer, intent(out) :: fptr(:)
+      integer, optional, intent(out) :: rc
+
+      ! local declarations
+      type(c_ptr) :: cptr
+      integer(ESMF_KIND_I8), allocatable :: fp_shape(:)
+      integer(ESMF_KIND_I8) :: local_size
+      integer :: status
+
+      local_size = FieldGetLocalSize(x, _RC)
+      fp_shape = [ local_size ]
+      call FieldGetCptr(x, cptr, _RC)
+      call c_f_pointer(cptr, fptr, fp_shape)
+
+      _RETURN(_SUCCESS)
+   end subroutine assign_fptr_i4_rank1
+
+   subroutine assign_fptr_i8_rank1(x, fptr, rc)
+      type(ESMF_Field), intent(inout) :: x
+      integer(kind=ESMF_KIND_I8), pointer, intent(out) :: fptr(:)
+      integer, optional, intent(out) :: rc
+
+      ! local declarations
+      type(c_ptr) :: cptr
+      integer(ESMF_KIND_I8), allocatable :: fp_shape(:)
+      integer(ESMF_KIND_I8) :: local_size
+      integer :: status
+
+      local_size = FieldGetLocalSize(x, _RC)
+      fp_shape = [ local_size ]
+      call FieldGetCptr(x, cptr, _RC)
+      call c_f_pointer(cptr, fptr, fp_shape)
+
+      _RETURN(_SUCCESS)
+   end subroutine assign_fptr_i8_rank1
 
 end module MAPL_FieldPointerUtilities

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -848,8 +848,11 @@ contains
 
       real(kind=ESMF_KIND_R4), pointer :: r4_1d(:),r4_2d(:,:),r4_3d(:,:,:),r4_4d(:,:,:,:)
       real(kind=ESMF_KIND_R8), pointer :: r8_1d(:),r8_2d(:,:),r8_3d(:,:,:),r8_4d(:,:,:,:)
+      integer(kind=ESMF_KIND_I4), pointer :: i4_1d(:),i4_2d(:,:),i4_3d(:,:,:),i4_4d(:,:,:,:)
+      integer(kind=ESMF_KIND_I8), pointer :: i8_1d(:),i8_2d(:,:),i8_3d(:,:,:),i8_4d(:,:,:,:)
 
       call ESMF_FieldGet(field,rank=rank,typekind=tk,_RC)
+      _ASSERT(rank > 0 .and. rank < 5, "Unsupported rank")
       if (tk == ESMF_TypeKind_R4) then
          if (rank==1) then
             call ESMF_FieldGet(field,0,farrayptr=r4_1d,_RC)
@@ -863,8 +866,6 @@ contains
          else if (rank ==4) then
             call ESMF_FieldGet(field,0,farrayptr=r4_4d,_RC)
             local_count = shape(r4_4d)
-         else
-            _FAIL("Unsupported rank")
          end if
       else if (tk == ESMF_TypeKind_R8) then
          if (rank==1) then
@@ -879,8 +880,34 @@ contains
          else if (rank ==4) then
             call ESMF_FieldGet(field,0,farrayptr=r8_4d,_RC)
             local_count = shape(r8_4d)
-         else
-            _FAIL("Unsupported rank")
+         end if
+      else if (tk == ESMF_TypeKind_I4) then
+         if (rank==1) then
+            call ESMF_FieldGet(field,0,farrayptr=i4_1d,_RC)
+            local_count = shape(i4_1d)
+         else if (rank ==2) then
+            call ESMF_FieldGet(field,0,farrayptr=i4_2d,_RC)
+            local_count = shape(i4_2d)
+         else if (rank ==3) then
+            call ESMF_FieldGet(field,0,farrayptr=i4_3d,_RC)
+            local_count = shape(i4_3d)
+         else if (rank ==4) then
+            call ESMF_FieldGet(field,0,farrayptr=i4_4d,_RC)
+            local_count = shape(i4_4d)
+         end if
+      else if (tk == ESMF_TypeKind_I8) then
+         if (rank==1) then
+            call ESMF_FieldGet(field,0,farrayptr=i8_1d,_RC)
+            local_count = shape(i8_1d)
+         else if (rank ==2) then
+            call ESMF_FieldGet(field,0,farrayptr=i8_2d,_RC)
+            local_count = shape(i8_2d)
+         else if (rank ==3) then
+            call ESMF_FieldGet(field,0,farrayptr=i8_3d,_RC)
+            local_count = shape(i8_3d)
+         else if (rank ==4) then
+            call ESMF_FieldGet(field,0,farrayptr=i8_4d,_RC)
+            local_count = shape(i8_4d)
          end if
       else
          _FAIL("Unsupported type")

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -935,6 +935,8 @@ contains
       ! If you made it this far, you had an unsupported type.
       _FAIL("Unsupported type")
 
+      _RETURN(_SUCCESS)
+
    end subroutine MAPL_FieldGetLocalElementCount
 
    function FieldsHaveUndef(fields,rc) result(all_have_undef)

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -852,6 +852,7 @@ contains
       integer(kind=ESMF_KIND_I8), pointer :: i8_1d(:),i8_2d(:,:),i8_3d(:,:,:),i8_4d(:,:,:,:)
 
       call ESMF_FieldGet(field,rank=rank,typekind=tk,_RC)
+
       if (tk == ESMF_TypeKind_R4) then
          select case(rank)
          case(1)
@@ -869,7 +870,10 @@ contains
          case default
             _FAIL("Unsupported rank")
          end select
-      else if (tk == ESMF_TypeKind_R8) then
+         _RETURN(_SUCCESS)
+      end if
+      
+      if (tk == ESMF_TypeKind_R8) then
          select case(rank)
          case(1)
             call ESMF_FieldGet(field,0,farrayptr=r8_1d,_RC)
@@ -886,7 +890,10 @@ contains
          case default
             _FAIL("Unsupported rank")
          end select
-      else if (tk == ESMF_TypeKind_I4) then
+         _RETURN(_SUCCESS)
+      end if
+
+      if (tk == ESMF_TypeKind_I4) then
          select case(rank)
          case(1)
             call ESMF_FieldGet(field,0,farrayptr=i4_1d,_RC)
@@ -903,7 +910,10 @@ contains
          case default
             _FAIL("Unsupported rank")
          end select
-      else if (tk == ESMF_TypeKind_I8) then
+         _RETURN(_SUCCESS)
+      end if
+
+      if (tk == ESMF_TypeKind_I8) then
          select case(rank)
          case(1)
             call ESMF_FieldGet(field,0,farrayptr=i8_1d,_RC)
@@ -920,10 +930,11 @@ contains
          case default
             _FAIL("Unsupported rank")
          end select
-      else
-         _FAIL("Unsupported type")
       end if
-      _RETURN(_SUCCESS)
+
+      ! If you made it this far, you had an unsupported type.
+      _FAIL("Unsupported type")
+
    end subroutine MAPL_FieldGetLocalElementCount
 
    function FieldsHaveUndef(fields,rc) result(all_have_undef)

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -852,63 +852,74 @@ contains
       integer(kind=ESMF_KIND_I8), pointer :: i8_1d(:),i8_2d(:,:),i8_3d(:,:,:),i8_4d(:,:,:,:)
 
       call ESMF_FieldGet(field,rank=rank,typekind=tk,_RC)
-      _ASSERT(rank > 0 .and. rank < 5, "Unsupported rank")
       if (tk == ESMF_TypeKind_R4) then
-         if (rank==1) then
+         select case(rank)
+         case(1)
             call ESMF_FieldGet(field,0,farrayptr=r4_1d,_RC)
             local_count = shape(r4_1d)
-         else if (rank ==2) then
+         case(2)
             call ESMF_FieldGet(field,0,farrayptr=r4_2d,_RC)
             local_count = shape(r4_2d)
-         else if (rank ==3) then
+         case(3)
             call ESMF_FieldGet(field,0,farrayptr=r4_3d,_RC)
             local_count = shape(r4_3d)
-         else if (rank ==4) then
+         case(4)
             call ESMF_FieldGet(field,0,farrayptr=r4_4d,_RC)
             local_count = shape(r4_4d)
-         end if
+         case default
+            _FAIL("Unsupported rank")
+         end select
       else if (tk == ESMF_TypeKind_R8) then
-         if (rank==1) then
+         select case(rank)
+         case(1)
             call ESMF_FieldGet(field,0,farrayptr=r8_1d,_RC)
             local_count = shape(r8_1d)
-         else if (rank ==2) then
+         case(2)
             call ESMF_FieldGet(field,0,farrayptr=r8_2d,_RC)
             local_count = shape(r8_2d)
-         else if (rank ==3) then
+         case(3)
             call ESMF_FieldGet(field,0,farrayptr=r8_3d,_RC)
             local_count = shape(r8_3d)
-         else if (rank ==4) then
+         case(4)
             call ESMF_FieldGet(field,0,farrayptr=r8_4d,_RC)
             local_count = shape(r8_4d)
-         end if
+         case default
+            _FAIL("Unsupported rank")
+         end select
       else if (tk == ESMF_TypeKind_I4) then
-         if (rank==1) then
+         select case(rank)
+         case(1)
             call ESMF_FieldGet(field,0,farrayptr=i4_1d,_RC)
             local_count = shape(i4_1d)
-         else if (rank ==2) then
+         case(2)
             call ESMF_FieldGet(field,0,farrayptr=i4_2d,_RC)
             local_count = shape(i4_2d)
-         else if (rank ==3) then
+         case(3)
             call ESMF_FieldGet(field,0,farrayptr=i4_3d,_RC)
             local_count = shape(i4_3d)
-         else if (rank ==4) then
+         case(4)
             call ESMF_FieldGet(field,0,farrayptr=i4_4d,_RC)
             local_count = shape(i4_4d)
-         end if
+         case default
+            _FAIL("Unsupported rank")
+         end select
       else if (tk == ESMF_TypeKind_I8) then
-         if (rank==1) then
+         select case(rank)
+         case(1)
             call ESMF_FieldGet(field,0,farrayptr=i8_1d,_RC)
             local_count = shape(i8_1d)
-         else if (rank ==2) then
+         case(2)
             call ESMF_FieldGet(field,0,farrayptr=i8_2d,_RC)
             local_count = shape(i8_2d)
-         else if (rank ==3) then
+         case(3)
             call ESMF_FieldGet(field,0,farrayptr=i8_3d,_RC)
             local_count = shape(i8_3d)
-         else if (rank ==4) then
+         case(4)
             call ESMF_FieldGet(field,0,farrayptr=i8_4d,_RC)
             local_count = shape(i8_4d)
-         end if
+         case default
+            _FAIL("Unsupported rank")
+         end select
       else
          _FAIL("Unsupported type")
       end if

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -69,15 +69,22 @@ contains
 
       conformable = .FALSE.
       same_typekind = .FALSE.
+
+      ! Get fields from state and confirm typekind match and conformable.
       call get_field(importState, import_field, _RC)
       call ESMF_FieldGet(import_field, typekind=typekind, _RC)
+      ! This check goes away if ESMF_TYPEKIND_R8 is supported.
       _ASSERT(typekind==ESMF_TYPEKIND_R4, 'Only ESMF_TYPEKIND_R4 is supported.')
+
       call get_field(exportState, export_field, _RC)
-      conformable = FieldsAreConformable(import_field, export_field, _RC)
-      _ASSERT(conformable, 'Import and export fields are not conformable.')
       same_typekind = FieldsAreSameTypeKind(import_field, export_field, _RC)
       _ASSERT(same_typekind, 'Import and export fields are different typekinds.')
+
+      conformable = FieldsAreConformable(import_field, export_field, _RC)
+      _ASSERT(conformable, 'Import and export fields are not conformable.')
+
       this%typekind = typekind
+      ! Create and initialize field values. 
       call this%create_fields(import_field, export_field, _RC)
       call this%clear(_RC)
       _RETURN(_SUCCESS)

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -90,6 +90,7 @@ contains
       type(ESMF_Field), intent(inout) :: import_field
       type(ESMF_Field), intent(inout) :: export_field
       integer, optional, intent(out) :: rc
+
       integer :: status
 
       if(this%initialized()) then
@@ -129,6 +130,8 @@ contains
    subroutine update_result(this, rc)
       class(AccumulatorAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
+      
+      integer :: status
 
       call FieldCopy(this%accumulation_field, this%result_field, _RC)
       this%update_calculated = .TRUE.
@@ -196,8 +199,8 @@ contains
 
    end subroutine accumulate
 
-   subroutine accumulate_R4(accumulation_field, update_field, rc)
-      type(ESMF_Field), intent(inout) :: accumulation_field
+   subroutine accumulate_R4(this, update_field, rc)
+      class(AccumulatorAction), intent(inout) :: this
       type(ESMF_Field), intent(inout) :: update_field
       integer, optional, intent(out) :: rc
 
@@ -208,7 +211,7 @@ contains
 
       current => null()
       latest => null()
-      call assign_fptr(accumulation_field, current, _RC)
+      call assign_fptr(this%accumulation_field, current, _RC)
       call assign_fptr(update_field, latest, _RC)
       where(current /= UNDEF .and. latest /= UNDEF)
         current = current + latest

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -15,6 +15,7 @@ module mapl3g_AccumulatorAction
       type(ESMF_Field) :: result_field
       real(kind=ESMF_KIND_R4) :: CLEAR_VALUE_R4 = 0.0_ESMF_KIND_R4
       logical :: update_calculated = .FALSE.
+      type(ESMF_TypeKind_Flag) :: typekind = ESMF_TYPEKIND_R4
    contains
       ! Implementations of deferred procedures
       procedure :: invalidate
@@ -79,13 +80,23 @@ contains
 
       integer :: status
       type(ESMF_Field) :: import_field, export_field
-      logical :: fields_are_conformable
+      type(ESMF_TypeKind_Flag) :: typekind
+      logical :: conformable = .FALSE.
+      logical :: same_typekind = .FALSE.
 
       call this%pre_initialize(_RC)
       call get_field(importState, import_field, _RC)
       call get_field(exportState, export_field, _RC)
+      conformable = FieldsAreConformable(import_field, export_field, _RC)
+      _ASSERT(conformable, 'Import and export fields are not conformable.')
+      same_typekind = FieldsAreSameTypeKind(import_field, export_field, _RC)
+      _ASSERT(same_typekind, 'Import and export fields are not conformable.')
+
       this%accumulation_field = ESMF_FieldCreate(import_field, _RC)
       this%result_field = ESMF_FieldCreate(export_field, _RC)
+      call ESMF_FieldGet(import_field, typekind=typekind, _RC)
+      _ASSERT(typekind==ESMF_TYPEKIND_R4, 'Only ESMF_TYPEKIND_R4 is supported.')
+      this%typekind = typekind
       call this%post_initialize(_RC)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(clock)

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -24,11 +24,12 @@ module mapl3g_AccumulatorAction
       ! Helpers
       procedure :: accumulate
       procedure :: initialized
-      procedure :: clear_accumulator
+      procedure :: clear
+      procedure :: clear_post
       procedure :: accumulate_R4
-      procedure :: post_initialize
-      procedure :: pre_initialize
-      procedure :: pre_update
+      procedure :: initialize_post
+      procedure :: initialize_pre
+      procedure :: update_pre
    end type AccumulatorAction
 
 contains
@@ -40,7 +41,7 @@ contains
 
    end function initialized
 
-   subroutine clear_accumulator(this, rc)
+   subroutine clear(this, rc)
       class(AccumulatorAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       
@@ -53,23 +54,10 @@ contains
       else
          _FAIL('Unsupported typekind')
       end if
+      call this%clear_post(_RC)
       _RETURN(_SUCCESS)
 
-   end subroutine clear_accumulator
-
-   subroutine pre_initialize(this, rc)
-      class(AccumulatorAction), intent(inout) :: this
-      integer, optional, intent(out) :: rc
-      
-      integer :: status
-
-      if(this%initialized()) then
-         call ESMF_FieldDestroy(this%accumulation_field, _RC)
-         call ESMF_FieldDestroy(this%result_field, _RC)
-      end if
-      _RETURN(_SUCCESS)
-      
-   end subroutine pre_initialize
+   end subroutine clear
 
    subroutine initialize(this, importState, exportState, clock, rc)
       class(AccumulatorAction), intent(inout) :: this
@@ -84,7 +72,11 @@ contains
       logical :: conformable = .FALSE.
       logical :: same_typekind = .FALSE.
 
-      call this%pre_initialize(_RC)
+      call this%initialize_pre(_RC)
+      if(this%initialized()) then
+         call ESMF_FieldDestroy(this%accumulation_field, _RC)
+         call ESMF_FieldDestroy(this%result_field, _RC)
+      end if
       call get_field(importState, import_field, _RC)
       call get_field(exportState, export_field, _RC)
       conformable = FieldsAreConformable(import_field, export_field, _RC)
@@ -97,22 +89,12 @@ contains
       call ESMF_FieldGet(import_field, typekind=typekind, _RC)
       _ASSERT(typekind==ESMF_TYPEKIND_R4, 'Only ESMF_TYPEKIND_R4 is supported.')
       this%typekind = typekind
-      call this%post_initialize(_RC)
+      call this%initialize_post(_RC)
+      call this%clear(_RC)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(clock)
 
    end subroutine initialize
-
-   subroutine post_initialize(this, rc)
-      class(AccumulatorAction), intent(inout) :: this
-      integer, optional, intent(out) :: rc
-      
-      integer :: status
-
-      call this%clear_accumulator(_RC)
-      _RETURN(_SUCCESS)
-
-   end subroutine post_initialize
 
    subroutine update(this, importState, exportState, clock, rc)
       class(AccumulatorAction), intent(inout) :: this
@@ -126,29 +108,19 @@ contains
       
       _ASSERT(this%initialized(), 'Accumulator has not been initialized.')
       if(.not. this%update_calculated) then
-         call this%pre_update(_RC)
+         call this%update_pre(_RC)
+         call FieldCopy(this%accumulation_field, this%result_field, _RC)
+         this%update_calculated = .TRUE.
       end if
       call get_field(exportState, export_field, _RC)
       call FieldCopy(this%result_field, export_field, _RC)
 
-      call this%clear_accumulator(_RC)
+      call this%clear(_RC)
       _UNUSED_DUMMY(clock)
       _UNUSED_DUMMY(importState)
       _RETURN(_SUCCESS)
 
    end subroutine update
-
-   subroutine pre_update(this, rc)
-      class(AccumulatorAction), intent(inout) :: this
-      integer, optional, intent(out) :: rc
-      
-      integer :: status
-
-      call FieldCopy(this%accumulation_field, this%result_field, _RC)
-      this%update_calculated = .TRUE.
-      _RETURN(_SUCCESS)
-
-   end subroutine pre_update
 
    subroutine invalidate(this, importState, exportState, clock, rc)
       class(AccumulatorAction), intent(inout) :: this
@@ -232,5 +204,50 @@ contains
       _RETURN(_SUCCESS)
 
    end subroutine accumulate_R4
+
+   !============================= HOOK METHODS =================================
+   ! These are hook methods that can be overwritten by extending types.
+
+   subroutine update_pre(this, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      _RETURN(_SUCCESS)
+
+   end subroutine update_pre
+
+   subroutine clear_post(this, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      
+   end subroutine clear_post
+   
+   subroutine initialize_pre(this, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      
+   end subroutine initialize_pre
+
+   subroutine initialize_post(this, rc)
+      class(AccumulatorAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize_post
 
 end module mapl3g_AccumulatorAction

--- a/generic3g/actions/AccumulatorAction.F90
+++ b/generic3g/actions/AccumulatorAction.F90
@@ -22,11 +22,12 @@ module mapl3g_AccumulatorAction
       procedure :: initialize
       procedure :: update
       ! Helpers
-      procedure :: accumulate
       procedure :: initialized
-      procedure :: clear
-      procedure :: clear_post
+      procedure :: accumulate
       procedure :: accumulate_R4
+      procedure :: clear
+      ! These are hooks for additional code for subtypes.
+      procedure :: clear_post
       procedure :: initialize_post
       procedure :: initialize_pre
       procedure :: update_pre

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -22,6 +22,8 @@ module mapl3g_MeanAction
       procedure :: increment_counter
    end type MeanAction
 
+   type(ESMF_TypeKind_Flag), parameter :: TK_COUNTER = TYPE_KIND_R8
+
 contains
 
    subroutine mean_pre_initialize(this, rc)
@@ -45,13 +47,16 @@ contains
       integer :: status
       type(ESMF_Geom) :: geom
       type(ESMF_Grid) :: grid
-      type(ESMF_TypeKind_Flag) :: typekind
+      type(ESMF_TypeKind_Flag) :: tk_accum
       type(ESMF_StaggerLoc) :: stagger_loc
       integer :: gridToFieldMap(:)
       type(UngriddedDims), optional, intent(in) :: ungridded_dims
       integer, optional, intent(in) :: num_levels
       type(VerticalStaggerLoc), optional, intent(in) :: vert_staggerloc
       ! Get from accumulation field
+
+      call ESMF_FieldGet(this%accumulation_field, typekind=tk_accum, _RC)
+      if(tk_accum /= TK_COUNTER)
 
       this%counter_field =  MAPL_FieldCreate(geom, typekind, gridToFieldMap=gridToFieldMap,&
          ungridded_dims=ungridded_dims, num_levels, vert_staggerloc=vert_staggerloc, _RC)

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -55,7 +55,6 @@ contains
          call ESMF_FieldGet(f, dimCount=ndims, _RC)
          allocate(gmap(ndims))
          call ESMF_FieldGet(f, geom=geom, gridToFieldMap=gmap, _RC)
-         !this%counter_field =  MAPL_FieldCreate(geom, typekind=COUNTER_TYPEKIND, gridToFieldMap=gmap, _RC)
          this%counter_field =  MAPL_FieldCreate(geom, typekind=ESMF_TYPEKIND_I4, gridToFieldMap=gmap, _RC)
       end associate
       call this%clear(_RC)

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -15,7 +15,6 @@ module mapl3g_MeanAction
    type, extends(AccumulatorAction) :: MeanAction
       type(ESMF_Field) :: counter_field
    contains
-!      procedure :: clear => clear_mean_accumulator
       procedure :: clear_post => clear_mean_post
       procedure :: initialize_post => mean_initialize_post
       procedure :: initialize_pre => mean_initialize_pre
@@ -59,18 +58,6 @@ contains
       _RETURN(_SUCCESS)
 
    end subroutine mean_initialize_post
-
-!   subroutine clear_mean_accumulator(this, rc)
-!      class(MeanAction), intent(inout) :: this
-!      integer, optional, intent(out) :: rc
-!      
-!      integer :: status
-!
-!      call this%AccumulatorAction%clear(_RC)
-!      call FieldSet(this%counter_field, this%CLEAR_VALUE_R4, _RC)
-!      _RETURN(_SUCCESS)
-!
-!   end subroutine clear_mean_accumulator
 
    subroutine clear_mean_post(this, rc)
       class(MeanAction), intent(inout) :: this

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -17,10 +17,10 @@ module mapl3g_MeanAction
    contains
       procedure :: clear => clear_mean
       procedure :: create_fields => create_fields_mean
-      procedure :: accumulate_R4 => accumulate_mean_R4
       procedure :: update_result => update_result_mean
       procedure :: calculate_mean
       procedure :: calculate_mean_R4
+      procedure :: accumulate_R4
    end type MeanAction
 
    type(ESMF_TypeKind_Flag), parameter :: COUNTER_TYPEKIND = ESMF_TYPEKIND_I4
@@ -40,7 +40,7 @@ contains
       integer :: ndims
 
       call this%AccumulatorAction%create_fields(import_field, export_field, _RC)
-      if(this%initialized()) then
+      if(ESMF_FieldIsCreated(this%counter_field)) then
          call ESMF_FieldDestroy(this%counter_field, _RC)
       end if
       associate(f => this%accumulation_field)
@@ -108,7 +108,7 @@ contains
       counter => null()
       call assign_fptr(this%accumulation_field, current_ptr, _RC)
       call assign_fptr(this%counter_field, counter, _RC)
-      where(current_ptr /= UNDEF .and. counter /= 0)
+      where(counter /= 0)
          current_ptr = current_ptr / counter
       elsewhere
          current_ptr = UNDEF
@@ -117,7 +117,7 @@ contains
 
    end subroutine calculate_mean_R4
 
-   subroutine accumulate_mean_R4(this, update_field, rc)
+   subroutine accumulate_R4(this, update_field, rc)
       class(MeanAction), intent(inout) :: this
       type(ESMF_Field), intent(inout) :: update_field
       integer, optional, intent(out) :: rc
@@ -134,12 +134,12 @@ contains
       call assign_fptr(this%accumulation_field, current, _RC)
       call assign_fptr(update_field, latest, _RC)
       call assign_fptr(this%counter_field, counter, _RC)
-      where(current /= UNDEF .and. latest /= UNDEF)
+      where(latest /= UNDEF)
         current = current + latest
         counter = counter + 1_COUNTER_KIND
       end where
       _RETURN(_SUCCESS)
 
-   end subroutine accumulate_mean_R4
+   end subroutine accumulate_R4
 
 end module mapl3g_MeanAction

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -24,6 +24,9 @@ module mapl3g_MeanAction
       procedure :: calculate_mean_R4
    end type MeanAction
 
+   type(ESMF_TypeKind_Flag), parameter :: COUNTER_TYPEKIND = ESMF_TYPEKIND_I4
+   integer, parameter :: COUNTER_KIND = ESMF_KIND_I4
+
 contains
 
    subroutine mean_initialize_pre(this, rc)
@@ -52,7 +55,8 @@ contains
          call ESMF_FieldGet(f, dimCount=ndims, _RC)
          allocate(gmap(ndims))
          call ESMF_FieldGet(f, geom=geom, gridToFieldMap=gmap, _RC)
-         this%counter_field =  MAPL_FieldCreate(geom, typekind=this%typekind, gridToFieldMap=gmap, _RC) !, &
+         !this%counter_field =  MAPL_FieldCreate(geom, typekind=COUNTER_TYPEKIND, gridToFieldMap=gmap, _RC)
+         this%counter_field =  MAPL_FieldCreate(geom, typekind=ESMF_TYPEKIND_I4, gridToFieldMap=gmap, _RC)
       end associate
       call this%clear(_RC)
       _RETURN(_SUCCESS)
@@ -64,8 +68,10 @@ contains
       integer, optional, intent(out) :: rc
       
       integer :: status
+      integer(COUNTER_KIND), pointer :: counter(:) => null()
 
-      call FieldSet(this%counter_field, this%CLEAR_VALUE_R4, _RC)
+      call assign_fptr(this%counter_field, counter, _RC)
+      counter = 0_COUNTER_KIND
       _RETURN(_SUCCESS)
 
    end subroutine clear_mean_post
@@ -76,7 +82,7 @@ contains
 
       integer :: status
 
-      if(this%typekind == ESMF_TypeKind_R4) then
+      if(this%typekind == ESMF_TYPEKIND_R4) then
          call this%calculate_mean_R4(_RC)
       else
          _FAIL('Unsupported typekind')
@@ -102,7 +108,7 @@ contains
 
       integer :: status
       real(kind=ESMF_KIND_R4), pointer :: current_ptr(:) => null()
-      real(kind=ESMF_KIND_R4), pointer :: counter(:) => null()
+      integer(kind=COUNTER_KIND), pointer :: counter(:) => null()
       real(kind=ESMF_KIND_R4), parameter :: UNDEF = MAPL_UNDEFINED_REAL
 
       call assign_fptr(this%accumulation_field, current_ptr, _RC)
@@ -124,7 +130,7 @@ contains
       integer :: status
       real(kind=ESMF_KIND_R4), pointer :: current(:) => null()
       real(kind=ESMF_KIND_R4), pointer :: latest(:) => null()
-      real(kind=ESMF_KIND_R4), pointer :: counter(:) => null()
+      integer(kind=COUNTER_KIND), pointer :: counter(:) => null()
       real(kind=ESMF_KIND_R4) :: undef
 
       undef = MAPL_UNDEFINED_REAL
@@ -133,7 +139,7 @@ contains
       call assign_fptr(this%counter_field, counter, _RC)
       where(current /= undef .and. latest /= undef)
         current = current + latest
-        counter = counter + 1_ESMF_KIND_R4
+        counter = counter + 1_COUNTER_KIND
       end where
       _RETURN(_SUCCESS)
 

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -39,7 +39,7 @@ contains
       integer, allocatable :: gmap(:)
       integer :: ndims
 
-      call this%AccumulatorAction%create_fields(import_field, export_fields, _RC)
+      call this%AccumulatorAction%create_fields(import_field, export_field, _RC)
       if(this%initialized()) then
          call ESMF_FieldDestroy(this%counter_field, _RC)
       end if

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -15,18 +15,19 @@ module mapl3g_MeanAction
    type, extends(AccumulatorAction) :: MeanAction
       type(ESMF_Field) :: counter_field
    contains
-      procedure :: clear_accumulator => clear_mean_accumulator
-      procedure :: post_initialize => mean_post_initialize
-      procedure :: pre_initialize => mean_pre_initialize
+!      procedure :: clear => clear_mean_accumulator
+      procedure :: clear_post => clear_mean_post
+      procedure :: initialize_post => mean_initialize_post
+      procedure :: initialize_pre => mean_initialize_pre
       procedure :: accumulate_R4 => accumulate_mean_R4
-      procedure :: pre_update => mean_pre_update
+      procedure :: update_pre => mean_update_pre
       procedure :: calculate_mean
       procedure :: calculate_mean_R4
    end type MeanAction
 
 contains
 
-   subroutine mean_pre_initialize(this, rc)
+   subroutine mean_initialize_pre(this, rc)
       class(MeanAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       
@@ -35,12 +36,11 @@ contains
       if(this%initialized()) then
          call ESMF_FieldDestroy(this%counter_field, _RC)
       end if
-      call this%AccumulatorAction%pre_initialize(_RC)
       _RETURN(_SUCCESS)
 
-   end subroutine mean_pre_initialize
+   end subroutine mean_initialize_pre
 
-   subroutine mean_post_initialize(this, rc)
+   subroutine mean_initialize_post(this, rc)
       class(MeanAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       
@@ -55,22 +55,33 @@ contains
          call ESMF_FieldGet(f, geom=geom, gridToFieldMap=gmap, _RC)
          this%counter_field =  MAPL_FieldCreate(geom, typekind=this%typekind, gridToFieldMap=gmap, _RC) !, &
       end associate
-      call this%clear_accumulator(_RC)
+      call this%clear(_RC)
       _RETURN(_SUCCESS)
 
-   end subroutine mean_post_initialize
+   end subroutine mean_initialize_post
 
-   subroutine clear_mean_accumulator(this, rc)
+!   subroutine clear_mean_accumulator(this, rc)
+!      class(MeanAction), intent(inout) :: this
+!      integer, optional, intent(out) :: rc
+!      
+!      integer :: status
+!
+!      call this%AccumulatorAction%clear(_RC)
+!      call FieldSet(this%counter_field, this%CLEAR_VALUE_R4, _RC)
+!      _RETURN(_SUCCESS)
+!
+!   end subroutine clear_mean_accumulator
+
+   subroutine clear_mean_post(this, rc)
       class(MeanAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
       
       integer :: status
 
-      call this%AccumulatorAction%clear_accumulator(_RC)
       call FieldSet(this%counter_field, this%CLEAR_VALUE_R4, _RC)
       _RETURN(_SUCCESS)
 
-   end subroutine clear_mean_accumulator
+   end subroutine clear_mean_post
 
    subroutine calculate_mean(this, rc)
       class(MeanAction), intent(inout) :: this
@@ -87,17 +98,16 @@ contains
 
    end subroutine calculate_mean
 
-   subroutine mean_pre_update(this, rc)
+   subroutine mean_update_pre(this, rc)
       class(MeanAction), intent(inout) :: this
       integer, optional, intent(out) :: rc
 
       integer :: status
 
       call this%calculate_mean(_RC)
-      call this%AccumulatorAction%pre_update(_RC)
       _RETURN(_SUCCESS)
 
-   end subroutine mean_pre_update
+   end subroutine mean_update_pre
 
    subroutine calculate_mean_R4(this, rc)
       class(MeanAction), intent(inout) :: this

--- a/generic3g/actions/MeanAction.F90
+++ b/generic3g/actions/MeanAction.F90
@@ -10,20 +10,55 @@ module mapl3g_MeanAction
    public :: MeanAction
 
    type, extends(AccumulatorAction) :: MeanAction
-      !private
-      integer(ESMF_KIND_R8) :: counter_scalar = 0_ESMF_KIND_I8
-      logical, allocatable :: valid_mean(:)
+      type(ESMF_Field) :: counter_field
    contains
-      procedure :: invalidate => invalidate_mean_accumulator
       procedure :: clear_accumulator => clear_mean_accumulator
-      procedure :: update => update_mean_accumulator
+      procedure :: post_initialize => mean_post_initialize
+      procedure :: pre_initialize => mean_pre_initialize
+      procedure :: accumulate_R4 => accumulate_mean_R4
+      procedure :: pre_update => mean_pre_update
       procedure :: calculate_mean
       procedure :: calculate_mean_R4
-      procedure :: clear_valid_mean
-      procedure :: accumulate_R4 => accumulate_mean_R4
+      procedure :: increment_counter
    end type MeanAction
 
 contains
+
+   subroutine mean_pre_initialize(this, rc)
+      class(MeanAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+
+      if(this%initialized()) then
+         call ESMF_FieldDestroy(this%counter_field, _RC)
+      end if
+      call Accumulator%pre_initialize(_RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine mean_pre_initialize
+
+   subroutine mean_post_initialize(this, rc)
+      class(MeanAction), intent(inout) :: this
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      type(ESMF_Geom) :: geom
+      type(ESMF_Grid) :: grid
+      type(ESMF_TypeKind_Flag) :: typekind
+      type(ESMF_StaggerLoc) :: stagger_loc
+      integer :: gridToFieldMap(:)
+      type(UngriddedDims), optional, intent(in) :: ungridded_dims
+      integer, optional, intent(in) :: num_levels
+      type(VerticalStaggerLoc), optional, intent(in) :: vert_staggerloc
+      ! Get from accumulation field
+
+      this%counter_field =  MAPL_FieldCreate(geom, typekind, gridToFieldMap=gridToFieldMap,&
+         ungridded_dims=ungridded_dims, num_levels, vert_staggerloc=vert_staggerloc, _RC)
+      call AccumulatorAction%post_initialize(_RC)
+      _RETURN(_SUCCESS)
+
+   end subroutine mean_post_initialize
 
    subroutine clear_mean_accumulator(this, rc)
       class(MeanAction), intent(inout) :: this
@@ -31,26 +66,11 @@ contains
       
       integer :: status
 
-      this%counter_scalar = 0_ESMF_KIND_R8
-      call this%clear_valid_mean(_RC)
       call this%AccumulatorAction%clear_accumulator(_RC)
+      call FieldSet(this%counter_field, 0_ESMF_KIND_R8, _RC)
       _RETURN(_SUCCESS)
 
    end subroutine clear_mean_accumulator
-
-   subroutine clear_valid_mean(this, rc)
-      class(MeanAction), intent(inout) :: this
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      integer :: local_size
-
-      if(allocated(this%valid_mean)) deallocate(this%valid_mean)
-      local_size = FieldGetLocalSize(this%accumulation_field, _RC)
-      allocate(this%valid_mean(local_size), source = .FALSE.)
-      _RETURN(_SUCCESS)
-
-   end subroutine clear_valid_mean
 
    subroutine calculate_mean(this, rc)
       class(MeanAction), intent(inout) :: this
@@ -59,7 +79,6 @@ contains
       integer :: status
       type(ESMF_TypeKind_Flag) :: tk
 
-      _ASSERT(this%counter_scalar > 0, 'Cannot calculate mean for zero steps')
       call ESMF_FieldGet(this%accumulation_field, typekind=tk, _RC)
       if(tk == ESMF_TypeKind_R4) then
          call this%calculate_mean_R4(_RC)
@@ -70,38 +89,17 @@ contains
 
    end subroutine calculate_mean
 
-   subroutine update_mean_accumulator(this, importState, exportState, clock, rc)
+   subroutine mean_pre_update(this, rc)
       class(MeanAction), intent(inout) :: this
-      type(ESMF_State) :: importState
-      type(ESMF_State) :: exportState
-      type(ESMF_Clock) :: clock
       integer, optional, intent(out) :: rc
 
       integer :: status
-      
-      _ASSERT(this%initialized(), 'Accumulator has not been initialized.')
-      if(.not. this%update_calculated) then
-         call this%calculate_mean(_RC)
-      end if
-      call this%AccumulatorAction%update(importState, exportState, clock, _RC)
+
+      call this%calculate_mean(_RC)
+      call Accumulator%pre_update(_RC)
       _RETURN(_SUCCESS)
 
-   end subroutine update_mean_accumulator
-
-   subroutine invalidate_mean_accumulator(this, importState, exportState, clock, rc)
-      class(MeanAction), intent(inout) :: this
-      type(ESMF_State) :: importState
-      type(ESMF_State) :: exportState
-      type(ESMF_Clock) :: clock
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-      
-      call this%AccumulatorAction%invalidate(importState, exportState, clock, _RC)
-      this%counter_scalar = this%counter_scalar + 1
-      _RETURN(_SUCCESS)
-
-   end subroutine invalidate_mean_accumulator
+   end mean_pre_update
 
    subroutine calculate_mean_R4(this, rc)
       class(MeanAction), intent(inout) :: this
@@ -109,11 +107,13 @@ contains
 
       integer :: status
       real(kind=ESMF_KIND_R4), pointer :: current_ptr(:) => null()
+      real(kind=ESMF_KIND_R8), pointer :: counter(:) => null()
       real(kind=ESMF_KIND_R4), parameter :: UNDEF = MAPL_UNDEFINED_REAL
 
       call assign_fptr(this%accumulation_field, current_ptr, _RC)
-      where(current_ptr /= UNDEF .and. this%valid_mean)
-         current_ptr = current_ptr / this%counter_scalar
+      call assign_fptr(this%counter_field, counter, _RC)
+      where(current_ptr /= UNDEF .and. counter /= 0)
+         current_ptr = current_ptr / counter
       elsewhere
          current_ptr = UNDEF
       end where
@@ -129,16 +129,16 @@ contains
       integer :: status
       real(kind=ESMF_KIND_R4), pointer :: current(:)
       real(kind=ESMF_KIND_R4), pointer :: latest(:)
+      real(kind=ESMF_KIND_R8), pointer :: counter(:) => null()
       real(kind=ESMF_KIND_R4) :: undef
 
       undef = MAPL_UNDEFINED_REAL
       call assign_fptr(this%accumulation_field, current, _RC)
       call assign_fptr(update_field, latest, _RC)
+      call assign_fptr(this%counter_field, _RC)
       where(current /= undef .and. latest /= undef)
         current = current + latest
-        this%valid_mean = .TRUE.
-      elsewhere(latest == undef)
-        current = undef
+        counter = count+1
       end where
       _RETURN(_SUCCESS)
 

--- a/generic3g/tests/Test_AccumulatorAction.pf
+++ b/generic3g/tests/Test_AccumulatorAction.pf
@@ -130,7 +130,7 @@ contains
    end subroutine test_accumulate
 
    @Test
-   subroutine test_clear_accumulator()
+   subroutine test_clear()
       type(AccumulatorAction) :: acc
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
@@ -141,12 +141,12 @@ contains
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call FieldSet(acc%accumulation_field, TEST_VALUE, _RC)
-      call acc%clear_accumulator(_RC)
+      call acc%clear(_RC)
       is_expected_value = FieldIsConstant(acc%accumulation_field, acc%CLEAR_VALUE_R4, _RC)
       @assertTrue(is_expected_value, 'accumulation_field was not cleared.')
       call destroy_objects(importState, exportState, clock, _RC)
 
-   end subroutine test_clear_accumulator
+   end subroutine test_clear
 
    @Test
    subroutine test_accumulate_R4()

--- a/generic3g/tests/Test_MeanAction.pf
+++ b/generic3g/tests/Test_MeanAction.pf
@@ -68,7 +68,7 @@ contains
    end subroutine test_calculate_mean_R4
 
    @Test
-   subroutine test_clear_accumulator()
+   subroutine test_clear()
       type(MeanAction) :: acc
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
@@ -79,12 +79,12 @@ contains
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call FieldSet(acc%counter_field, COUNTER, _RC)
-      call acc%clear_accumulator(_RC)
+      call acc%clear(_RC)
       cleared = FieldIsConstant(acc%counter_field, real(0, R4), _RC)
       @assertTrue(cleared, 'Counter field is nonzero.')
       call destroy_objects(importState, exportState, clock, _RC)
 
-   end subroutine test_clear_accumulator
+   end subroutine test_clear
 
    @Test
    subroutine test_invalidate()
@@ -101,7 +101,7 @@ contains
       call get_field(importState, importField, _RC)
       call FieldSet(importField, 1.0_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      counter_is_set = FieldIsConstant(acc%counter_field, this%CLEAR_VALUE_R4, _RC)
+      counter_is_set = FieldIsConstant(acc%counter_field, acc%CLEAR_VALUE_R4, _RC)
       @assertTrue(counter_is_set, 'Counter field is nonzero.')
       do i=1, N
          call acc%invalidate(importState, exportState, clock, _RC)

--- a/generic3g/tests/Test_MeanAction.pf
+++ b/generic3g/tests/Test_MeanAction.pf
@@ -23,30 +23,20 @@ contains
       integer(kind=ESMF_KIND_I4), pointer :: ifptr(:)
       integer :: n
       logical, allocatable :: mask(:)
-      
+
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
+      call assign_fptr(acc%accumulation_field, fptr, _RC)
       call assign_fptr(acc%counter_field, ifptr, _RC)
       ifptr = COUNTER
+      n = size(fptr)-1
 
       ! All points are not UNDEF and counter > 0
       call acc%calculate_mean_R4(_RC)
       matches_expected = FieldIsConstant(acc%accumulation_field, MEAN, _RC)
       @assertTrue(matches_expected, 'accumulation_field not equal to MEAN')
 
-      ! One point is UNDEF
-      call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      call assign_fptr(acc%accumulation_field, fptr, _RC)
-      n = size(fptr)-1
-      call set_undef(fptr(n))
-      allocate(mask(size(fptr)))
-      mask = .TRUE.
-      mask(n) = .FALSE.
-      call acc%calculate_mean_R4(_RC)
-      @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
-      @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
-      
       ! counter 0 at one point
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
       call assign_fptr(acc%counter_field, fptr, _RC)
@@ -56,16 +46,6 @@ contains
       call acc%calculate_mean_R4(_RC)
       @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
       @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
-      
-      ! One point is UNDEF; counter 0 at one point
-      call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      call assign_fptr(acc%accumulation_field, fptr, _RC)
-      call set_undef(fptr(n))
-      mask = mask .or. (.not. undef(fptr))
-      call acc%calculate_mean_R4(_RC)
-      @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
-      @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
-      call destroy_objects(importState, exportState, clock, _RC)
 
    end subroutine test_calculate_mean_R4
 
@@ -141,29 +121,13 @@ contains
       call assign_fptr(update_field, upPtr, _RC)
       upPtr = UPDATE_VALUE
 
-      ! accumulated not undef, update_field not undef
+      ! update_field not undef
       call acc%accumulate_R4(update_field, _RC)
       result_value = result_value + UPDATE_VALUE
       call assign_fptr(acc%accumulation_field, accPtr, _RC)
       @assertTrue(all(accPtr == result_value), 'accumulation_field not equal to expected value.')
 
-      ! accumulated undef at point, update_field not undef
-      call assign_fptr(acc%accumulation_field, accPtr, _RC)
-      n = size(accPtr) - 1
-      call set_undef(accPtr(n))
-      call acc%accumulate_R4(update_field, _RC)
-      result_value = result_value + UPDATE_VALUE
-      @assertTrue(undef(accPtr(n)), 'invalid point is not UNDEF')
-      @assertTrue(all(pack(accPtr, .not. undef(accPtr)) == result_value), 'valid point not equal to expected value.')
-
-      ! accumulated undef at point, update_field undef at point
-      n = size(upPtr) - 1
-      call set_undef(upPtr(n))
-      call acc%accumulate_R4(update_field, _RC)
-      result_value = result_value + UPDATE_VALUE
-      @assertTrue(undef(accPtr(n)), 'invalid point is not UNDEF')
-
-      ! accumulated not undef, update_field undef at point
+      ! update_field undef at point
       call FieldSet(importField, result_value, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call acc%accumulate_R4(update_field, _RC)
@@ -191,5 +155,50 @@ contains
       call destroy_objects(importState, exportState, clock, _RC)
 
    end subroutine test_initialize
-   
+
+   @Test
+   subroutine test_accumulate_with_undef_some_steps()
+      type(MeanAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      type(ESMF_Field) :: update_field
+      integer :: n
+      real(kind=ESMF_KIND_R4), parameter :: UPDATE_VALUE = 3.0_R4
+      real(kind=ESMF_KIND_R4), pointer :: upPtr(:), accPtr(:)
+      integer(kind=ESMF_KIND_I4), pointer :: countPtr(:)
+      logical, allocatable :: mask(:)
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      call initialize_field(update_field, typekind=ESMF_TYPEKIND_R4, _RC)
+      call assign_fptr(update_field, upPtr, _RC)
+      upPtr = UPDATE_VALUE
+      allocate(mask(size(upPtr)))
+      mask = .TRUE.
+
+      call acc%accumulate(update_field, _RC)
+      call acc%accumulate(update_field, _RC)
+
+      call assign_fptr(update_field, upPtr, _RC)
+      n = size(upPtr) - 1
+      call set_undef(upPtr(n)) 
+      call acc%accumulate(update_field, _RC)
+      mask(n) = .FALSE.
+
+      call assign_fptr(update_field, upPtr, _RC)
+      upPtr = UPDATE_VALUE
+      call acc%accumulate(update_field, _RC)
+      call acc%accumulate(update_field, _RC)
+
+      call assign_fptr(acc%counter_field, countPtr, _RC)
+      @assertEqual(4, countPtr(n), 'Missing point counter does not match.')
+      @assertTrue(all(pack(countPtr, mask) == 5), 'Other point counters do not match.')
+
+      call assign_fptr(acc%accumulation_field, accPtr, _RC)
+      @assertEqual(4*UPDATE_VALUE, accPtr(n), 'Missing point does not match.')
+      @assertTrue(all(pack(accPtr, mask) == 5*UPDATE_VALUE), 'Other points do not match.')
+
+   end subroutine test_accumulate_with_undef_some_steps
+
 end module Test_MeanAction

--- a/generic3g/tests/Test_MeanAction.pf
+++ b/generic3g/tests/Test_MeanAction.pf
@@ -16,7 +16,7 @@ contains
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
       integer :: status
-      integer(kind=ESMF_KIND_I8), parameter :: COUNTER = 4
+      real(kind=ESMF_KIND_R4), parameter :: COUNTER = 4_R4
       real(kind=ESMF_KIND_R4), parameter :: MEAN = 4.0_R4
       logical :: matches_expected
       real(kind=ESMF_KIND_R4), pointer :: fptr(:)
@@ -26,10 +26,9 @@ contains
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      acc%counter_scalar = COUNTER
+      call FieldSet(acc%counter_field, COUNTER, _RC)
 
-      ! All points are not UNDEF and valid_mean .TRUE.
-      acc%valid_mean = .TRUE.
+      ! All points are not UNDEF and counter > 0
       call acc%calculate_mean_R4(_RC)
       matches_expected = FieldIsConstant(acc%accumulation_field, MEAN, _RC)
       @assertTrue(matches_expected, 'accumulation_field not equal to MEAN')
@@ -46,21 +45,21 @@ contains
       @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
       @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
       
-      ! valid_mean .FALSE. at one point
-      acc%valid_mean = .TRUE.
+      ! counter 0 at one point
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      acc%valid_mean(n) = .FALSE.
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      fptr(n) = 0
+      mask = fptr /= 0
+      call assign_fptr(acc%accumulation_field, fptr, _RC)
       call acc%calculate_mean_R4(_RC)
-      @assertTrue(all(pack(fptr, acc%valid_mean) == MEAN), 'Some valid points not equal to MEAN')
+      @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
       @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
       
-      ! One point is UNDEF; valid_mean .FALSE. at one point
-      acc%valid_mean = .TRUE.
+      ! One point is UNDEF; counter 0 at one point
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      acc%valid_mean(n) = .FALSE.
       call assign_fptr(acc%accumulation_field, fptr, _RC)
       call set_undef(fptr(n))
-      mask = (.not. undef(fptr)) .and. acc%valid_mean
+      mask = mask .or. (.not. undef(fptr))
       call acc%calculate_mean_R4(_RC)
       @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')
       @assertTrue(undef(fptr(n)), 'mean at point was not UNDEF')
@@ -69,61 +68,23 @@ contains
    end subroutine test_calculate_mean_R4
 
    @Test
-   subroutine test_calculate_mean()
-      type(MeanAction) :: acc
-      type(ESMF_State) :: importState, exportState
-      type(ESMF_Clock) :: clock
-      integer :: status
-      integer(kind=ESMF_KIND_I8), parameter :: COUNTER = 4
-      real(kind=ESMF_KIND_R4), parameter :: MEAN = 4.0_R4
-      logical :: matches_expected
-      
-      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
-      call acc%initialize(importState, exportState, clock, _RC)
-      call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      acc%counter_scalar = 0_I8
-      acc%valid_mean = .TRUE.
-      call acc%calculate_mean()
-      @assertExceptionRaised()
-      acc%counter_scalar = COUNTER
-      call acc%calculate_mean()
-      matches_expected = FieldIsConstant(acc%accumulation_field, MEAN, _RC)
-      @assertTrue(matches_expected, 'accumulation_field not equal to MEAN.')
-      call destroy_objects(importState, exportState, clock, _RC)
-
-   end subroutine test_calculate_mean
-
-   @Test
    subroutine test_clear_accumulator()
       type(MeanAction) :: acc
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
       integer :: status
+      real(kind=ESMF_KIND_R4), parameter :: COUNTER = 4_R4
+      logical :: cleared = .FALSE.
 
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      acc%counter_scalar = 4
+      call FieldSet(acc%counter_field, COUNTER, _RC)
       call acc%clear_accumulator(_RC)
-      @assertTrue(acc%counter_scalar == 0_I8, 'counter_scalar is nonzero.')
+      cleared = FieldIsConstant(acc%counter_field, real(0, R4), _RC)
+      @assertTrue(cleared, 'Counter field is nonzero.')
       call destroy_objects(importState, exportState, clock, _RC)
 
    end subroutine test_clear_accumulator
-
-   @Test
-   subroutine test_clear_valid_mean()
-      type(MeanAction) :: acc
-      type(ESMF_State) :: importState, exportState
-      type(ESMF_Clock) :: clock
-      integer :: status
-
-      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
-      call acc%initialize(importState, exportState, clock, _RC)
-      acc%valid_mean = .TRUE.
-      call acc%clear_valid_mean(_RC)
-      @assertTrue(.not. any(acc%valid_mean), 'valid_mean .TRUE. in elements')
-      call destroy_objects(importState, exportState, clock, _RC)
-
-   end subroutine test_clear_valid_mean
 
    @Test
    subroutine test_invalidate()
@@ -131,19 +92,22 @@ contains
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
       integer :: status
-      integer(kind=ESMF_KIND_I8), parameter :: N = 4_I8
+      integer, parameter :: N = 4
       integer :: i
       type(ESMF_Field) :: importField
+      logical :: counter_is_set = .FALSE.
 
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call get_field(importState, importField, _RC)
       call FieldSet(importField, 1.0_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      @assertTrue(acc%counter_scalar == 0_I8, 'counter_scalar is nonzero')
+      counter_is_set = FieldIsConstant(acc%counter_field, this%CLEAR_VALUE_R4, _RC)
+      @assertTrue(counter_is_set, 'Counter field is nonzero.')
       do i=1, N
          call acc%invalidate(importState, exportState, clock, _RC)
       end do
-      @assertTrue(acc%counter_scalar == N, 'counter_scalar not equal to N')
+      counter_is_set = FieldIsConstant(acc%counter_field, real(N, R4), _RC)
+      @assertTrue(counter_is_set, 'counter_scalar not equal to N')
       call destroy_objects(importState, exportState, clock, _RC)
 
    end subroutine test_invalidate
@@ -202,4 +166,20 @@ contains
 
    end subroutine test_accumulate_mean_R4
 
+   @Test
+   subroutine test_initialize()
+      type(MeanAction) :: acc
+      type(ESMF_State) :: importState, exportState
+      type(ESMF_Clock) :: clock
+      integer :: status
+      logical :: equals_expected_value 
+
+      call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
+      call acc%initialize(importState, exportState, clock, _RC)
+      equals_expected_value = FieldIsConstant(acc%counter_field, acc%CLEAR_VALUE_R4, _RC)
+      @assertTrue(equals_expected_value, 'counter_field was not cleared.')
+      call destroy_objects(importState, exportState, clock, _RC)
+
+   end subroutine test_initialize
+   
 end module Test_MeanAction

--- a/generic3g/tests/Test_MeanAction.pf
+++ b/generic3g/tests/Test_MeanAction.pf
@@ -16,17 +16,19 @@ contains
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
       integer :: status
-      real(kind=ESMF_KIND_R4), parameter :: COUNTER = 4_R4
+      integer(kind=ESMF_KIND_I4), parameter :: COUNTER = 4
       real(kind=ESMF_KIND_R4), parameter :: MEAN = 4.0_R4
       logical :: matches_expected
       real(kind=ESMF_KIND_R4), pointer :: fptr(:)
+      integer(kind=ESMF_KIND_I4), pointer :: ifptr(:)
       integer :: n
       logical, allocatable :: mask(:)
       
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      call FieldSet(acc%counter_field, COUNTER, _RC)
+      call assign_fptr(acc%counter_field, ifptr, _RC)
+      ifptr = COUNTER
 
       ! All points are not UNDEF and counter > 0
       call acc%calculate_mean_R4(_RC)
@@ -73,14 +75,17 @@ contains
       type(ESMF_State) :: importState, exportState
       type(ESMF_Clock) :: clock
       integer :: status
-      real(kind=ESMF_KIND_R4), parameter :: COUNTER = 4_R4
+      integer(kind=ESMF_KIND_I4), parameter :: COUNTER = 4
       logical :: cleared = .FALSE.
+      integer(kind=ESMF_KIND_I4), pointer :: fptr(:)
 
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      call FieldSet(acc%counter_field, COUNTER, _RC)
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      fptr = COUNTER
       call acc%clear(_RC)
-      cleared = FieldIsConstant(acc%counter_field, real(0, R4), _RC)
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      cleared = all(fptr == 0)
       @assertTrue(cleared, 'Counter field is nonzero.')
       call destroy_objects(importState, exportState, clock, _RC)
 
@@ -96,17 +101,20 @@ contains
       integer :: i
       type(ESMF_Field) :: importField
       logical :: counter_is_set = .FALSE.
+      integer(kind=ESMF_KIND_I4), pointer :: fptr(:)
 
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call get_field(importState, importField, _RC)
       call FieldSet(importField, 1.0_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      counter_is_set = FieldIsConstant(acc%counter_field, acc%CLEAR_VALUE_R4, _RC)
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      counter_is_set = all(fptr == 0)
       @assertTrue(counter_is_set, 'Counter field is nonzero.')
       do i=1, N
          call acc%invalidate(importState, exportState, clock, _RC)
       end do
-      counter_is_set = FieldIsConstant(acc%counter_field, real(N, R4), _RC)
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      counter_is_set = all(fptr == N)
       @assertTrue(counter_is_set, 'counter_scalar not equal to N')
       call destroy_objects(importState, exportState, clock, _RC)
 
@@ -173,10 +181,12 @@ contains
       type(ESMF_Clock) :: clock
       integer :: status
       logical :: equals_expected_value 
+      integer(kind=ESMF_KIND_I4), pointer :: fptr(:)
 
       call initialize_objects(importState, exportState, clock, ESMF_TYPEKIND_R4, _RC)
       call acc%initialize(importState, exportState, clock, _RC)
-      equals_expected_value = FieldIsConstant(acc%counter_field, acc%CLEAR_VALUE_R4, _RC)
+      call assign_fptr(acc%counter_field, fptr, _RC)
+      equals_expected_value = all(fptr == 0)
       @assertTrue(equals_expected_value, 'counter_field was not cleared.')
       call destroy_objects(importState, exportState, clock, _RC)
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Time Averaging in MAPL3 needs a counter for each grid point so that the counts can vary points to account for a variable number of updates to the accumulation field over the field.
