### PR TITLE
fixes #3280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed MAPL_ESMFRegridder to require the dstMaskValues to be added as grid attribute to use fixed masking, fixes UFS issue
 - Increased formatting width of time index in ExtData2G diagnostic print
 
 ### Fixed

--- a/base/MAPL_XYGridFactory.F90
+++ b/base/MAPL_XYGridFactory.F90
@@ -1037,6 +1037,9 @@ contains
       mask = MAPL_MASK_IN
       where(fptr==MAPL_UNDEF) mask = MAPL_MASK_OUT
 
+      call ESMF_AttributeSet(grid, name=MAPL_DESTINATIONMASK, &
+           itemCount=1, valueList=[MAPL_MASK_OUT], _RC)
+
       _RETURN(_SUCCESS)
     end subroutine add_mask
 

--- a/shared/Constants/InternalConstants.F90
+++ b/shared/Constants/InternalConstants.F90
@@ -23,6 +23,7 @@ module MAPL_InternalConstantsMod
    character(len=*), parameter  :: MAPL_GRID_NAME_DEFAULT       = 'UNKNOWN'
    character(len=*), parameter  :: MAPL_GRID_FILE_NAME_DEFAULT  = 'UNKNOWN'
    character(len=*), parameter  :: MAPL_CF_COMPONENT_SEPARATOR  = '.'
+   character(len=*), parameter  :: MAPL_DESTINATIONMASK         = "MAPL_DestinationMask"
 
    enum, bind(c)
       enumerator MAPL_TimerModeOld


### PR DESCRIPTION
Here's my quick proposal to fix the UFS issue with the masking, would be easy to back port. We set the destination mask values as an attribute in the grid, if they don't no masking applied. If they are there, we can mask all the values set in the grid

The other way to fix this would for for @metdyn to use dynamic masking in the sampler.

Either way @metdyn should probably test this with geostationary sampler.

I've made this contingent if we want a different solution but put it here for debate.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

