### PR TITLE
Remove a print from last commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated ExtData so that if files are missing in a sequence the last value will be perisisted if one has not chosen `exact` option
 
 ### Fixed
 
@@ -31,8 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated ExtData so that if files are missing in a sequence the last value will be perisisted if one has not chosen `exact` option
-- Changed MAPL_ESMFRegridder to require the dstMaskValues to be added as grid attribute to use fixed masking, fixes UFS issue
 - Increased formatting width of time index in ExtData2G diagnostic print
 - Updated GitHub checkout action to use blobless clones
 - Update CI to use Baselibs 7.29.0 by default

--- a/gridcomps/ExtData2G/ExtDataBracket.F90
+++ b/gridcomps/ExtData2G/ExtDataBracket.F90
@@ -188,8 +188,6 @@ contains
 
       right_node_set = this%right_node%check_if_initialized(_RC)
       left_node_set = this%left_node%check_if_initialized(_RC)
-      call ESMF_TimePrint(this%left_node%time,options='string',preString='left bracket time: ')
-      call ESMF_TimePrint(this%right_node%time,options='string',preString='right bracket time: ')
 
       alpha = 0.0
       if ( (.not.this%disable_interpolation) .and. (.not.this%intermittent_disable) .and. right_node_set .and. left_node_set) then


### PR DESCRIPTION
The last PR to develop to update ExtData, I forgot to remove a time print, also put the changeling entry in the wrong place.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [X] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

