### PR TITLE
Revise location_index for IODA file in Trajectory sampler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added loggers when writing or reading weight files
 - Added new option to AGCM.rc `overwrite_checkpoint` to allow checkpoint files to be overwritten. By default still will not overwrite checkpoints
+- Added use_NWP_1_file=1 option in Trajectory sampler (HISTORY.rc) to generate the correct location_index_ioda array, mapping back to location points in the single IODA observation input file
 
 ### Changed
 

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -26,6 +26,8 @@ module MAPL_ObsUtilMod
   type :: obs_unit
      integer :: nobs_epoch
      integer :: ngeoval
+     integer :: count_location_until_matching_file
+     integer :: count_location_in_matching_file
      logical :: export_all_geoval
      type(FileMetadata), allocatable :: metadata
      type(NetCDF4_FileFormatter), allocatable :: file_handle

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -5384,8 +5384,6 @@ ENDDO PARSER
   ! __ for each collection: find union fields, write to collection.rcx
   ! __ note: this subroutine is called by MPI root only
   !
-  ! __ note: this subroutine is called by MPI root only
-  !
   subroutine regen_rcx_for_obs_platform (config, nlist, list, rc)
     use  MAPL_scan_pattern_in_file
     use MAPL_ObsUtilMod, only : obs_platform, union_platform
@@ -5443,7 +5441,6 @@ ENDDO PARSER
     ! __ global set for call split_string by space
     length_mx = ESMF_MAXSTR2
     mxseg = 100
-
 
     ! __ s1. scan get  platform name + index_name_x  var_name_lat/lon/time
     do k=1, nplf

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -57,7 +57,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: var_name_lon_full
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
-     integer                        :: use_NWP_1_file
+     logical                        :: use_NWP_1_file = .false.
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -58,6 +58,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
      integer                        :: use_NWP_1_file
+     integer, dimension(2), parameter :: use_NWP_1_file_param = [0, 1]
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -40,7 +40,6 @@ module HistoryTrajectoryMod
      type(VerticalData) :: vdata
      logical :: do_vertical_regrid
 
-
      type(LocstreamRegridder) :: regridder
      type(TimeData)           :: time_info
      type(ESMF_Clock)         :: clock
@@ -48,13 +47,7 @@ module HistoryTrajectoryMod
      type(ESMF_Time)          :: RingTime
      type(ESMF_TimeInterval), public  :: epoch_frequency
 
-
      integer                        :: nobs_type
-!     character(len=ESMF_MAXSTR)     :: nc_index
-!     character(len=ESMF_MAXSTR)     :: nc_time
-!     character(len=ESMF_MAXSTR)     :: nc_latitude
-!     character(len=ESMF_MAXSTR)     :: nc_longitude
-
      character(len=ESMF_MAXSTR)     :: index_name_x
      character(len=ESMF_MAXSTR)     :: var_name_time
      character(len=ESMF_MAXSTR)     :: var_name_lat

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -58,7 +58,6 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
      integer                        :: use_NWP_1_file
-     integer, dimension(2), parameter :: use_NWP_1_file_param = [0, 1]
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -40,12 +40,14 @@ module HistoryTrajectoryMod
      type(VerticalData) :: vdata
      logical :: do_vertical_regrid
 
+
      type(LocstreamRegridder) :: regridder
      type(TimeData)           :: time_info
      type(ESMF_Clock)         :: clock
      type(ESMF_Alarm), public :: alarm
      type(ESMF_Time)          :: RingTime
      type(ESMF_TimeInterval), public  :: epoch_frequency
+
 
      integer                        :: nobs_type
 !     character(len=ESMF_MAXSTR)     :: nc_index
@@ -62,6 +64,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: var_name_lon_full
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
+     integer                        :: use_NWP_1_file
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -75,8 +75,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_ConfigGetAttribute(config, value=traj%use_NWP_1_file, default=0, &
               label=trim(string)//'use_NWP_1_file:', _RC)
          if (mapl_am_I_root()) then
-            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), &
-                 'use_NWP_1_file: wrong input')
+            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), 'use_NWP_1_file: wrong input')
             if (traj%use_NWP_1_file == 1) then
                write(6,105) 'WARNING: Traj sampler: use_NWP_1_file is ON'
                write(6,105) 'WARNING: USER needs to check if observation file is fetched correctly'

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -886,7 +886,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   !!        now we know
                   !!        ___x  x  x x x ___ ---------------------------------- o --o ---o -- o --
                   !!           negative index (extra) at Tmin                      missing Tmax
