### PR TITLE
Feature/fixes #3175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow update offsets of &#177;timestep in ExtData2G
 - Minor revision (and generalization) of grid-def for GSI purposes
 - Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
+- Allow lat-lon grid factory to detect and use CF compliant lat-lon bounds in a file when making a grid
 
 ### Changed
 
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue of some Baselibs builds appearing to support zstandard. This is not possible due to Baselibs building HDF5 and netCDF as static libraries
+- Fixed a bug where the periodicity around the earth of the lat-lon grid was not being set properly when grid did not span from pole to pole
 
 ### Removed
 

--- a/base/MAPL_LatLonGridFactory.F90
+++ b/base/MAPL_LatLonGridFactory.F90
@@ -851,10 +851,13 @@ contains
          end if
 
          if (abs(this%lat_centers(1) + 90) < 1000*epsilon(1.0)) then
+            write(*,*)'bmaa here 1'
             this%pole = 'PC'
          else if (abs(this%lat_corners(1) + 90) < 1000*epsilon(1.0)) then
+            write(*,*)'bmaa here 2'
             this%pole = 'PE'
          else ! assume XY
+            write(*,*)'bmaa here 3'
             this%pole = 'XY'
             this%lat_range = RealMinMax(this%lat_centers(1), this%lat_centers(jm))
          end if
@@ -1987,18 +1990,18 @@ contains
       end select
       im = metadata%get_dimension(coord_name, _RC)
       allocate(coord_bounds(im+1), _STAT)
-      allocate(file_bounds(im,2), _STAT)
+      allocate(file_bounds(2,im), _STAT)
       source_file = metadata%get_source_file() 
- 
+
       call file_formatter%open(source_file, PFIO_READ, _RC)
-      call file_formatter%get_var(coord_name, file_bounds, _RC)
+      call file_formatter%get_var(bnds_name, file_bounds, _RC)
       call file_formatter%close(_RC)
       do i=1,im-1
-         _ASSERT(file_bounds(i,2)==file_bounds(i+1,1), "Bounds are not contiguous in file")
+         _ASSERT(file_bounds(2,i)==file_bounds(1,i+1), "Bounds are not contiguous in file")
       enddo
       do i=1,im
-         coord_bounds(i) = file_bounds(i,1)
-         coord_bounds(i+1) = file_bounds(i,2)
+         coord_bounds(i) = file_bounds(1,i)
+         coord_bounds(i+1) = file_bounds(2,i)
       enddo
 
       _RETURN(_SUCCESS)

--- a/base/MAPL_LatLonGridFactory.F90
+++ b/base/MAPL_LatLonGridFactory.F90
@@ -1874,14 +1874,12 @@ contains
       integer :: i
       _UNUSED_DUMMY(this)
 
-      if (allocated(this%lon_bounds_name) .and. allocated(this%lat_bounds_name)) then
-         vars = 'lon,lat,'//this%lon_bounds_name//','//this%lat_bounds_name
-      else if (allocated(this%lon_bounds_name) .and. (.not. allocated(this%lat_bounds_name))) then
-         vars = 'lon,lat,'//this%lon_bounds_name
-      else if (allocated(this%lat_bounds_name) .and. (.not. allocated(this%lon_bounds_name))) then
-         vars = 'lon,lat,'//this%lat_bounds_name
-      else if ((.not.allocated(this%lat_bounds_name)) .and. (.not. allocated(this%lon_bounds_name))) then
-         vars = 'lon,lat'
+      vars = 'lon,lat'
+      if (allocated(this%lon_bounds_name)) then
+         vars = vars // ',' // this%lon_bounds_name
+      end if
+      if (allocated(this%lat_bounds_name)) then
+         vars = vars // ',' // this%lat_bounds_name
       end if
 
    end function get_file_format_vars

--- a/base/MAPL_LatLonGridFactory.F90
+++ b/base/MAPL_LatLonGridFactory.F90
@@ -1871,6 +1871,7 @@ contains
       class (LatLonGridFactory), intent(inout) :: this
 
       character(len=:), allocatable :: vars
