### PR TITLE
fixes #3201

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,8 @@ workflows:
           fixture_branch: feature/mathomp4/mapldevelop
           checkout_mapl_branch: true
           mepodevelop: false
-          rebuild_procs: 1
+          rebuild_procs: 4
+          build_type: Release
 
   build-and-publish-docker:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.25.0
+baselibs_version: &baselibs_version v7.27.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.25.0-openmpi_5.0.2-gcc_13.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v7.27.0-openmpi_5.0.5-gcc_14.2.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -86,7 +86,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu20-geos-env:v7.27.0-intelmpi_2021.13-ifort_2021.13
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug where c null character is not removed from end of string when reading netcdf attribute in NetCDF4\_FileFormatter.F90
+
 ### Removed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed bug where c null character is not removed from end of string when reading netcdf attribute in NetCDF4\_FileFormatter.F90
-
 ### Removed
 
 ### Deprecated
+
+## [2.50.3] - 2024-12-02
+
+### Fixed
+
+- Fixed bug where c null character is not removed from end of string when reading netcdf attribute in NetCDF4\_FileFormatter.F90
 
 ## [2.50.2] - 2024-10-30
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.50.2
+  VERSION 2.50.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -993,7 +993,9 @@ contains
             status = nf90_get_att(this%ncid, varid, trim(attr_name), str)
             !$omp end critical
             _VERIFY(status)
-            if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
+            if (len > 0) then
+               if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
+            end if
             call cf%add_attribute(trim(attr_name), str)
             deallocate(str)
          case (NF90_STRING)
@@ -1090,7 +1092,9 @@ contains
             status = nf90_get_att(this%ncid, varid, trim(attr_name), str)
             !$omp end critical
             _VERIFY(status)
-            if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
+            if (len > 0) then
+               if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
+            end if
             call var%add_attribute(trim(attr_name), str)
             deallocate(str)
          case (NF90_STRING)

--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -20,6 +20,7 @@ module pFIO_NetCDF4_FileFormatterMod
    use pfio_NetCDF_Supplement
    use netcdf
    use mpi
+   use, intrinsic :: iso_c_binding, only: C_NULL_CHAR
    implicit none
    private
 
@@ -992,6 +993,7 @@ contains
             status = nf90_get_att(this%ncid, varid, trim(attr_name), str)
             !$omp end critical
             _VERIFY(status)
+            if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
             call cf%add_attribute(trim(attr_name), str)
             deallocate(str)
          case (NF90_STRING)
@@ -1088,6 +1090,7 @@ contains
             status = nf90_get_att(this%ncid, varid, trim(attr_name), str)
             !$omp end critical
             _VERIFY(status)
+            if (str(len:len) == C_NULL_CHAR) str = str(1:len-1)
             call var%add_attribute(trim(attr_name), str)
             deallocate(str)
          case (NF90_STRING)


### PR DESCRIPTION
Checks if the last character of a string retrieved from `nf90_get_att` is the `C_NULL_CHAR` and removes if it is when adding attributes to a `FileMetadata` object in `NetCDF4_FileFormatter.F90`

## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [X] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