-
+                  !
                   !  count non-positive index on the left Tmin  (extra)
                   !
                   jj = 0
@@ -915,17 +915,14 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   j = this%obs(k)%nobs_epoch - this%obs(k)%count_location_in_matching_file
                   if (j/=0) &
                      write(6, *) trim(this%obs(k)%name)//'count_location_in_matching_file diff from cutted nobs_epoch'
-                  !!_ASSERT(j==0, trim(this%obs(k)%name)//'count_location_in_matching_file diff from cutted nobs_epoch')
                   j = minval(this%obs(k)%location_index_ioda(:))
                   if (j/=1) &
                        write(6,*) trim(this%obs(k)%name)//' min =', j, &
                        ' this%obs(k)%location_index_ioda(:) start diff from 1'
-                  !!_ASSERT(j==1, trim(this%obs(k)%name)//'this%obs(k)%location_index_ioda(:) did not start from 1')
                   j = maxval(this%obs(k)%location_index_ioda(:))
                   if (j/=this%obs(k)%count_location_in_matching_file) &
                        write(6,*) trim(this%obs(k)%name)//' max =', j, &
                        ' this%obs(k)%location_index_ioda(:) end diff from obs file max pts'
-                  !!_ASSERT(j==this%obs(k)%count_location_in_matching_file, trim(this%obs(k)%name)//'this%obs(k)%location_index_ioda(:) did not end at obs file max pts')
                enddo
             end if
          else

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -25,7 +25,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
   use, intrinsic :: iso_fortran_env, only: REAL64
   use, intrinsic :: iso_fortran_env, only: INT64
   implicit none
-
+  integer, parameter :: use_NWP_1_file_param(2) = [0, 1]
    contains
 
      module procedure HistoryTrajectory_from_config
@@ -75,7 +75,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_ConfigGetAttribute(config, value=traj%use_NWP_1_file, default=0, &
               label=trim(string)//'use_NWP_1_file:', _RC)
          if (mapl_am_I_root()) then
-            _ASSERT ( ANY(traj%use_NPW_1_file_param == traj%use_NWP_1_file), &
+            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), &
                  'use_NWP_1_file: wrong input')
             if (traj%use_NWP_1_file == 1) then
                write(6,105) 'WARNING: Traj sampler: use_NWP_1_file is ON'


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
`location_index_ioda` in Trajectory sampler is creating problems (found by @mjkagnes123), when the code is using the previously designed index mapping scheme.  For the 29 IODA files (NPW platform), about 6 of them shows either missing points and/or extra points that does not belong to a single IODA file.  This is because, we did not expect to see, e.g., 
aircraft.20190801T210000Z.nc4  contains time points: [20 points at 15 Z,  mid,  20 points at 21 Z ] 
aircraft.20190802T030000Z.nc4  contains time points: [10 points at 21 Z,  mid, 20 points at 03 Z ]

Our time slice scheme follows the python convention and will create a file:
aircraft.jedi.20190802_0300z.nc4  contains time points:  [30 points at 21 Z, mid, zero points at 03 Z].

In this case, we would not be able to recover the IODA location_index in aircraft.20190802T030000Z.nc4.  In other words, we have extra points at lower bound and missing points at upper bound. This does not occur, if observation files does not contain exactly points at 21 Z or 03Z.   This explains why we had the right `location_index_ioda` for about 60% of the NPW platforms (IODA files), but wrong index for the rest. 

Now, `location_index_ioda` in Trajectory sampler is revised to allow for reading in a single observation input file, such as `sondes.20190801T210000Z.nc4`, then generate the sampled GEOVAL values along the trajectory (in time ordered sequence) and return an array index (location_index_ioda) mapping back to the location points in the input IODA file, with the exact number of points.  This is controlled by setting `jedi.use_NWP_1_file: .true.` in HISTORY.rc.   

Note, the default (`use_NWP_1_file=0`) is our standard method, using our designed PYTHON style for time slicing:  [ T1 ,  T1 + Epoch), with T1=21Z,  Epoch=6 hr, for example.    Here we will analyze an expanded time window [T1 - Epoch, T1 + 2*Epoch).  




## Related Issue