+      integer :: i
       _UNUSED_DUMMY(this)
 
       if (allocated(this%lon_bounds_name) .and. allocated(this%lat_bounds_name)) then

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -48,8 +48,8 @@ module MAPL_ESMFFieldBundleRead
          type(StringVariableMap), pointer :: variables
          type(Variable), pointer :: this_variable
          type(StringVariableMapIterator) :: var_iter
-         character(len=:), pointer :: var_name,dim_name
-         character(len=:), allocatable :: lev_name
+         character(len=:), pointer :: var_name_ptr,dim_name
+         character(len=:), allocatable :: lev_name,var_name
          type(ESMF_Field) :: field
          type (StringVector), pointer :: dimensions
          type (StringVectorIterator) :: dim_iter
@@ -71,14 +71,15 @@ module MAPL_ESMFFieldBundleRead
          factory => get_factory(file_grid,rc=status)
          _VERIFY(status)
          grid_vars = factory%get_file_format_vars()
-         exclude_vars = grid_vars//",lev,time,lons,lats,time_bnds"
+         exclude_vars = ","//grid_vars//",lev,time,time_bnds,"
          if (has_vertical_level) lev_size = metadata%get_dimension(trim(lev_name))
 
          variables => metadata%get_variables()
          var_iter = variables%begin()
          do while (var_iter /= variables%end())
             var_has_levels = .false.
-            var_name => var_iter%key()
+            var_name_ptr => var_iter%key()
+            var_name = ","//var_name_ptr//","
             this_variable => var_iter%value()
 
             if (has_vertical_level) then
@@ -91,29 +92,20 @@ module MAPL_ESMFFieldBundleRead
                enddo
             end if
 
