### PR TITLE
Vertical regridding - fix for the case of vertical stagger mismatch

### DIFF
--- a/generic3g/specs/FieldSpec.F90
+++ b/generic3g/specs/FieldSpec.F90
@@ -854,7 +854,6 @@ contains
          ! TODO: DO WE NEED TO RESTRICT SPEC's VERTICAL GRID TO MODEL?
          ! NOTE: we cannot import ModelVerticalGrid (circular dependency)
          _ASSERT(spec%vertical_grid%get_units() == this%vertical_grid%get_units(), 'units must match')
-         _ASSERT(spec%vertical_dim_spec == this%vertical_dim_spec, 'temporary restriction')
          ! Field (to be regridded) should have the same typekind as the underlying vertical grid
          ! TODO: Should we add a typekind class variable to VerticalGrid?
          _ASSERT(spec%typekind == this%typekind, 'typekind must match')
@@ -866,6 +865,7 @@ contains
               'ignore', this%geom, this%typekind, this%units, this%vertical_dim_spec, _RC)
          action = VerticalRegridAction(v_in_coord, v_out_coupler, v_out_coord, v_out_coupler, this%regrid_method)
          spec%vertical_grid = this%vertical_grid
+         spec%vertical_dim_spec = this%vertical_dim_spec
       end select
 
       _RETURN(_SUCCESS)

--- a/generic3g/tests/scenarios/vertical_regridding/expectations.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding/expectations.yaml
@@ -5,8 +5,8 @@
 
 - component: A
   export:
-    E_A: {status: complete}
+    E_A: {status: complete, typekind: R4, rank: 3, value: 15.}
 
 - component: B
   import:
-    I_B: {status: complete}
+    I_B: {status: complete, typekind: R4, rank: 3, value: 15.}

--- a/generic3g/tests/scenarios/vertical_regridding_2/A.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/A.yaml
@@ -21,3 +21,8 @@ mapl:
         units: hPa
         default_value: 17.
         vertical_dim_spec: center
+      PLE:
+        standard_name: air_pressure_ple_edge
+        units: hPa
+        default_value: 13.
+        vertical_dim_spec: edge

--- a/generic3g/tests/scenarios/vertical_regridding_2/B.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/B.yaml
@@ -11,7 +11,7 @@ mapl:
       class: fixed_levels
       standard_name: air_pressure
       units: hPa
-      levels: [17.]
+      levels: [13.]
 
   states:
     import:

--- a/generic3g/tests/scenarios/vertical_regridding_2/expectations.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/expectations.yaml
@@ -5,16 +5,17 @@
 
 - component: A
   export:
-    PL: {status: complete}
+    PL: {status: empty}
+    PLE: {status: complete, typekind: R4, rank: 3, value: 13.}
 
 - component: B
   import:
-    I_B: {status: complete}
+    I_B: {status: complete, typekind: R4, rank: 3, value: 13.}
 
 - component: C
   export:
-    ZL: {status: complete}
+    ZL: {status: complete, typekind: R4, rank: 3, value: 23.}
 
 - component: D
   import:
-    I_D: {status: complete}
+    I_D: {status: complete, typekind: R4, rank: 3, value: 23.}

--- a/generic3g/tests/scenarios/vertical_regridding_2/parent.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_2/parent.yaml
@@ -21,7 +21,7 @@ mapl:
   states: {}
 
   connections:
-    - src_name: PL
+    - src_name: PLE
       dst_name: I_B
       src_comp: A
       dst_comp: B


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Resolve issue in the case there is a mismatch (edge vs center vertical staggering) in vertical regridding. Removed the temporary restriction of matching `vertical_dim_spec`s in case of vertical regridding.

Plus, updated tests.
## Related Issue

