### PR TITLE
Updates for f2py-meson support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- refactored tableEnd check
+- Change minimum CMake version to 3.24
+  - This is needed for f2py and meson support
+- Refactored tableEnd check
 - Added commandline options to `checkpoint_benchmark.x` and `restart_benchmark.x` to allow for easier testing of different configurations. Note that the old configuration file style of input is allowed via the `--config_file` option (which overrides any other command line options)
 - Update ESMF version for Baselibs to match that of Spack for consistency
 - Update `components.yaml`
@@ -28,9 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - GSL 2.8
       - jpeg 9f
       - Various build fixes
-  - ESMA_cmake v3.52.0
+  - ESMA_cmake v3.55.0
     - Fixes for using MAPL as a library in spack builds of GEOSgcm
     - Various backports from v4
+    - Code for capturing `mepo status` output
+    - Fixes for f2py and meson (NOTE: Requires CMake minimum version of 3.24 in project for complete functionality)
+    - Fixes for `MPI_STACK` code run multiple times
 - Updates to CI
   - Use v7.27.0 Baselibs
   - Use GCC 14 for GNU tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.23)
+cmake_minimum_required (VERSION 3.24)
 
 get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT is_multi_config AND NOT (CMAKE_BUILD_TYPE OR DEFINED ENV{CMAKE_BUILD_TYPE}))

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.31.0
+  tag: v4.32.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.52.0
+  tag: v3.55.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR updates some of the CMake in MAPL to support use of `f2py` with `meson` (aka Python 3.12+). The changes are:

- Update the `cmake_minimum_version` to 3.24
- Update to ESMA_cmake v3.55.0 (which has the needed bits inside)

Also, weirdly, the ESMA_env version was never ticked up to 4.32 even though I thought I did that (as the changelog says). My bad.

## Related Issue

