### PR TITLE
Trajectory sampler: use a single obs file at each Epoch time and restore obs location for output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added utility to prepare inputs for ExtDatDriver.x so that ExtData can simulate a real GEOS run
 - Added loggers when writing or reading weight files
 - Added new option to AGCM.rc `overwrite_checkpoint` to allow checkpoint files to be overwritten. By default still will not overwrite checkpoints
-- Added use_NWP_1_file=1 option in Trajectory sampler (HISTORY.rc) to generate the correct location_index_ioda array, mapping back to location points in the single IODA observation input file
+- The trajectory sampler netCDF output variable `location_index_in_iodafile` can be turned off, after we add two control variables: `use_NWP_1_file` and `restore_2_obs_vector` for users.  When set to true, the two options will select only one obs file at each Epoch interval, and will rotate the output field index back to the location vector inthe obs file before generating netCDF output.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added loggers when writing or reading weight files
 - Added new option to AGCM.rc `overwrite_checkpoint` to allow checkpoint files to be overwritten. By default still will not overwrite checkpoints
+- Added use_NWP_1_file=1 option in Trajectory sampler (HISTORY.rc) to generate the correct location_index_ioda array, mapping back to location points in the single IODA observation input file
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added loggers when writing or reading weight files
 - Added new option to AGCM.rc `overwrite_checkpoint` to allow checkpoint files to be overwritten. By default still will not overwrite checkpoints
 - The trajectory sampler netCDF output variable `location_index_in_iodafile` can be turned off, after we add two control variables: `use_NWP_1_file` and `restore_2_obs_vector` for users.  When set to true, the two options will select only one obs file at each Epoch interval, and will rotate the output field index back to the location vector inthe obs file before generating netCDF output.
+- Support `splitfield: 1` in HISTORY.rc for trajectory sampler
 
 ### Changed
 

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -26,6 +26,8 @@ module MAPL_ObsUtilMod
   type :: obs_unit
      integer :: nobs_epoch
      integer :: ngeoval
+     integer :: count_location_until_matching_file
+     integer :: count_location_in_matching_file
      logical :: export_all_geoval
      type(FileMetadata), allocatable :: metadata
      type(NetCDF4_FileFormatter), allocatable :: file_handle

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -40,6 +40,7 @@ module MAPL_ObsUtilMod
      real(kind=REAL64), allocatable :: lats(:)
      real(kind=REAL64), allocatable :: times_R8(:)
      integer,           allocatable :: location_index_ioda(:)
+     integer,           allocatable :: restore_index(:)
      real(kind=REAL32), allocatable :: p2d(:)
      real(kind=REAL32), allocatable :: p3d(:,:)
   end type obs_unit

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -53,7 +53,7 @@ module MAPL_ObsUtilMod
      character (len=ESMF_MAXSTR) :: var_name_time=''
      character (len=ESMF_MAXSTR) :: file_name_template=''
      integer :: ngeoval=0
-     integer :: nentry_name=0
+     integer :: nfield_name_mx=12
      character (len=ESMF_MAXSTR), allocatable :: field_name(:,:)
      !character (len=ESMF_MAXSTR), allocatable :: field_name(:)
   end type obs_platform
@@ -771,7 +771,7 @@ contains
     copy_platform_nckeys%var_name_lon = a%var_name_lon
     copy_platform_nckeys%var_name_lat = a%var_name_lat
     copy_platform_nckeys%var_name_time = a%var_name_time
-    copy_platform_nckeys%nentry_name = a%nentry_name
+    copy_platform_nckeys%nfield_name_mx = a%nfield_name_mx
     _RETURN(_SUCCESS)
 
   end function copy_platform_nckeys
@@ -784,7 +784,7 @@ contains
     integer, optional, intent(out) :: rc
 
     character (len=ESMF_MAXSTR), allocatable :: field_name_loc(:,:)
-    integer :: nfield, nentry_name
+    integer :: nfield, nfield_name_mx
     integer, allocatable :: tag(:)
     integer :: i, j, k
     integer :: status
@@ -805,9 +805,9 @@ contains
     enddo
     union_platform%ngeoval=k
     nfield=k
