### PR TITLE
Prepare for 2.51.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [2.51.0] - 2024-12-06
+
+### Added
+
 - Added macro `_RETURN(_SUCCESS)` to fetch_data
 - Allow update offsets of &#177;timestep in ExtData2G
 - Minor revision (and generalization) of grid-def for GSI purposes
 - Add ability to use an `ESMF_CONFIG_FILE` environment variable to specify name of file to pass in pre-`ESMF_Initialize` options to ESMF (see [ESMF Docs](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node4.html#SECTION04024000000000000000) for allowed flags.
 - Allow lat-lon grid factory to detect and use CF compliant lat-lon bounds in a file when making a grid
 - PFIO/Variable class, new procedures to retrieve string/reals/int attributes from a variable
-- Added a call in GenericRefresh to allow GC's refresh method to be called; in support 
+- Added a call in GenericRefresh to allow GC's refresh method to be called; in support
   of CICE6 rewind
 
 ### Changed
@@ -57,10 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates to support llvm-flang
 - Trajectory sampler: fix a bug when group_name does not exist in netCDF file and a bug that omitted the first time point
 - Fixed a bug where the periodicity around the earth of the lat-lon grid was not being set properly when grid did not span from pole to pole
-
-### Removed
-
-### Deprecated
 
 ## [2.50.3] - 2024-12-02
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.50.3
+  VERSION 2.51.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
Prepare for a 2.51.0 release.

Tested and shown zero-diff to MAPL 2.50