### PR TITLE
CI Updates for GCC 14 with Ubuntu 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,13 @@ parameters:
     default: ""
 
 # Anchors to prevent forgetting to update a version
-os_version: &os_version ubuntu20
+os_version: &os_version ubuntu24
 baselibs_version: &baselibs_version v7.27.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@4
+  ci: geos-esm/circleci-tools@dev:1ef5d6c1aef6b1e47797d2d72448b55206869eb1
 
 workflows:
   build-and-test-MAPL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:1ef5d6c1aef6b1e47797d2d72448b55206869eb1
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-and-test-MAPL:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build and Test MAPL GNU
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v7.27.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v7.27.0-openmpi_5.0.5-gcc_14.2.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests
@@ -86,7 +86,7 @@ jobs:
     name: Build and Test MAPL Intel
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.27.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v7.27.0-intelmpi_2021.13-ifort_2021.13
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increased formatting width of time index in ExtData2G diagnostic print
-- Update CI to use Ubuntu24 images
+- Update CI to use Ubuntu 24 images
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increased formatting width of time index in ExtData2G diagnostic print
+- Update CI to use Ubuntu24 images
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix profiler ExclusiveColumn test for GCC 14
+
 ### Removed
 
 ### Deprecated

--- a/profiler/tests/test_ExclusiveColumn.pf
+++ b/profiler/tests/test_ExclusiveColumn.pf
@@ -11,15 +11,15 @@ contains
       class(AbstractMeterNode), pointer :: subnode
       class(AbstractMeter), pointer :: t
       type(ExclusiveColumn) :: c
-      type(UnlimitedVector) :: v
+      type(UnlimitedVector), target :: v
       integer :: i
       integer :: expected(3)
-      class(*), allocatable :: q
-      
+      class(*), pointer :: q
+
       node = MeterNode('top', AdvancedMeter(MpiTimerGauge()))
       t => node%get_meter()
       call t%add_cycle(10.0d0)
-      
+
       call node%add_child('a', AdvancedMeter(MpiTimerGauge()))
       subnode => node%get_child('a')
       t => subnode%get_meter()
@@ -33,7 +33,7 @@ contains
       v = c%get_rows(node)
       expected = [7,1,2]
       do i = 1, 3
-         q = v%at(i)
+         q => v%at(i)
          select type (q)
          type is (integer)
             @assertEqual(expected(i), q)


### PR DESCRIPTION
# NOTE

I am putting this in draft and am going to put the edits into #3256 as that is a hotfix and will apply the CI fixes to all branches via GitFlow

---

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR has a bug fix for one of the profiler tests that was found needed by GCC 14 with Ubuntu 24 CI images. This is similar to #2946 which had a similar fix in a different profiler test.

## Related Issue