-    nentry_name=union_platform%nentry_name
+    nfield_name_mx=union_platform%nfield_name_mx
     if ( allocated (union_platform%field_name) ) deallocate(union_platform%field_name)
-    allocate(union_platform%field_name(nentry_name, nfield))
+    allocate(union_platform%field_name(nfield_name_mx, nfield))
     do i=1, a%ngeoval
        union_platform%field_name(:,i) = a%field_name(:,i)
     enddo
@@ -953,6 +953,7 @@ contains
     if (lenmax < slen) then
        if (MAPL_AM_I_ROOT())  write(6,*) 'pathlen vs filename_max_char_len: ', slen, lenmax
        _FAIL ('PATHLEN is greater than filename_max_char_len')
+       STOP 'lenmax < slen'
     end if
     if (slen>0) filename(1:slen)=c_filename(1:slen)
 

--- a/base/Plain_netCDF_Time.F90
+++ b/base/Plain_netCDF_Time.F90
@@ -840,6 +840,13 @@ contains
     wc=0
     ios=0
     string = trim( adjustl(string_in) )
+    str_piece(:)=''
+    i = index (string, mark)
+    if (i==0) then
+       nseg=1
+       str_piece(1)=string
+       return
+    end if
     do while (ios==0)
        i = index (string, mark)
        !!print*, 'index=', i
@@ -858,5 +865,47 @@ contains
   end subroutine split_string_by_space
 
 
+  subroutine split_string_by_seperator (string_in, length_mx, seperator_in, &
+       mxseg, nseg, str_piece, jstatus)
+    character (len=length_mx), intent (in) :: string_in
+    integer,           intent (in) :: length_mx
+    character (len=length_mx), intent (in) :: seperator_in
+    integer,           intent (in) :: mxseg
+    integer,           intent (out):: nseg
+    character (len=length_mx), intent (out):: str_piece(mxseg)
+    integer,           intent (out):: jstatus
+    character (len=length_mx) :: string_sc, string_oper, string_aux
+    character (len=1) :: mark, CH
+    integer :: ios
+    integer :: wc
+    integer :: len1, len2
+    !
+    !  "xxxx;  yy; zz;   uu,   vv,"
+    !  seperator = ";,"
+    !
+
+    !__ s1. replace seperator by space
+    !
+    string_sc = trim( adjustl(string_in) )
+    string_oper = trim( adjustl(seperator_in) )
+    len1 = len_trim(string_sc)
+    len2 = len_trim(string_oper)
+    string_aux=string_sc
+    do i = 1, len1
+       CH = string_sc(i:i)
+       do j = 1, len2
+          mark = string_oper(j:j)
+          if (CH==mark) then
+             string_aux(i:i)=' '
+          end if
+       end do
+    end do
+
+    !__ s2. split by space
+    call split_string_by_space (string_aux, length_mx, &
+       mxseg, nseg, str_piece, jstatus)
+
+    return
+  end subroutine split_string_by_seperator
 
 end module MAPL_scan_pattern_in_file

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -5384,8 +5384,6 @@ ENDDO PARSER
   ! __ for each collection: find union fields, write to collection.rcx
   ! __ note: this subroutine is called by MPI root only
   !
-  ! __ note: this subroutine is called by MPI root only
-  !
   subroutine regen_rcx_for_obs_platform (config, nlist, list, rc)
     use  MAPL_scan_pattern_in_file
     use MAPL_ObsUtilMod, only : obs_platform, union_platform
@@ -5443,7 +5441,6 @@ ENDDO PARSER
     ! __ global set for call split_string by space
     length_mx = ESMF_MAXSTR2
     mxseg = 100
-
 
     ! __ s1. scan get  platform name + index_name_x  var_name_lat/lon/time
     do k=1, nplf

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -71,6 +71,7 @@ module HistoryTrajectoryMod
      integer                        :: obsfile_Te_index
      logical                        :: active               ! case: when no obs. exist
      logical                        :: level_by_level = .false.
+     !
      ! note
      ! for MPI_GATHERV of 3D data in procedure :: append_file
      ! we have choice LEVEL_BY_LEVEL or ALL_AT_ONCE  (timing in sec below for extdata)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -57,7 +57,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: var_name_lon_full
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
-     integer                        :: use_NWP_1_file
+     logical                        :: use_NWP_1_file = .false.
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -58,6 +58,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
      integer                        :: use_NWP_1_file
