### PR TITLE
ESMF_TimeIntervalGet expects a string instead of an allocatable

### DIFF
--- a/generic3g/tests/Test_ComponentSpecParser.pf
+++ b/generic3g/tests/Test_ComponentSpecParser.pf
@@ -189,7 +189,8 @@ contains
       type(ESMF_HConfig) :: hconfig
       type(ESMF_TimeInterval) :: actual
       integer :: rc, status
-      character(len=:), allocatable :: expected_timestring, actual_timestring, msg
+      character(len=ESMF_MAXSTR):: expected_timestring, actual_timestring
+      character(len=:), allocatable:: msg
 
       ! Test with correct key for run_dt
       d = [10, 3, 7, 13, 57, 32]


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
A small fix - `ESMF_TimeIntervalGet` expects a fixed length string instead of an allocatable. This was exposed while running the `generic3g` tests, using `gfortran`, on a Mac.
## Related Issue