-            write(*,*)'bmaa exclude ',','//trim(exclude_vars)//','
-            write(*,*)'bmaa var_name ',trim(var_name)
-            write(*,*)'bmaa index(exclude_var,var_name) ',index(','//trim(exclude_vars)//',',','//trim(var_name)//',')
-            write(*,*)'bmaa hardcode string index comma vs no ',index(',lon,lat,lon_bnds,lat_bnds,lev,time,lons,lats,time_bnds,',",lat_bnds,"),index(',lon,lat,lon_bnds,lat_bnds,lev,time,lons,lats,time_bnds,',"lat_bnds")
-            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",lat_bnds,"),index(exclude_vars,"lat_bnds")
-            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",time_bnds,"),index(exclude_vars,"time_bnds")
-            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",time,"),index(exclude_vars,"time")
-            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",lat,"),index(exclude_vars,"lat")
-
-            if (index(','//trim(exclude_vars)//',',','//trim(var_name)//',') > 0) then
+            if (index(trim(exclude_vars),trim(var_name)) > 0) then
                call var_iter%next()
                   cycle
                end if
             create_variable = .true.
             if (present(only_vars)) then
-               if (index(','//trim(only_vars)//',',','//trim(var_name)//',') < 1) create_variable = .false.
+               if (index(','//trim(only_vars)//',',trim(var_name)) < 1) create_variable = .false.
             end if
             if (create_variable) then
                if(var_has_levels) then
                    if (grid_size(3) == lev_size) then
                       location=MAPL_VLocationCenter
                       dims = MAPL_DimsHorzVert
-                      field= ESMF_FieldCreate(grid,name=trim(var_name),typekind=ESMF_TYPEKIND_R4, &
+                      field= ESMF_FieldCreate(grid,name=trim(var_name_ptr),typekind=ESMF_TYPEKIND_R4, &
                         ungriddedUbound=[grid_size(3)],ungriddedLBound=[1], rc=status)
                         block
                            real, pointer :: ptr3d(:,:,:)
@@ -123,7 +115,7 @@ module MAPL_ESMFFieldBundleRead
                    else if (grid_size(3)+1 == lev_size) then
                       location=MAPL_VLocationEdge
                       dims = MAPL_DimsHorzVert
-                      field= ESMF_FieldCreate(grid,name=trim(var_name),typekind=ESMF_TYPEKIND_R4, &
+                      field= ESMF_FieldCreate(grid,name=trim(var_name_ptr),typekind=ESMF_TYPEKIND_R4, &
                         ungriddedUbound=[grid_size(3)],ungriddedLBound=[0], rc=status)
                         block
                            real, pointer :: ptr3d(:,:,:)
@@ -134,7 +126,7 @@ module MAPL_ESMFFieldBundleRead
                else
                    location=MAPL_VLocationNone
                    dims = MAPL_DimsHorzOnly
-                   field= ESMF_FieldCreate(grid,name=trim(var_name),typekind=ESMF_TYPEKIND_R4, &
+                   field= ESMF_FieldCreate(grid,name=trim(var_name_ptr),typekind=ESMF_TYPEKIND_R4, &
                       rc=status)
                         block
                            real, pointer :: ptr2d(:,:)
@@ -146,9 +138,8 @@ module MAPL_ESMFFieldBundleRead
                _VERIFY(status)
                call ESMF_AttributeSet(field,name='VLOCATION',value=location,rc=status)
                _VERIFY(status)
-               write(*,*)"bmaa getting units for ",trim(var_name)
-               units = metadata%get_var_attr_string(var_name,'units',_RC)
-               long_name = metadata%get_var_attr_string(var_name,'long_name',_RC)
+               units = metadata%get_var_attr_string(var_name_ptr,'units',_RC)
+               long_name = metadata%get_var_attr_string(var_name_ptr,'long_name',_RC)
                call ESMF_AttributeSet(field,name='UNITS',value=units,rc=status)
                _VERIFY(status)
                call ESMF_AttributeSet(field,name='LONG_NAME',value=long_name,rc=status)

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -91,6 +91,15 @@ module MAPL_ESMFFieldBundleRead
                enddo
             end if
 
+            write(*,*)'bmaa exclude ',','//trim(exclude_vars)//','
+            write(*,*)'bmaa var_name ',trim(var_name)
+            write(*,*)'bmaa index(exclude_var,var_name) ',index(','//trim(exclude_vars)//',',','//trim(var_name)//',')
+            write(*,*)'bmaa hardcode string index comma vs no ',index(',lon,lat,lon_bnds,lat_bnds,lev,time,lons,lats,time_bnds,',",lat_bnds,"),index(',lon,lat,lon_bnds,lat_bnds,lev,time,lons,lats,time_bnds,',"lat_bnds")
+            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",lat_bnds,"),index(exclude_vars,"lat_bnds")
+            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",time_bnds,"),index(exclude_vars,"time_bnds")
+            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",time,"),index(exclude_vars,"time")
+            write(*,*)'bmaa allocatable string index comma vs no ',index(exclude_vars,",lat,"),index(exclude_vars,"lat")
+
             if (index(','//trim(exclude_vars)//',',','//trim(var_name)//',') > 0) then
                call var_iter%next()
                   cycle
@@ -137,6 +146,7 @@ module MAPL_ESMFFieldBundleRead
                _VERIFY(status)
                call ESMF_AttributeSet(field,name='VLOCATION',value=location,rc=status)
                _VERIFY(status)
+               write(*,*)"bmaa getting units for ",trim(var_name)
                units = metadata%get_var_attr_string(var_name,'units',_RC)
                long_name = metadata%get_var_attr_string(var_name,'long_name',_RC)
                call ESMF_AttributeSet(field,name='UNITS',value=units,rc=status)

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -71,7 +71,7 @@ module MAPL_ESMFFieldBundleRead
          factory => get_factory(file_grid,rc=status)
          _VERIFY(status)
          grid_vars = factory%get_file_format_vars()
-         exclude_vars = grid_vars//",lev,time,lons,lats"
+         exclude_vars = grid_vars//",lev,time,lons,lats,time_bnds"
          if (has_vertical_level) lev_size = metadata%get_dimension(trim(lev_name))
 
          variables => metadata%get_variables()


### PR DESCRIPTION
Fixes #3175 
Address 2 issues.
1. The pole should have no effect on the grid periodicity in the longitude direction
2. If the file has CF compliant bounds for the coordinate we should use those to define the edges rather than the heuristics and so forth.

I have confirmed that this is zero-diff at least with the files we are using for ExtData now. This will allow Bin and Mike to use these files with bounds.

## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [X] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