+     integer, dimension(2), parameter :: use_NWP_1_file_param = [0, 1]
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -58,6 +58,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
      logical                        :: use_NWP_1_file = .false.
+     logical                        :: restore_2_obs_vector = .false.
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -40,7 +40,6 @@ module HistoryTrajectoryMod
      type(VerticalData) :: vdata
      logical :: do_vertical_regrid
 
-
      type(LocstreamRegridder) :: regridder
      type(TimeData)           :: time_info
      type(ESMF_Clock)         :: clock
@@ -48,13 +47,7 @@ module HistoryTrajectoryMod
      type(ESMF_Time)          :: RingTime
      type(ESMF_TimeInterval), public  :: epoch_frequency
 
-
      integer                        :: nobs_type
-!     character(len=ESMF_MAXSTR)     :: nc_index
-!     character(len=ESMF_MAXSTR)     :: nc_time
-!     character(len=ESMF_MAXSTR)     :: nc_latitude
-!     character(len=ESMF_MAXSTR)     :: nc_longitude
-
      character(len=ESMF_MAXSTR)     :: index_name_x
      character(len=ESMF_MAXSTR)     :: var_name_time
      character(len=ESMF_MAXSTR)     :: var_name_lat

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -58,7 +58,6 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
      integer                        :: use_NWP_1_file
-     integer, dimension(2), parameter :: use_NWP_1_file_param = [0, 1]
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod.F90
@@ -40,12 +40,14 @@ module HistoryTrajectoryMod
      type(VerticalData) :: vdata
      logical :: do_vertical_regrid
 
+
      type(LocstreamRegridder) :: regridder
      type(TimeData)           :: time_info
      type(ESMF_Clock)         :: clock
      type(ESMF_Alarm), public :: alarm
      type(ESMF_Time)          :: RingTime
      type(ESMF_TimeInterval), public  :: epoch_frequency
+
 
      integer                        :: nobs_type
 !     character(len=ESMF_MAXSTR)     :: nc_index
@@ -62,6 +64,7 @@ module HistoryTrajectoryMod
      character(len=ESMF_MAXSTR)     :: var_name_lon_full
      character(len=ESMF_MAXSTR)     :: datetime_units
      character(len=ESMF_MAXSTR)     :: Location_index_name
+     integer                        :: use_NWP_1_file
      integer                        :: epoch        ! unit: second
      integer(kind=ESMF_KIND_I8)     :: epoch_index(2)
      real(kind=ESMF_KIND_R8), pointer:: obsTime(:)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -1023,7 +1023,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             nx=this%obs(k)%nobs_epoch
             if (nx >0) then
                if (mapl_am_i_root()) then
-                  call this%obs(k)%file_handle%put_var(this%var_name_time, real(this%obs(k)%times_R8), &
+                  call this%obs(k)%file_handle%put_var(this%var_name_time, this%obs(k)%times_R8, &
                        start=[is], count=[nx], _RC)
                   call this%obs(k)%file_handle%put_var(this%var_name_lon, this%obs(k)%lons, &
                        start=[is], count=[nx], _RC)

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -573,7 +573,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          type(ESMF_VM) :: vm
          integer :: mypet, petcount, mpic
 
-         integer :: i, j, k, L, ii, jj, jj2, kk
+         integer :: i, j, k, L, ii, jj, jj2
          integer :: fid_s, fid_e
          integer(kind=ESMF_KIND_I8) :: j0, j1
          integer(kind=ESMF_KIND_I8) :: jt1, jt2
@@ -584,7 +584,6 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          integer :: arr(1)
          integer :: sec
          integer, allocatable :: ix(:) !  counter for each obs(k)%nobs_epoch
-         integer, allocatable :: marker(:)
          integer :: nx2
          logical :: EX ! file
          logical :: zero_obs
@@ -718,7 +717,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                            ! for each obs type use the correct starting point
                            ! if: use_nwp_1_file:  index_ioda = [ 1, Nobs ] : restore_2_obs_vector is exact
                            ! else                 index_ioda = [ -M, 0 ] + [1, Nobs1] + [Nob1+1, Nobs2] : restore_2_obs_vector may fail
-                           !                                      File1       File2         File3
+                           !                                      File1     File(center)         File3
                            ! why: bc we have no restriction on observation file name vs content, hence unexpected things can happen
                            !      use use_nwp_1_file + restore_2_obs_vector only when filename and content are systematic
                            location_index_ioda_full(len+jj) = jj2 - this%obs(k)%count_location_until_matching_file
@@ -891,13 +890,12 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                     'epoch_index(1:2), nx', this%epoch_index(1), &
                     this%epoch_index(2), this%nobs_epoch)
                !
