### PR TITLE
Add ability, in Scenarios tests, to allow for testing array slices in the k direction

### DIFF
--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -100,6 +100,7 @@ contains
       params = [params, add_params('field status', check_field_status)]
       params = [params, add_params('field typekind', check_field_typekind)]
       params = [params, add_params('field value', check_field_value)]
+      params = [params, add_params('field k_values', check_field_k_values)]
       params = [params, add_params('field exists', check_field_rank)]
 
       ! Service oriented tests
@@ -453,7 +454,6 @@ contains
       character(*), intent(in) :: description
       integer, intent(out) :: rc
 
-      character(len=:), allocatable :: expected_field_typekind_str
       real :: expected_field_value
       integer :: rank
       type(ESMF_TypeKind_Flag) :: typekind
@@ -517,6 +517,73 @@ contains
 
       rc = 0
    end subroutine check_field_value
+
+   subroutine check_field_k_values(expectations, state, short_name, description, rc)
+      type(ESMF_HConfig), intent(in) :: expectations
+      type(ESMF_State), intent(inout) :: state
+      character(*), intent(in) :: short_name
+      character(*), intent(in) :: description
+      integer, intent(out) :: rc
+
+      real, allocatable :: expected_k_values(:)
+      integer :: rank
+      type(ESMF_TypeKind_Flag) :: typekind
+      integer :: status
+      character(len=:), allocatable :: msg
+      type(ESMF_Field) :: field
+      type(ESMF_StateItem_Flag) :: itemtype
+
+      msg = description
+
+      itemtype = get_itemtype(state, short_name, _RC)
+      if (itemtype /= ESMF_STATEITEM_FIELD) then ! that's ok
+         rc = 0
+         return
+      end if
+
+      if (.not. ESMF_HConfigIsDefined(expectations,keyString='k_values')) then
+         rc = 0
+         return
+      end if
+
+      expected_k_values = ESMF_HConfigAsR4Seq(expectations,keyString='k_values',_RC)
+
+      call ESMF_StateGet(state, short_name, field, _RC)
+      call ESMF_FieldGet(field, typekind=typekind, rank=rank, rc=status)
+      @assert_that('field get failed '//short_name,  status, is(0))
+
+      if (typekind == ESMF_TYPEKIND_R4) then
+         block
+            real(kind=ESMF_KIND_R4), pointer :: x3(:, :, :), x4(:, :, :, :)
+            select case(rank)
+            case(3)
+               call ESMF_FieldGet(field, farrayptr=x3, _RC)
+               @assert_that("value of "//short_name, x3(1, 1, :), is(equal_to(expected_k_values)))
+            case(4)
+               call ESMF_FieldGet(field, farrayptr=x4, _RC)
+               @assert_that("value of "//short_name, x4(1, 1, :, 1), is(equal_to(expected_k_values)))
+            case default
+
+            end select
+         end block
+      elseif (typekind == ESMF_TYPEKIND_R8) then
+         block
+            real(kind=ESMF_KIND_R8), pointer :: x3(:, :, :), x4(:, :, :, :)
+            select case(rank)
+            case(3)
+               call ESMF_FieldGet(field, farrayptr=x3, _RC)
+               @assert_that("value of "//short_name, x3(1, 1, :), is(equal_to(expected_k_values)))
+            case(4)
+               call ESMF_FieldGet(field, farrayptr=x4, _RC)
+               @assert_that("value of "//short_name, x4(1, 1, :, 1), is(equal_to(expected_k_values)))
+            end select
+         end block
+      else
+         _VERIFY(-1)
+      end if
+
+      rc = 0
+   end subroutine check_field_k_values
 
    subroutine check_field_rank(expectations, state, short_name, description, rc)
       type(ESMF_HConfig), intent(in) :: expectations

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -486,13 +486,13 @@ contains
             real(kind=ESMF_KIND_R4), pointer :: x2(:,:),x3(:,:,:),x4(:,:,:,:)
             select case(rank)
             case(2)
-               call ESMF_FieldGet(field, farrayptr=x2, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x2, _RC)
                @assert_that('value of '//short_name, all(x2 == expected_field_value), is(true()))
             case(3)
-               call ESMF_FieldGet(field, farrayptr=x3, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x3, _RC)
                @assert_that('value of '//short_name, all(x3 == expected_field_value), is(true()))
             case(4)
-               call ESMF_FieldGet(field, farrayptr=x4, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x4, _RC)
                @assert_that('value of '//short_name, all(x4 == expected_field_value), is(true()))
             end select
          end block
@@ -501,13 +501,13 @@ contains
             real(kind=ESMF_KIND_R8), pointer :: x2(:,:),x3(:,:,:),x4(:,:,:,:)
             select case(rank)
             case(2)
-               call ESMF_FieldGet(field, farrayptr=x2, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x2, _RC)
                @assert_that('value of '//short_name, all(x2 == expected_field_value), is(true()))
             case(3)
-               call ESMF_FieldGet(field, farrayptr=x3, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x3, _RC)
                @assert_that('value of '//short_name, all(x3 == expected_field_value), is(true()))
             case(4)
-               call ESMF_FieldGet(field, farrayptr=x4, _RC)
+               call ESMF_FieldGet(field, farrayPtr=x4, _RC)
                @assert_that('value of '//short_name, all(x4 == expected_field_value), is(true()))
             end select
          end block
@@ -532,6 +532,7 @@ contains
       character(len=:), allocatable :: msg
       type(ESMF_Field) :: field
       type(ESMF_StateItem_Flag) :: itemtype
+      integer :: i, j, l, shape3(3), shape4(4)
 
       msg = description
 
@@ -557,13 +558,25 @@ contains
             real(kind=ESMF_KIND_R4), pointer :: x3(:, :, :), x4(:, :, :, :)
             select case(rank)
             case(3)
-               call ESMF_FieldGet(field, farrayptr=x3, _RC)
-               @assert_that("value of "//short_name, x3(1, 1, :), is(equal_to(expected_k_values)))
+               call ESMF_FieldGet(field, farrayPtr=x3, _RC)
+               shape3 = shape(x3)
+               do i = 1, shape3(1)
+                  do j = 1, shape3(2)
+                     @assert_that("value of "//short_name, x3(i, j, :), is(equal_to(expected_k_values)))
+                  end do
+               end do
             case(4)
-               call ESMF_FieldGet(field, farrayptr=x4, _RC)
-               @assert_that("value of "//short_name, x4(1, 1, :, 1), is(equal_to(expected_k_values)))
+               call ESMF_FieldGet(field, farrayPtr=x4, _RC)
+               shape4 = shape(x4)
+               do i = 1, shape4(1)
+                  do j = 1, shape4(2)
+                     do l = 1, shape4(4)
+                        @assert_that("value of "//short_name, x4(i, j, :, l), is(equal_to(expected_k_values)))
+                     end do
+                  end do
+               end do
             case default
-
+               error stop "invalid rank"
             end select
          end block
       elseif (typekind == ESMF_TYPEKIND_R8) then
@@ -571,11 +584,25 @@ contains
             real(kind=ESMF_KIND_R8), pointer :: x3(:, :, :), x4(:, :, :, :)
             select case(rank)
             case(3)
-               call ESMF_FieldGet(field, farrayptr=x3, _RC)
-               @assert_that("value of "//short_name, x3(1, 1, :), is(equal_to(expected_k_values)))
+               call ESMF_FieldGet(field, farrayPtr=x3, _RC)
+               shape3 = shape(x3)
+               do i = 1, shape3(1)
+                  do j = 1, shape3(2)
+                     @assert_that("value of "//short_name, x3(i, j, :), is(equal_to(expected_k_values)))
+                  end do
+               end do
             case(4)
-               call ESMF_FieldGet(field, farrayptr=x4, _RC)
-               @assert_that("value of "//short_name, x4(1, 1, :, 1), is(equal_to(expected_k_values)))
+               call ESMF_FieldGet(field, farrayPtr=x4, _RC)
+               shape4 = shape(x4)
+               do i = 1, shape4(1)
+                  do j = 1, shape4(2)
+                     do l = 1, shape4(4)
+                        @assert_that("value of "//short_name, x4(i, j, :, l), is(equal_to(expected_k_values)))
+                     end do
+                  end do
+               end do
+            case default
+               error stop "invalid rank"
             end select
          end block
       else

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -58,11 +58,11 @@ module Test_Scenarios
 
    interface Scenario
       procedure :: new_Scenario
-   end interface
+   end interface Scenario
 
    interface ScenarioDescription
       procedure :: new_ScenarioDescription
-   end interface
+   end interface ScenarioDescription
 
 contains
 
@@ -470,7 +470,7 @@ contains
          return
       end if
 
-     if (.not. ESMF_HConfigIsDefined(expectations,keyString='value')) then
+      if (.not. ESMF_HConfigIsDefined(expectations,keyString='value')) then
          rc = 0
          return
       end if

--- a/generic3g/tests/scenarios/vertical_regridding_3/expectations.yaml
+++ b/generic3g/tests/scenarios/vertical_regridding_3/expectations.yaml
@@ -6,12 +6,12 @@
 - component: DYN
   export:
     PL: {status: complete}
-    T_DYN: {status: complete}
+    T_DYN: {status: complete, typekind: R4, rank: 3, k_values: [40., 20., 10., 5.]}
 
 - component: PHYS
   import:
-    T_PHYS: {status: complete}
+    T_PHYS: {status: complete, typekind: R4, rank: 3, k_values: [18., 6.]}
 
 - component: C
   import:
-    I_C: {status: complete}
+    I_C: {status: complete, typekind: R4, rank: 3, k_values: [40., 20., 10.]}


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Implement #3187
Scenarios testing - added ability to allow for testing array slices in expectations.yaml. We can now add tests like
```
I: {status: complete, typekind: R4, rank: 3, k_values: [40., 20., 10.]}
```


## Related Issue

