### PR TITLE
Fixes #3343 - test failures

### DIFF
--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -683,12 +683,13 @@ contains
       integer, intent(out) :: rc
 
       integer :: status
-      character(:), allocatable :: child_name
+      character(:), allocatable :: child_name, new_path
       type(GriddedComponentDriver) :: child
       type(ESMF_GridComp) :: child_gc
       type(OuterMetaComponent), pointer :: outer_meta
       integer :: idx
       type(GriddedComponentDriver), pointer :: user_component
+
 
       rc = 0
 
@@ -696,7 +697,6 @@ contains
          substates = states
          return
       end if
-
       outer_meta => get_outer_meta(gc, _RC)
 
       ! Parse path
@@ -714,8 +714,9 @@ contains
       child = outer_meta%get_child(child_name, _RC)
 
       child_gc = child%get_gridcomp()
+      new_path = component_path(idx+1:)
 
-      call get_substates(child_gc, child%get_states(), component_path(idx+1:), substates, _RC)
+      call get_substates(child_gc, child%get_states(), new_path, substates, _RC)
 
       return
    end subroutine get_substates


### PR DESCRIPTION
- Workaround for NAG with release flags.  Apparently memory was corrupted for empty strings in a recursive procedure.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
See commit

## Related Issue

