### PR TITLE
fixes #3262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added loggers when writing or reading weight files
+- Added new option to AGCM.rc `clobber_checkpoint` to allow checkpoint files to be overwritten. By default still will not clobber checkpoints
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added loggers when writing or reading weight files
-- Added new option to AGCM.rc `clobber_checkpoint` to allow checkpoint files to be overwritten. By default still will not clobber checkpoints
+- Added new option to AGCM.rc `overwrite_checkpoint` to allow checkpoint files to be overwritten. By default still will not overwrite checkpoints
 
 ### Changed
 

--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -3512,11 +3512,12 @@ module NCIOMod
   _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_ArrayReadNCpar_3d
 
-  subroutine MAPL_BundleWriteNCPar(Bundle, arrdes, CLOCK, filename, oClients, rc)
+  subroutine MAPL_BundleWriteNCPar(Bundle, arrdes, CLOCK, filename, clobber, oClients, rc)
     type(ESMF_FieldBundle), intent(inout)   :: Bundle
     type(ArrDescr), intent(inout)           :: arrdes
     type(ESMF_Clock), intent(in)            :: CLOCK
     character(len=*), intent(in  )         :: filename
+    logical, intent(in)                    :: clobber
     type (ClientManager), optional, intent(inout) :: oClients
     integer, optional, intent(out)          :: rc
 
@@ -3582,6 +3583,8 @@ module NCIOMod
     type(ESMF_Field) :: lons_field, lats_field
     logical :: isGridCapture, have_oclients
     real(kind=ESMF_KIND_R8), pointer :: grid_lons(:,:), grid_lats(:,:), lons_field_ptr(:,:), lats_field_ptr(:,:)
+    integer :: pfio_mode
+
     have_oclients = present(oClients)
 
     call ESMF_FieldBundleGet(Bundle,FieldCount=nVars, name=BundleName, rc=STATUS)
@@ -4174,9 +4177,11 @@ module NCIOMod
 
     else
 
+       pfio_mode = PFIO_NOCLOBBER 
+       if (clobber) pfio_mode = PFIO_CLOBBER
        if (arrdes%writers_comm /= mpi_comm_null) then
           if (arrdes%num_writers == 1) then
-             call formatter%create(trim(filename), rc=status)
+             call formatter%create(trim(filename), mode=pfio_mode, rc=status)
              _VERIFY(status)
              call formatter%write(cf,rc=status)
              _VERIFY(STATUS)
@@ -4189,7 +4194,7 @@ module NCIOMod
                 _VERIFY(status)
                 call cf%add_attribute("Split_Cubed_Sphere", writer_rank, _RC)
              else
-                call formatter%create_par(trim(filename),comm=arrdes%writers_comm,info=info,rc=status)
+                call formatter%create_par(trim(filename),mode=pfio_mode,comm=arrdes%writers_comm,info=info,rc=status)
                 _VERIFY(status)
              endif
              call formatter%write(cf,rc=status)
@@ -4307,13 +4312,14 @@ module NCIOMod
 
   end subroutine MAPL_BundleWriteNCPar
 
-  subroutine MAPL_StateVarWriteNCPar(filename, STATE, ARRDES, CLOCK, NAME, forceWriteNoRestart, oClients, RC)
+  subroutine MAPL_StateVarWriteNCPar(filename, STATE, ARRDES, CLOCK, NAME, forceWriteNoRestart, clobber, oClients, RC)
     character(len=*)            , intent(IN   ) :: filename
     type (ESMF_State)           , intent(IN   ) :: STATE
     type(ArrDescr)              , intent(INOUT) :: ARRDES
     type(ESMF_Clock)            , intent(IN   ) :: CLOCK
     character(len=*),   optional, intent(IN   ) :: NAME
     logical,            optional, intent(IN   ) :: forceWriteNoRestart
+    logical,            optional, intent(in  ) :: clobber
     type (ClientManager), optional, intent(inout) :: oClients
     integer,            optional, intent(  OUT) :: RC
 
@@ -4339,6 +4345,7 @@ module NCIOMod
     logical                            :: is_test_framework, isGridCapture
     integer :: fieldIsValid
     type(ESMF_Array) :: array
+    logical :: local_clobber
 
     call ESMF_StateGet(STATE,ITEMCOUNT=ITEMCOUNT,RC=STATUS)
     _VERIFY(STATUS)
@@ -4358,9 +4365,9 @@ module NCIOMod
     _VERIFY(STATUS)
 
     forceWriteNoRestart_ = .false.
