### PR TITLE
Fixes #3247 - Initial implementation of StateItemAspect.

### DIFF
--- a/generic3g/specs/AspectMap.F90
+++ b/generic3g/specs/AspectMap.F90
@@ -1,0 +1,20 @@
+module mapl3g_AspectMap
+   use mapl3g_StateItemAspect
+
+#define Key __CHARACTER_DEFERRED
+#define T StateItemAspect
+#define T_polymorphic
+#define Map AspectMap
+#define MapIterator AspectMapIterator
+#define Pair AspectPairIterator
+
+#include "map/template.inc"
+
+#undef Pair
+#undef MapIterator
+#undef Map
+#undef T_polymorphic
+#undef T
+#undef Key
+
+end module mapl3g_AspectMap

--- a/generic3g/specs/CMakeLists.txt
+++ b/generic3g/specs/CMakeLists.txt
@@ -1,4 +1,10 @@
 target_sources(MAPL.generic3g PRIVATE
+  StateItemAspect.F90
+  AspectMap.F90
+  GeomAspect.F90
+  UngriddedDimsAspect.F90
+  UnitsAspect.F90
+
   VariableSpec.F90
   StateItem.F90
   VariableSpecVector.F90

--- a/generic3g/specs/GeomAspect.F90
+++ b/generic3g/specs/GeomAspect.F90
@@ -1,0 +1,93 @@
+#include "MAPL_Generic.h"
+
+module mapl3g_GeomAspect
+   use mapl3g_StateItemAspect
+   use mapl3g_geom_mgr, only: MAPL_SameGeom
+   use mapl3g_regridder_mgr, only: EsmfRegridderParam
+   use mapl3g_ExtensionAction
+   use mapl3g_RegridAction
+   use mapl3g_NullAction
+   use mapl_ErrorHandling
+   use ESMF, only: ESMF_Geom
+   implicit none
+   private
+
+   public :: GeomAspect
+
+
+   type, extends(StateItemAspect) :: GeomAspect
+      private
+      type(ESMF_Geom) :: geom
+      type(EsmfRegridderParam) :: regridder_param
+   contains
+      procedure :: matches
+      procedure :: make_action
+      procedure :: supports_conversion_general
+      procedure :: supports_conversion_specific
+   end type GeomAspect
+
+   interface GeomAspect
+      procedure new_GeomAspect
+   end interface
+
+contains
+
+   function new_GeomAspect(geom, regridder_param, is_mirror, is_time_dependent) result(aspect)
+      type(GeomAspect) :: aspect
+      type(ESMF_Geom), intent(in) :: geom
+      type(EsmfRegridderParam), intent(in) :: regridder_param
+      logical, optional, intent(in) :: is_mirror
+      logical, optional, intent(in) :: is_time_dependent
+
+      aspect%geom = geom
+      aspect%regridder_param = regridder_param
+      call aspect%set_mirror(is_mirror)
+      call aspect%set_time_dependent(is_time_dependent)
+
+   end function new_GeomAspect
+
+   ! Generally, geoms can be converted via RouteHandle, but there
+   ! are definitely many exceptions.   A better implementation here could attempt to create
+   ! the relevant regridder.
+   logical function supports_conversion_general(src)
+      class(GeomAspect), intent(in) :: src
+      supports_conversion_general = .true.
+   end function supports_conversion_general
+
+   logical function supports_conversion_specific(src, dst)
+      class(GeomAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+      supports_conversion_specific = .true.
+   end function supports_conversion_specific
+
+   logical function matches(src, dst)
+      class(GeomAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+
+      select type(dst)
+      class is (GeomAspect)
+         matches = MAPL_SameGeom(src%geom, dst%geom)
+      class default
+         matches = .false.
+      end select
+
+   end function matches
+
+   function make_action(src, dst, rc) result(action)
+      class(ExtensionAction), allocatable :: action
+      class(GeomAspect), intent(in) :: src
+      class(StateItemAspect), intent(in)  :: dst
+      integer, optional, intent(out) :: rc
+
+      select type(dst)
+      class is (GeomAspect)
+         action = RegridAction(src%geom, dst%geom, dst%regridder_param)
+      class default
+         action = NullAction()
+         _FAIL('src is GeomAspect but dst is different subclass')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function make_action
+
+end module mapl3g_GeomAspect

--- a/generic3g/specs/UngriddedDimsAspect.F90
+++ b/generic3g/specs/UngriddedDimsAspect.F90
@@ -1,0 +1,77 @@
+#include "MAPL_Generic.h"
+
+module mapl3g_UngriddedDimsAspect
+   use mapl3g_StateItemAspect
+   use mapl3g_ExtensionAction
+   use mapl3g_UngriddedDims
+   use mapl3g_NullAction
+   use mapl_ErrorHandling
+   implicit none
+   private
+
+   public :: UngriddedDimsAspect
+
+
+   type, extends(StateItemAspect) :: UngriddedDimsAspect
+      private
+      type(UngriddedDims) :: ungridded_dims
+   contains
+      procedure :: matches
+      procedure :: supports_conversion_general
+      procedure :: supports_conversion_specific
+      procedure :: make_action
+   end type UngriddedDimsAspect
+
+   interface UngriddedDimsAspect
+      procedure new_UngriddedDimsAspect
+   end interface
+
+contains
+
+   ! Time dependent ungridded_dims is not supported.
+   function new_UngriddedDimsAspect(ungridded_dims, is_mirror) result(aspect)
+      type(UngriddedDimsAspect) :: aspect
+      type(UngriddedDims), intent(in) :: ungridded_dims
+      logical, optional, intent(in) :: is_mirror
+
+      aspect%ungridded_dims = ungridded_dims
+      call aspect%set_mirror(is_mirror)
+
+   end function new_UngriddedDimsAspect
+
+   logical function supports_conversion_general(src)
+      class(UngriddedDimsAspect), intent(in) :: src
+      supports_conversion_general = .false.
+   end function supports_conversion_general
+
+   logical function supports_conversion_specific(src, dst)
+      class(UngriddedDimsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+      supports_conversion_specific = .false.
+   end function supports_conversion_specific
+
+   logical function matches(src, dst)
+      class(UngriddedDimsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+
+      select type(dst)
+      class is (UngriddedDimsAspect)
+         matches = (src%ungridded_dims == dst%ungridded_dims)
+      class default
+         matches = .false.
+      end select
+
+   end function matches
+
+   function make_action(src, dst, rc) result(action)
+      class(ExtensionAction), allocatable :: action
+      class(UngriddedDimsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in)  :: dst
+      integer, optional, intent(out) :: rc
+
+      action = NullAction()
+
+      _RETURN(_SUCCESS)
+   end function make_action
+
+end module mapl3g_UngriddedDimsAspect

--- a/generic3g/specs/UnitsAspect.F90
+++ b/generic3g/specs/UnitsAspect.F90
@@ -1,0 +1,91 @@
+#include "MAPL_Generic.h"
+
+module mapl3g_UnitsAspect
+   use mapl3g_StateItemAspect
+   use mapl3g_ExtensionAction
+   use mapl3g_ConvertUnitsAction
+   use mapl3g_NullAction
+   use mapl_ErrorHandling
+   use udunits2f, only: are_convertible
+   implicit none
+   private
+
+   public :: UnitsAspect
+
+
+   type, extends(StateItemAspect) :: UnitsAspect
+      private
+      character(:), allocatable :: units
+   contains
+      procedure :: matches
+      procedure :: supports_conversion_general
+      procedure :: supports_conversion_specific
+      procedure :: make_action
+   end type UnitsAspect
+
+   interface UnitsAspect
+      procedure new_UnitsAspect
+   end interface
+
+contains
+
+   function new_UnitsAspect(units, is_mirror, is_time_dependent) result(aspect)
+      type(UnitsAspect) :: aspect
+      character(*), intent(in) :: units
+      logical, optional, intent(in) :: is_mirror
+      logical, optional, intent(in) :: is_time_dependent
+
+      aspect%units = units
+      call aspect%set_mirror(is_mirror)
+      call aspect%set_mirror(is_time_dependent)
+
+   end function new_UnitsAspect
+
+   logical function supports_conversion_general(src)
+      class(UnitsAspect), intent(in) :: src
+      supports_conversion_general = .true.
+   end function supports_conversion_general
+
+   logical function supports_conversion_specific(src, dst)
+      class(UnitsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+
+      select type (dst)
+      class is (UnitsAspect)
+         supports_conversion_specific = are_convertible(src%units, dst%units)
+      class default
+         supports_conversion_specific = .false.
+      end select
+
+   end function supports_conversion_specific
+
+   logical function matches(src, dst)
+      class(UnitsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+
+      select type(dst)
+      class is (UnitsAspect)
+         matches = (src%units == dst%units)
+      class default
+         matches = .false.
+      end select
+
+   end function matches
+
+   function make_action(src, dst, rc) result(action)
+      class(ExtensionAction), allocatable :: action
+      class(UnitsAspect), intent(in) :: src
+      class(StateItemAspect), intent(in)  :: dst
+      integer, optional, intent(out) :: rc
+
+      select type(dst)
+      class is (UnitsAspect)
+         action = ConvertUnitsAction(src%units, dst%units)
+      class default
+         _FAIL('UnitsApsect cannot convert from other supclass.')
+      end select
+
+      _RETURN(_SUCCESS)
+   end function make_action
+
+end module mapl3g_UnitsAspect

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ set(MODULE_DIRECTORY "${esma_include}/MAPL.generic3g/tests")
 add_subdirectory(gridcomps)
 
 set (test_srcs
+  Test_BaseAspect.pf
+  Test_BaseItemSpec.pf
+
   Test_VirtualConnectionPt.pf
 
   Test_ConfigurableGridComp.pf
@@ -43,7 +46,7 @@ add_pfunit_ctest(
   LINK_LIBRARIES MAPL.generic3g MAPL.shared MAPL.pfunit configurable_gridcomp
   EXTRA_INITIALIZE Initialize
   EXTRA_USE MAPL_pFUnit_Initialize
-  OTHER_SOURCES MockUserGridComp.F90 MockItemSpec.F90 accumulator_action_test_common.F90
+  OTHER_SOURCES MockUserGridComp.F90 MockItemSpec.F90 accumulator_action_test_common.F90 MockAspect.F90
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   MAX_PES 4
 )

--- a/generic3g/tests/MockAspect.F90
+++ b/generic3g/tests/MockAspect.F90
@@ -1,0 +1,76 @@
+#include "MAPL_Generic.h"
+
+module MockAspect_mod
+   use mapl3g_StateItemASpect
+   use mapl3g_ExtensionAction
+   use mapl3g_NullAction
+   implicit none
+   private
+
+   public :: MockAspect
+
+   type, extends(StateItemAspect) :: MockAspect
+      integer :: value
+      logical :: supports_conversion_
+   contains
+      procedure :: matches
+      procedure :: make_action
+      procedure :: supports_conversion_general
+      procedure :: supports_conversion_specific
+   end type MockAspect
+
+   interface MockAspect
+      procedure :: new_MockAspect
+   end interface MockAspect
+
+contains
+
+   function new_MockAspect(mirror, time_dependent, value, supports_conversion) result(aspect)
+      type(MockAspect) :: aspect
+      logical, intent(in) :: mirror
+      logical, intent(in) :: time_dependent
+      integer, intent(in) :: value
+      logical, intent(in) :: supports_conversion
+
+      call aspect%set_mirror(mirror)
+      call aspect%set_time_dependent(time_dependent)
+
+      aspect%value = value
+      aspect%supports_conversion_ = supports_conversion
+
+   end function new_MockAspect
+
+   logical function matches(src, dst)
+      class(MockAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+
+      select type (dst)
+      type is (MockAspect)
+         matches = (src%value == dst%value)
+      class default
+         matches = .false.
+      end select
+   end function matches
+
+   logical function supports_conversion_general(src)
+      class(MockAspect), intent(in) :: src
+      supports_conversion_general = src%supports_conversion_
+   end function supports_conversion_general
+
+   logical function supports_conversion_specific(src, dst)
+      class(MockAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+      supports_conversion_specific = src%supports_conversion_
+   end function supports_conversion_specific
+
+   function make_action(src, dst, rc) result(action)
+      class(ExtensionAction), allocatable :: action
+      class(MockAspect), intent(in) :: src
+      class(StateItemAspect), intent(in) :: dst
+      integer, optional, intent(out) :: rc
+
+      action = NullAction()
+      if (present(rc)) rc = 0
+   end function make_action
+   
+end module MockAspect_mod

--- a/generic3g/tests/MockItemSpec.F90
+++ b/generic3g/tests/MockItemSpec.F90
@@ -38,6 +38,8 @@ module MockItemSpecMod
       procedure :: add_to_state
       procedure :: add_to_bundle
       procedure :: write_formatted
+
+      procedure :: get_aspect_priorities
    end type MockItemSpec
 
    type, extends(ExtensionAction) :: MockAction
@@ -369,4 +371,19 @@ contains
      end if
    end function new_NameAdapter
      
+   function get_aspect_priorities(src_spec, dst_spec) result(order)
+      character(:), allocatable :: order
+      class(MockItemSpec), intent(in) :: src_spec
+      class(StateItemSpec), intent(in) :: dst_spec
+
+      select case (src_spec%name)
+      case ('1')
+         order = 'a1'
+      case ('3')
+         order = 'a1::b2::c3'
+      case default
+         order = ''
+      end select
+   end function get_aspect_priorities
+
 end module MockItemSpecMod

--- a/generic3g/tests/Test_BaseAspect.pf
+++ b/generic3g/tests/Test_BaseAspect.pf
@@ -49,16 +49,15 @@ contains
    subroutine test_can_connect_to()
       integer :: i
       character(4) :: buf
+      type(Expectation) :: expect
+      type(MockAspect) :: src, dst
 
       do i = 1, size(EXPECTATIONS)
          write(buf, '(i0)') i
-         associate (expect => EXPECTATIONS(i))
-           associate (src => MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion))
-             associate (dst => MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.)) ! last is unused
-               @assert_that('case: '//trim(buf), src%can_connect_to(dst), is(expect%can_connect_to))
-             end associate
-           end associate
-         end associate
+         expect = EXPECTATIONS(i)
+         src = MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion)
+         dst = MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.) ! last is unused
+         @assert_that('case: '//trim(buf), src%can_connect_to(dst), is(expect%can_connect_to))
       end do
       
    end subroutine test_can_connect_to
@@ -67,16 +66,15 @@ contains
    subroutine test_needs_extension_for()
       integer :: i
       character(4) :: buf
+      type(Expectation) :: expect
+      type(MockAspect) :: src, dst
 
       do i = 1, size(EXPECTATIONS)
          write(buf, '(i0)') i
-         associate (expect => EXPECTATIONS(i))
-           associate (src => MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion))
-             associate (dst => MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.)) ! last is unused
-               @assert_that('case: '//trim(buf), src%needs_extension_for(dst), is(expect%needs_extension_for))
-             end associate
-           end associate
-         end associate
+         expect = EXPECTATIONS(i)
+         src = MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion)
+         dst = MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.) ! last is unused
+         @assert_that('case: '//trim(buf), src%needs_extension_for(dst), is(expect%needs_extension_for))
       end do
       
    end subroutine test_needs_extension_for

--- a/generic3g/tests/Test_BaseAspect.pf
+++ b/generic3g/tests/Test_BaseAspect.pf
@@ -1,0 +1,84 @@
+#include "MAPL_TestErr.h"
+
+module Test_BaseAspect
+   use MockAspect_mod
+   use mapl3g_StateItemAspect
+   use funit, expectation_shadow => expectation
+   implicit none
+
+   logical, parameter, private :: T = .true., F = .false.
+
+   type :: Expectation
+      ! input
+      logical :: src_mirror, dst_mirror
+      logical :: src_time_dependent, dst_time_dependent
+      integer ::src_value, dst_value
+      logical :: src_supports_conversion
+      ! output
+      logical :: can_connect_to, needs_extension_for
+   end type Expectation
+
+   type(Expectation), parameter :: EXPECTATIONS(*) = [ &
+        !           M  M
+        Expectation(F, F, F, F, 1, 1, F,    T, F), & ! simple matching values
+        Expectation(F, F, F, F, 1, 2, F,    F, T), & ! needs extension but conversion not supported
+        Expectation(F, F, F, F, 1, 2, T,    T, T), & ! needs extension and can supports conversion
+ 
+        Expectation(F, T, F, F, 1, 1, F,    T, F), & ! import is mirror - always can connect
+        Expectation(F, T, F, F, 1, 2, F,    T, F), &
+        Expectation(T, F, F, F, 1, 1, F,    T, F), & ! export is mirror - always can connect (but ...)
+        Expectation(T, F, F, F, 1, 2, F,    T, F), &
+
+        Expectation(F, F, T, F, 1, 1, F,    F, T), & ! time dependent export - always needs extension even for exact match
+        Expectation(F, F, T, F, 1, 2, F,    F, T), & 
+        Expectation(F, F, T, F, 1, 1, T,    T, T), & ! time dependent export with conversion
+        Expectation(F, F, T, F, 1, 2, T,    T, T), & 
+
+        Expectation(F, F, F, T, 1, 1, F,    F, T), & ! time dependent import - always needs extension even for exact match
+        Expectation(F, F, F, T, 1, 2, F,    F, T), & 
+        Expectation(F, F, F, T, 1, 1, T,    T, T), & ! time dependent import with conversion
+        Expectation(F, F, F, T, 1, 2, T,    T, T) & 
+
+
+        ]
+
+
+contains
+
+   @test
+   subroutine test_can_connect_to()
+      integer :: i
+      character(4) :: buf
+
+      do i = 1, size(EXPECTATIONS)
+         write(buf, '(i0)') i
+         associate (expect => EXPECTATIONS(i))
+           associate (src => MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion))
+             associate (dst => MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.)) ! last is unused
+               @assert_that('case: '//trim(buf), src%can_connect_to(dst), is(expect%can_connect_to))
+             end associate
+           end associate
+         end associate
+      end do
+      
+   end subroutine test_can_connect_to
+
+   @test
+   subroutine test_needs_extension_for()
+      integer :: i
+      character(4) :: buf
+
+      do i = 1, size(EXPECTATIONS)
+         write(buf, '(i0)') i
+         associate (expect => EXPECTATIONS(i))
+           associate (src => MockAspect(expect%src_mirror, expect%src_time_dependent, expect%src_value, expect%src_supports_conversion))
+             associate (dst => MockAspect(expect%dst_mirror, expect%dst_time_dependent, expect%dst_value, .true.)) ! last is unused
+               @assert_that('case: '//trim(buf), src%needs_extension_for(dst), is(expect%needs_extension_for))
+             end associate
+           end associate
+         end associate
+      end do
+      
+   end subroutine test_needs_extension_for
+   
+end module Test_BaseAspect

--- a/generic3g/tests/Test_BaseItemSpec.pf
+++ b/generic3g/tests/Test_BaseItemSpec.pf
@@ -1,0 +1,63 @@
+! Test suite that focuses on methods implemented in base class StateItemSpec
+
+module Test_BaseItemSpec
+   use MockItemSpecMod
+   use gftl2_StringVector
+   use funit
+   implicit none
+
+contains
+
+   @test
+   ! Just needed for bootstrapping from older adapters => aspects
+   subroutine get_aspect_empty()
+      type(StringVector) :: aspect_names
+      type(MockItemSpec) :: spec, goal
+
+      spec = MockItemSpec(name='0')
+      goal = MockItemSpec(name='0')
+
+      aspect_names = spec%get_aspect_order(goal)
+      associate ( expected => aspect_names%size() ) ! returns INT64
+        @assert_that(int(expected), is(0))
+      end associate
+
+   end subroutine get_aspect_empty
+
+   @test
+   subroutine get_aspect_one()
+      type(StringVector) :: aspect_names
+      type(MockItemSpec) :: spec, goal
+
+      spec = MockItemSpec(name='1')
+      goal = MockItemSpec(name='0')
+
+      aspect_names = spec%get_aspect_order(goal)
+      associate ( expected => aspect_names%size() ) ! returns INT64
+        @assert_that(int(expected), is(1))
+      end associate
+
+      @assertEqual(aspect_names%of(1), 'a1')
+
+   end subroutine get_aspect_one
+
+   @test
+   subroutine get_aspect_multi()
+      type(StringVector) :: aspect_names
+      type(MockItemSpec) :: spec, goal
+
+      spec = MockItemSpec(name='3')
+      goal = MockItemSpec(name='0')
+
+      aspect_names = spec%get_aspect_order(goal)
+      associate ( expected => aspect_names%size() ) ! returns INT64
+        @assert_that(int(expected), is(3))
+      end associate
+
+      @assertEqual(aspect_names%of(1), 'a1')
+      @assertEqual(aspect_names%of(2), 'b2')
+      @assertEqual(aspect_names%of(3), 'c3')
+
+   end subroutine get_aspect_multi
+
+end module Test_BaseItemSpec

--- a/generic3g/tests/Test_ComponentSpecParser.pf
+++ b/generic3g/tests/Test_ComponentSpecParser.pf
@@ -182,14 +182,15 @@ contains
 
    @test
    subroutine test_parse_run_dt()
-      integer(kind=ESMF_KIND_R4) :: d(6)
+      integer(kind=ESMF_KIND_I4) :: d(6)
       type(ESMF_TimeInterval) :: expected
       character(len=:), allocatable :: iso_duration
       character(len=:), allocatable :: content
       type(ESMF_HConfig) :: hconfig
       type(ESMF_TimeInterval) :: actual
       integer :: rc, status
-      character(len=:), allocatable :: expected_timestring, actual_timestring, msg
+      character(len=:), allocatable :: msg
+      character(len=ESMF_MAXSTR) :: expected_timestring, actual_timestring
 
       ! Test with correct key for run_dt
       d = [10, 3, 7, 13, 57, 32]
@@ -200,7 +201,7 @@ contains
       actual = parse_run_dt(hconfig, _RC)
       call ESMF_TimeIntervalGet(expected, timeString=expected_timestring, _RC)
       call ESMF_TimeIntervalGet(actual, timeString=actual_timestring, _RC)
-      msg = actual_timestring // ' /= ' // expected_timestring
+      msg = trim(actual_timestring) // ' /= ' // trim(expected_timestring)
       @assertTrue(actual == expected, msg)
       call ESMF_HConfigDestroy(hconfig, _RC)
       

--- a/geom_mgr/CubedSphere/CubedSphereGeomFactory_smod.F90
+++ b/geom_mgr/CubedSphere/CubedSphereGeomFactory_smod.F90
@@ -216,7 +216,7 @@ contains
       integer, allocatable :: ivar(:,:)
       integer, allocatable :: ivar2(:,:,:)
 
-      real(REAL64), allocatable :: temp_coords(:)
+      real(ESMF_KIND_R8), allocatable :: temp_coords(:)
 
       integer :: status, i
       integer, parameter :: ncontact = 4


### PR DESCRIPTION
- Some simple tests have been implemented for generic Aspect logic.
- Some subclasses have been implemented - but not tested.
- High level logic has been added to exercise aspects, but it is not currently activated as the default aspect list is empty.
- Next step is to convert adapters to aspects one at a time and see if things still work.  Undoubtedly this will expose problems with new logic.
- Everything compiles and tests pass, such as they are.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

