### PR TITLE
Updates for Ford docs

### DIFF
--- a/.github/actions/deploy-ford-docs/action.yml
+++ b/.github/actions/deploy-ford-docs/action.yml
@@ -49,14 +49,14 @@ runs:
         repository: Goddard-Fortran-Ecosystem/gFTL
         path: gFTL
         fetch-depth: 1
-        ref: v1.13.0
+        ref: v1.14.0
 
     - name: Build gFTL
       run: |
         cd gFTL
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_Fortran_COMPILER=gfortran-10 -DCMAKE_INSTALL_PREFIX=../install
+        cmake .. -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_INSTALL_PREFIX=../install
         make -j$(nproc) install
       shell: bash
 

--- a/docs/Ford/docs-with-remote-esmf.md
+++ b/docs/Ford/docs-with-remote-esmf.md
@@ -7,8 +7,8 @@ coloured_edges: true
 graph_maxdepth: 4
 graph_maxnodes: 32
 include: ../../include/
-         ../../gFTL/install/GFTL-1.13/include/v1
-         ../../gFTL/install/GFTL-1.13/include/v2
+         ../../gFTL/install/GFTL-1.14/include/v1
+         ../../gFTL/install/GFTL-1.14/include/v2
 exclude: **/EsmfRegridder.F90
          **/FieldBLAS_IntrinsicFunctions.F90
          **/GeomManager.F90

--- a/docs/Ford/docs-with-remote-esmf.public_private_protected.md
+++ b/docs/Ford/docs-with-remote-esmf.public_private_protected.md
@@ -8,8 +8,8 @@ coloured_edges: true
 graph_maxdepth: 4
 graph_maxnodes: 32
 include: ../../include/
-         ../../gFTL/install/GFTL-1.13/include/v1
-         ../../gFTL/install/GFTL-1.13/include/v2
+         ../../gFTL/install/GFTL-1.14/include/v1
+         ../../gFTL/install/GFTL-1.14/include/v2
 exclude: **/EsmfRegridder.F90
          **/FieldBLAS_IntrinsicFunctions.F90
          **/GeomManager.F90

--- a/docs/Ford/ford-ci.md
+++ b/docs/Ford/ford-ci.md
@@ -8,8 +8,8 @@ coloured_edges: true
 graph_maxdepth: 4
 graph_maxnodes: 32
 include: ../../include/
-         ../../gFTL/install/GFTL-1.13/include/v1
-         ../../gFTL/install/GFTL-1.13/include/v2
+         ../../gFTL/install/GFTL-1.14/include/v1
+         ../../gFTL/install/GFTL-1.14/include/v2
 exclude: **/EsmfRegridder.F90
          **/FieldBLAS_IntrinsicFunctions.F90
          **/GeomManager.F90


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

In trying to test a merge to `release/MAPL-v3` (see #3284) I saw the Ford docs broke because `gfortran-10` is no longer on the `ubuntu-latest` image. So, we update to use `gfortran` which should be good enough. 

I also updated to gFTL v1.14 because...it's latest.

## Related Issue

