### PR TITLE
Follow up for #3231

### DIFF
--- a/generic3g/vertical/BasicVerticalGrid.F90
+++ b/generic3g/vertical/BasicVerticalGrid.F90
@@ -87,7 +87,7 @@ contains
          _RETURN(_SUCCESS)
       end if
 
-      _RETURN(_SUCCESS)
+      _FAIL("BasicVerticalGrid::can_connect_to - NOT implemented yet")
    end function can_connect_to
 
    logical function is_identical_to(this, that, rc)

--- a/gridcomps/configurable/ConfigurableGridComp.F90
+++ b/gridcomps/configurable/ConfigurableGridComp.F90
@@ -35,6 +35,10 @@ contains
       integer :: status
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(gridcomp)
+      _UNUSED_DUMMY(importState)
+      _UNUSED_DUMMY(exportState)
+      _UNUSED_DUMMY(clock)
    end subroutine init
 
    recursive subroutine run(gridcomp, importState, exportState, clock, rc)
@@ -45,12 +49,13 @@ contains
       integer, intent(out) :: rc
 
       integer :: status
-      character(len=ESMF_MAXSTR) :: gc_name
 
-      call ESMF_GridCompGet(gridcomp, name=gc_name, _RC)
       call MAPL_RunChildren(gridcomp, phase_name="run", _RC)
 
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(importState)
+      _UNUSED_DUMMY(exportState)
+      _UNUSED_DUMMY(clock)
    end subroutine run
 
 end module ConfigurableGridComp
@@ -64,6 +69,7 @@ subroutine setServices(gridcomp, rc)
 
    integer :: status
 
-   call Configurable_setServices(gridcomp,_RC)
+   call Configurable_setServices(gridcomp, _RC)
+
    _RETURN(_SUCCESS)
 end subroutine setServices


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Follow up for PR #3231 
- ConfigurableGridComp - cleanup
- Bug fix - BasicVerticalGrid::can_connect_to fails if dst id is different from this id
## Related Issue

