### PR TITLE
Feature/wdboggs/component timestep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tests for time accumulation
 - Add variable to FieldSpec for accumulation type
 - Add accumulation type variable to VariableSpec and ComponentSpecParser
+_ Add run_dt to ComponentSpec and ComponentSpecParser
 
 ### Changed
 

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -89,7 +89,7 @@ esma_add_fortran_submodules(
   SUBDIRECTORY ComponentSpecParser
   SOURCES parse_child.F90 parse_children.F90 parse_connections.F90
           parse_var_specs.F90 parse_geometry_spec.F90 parse_component_spec.F90
-          parse_setservices.F90)
+          parse_setservices.F90, parse_run_dt.F90)
 
 esma_add_fortran_submodules(
   TARGET MAPL.generic3g

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -89,7 +89,7 @@ esma_add_fortran_submodules(
   SUBDIRECTORY ComponentSpecParser
   SOURCES parse_child.F90 parse_children.F90 parse_connections.F90
           parse_var_specs.F90 parse_geometry_spec.F90 parse_component_spec.F90
-          parse_setservices.F90, parse_run_dt.F90)
+          parse_setservices.F90 parse_run_dt.F90)
 
 esma_add_fortran_submodules(
   TARGET MAPL.generic3g

--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -62,6 +62,7 @@ module mapl3g_ComponentSpecParser
    character(*), parameter :: KEY_UNGRIDDED_DIM_COORDINATES = 'coordinates'
    character(*), parameter :: KEY_VERTICAL_DIM_SPEC = 'vertical_dim_spec'
    character(*), parameter :: KEY_ACCUMULATION_TYPE = 'accumulation_type'
+   character(*), parameter :: KEY_RUN_DT = 'run_dt'
 
    !>
    ! Submodule declarations
@@ -109,6 +110,12 @@ module mapl3g_ComponentSpecParser
          type(ESMF_HConfig), intent(in) :: hconfig
          integer, optional, intent(out) :: rc
       end function parse_child
+
+      module function parse_run_dt(hconfig, rc) result(run_dt)
+         type(ESMF_TimeInterval) :: run_dt
+         type(ESMF_HConfig), intent(in) :: hconfig
+         integer, optional, intent(out) :: rc
+      end function parse_run_dt
 
    END INTERFACE
 

--- a/generic3g/ComponentSpecParser.F90
+++ b/generic3g/ComponentSpecParser.F90
@@ -38,6 +38,7 @@ module mapl3g_ComponentSpecParser
    public :: parse_child
    public :: parse_SetServices
    public :: parse_geometry_spec
+   public :: parse_run_dt
 
 !!$   public :: parse_ChildSpecMap
 !!$   public :: parse_ChildSpec

--- a/generic3g/ComponentSpecParser/parse_component_spec.F90
+++ b/generic3g/ComponentSpecParser/parse_component_spec.F90
@@ -22,6 +22,7 @@ contains
       spec%var_specs = parse_var_specs(mapl_cfg, _RC)
       spec%connections = parse_connections(mapl_cfg, _RC)
       spec%children = parse_children(mapl_cfg, _RC)
+      spec%run_dt = parse_run_dt(mapl_cfg, _RC)
 
       call ESMF_HConfigDestroy(mapl_cfg, _RC)
 

--- a/generic3g/ComponentSpecParser/parse_run_dt.F90
+++ b/generic3g/ComponentSpecParser/parse_run_dt.F90
@@ -1,7 +1,7 @@
 #include "MAPL_ErrLog.h"
 
 submodule (mapl3g_ComponentSpecParser) parse_run_dt_smod
-
+   use MAPL_TimeStringConversion, only: parse_isostring => string_to_esmf_timeinterval
 contains
 
       module function parse_run_dt(hconfig, rc) result(run_dt)
@@ -15,22 +15,10 @@ contains
 
          has_run_dt = ESMF_HConfigIsDefined(hconfig, keyString=KEY_RUN_DT, _RC)
          _RETURN_UNLESS(has_run_dt)
-
          iso_duration = ESMF_HConfigAsString(hconfig, keyString=KEY_RUN_DT, _RC)
-         call parse_isostring(isostring, run_dt, _RC) 
+         run_dt = parse_isostring(iso_duration, _RC)
          _RETURN(_SUCCESS)
 
       end function parse_run_dt
-
-      subroutine parse_isostring(isostring, ti, rc)
-         character(len=*), intent(in) :: isostring
-         type(ESMF_TimeInterval), intent(out) :: ti
-         integer, optional, intent(out) :: rc
-
-         integer :: status
-
-         call ESMF_TimeIntervalSet(ti, isostring, _RC)
-
-      end subroutine parse_isostring
 
 end submodule parse_run_dt_smod

--- a/generic3g/ComponentSpecParser/parse_run_dt.F90
+++ b/generic3g/ComponentSpecParser/parse_run_dt.F90
@@ -1,0 +1,36 @@
+#include "MAPL_ErrLog.h"
+
+submodule (mapl3g_ComponentSpecParser) parse_run_dt_smod
+
+contains
+
+      module function parse_run_dt(hconfig, rc) result(run_dt)
+         type(ESMF_TimeInterval) :: run_dt
+         type(ESMF_HConfig), intent(in) :: hconfig
+         integer, optional, intent(out) :: rc
+         
+         integer :: status
+         logical :: has_run_dt
+         character(len=:), allocatable :: iso_duration
+
+         has_run_dt = ESMF_HConfigIsDefined(hconfig, keyString=KEY_RUN_DT, _RC)
+         _RETURN_UNLESS(has_run_dt)
+
+         iso_duration = ESMF_HConfigAsString(hconfig, keyString=KEY_RUN_DT, _RC)
+         call parse_isostring(isostring, run_dt, _RC) 
+         _RETURN(_SUCCESS)
+
+      end function parse_run_dt
+
+      subroutine parse_isostring(isostring, ti, rc)
+         character(len=*), intent(in) :: isostring
+         type(ESMF_TimeInterval), intent(out) :: ti
+         integer, optional, intent(out) :: rc
+
+         integer :: status
+
+         call ESMF_TimeIntervalSet(ti, isostring, _RC)
+
+      end subroutine parse_isostring
+
+end submodule parse_run_dt_smod

--- a/generic3g/specs/ComponentSpec.F90
+++ b/generic3g/specs/ComponentSpec.F90
@@ -21,7 +21,7 @@ module mapl3g_ComponentSpec
       type(ConnectionVector) :: connections
       type(ChildSpecMap) :: children
       type(ESMF_HConfig), allocatable :: geom_hconfig ! optional
-      type(ESMF_TimeInterval) :: run_dt
+      type(ESMF_TimeInterval), allocatable :: run_dt
    contains
       procedure :: has_geom_hconfig
       procedure :: add_var_spec

--- a/generic3g/specs/ComponentSpec.F90
+++ b/generic3g/specs/ComponentSpec.F90
@@ -21,6 +21,7 @@ module mapl3g_ComponentSpec
       type(ConnectionVector) :: connections
       type(ChildSpecMap) :: children
       type(ESMF_HConfig), allocatable :: geom_hconfig ! optional
+      type(ESMF_TimeInterval) :: run_dt
    contains
       procedure :: has_geom_hconfig
       procedure :: add_var_spec
@@ -33,13 +34,15 @@ module mapl3g_ComponentSpec
 
 contains
 
-   function new_ComponentSpec(var_specs, connections) result(spec)
+   function new_ComponentSpec(var_specs, connections, run_dt) result(spec)
       type(ComponentSpec) :: spec
       type(VariableSpecVector), optional, intent(in) :: var_specs
       type(ConnectionVector), optional, intent(in) :: connections
+      type(ESMF_TimeInterval), optional, intent(in) :: run_dt
 
       if (present(var_specs)) spec%var_specs = var_specs
       if (present(connections)) spec%connections = connections
+      if (present(run_dt)) spec%run_dt = run_dt
    end function new_ComponentSpec
 
    logical function has_geom_hconfig(this)

--- a/generic3g/tests/Test_ComponentSpecParser.pf
+++ b/generic3g/tests/Test_ComponentSpecParser.pf
@@ -180,4 +180,38 @@ contains
       
    end subroutine test_parse_ChildSpecMap_2
 
+   @test
+   subroutine test_parse_run_dt()
+      integer(kind=ESMF_KIND_R4) :: d(6)
+      type(ESMF_TimeInterval) :: expected
+      character(len=:), allocatable :: iso_duration
+      character(len=:), allocatable :: content
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_TimeInterval) :: actual
+      integer :: rc, status
+      character(len=:), allocatable :: expected_timestring, actual_timestring, msg
+
+      ! Test with correct key for run_dt
+      d = [10, 3, 7, 13, 57, 32]
+      call ESMF_TimeIntervalSet(expected, yy=d(1), mm=d(2), d=d(3), h=d(4), m=d(5), s=d(6), _RC)
+      iso_duration = 'P10Y3M7DT13H57M32S'
+      content = 'run_dt: ' // iso_duration
+      hconfig = ESMF_HConfigCreate(content=content, _RC)
+      actual = parse_run_dt(hconfig, _RC)
+      call ESMF_TimeIntervalGet(expected, timeString=expected_timestring, _RC)
+      call ESMF_TimeIntervalGet(actual, timeString=actual_timestring, _RC)
+      msg = actual_timestring // ' /= ' // expected_timestring
+      @assertTrue(actual == expected, msg)
+      call ESMF_HConfigDestroy(hconfig, _RC)
+      
+      ! Test with incorrect key for run_dt; should return without setting actual (invalid)
+      content = 'run_dmc: ' // iso_duration
+      hconfig = ESMF_HConfigCreate(content=content, _RC)
+      actual = parse_run_dt(hconfig, _RC)
+      call ESMF_TimeIntervalValidate(actual, rc=status)
+      @assertTrue(status /= ESMF_SUCCESS, 'ESMF_TimeInterval should be invalid.')
+      call ESMF_HConfigDestroy(hconfig, _RC)
+
+   end subroutine test_parse_run_dt
+
 end module Test_ComponentSpecParser


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
MAPL3 will support component-level timestep (`run_dt`). This PR adds an `ESMF_TimeInterval` (`run_dt`) to the `ComponentSpec` derived type, and it provides a parsing function for reading `run_dt` as an ISO8601 Duration string from an `ESMF_HConfig` and converting it into an `ESMF_TimeInterval`. If `run_dt` is not found in the `ESMF_HConfig`, the resulting `ESMF_TimeInterval` is not set. In this case, `run_dt` cannot be used. This is not treated as an error condition in the parsing, but it should be handled at a higher level.