-    if(present(forceWriteNoRestart)) then
-       forceWriteNoRestart_ = forceWriteNoRestart
-    endif
+    if(present(forceWriteNoRestart)) forceWriteNoRestart_ = forceWriteNoRestart
+    local_clobber = .false.
+    if (present(clobber)) local_clobber = clobber
 
     if(present(NAME)) then
        DOIT = ITEMNAMES==NAME
@@ -4494,7 +4501,7 @@ module NCIOMod
        call ESMF_AttributeSet(bundle_write, name="MAPL_GridCapture", value=isGridCapture, _RC)
     end if
 
-    call MAPL_BundleWriteNCPar(Bundle_Write, arrdes, CLOCK, filename, oClients=oClients, rc=status)
+    call MAPL_BundleWriteNCPar(Bundle_Write, arrdes, CLOCK, filename, clobber=local_clobber, oClients=oClients, rc=status)
     _VERIFY(STATUS)
 
     _RETURN(ESMF_SUCCESS)

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -1956,10 +1956,13 @@ contains
      integer :: hdr
      type(ESMF_Time) :: start_time, curr_time, target_time
      character(len=1) :: phase_
+     logical :: clobber_file
+
 
      call ESMF_GridCompGet(GC, NAME=comp_name, _RC)
      call MAPL_InternalStateGet (GC, STATE, _RC)
 
+     call MAPL_GetResource(state, clobber_file, LABEL="overwrite_checkpoint:", default = .false., _RC)
      call ESMF_ClockGet(clock, startTime=start_time, currTime=curr_time, _RC)
 
      call MAPL_GetResource(STATE, time_label, label='TARGET_TIME:', default='')
@@ -1979,12 +1982,15 @@ contains
         write(phase_, '(i1)') phase
 
         call MAPL_ESMFStateWriteToFile(import, CLOCK, trim(FILENAME)//"import_"//trim(POS)//"_runPhase"//phase_, &
-             FILETYPE, STATE, .false., state%grid%write_restart_by_oserver, _RC)
+             FILETYPE, STATE, .false., clobber=clobber_file, &
+             write_with_oserver=state%grid%write_restart_by_oserver, _RC)
         call MAPL_ESMFStateWriteToFile(export, CLOCK, trim(FILENAME)//"export_"//trim(POS)//"_runPhase"//phase_, &
-             FILETYPE, STATE, .false., state%grid%write_restart_by_oserver, _RC)
+             FILETYPE, STATE, .false., clobber=clobber_file, &
+             write_with_oserver=state%grid%write_restart_by_oserver, _RC)
         call MAPL_GetResource(STATE, hdr, default=0, LABEL="INTERNAL_HEADER:", _RC)
         call MAPL_ESMFStateWriteToFile(internal, CLOCK, trim(FILENAME)//"internal_"//trim(POS)//"_runPhase"//phase_, &
-             FILETYPE, STATE, hdr/=0, state%grid%write_restart_by_oserver, _RC)
+             FILETYPE, STATE, hdr/=0, clobber=clobber_file, &
+             write_with_oserver=state%grid%write_restart_by_oserver, _RC)
      end if
      _RETURN(_SUCCESS)
    end subroutine capture
@@ -2265,7 +2271,7 @@ contains
       call MAPL_InternalStateRetrieve(GC, STATE, RC=status)
       _VERIFY(status)
 
-      call MAPL_GetResource(state, clobber_file, LABEL="clobber_checkpoint:", default = .false., _RC)
+      call MAPL_GetResource(state, clobber_file, LABEL="overwrite_checkpoint:", default = .false., _RC)
 
       ! Finalize the children
       ! ---------------------
@@ -2725,7 +2731,7 @@ contains
       call MAPL_InternalStateRetrieve(GC, STATE, RC=status)
       _VERIFY(status)
 
-      call MAPL_GetResource(state, clobber_file, LABEL="clobber_checkpoint:", default = .false., _RC)
+      call MAPL_GetResource(state, clobber_file, LABEL="overwrite_checkpoint:", default = .false., _RC)
       if (.not.associated(STATE%RECORD)) then
          _RETURN(ESMF_SUCCESS)
       end if
@@ -10337,7 +10343,7 @@ contains
       call MAPL_InternalStateRetrieve(GC, STATE, RC=status)
       _VERIFY(status)
 
-      call MAPL_GetResource(state, clobber_file, LABEL="clobber_checkpoint:", default = .false., _RC)
+      call MAPL_GetResource(state, clobber_file, LABEL="overwrite_checkpoint:", default = .false., _RC)
 
       call MAPL_GetResource( STATE, FILENAME,         &
            LABEL="IMPORT_CHECKPOINT_FILE:", &


### PR DESCRIPTION
Fixes #3262 
Adds new option, `overwrite_checkpoint` to the `AGCM.rc` to allow checkpoints to be clobber/overwritten
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