-               !    Note: For IODA files, the default NPW_1_file=.false. we can see
-               !          the non-python array behavior in obs time sequence from observation files: for example:
-               !    ioda file split [1/2 15Z  :  1/2 21Z ]  [ 1/2 21Z :  1/2 3Z]   (aircraft)
+               !    Note: the time boundary issue can appear when we use python convention [T1, T2) but obs files donot
+               !    ioda file split [1/2data 15Z  :  1/2data 21Z ]  [ 1/2data 21Z :  1/2data 3Z]   (aircraft)
                !        ___x  x  x x x ___ ---------------------------------- o --o ---o -- o --
-               !           negative index (extra) at Tmin                      missing Tmax
-               !    our trajectory ioda_index will show: overcount at Tmin and missing points at Tmax
-               !    NPW_1_file=1 solves this issue.
+               !    debug:  negative index (extra) at Tmin                    missing Tmax
+               !    debug shows: overcount at Tmin and missing points at Tmax
+               !    use_NPW_1_file=.true. solves this issue, due to special treatment at time boundaries
                !
             end if
          else

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -75,8 +75,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_ConfigGetAttribute(config, value=traj%use_NWP_1_file, default=0, &
               label=trim(string)//'use_NWP_1_file:', _RC)
          if (mapl_am_I_root()) then
-            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), &
-                 'use_NWP_1_file: wrong input')
+            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), 'use_NWP_1_file: wrong input')
             if (traj%use_NWP_1_file == 1) then
                write(6,105) 'WARNING: Traj sampler: use_NWP_1_file is ON'
                write(6,105) 'WARNING: USER needs to check if observation file is fetched correctly'

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -886,7 +886,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   !!        now we know
                   !!        ___x  x  x x x ___ ---------------------------------- o --o ---o -- o --
                   !!           negative index (extra) at Tmin                      missing Tmax
-
+                  !
                   !  count non-positive index on the left Tmin  (extra)
                   !
                   jj = 0
@@ -915,17 +915,14 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
                   j = this%obs(k)%nobs_epoch - this%obs(k)%count_location_in_matching_file
                   if (j/=0) &
                      write(6, *) trim(this%obs(k)%name)//'count_location_in_matching_file diff from cutted nobs_epoch'
-                  !!_ASSERT(j==0, trim(this%obs(k)%name)//'count_location_in_matching_file diff from cutted nobs_epoch')
                   j = minval(this%obs(k)%location_index_ioda(:))
                   if (j/=1) &
                        write(6,*) trim(this%obs(k)%name)//' min =', j, &
                        ' this%obs(k)%location_index_ioda(:) start diff from 1'
-                  !!_ASSERT(j==1, trim(this%obs(k)%name)//'this%obs(k)%location_index_ioda(:) did not start from 1')
                   j = maxval(this%obs(k)%location_index_ioda(:))
                   if (j/=this%obs(k)%count_location_in_matching_file) &
                        write(6,*) trim(this%obs(k)%name)//' max =', j, &
                        ' this%obs(k)%location_index_ioda(:) end diff from obs file max pts'
-                  !!_ASSERT(j==this%obs(k)%count_location_in_matching_file, trim(this%obs(k)%name)//'this%obs(k)%location_index_ioda(:) did not end at obs file max pts')
                enddo
             end if
          else

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -504,8 +504,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
             do k=1, this%nobs_type
                if (this%obs(k)%nobs_epoch > 0) then
                   filename=trim(this%obs(k)%name)//trim(filename_suffix)
-                  call lgr%debug('%a %a', &
-                       "Sampling to new file : ",trim(filename))
+                  write(6,'(1x,a,2x,a)')  "Sampling to new file :",trim(filename)
                   call this%obs(k)%file_handle%create(trim(filename),_RC)
                   call this%obs(k)%file_handle%write(this%obs(k)%metadata,_RC)
                end if

--- a/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
+++ b/gridcomps/History/Sampler/MAPL_TrajectoryMod_smod.F90
@@ -25,7 +25,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
   use, intrinsic :: iso_fortran_env, only: REAL64
   use, intrinsic :: iso_fortran_env, only: INT64
   implicit none
-
+  integer, parameter :: use_NWP_1_file_param(2) = [0, 1]
    contains
 
      module procedure HistoryTrajectory_from_config
@@ -75,7 +75,7 @@ submodule (HistoryTrajectoryMod)  HistoryTrajectory_implement
          call ESMF_ConfigGetAttribute(config, value=traj%use_NWP_1_file, default=0, &
               label=trim(string)//'use_NWP_1_file:', _RC)
          if (mapl_am_I_root()) then
-            _ASSERT ( ANY(traj%use_NPW_1_file_param == traj%use_NWP_1_file), &
+            _ASSERT (ANY(use_NWP_1_file_param == traj%use_NWP_1_file), &
                  'use_NWP_1_file: wrong input')
             if (traj%use_NWP_1_file == 1) then
                write(6,105) 'WARNING: Traj sampler: use_NWP_1_file is ON'


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This PR continues https://github.com/GEOS-ESM/MAPL/pull/3279#event-15916592777

The trajectory sampler netCDF output variable `location_index_in_iodafile` can now be turned off, after we add two control variables: `use_NWP_1_file` and `restore_2_obs_vector` for users.  

1. when `use_NWP_1_file = .true.`,  code reads in a single obs file for each epoch
2. when `restore_2_obs_vector = .true.`,  code restores obs locations as input IODA file, the previous remapping ioda index is suppressed.



## Related Issue
I have anther PR on splitfield for sampler to be merged to this PR, which handles
` jedi.splitField:      1`

## Test performed:
1. ExtData run for 3 days with input

  jedi.use_NWP_1_file:       .true.
  jedi.restore_2_obs_vector: .true.
`  jedi.ObsPlatforms:         aircraft airs_aqua amsr2_gcom-w1 amsua_aqua amsua_metop-b amsua_n15 amsua_n18 amsua_n19 atms_n20 atms_npp avhrr3_metop-b avhrr3_n18 avhrr3_n19 cris-fsr_n20 cris-fsr_npp gmi_gpm gps iasi_metop-b mhs_metop-b mhs_n19 mls55_aura omi_aura ompsnm_npp satwind scatwind sfc sfcship sondes ssmis_f17`


input datetime (netcdf sondes.20190802T210000Z)
   dateTime = 1564787773, 1564787771, 1564787771, 1564787805, 1564787805,
      1564787872, 1564787882, 1564787886, 1564787889, 1564787891, 1564787898,
      ...
      1564792640, 1564792601, 1564789326, 1564789326, 1564792502, 1564792501,
      1564792437, 1564792374 ;

output: netcdf sondes.jedi.20190802_2100z 
 dateTime = 1564787773, 1564787771, 1564787771, 1564787805, 1564787805,
    1564787872, 1564787882, 1564787886, 1564787889, 1564787891, 1564787898,
...
    1564792640, 1564792601, 1564789326, 1564789326, 1564792502, 1564792501,
    1564792437, 1564792374 ;


input:
   longitude = 351.33, 351.33, 351.33, 351.3301, 351.3301, 351.335, 351.3365,
      351.3372, 351.3378, 351.3381, 351.3395, 351.3398, 351.3402, 351.3409,
...
      125.6533, 125.6533, 125.6533, 125.6533, 125.6533, 125.6533, 125.6533,
      125.6533 ;

output:
 longitude = 351.329956054688, 351.329986572266, 351.329986572266,
    351.330139160156, 351.330139160156, 351.335021972656, 351.336547851562,
...
    125.653289794922, 125.653289794922, 125.653289794922, 125.653289794922,
    125.653289794922, 125.653289794922 ;