### PR TITLE
Feature/wdboggs/outer meta component datetime compatibility 3357

### DIFF
--- a/esmf_utils/CMakeLists.txt
+++ b/esmf_utils/CMakeLists.txt
@@ -6,6 +6,7 @@ set(srcs
   UngriddedDims.F90
   UngriddedDimVector.F90
   LU_Bound.F90
+  ESMF_Time_Utilities.F90
   )
 
 esma_add_library(${this}

--- a/esmf_utils/ESMF_Time_Utilities.F90
+++ b/esmf_utils/ESMF_Time_Utilities.F90
@@ -38,6 +38,7 @@ contains
       call ESMF_TimeIntervalGet(larger, yy=lyy, mm=lmm, d=ld, h=lh, m=lm, s=ls, _RC)
       call ESMF_TimeIntervalGet(smaller, yy=syy, mm=smm, d=sd, h=sh, m=sm, s=ss, _RC)
       _RETURN_UNLESS(all([lyy, lmm, syy, smm]==0))
+!      _RETURN_UNLESS(all([syy, smm]==0) .or. all([ld, lh, lm, ls]==0))
       can_compare_intervals = .TRUE.
       _RETURN(_SUCCESS)
 

--- a/esmf_utils/ESMF_Time_Utilities.F90
+++ b/esmf_utils/ESMF_Time_Utilities.F90
@@ -1,0 +1,153 @@
+!wdb fixme deleteme should this be different include file
+#include "MAPL_Generic.h"
+module mapl3g_ESMF_Time_Utilities
+   use esmf
+   use mapl_ErrorHandling
+   implicit none !wdb fixme deleteme hsould replace this with new implicit none
+!   private !wdb fixme deleteme should this be private
+
+   public :: zero_time_interval
+   public :: intervals_are_compatible
+   public :: times_and_intervals_are_compatible
+   public :: interval_is_monthly
+   public :: interval_is_yearly
+   public :: interval_is_uniform
+   public :: UNIFORM
+   public :: MONTHLY
+   public :: YEARLY
+
+   interface zero_time_interval
+      module procedure :: get_zero
+   end interface zero_time_interval
+
+   integer, parameter :: UNIFORM = 1
+   integer, parameter :: MONTHLY = 2
+   integer, parameter :: YEARLY =  3
+
+   ! This value should not be accessed directly. Use get_zero() instead.
+   ! There is no constructor for ESMF_TimeInterval, so the value cannot be initialized
+   ! at construction. The get_zero() function initializes the value the first time
+   ! and returns a pointer to the value.
+   type(ESMF_TimeInterval), target :: ZERO_TI
+
+contains
+
+   function get_zero() result(zero)
+      type(ESMF_TimeInterval), pointer :: zero
+      logical, save :: zero_is_uninitialized = .TRUE.
+
+      if(zero_is_uninitialized) then
+         call ESMF_TimeIntervalSet(ZERO_TI, ns=0)
+         zero_is_uninitialized = .FALSE.
+      end if
+      zero => ZERO_TI
+
+   end function get_zero
+
+   logical function intervals_are_compatible(larger, smaller, rc) result(compatible)
+      type(ESMF_TimeInterval), intent(in) :: larger
+      type(ESMF_TimeInterval), intent(in) :: smaller
+      integer, optional, intent(out) :: rc
+      integer :: status
+      integer :: interval_type, interval_type2
+
+      associate(abs_larger => ESMF_TimeIntervalAbsValue(larger), abs_smaller => ESMF_TimeIntervalAbsValue(smaller))
+         if(abs_larger < abs_smaller) then
+            compatible = intervals_are_compatible(smaller, larger, _RC)
+            _RETURN(_SUCCESS)
+         end if
+
+         compatible = .FALSE.
+         interval_type = get_interval_type(larger)
+         interval_type2 = get_interval_type(smaller)
+         compatible = interval_type == interval_type2
+         _RETURN_UNLESS(compatible)
+         compatible = mod(abs_larger, abs_smaller) == get_zero()
+      end associate
+
+      _RETURN(_SUCCESS)
+
+   end function intervals_are_compatible
+
+   logical function times_and_intervals_are_compatible(time1, time2, larger, smaller, rc) result(compatible)
+      type(ESMF_Time), intent(in) :: time1
+      type(ESMF_Time), intent(in) :: time2
+      type(ESMF_TimeInterval), target, intent(in) :: larger
+      type(ESMF_TimeInterval), target, intent(in) :: smaller
+      integer, optional, intent(in) :: rc
+      integer :: status
+      logical :: compatible
+      type(ESMF_TimeInterval), pointer :: interval => null()
+
+      compatible = ESMF_TimeIntervalAbsValue(larger) >= ESMF_TimeIntervalAbsValue(smaller)
+      _RETURN_UNLESS(compatible)
+      compatible = intervals_are_compatible(larger, smaller, _RC)
+      _RETURN_UNLESS(compatible)
+      compatible = mod(ESMF_TimeIntervalAbsValue(time1 - time2), ESMF_TimeInterval(smaller))
+      _RETURN(_SUCCESS)
+
+   end function times_and_intervals_are_compatible
+
+   logical function interval_is_monthly(interval, rc)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      integer, optional, intent(out) :: rc 
+      integer :: status
+      integer :: mm
+      logical :: yearly
+
+      yearly = interval_is_yearly(interval, _RC)
+      call ESMF_TimeIntervalGet(interval, mm=mm, _RC)
+      interval_is_monthly = .not. yearly .and. mm /= 0
+      _RETURN(_SUCCESS)
+
+   end function interval_is_monthly(interval, rc)
+
+   logical function interval_is_yearly(interval, rc)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      integer, optional, intent(out) :: rc 
+      integer :: status
+      integer :: yy
+
+      call ESMF_TimeIntervalGet(interval, yy=yy, _RC)
+      interval_is_yearly = yy /= 0
+      _RETURN(_SUCCESS)
+
+   end function interval_is_yearly(interval, rc)
+
+   logical function interval_is_uniform(interval, rc) result(is_uniform)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      integer, optional, intent(out) :: rc 
+      integer :: status
+      logical :: is_yearly
+      logical :: is_monthly
+      
+      is_uniform = .FALSE.
+      is_yearly = interval_is_yearly(interval, _RC)
+      _RETURN_IF(is_yearly)
+      is_monthly = interval_is_monthly(interval, _RC)
+      _RETURN_IF(is_monthly)
+      is_uniform = .TRUE.
+      _RETURN(_SUCCESS)
+
+   end function interval_is_uniform
+
+   function get_interval_type(interval, rc) result(interval_type)
+      type(ESMF_TimeInterval), intent(in) :: interval
+      integer, optional, intent(out) :: rc
+      integer :: status
+      integer, intent(out) :: interval_type
+      logical :: lval
+
+      interval_type = MONTHLY
+      lval = interval_is_monthly(interval, _RC)
+      if(lval) return
+
+      interval_type = YEARLY
+      lval = interval_is_yearly(interval, _RC)
+      if(lval) return
+
+      interval_type = UNIFORM
+
+   end function get_interval_type
+
+end module mapl3g_ESMF_Time_Utilities

--- a/esmf_utils/ESMF_Time_Utilities.F90
+++ b/esmf_utils/ESMF_Time_Utilities.F90
@@ -42,7 +42,8 @@ contains
       _RETURN(_SUCCESS)
 
    end function can_compare_intervals
-
+      !all([syy, smm]==0) .or. all([ld, lh, lm, ls]==0)
+      
    function get_zero() result(zero)
       type(ESMF_TimeInterval), pointer :: zero
       logical, save :: zero_is_uninitialized = .TRUE.

--- a/esmf_utils/tests/CMakeLists.txt
+++ b/esmf_utils/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MODULE_DIRECTORY "${esma_include}/MAPL.esmf_utils.tests")
 set (test_srcs
   Test_InfoUtilities.pf
   Test_Ungridded.pf
-  Test_ESMF_Time_Utilities.F90
+  Test_ESMF_Time_Utilities.pf
   )
 
 add_pfunit_ctest(MAPL.esmf_utils.tests

--- a/esmf_utils/tests/CMakeLists.txt
+++ b/esmf_utils/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MODULE_DIRECTORY "${esma_include}/MAPL.esmf_utils.tests")
 set (test_srcs
   Test_InfoUtilities.pf
   Test_Ungridded.pf
+  Test_ESMF_Time_Utilities.F90
   )
 
 add_pfunit_ctest(MAPL.esmf_utils.tests

--- a/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
+++ b/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
@@ -8,45 +8,6 @@ module Test_ESMF_Time_Utilities
 contains
 
    @Test
-   subroutine test_units_in()
-      type(ESMF_TimeInterval) :: interval
-      integer :: status
-      logical, allocatable :: has_units(:)
-      integer(kind=ESMF_KIND_I4) :: units(6)
-
-      units = [0, 3, 0, 1, 4, 7]
-      call ESMF_TimeIntervalSet(interval, yy=units(1), mm=units(2), d=units(3), &
-         & h=units(4), m=units(5), s=units(6), _RC)
-      has_units = units_in(interval, _RC)
-      @assertEqual(units /= 0, has_units)
-
-   end subroutine test_units_in
-
-   @Test
-   subroutine test_can_compare_intervals()
-      type(ESMF_TimeInterval) :: interval1, interval2
-      integer :: status
-      logical :: can_compare
-
-      call ESMF_TimeIntervalSet(interval1, d=3, _RC)
-      call ESMF_TimeIntervalSet(interval2, h=7, _RC)
-      can_compare = can_compare_intervals(interval1, interval2, _RC)
-      @assertTrue(can_compare, 'The intervals can be compared.')
-
-      call ESMF_TimeIntervalSet(interval1, mm=2, _RC)
-      can_compare = can_compare_intervals(interval1, interval2, _RC)
-      @assertFalse(can_compare, 'The intervals cannot be compared.')
-
-      can_compare = can_compare_intervals(interval2, interval1, _RC)
-      @assertFalse(can_compare, 'The intervals cannot be compared.')
-
-      call ESMF_TimeIntervalSet(interval1, yy=2, _RC)
-      can_compare = can_compare_intervals(interval2, interval1, _RC)
-      @assertFalse(can_compare, 'The intervals cannot be compared.')
-
-   end subroutine test_can_compare_intervals
-
-   @Test
    subroutine test_get_zero()
       type(ESMF_TimeInterval) :: interval
       integer(ESMF_KIND_I4) :: ns

--- a/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
+++ b/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
@@ -1,0 +1,197 @@
+#include "MAPL_TestErr.h"
+module Test_ESMF_Time_Utilities
+   use mapl3g_ESMF_Time_Utilities
+   use esmf
+   use funit
+   implicit none
+
+contains
+
+   !@Test
+   subroutine test_get_zero()
+      type(ESMF_TimeInterval) :: interval
+      integer(ESMF_KIND_I4) :: ns
+      integer(ESMF_KIND_I4), parameter :: EXPECTED_NS = 0
+      integer(ESMF_KIND_I4), parameter :: INITIAL_NS = 1
+
+      call ESMF_TimeIntervalSet(interval, ns=INITIAL_NS, _RC)
+      actual = zero_time_interval()
+      call ESMF_TimeIntervalGet(actual, ns=ns, _RC)
+      @assertEqual(EXPECTED_NS, ns, 'Interval is not zero.')
+
+   end subroutine test_get_zero
+
+   !@Test
+   subroutine test_get_interval_type_yearly()
+      type(ESMF_TimeInterval) :: interval
+      integer :: interval_type
+
+      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertEqual(YEARLY, interval_type, 'The interval should be yearly.')
+      
+      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(interval_type == YEARLY, 'The interval should not be yearly.')
+      
+      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(interval_type == YEARLY, 'The interval should not be yearly.')
+
+   end subroutine test_get_interval_type_yearly
+
+   !@Test
+   subroutine test_get_interval_type_monthly()
+      type(ESMF_TimeInterval) :: interval
+      integer :: interval_type
+
+      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertEqual(MONTHLY, interval_type, 'The interval should be monthly.')
+
+      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertTrue(MONTHLY, interval_type, 'The interval should be monthly.')
+
+      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(MONTHLY, interval_type, 'The interval should not be monthly.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(MONTHLY, interval_type, 'The interval should not be monthly.')
+
+   end subroutine test_get_interval_type_monthly
+
+   !@Test
+   subroutine test_get_interval_type_uniform()
+      type(ESMF_TimeInterval) :: interval
+      integer :: interval_type
+
+      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertEqual(UNIFORM, interval_type, 'The interval should be uniform.')
+
+      call ESMF_TimeIntervalSet(interval, dd=3, h=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertEqual(UNIFORM, interval_type, 'The interval should be uniform.')
+
+      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, dd=3, _RC)
+      interval_type = get_interval_type(interval, _RC)
+      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
+
+   end subroutine test_get_interval_type_uniform
+
+   !@Test
+   subroutine test_interval_is_uniform()
+      type(ESMF_TimeInterval) :: interval
+      logical :: is_uniform
+
+      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
+      is_uniform = interval_is_uniform(interval, _RC)
+      @assertTrue(is_uniform, 'The interval is uniform.')
+
+      call ESMF_TimeIntervalSet(interval, dd=3, h=3, _RC)
+      is_uniform = interval_is_uniform(interval, _RC)
+      @assertTrue(is_uniform, 'The interval is uniform.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, dd=3, _RC)
+      is_uniform = interval_is_uniform(interval, _RC)
+      @assertFalse(is_uniform, 'The interval is not uniform.')
+
+      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
+      is_uniform = interval_is_uniform(interval, _RC)
+      @assertFalse(is_uniform, 'The interval is not uniform.')
+
+   end subroutine test_interval_is_uniform
+
+   !@Test
+   subroutine test_interval_is_yearly()
+      type(ESMF_TimeInterval) :: interval
+      logical :: is_yearly
+
+      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
+      is_yearly = interval_is_yearly(interval, _RC)
+      @assertTrue(is_yearly, 'The interval is yearly.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
+      is_yearly = interval_is_yearly(interval, _RC)
+      @assertTrue(is_yearly, 'The interval is yearly.')
+
+      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
+      is_yearly = interval_is_yearly(interval, _RC)
+      @assertFalse(is_yearly, 'The interval is not yearly.')
+
+   end subroutine test_interval_is_yearly
+   
+   !@Test
+   subroutine test_interval_is_monthly()
+      type(ESMF_TimeInterval) :: interval
+      logical :: is_monthly
+
+      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
+      is_monthly = interval_is_monthly(interval, _RC)
+      @assertTrue(is_monthly, 'The interval is monthly.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
+      is_monthly = interval_is_monthly(interval, _RC)
+      @assertTrue(is_monthly, 'The interval is monthly.')
+
+      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
+      is_monthly = interval_is_monthly(interval, _RC)
+      @assertFalse(is_monthly, 'The interval is not monthly.')
+
+      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
+      is_monthly = interval_is_monthly(interval, _RC)
+      @assertFalse(is_monthly, 'The interval is not monthly.')
+
+   end subroutine test_interval_is_monthly
+
+   !@Test
+   subroutine test_intervals_are_compatible()
+      type(ESMF_TimeInterval) :: larger
+      type(ESMF_TimeInterval) :: smaller
+      logical :: compatible
+
+      call ESMF_TimeIntervalSet(larger, yy=9, _RC)
+      call ESMF_TimeIntervalSet(smaller, yy=3, _RC)
+      compatible = intervals_are_compatible(larger, smaller, _RC)
+      @assertTrue(compatible, 'The intervals are compatible.')
+
+      compatible = intervals_are_compatible(smaller, larger, _RC)
+      @assertTrue(compatible, 'The intervals are compatible even when switched.')
+
+      call ESMF_TimeIntervalSet(smaller, mm=3, _RC)
+      compatible = intervals_are_compatible(larger, smaller, _RC)
+      @assertFalse(compatible, 'The intervals are different types.')
+
+      call ESMF_TimeIntervalSet(smaller, yy=6, _RC)
+      compatible = intervals_are_compatible(larger, smaller, _RC)
+      @assertFalse(compatible, 'The smaller interval does not divide the larger interval evenly.')
+
+   end subroutine test_intervals_are_compatible
+
+   !@Test
+   subroutine test_times_and_intervals_are_compatible()
+      integer(ESMF_KIND_I4), parameter :: YY = 3
+      integer(ESMF_KIND_I4), parameter :: MM = 3
+      integer(ESMF_KIND_I4), parameter :: DD = 3
+      integer(ESMF_KIND_I4), parameter :: H = 3
+      type(ESMF_TimeInterval) :: larger
+      type(ESMF_TimeInterval) :: smaller
+      type(ESMF_Time) :: time1
+      type(ESMF_Time) :: time2
+      logical :: compatible
+
+
+   end subroutine test_times_and_intervals_are_compatible
+
+end module Test_ESMF_Time_Utilities

--- a/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
+++ b/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
@@ -8,15 +8,55 @@ module Test_ESMF_Time_Utilities
 contains
 
    @Test
+   subroutine test_units_in()
+      type(ESMF_TimeInterval) :: interval
+      integer :: status
+      logical, allocatable :: has_units(:)
+      integer(kind=ESMF_KIND_I4) :: units(6)
+
+      units = [0, 3, 0, 1, 4, 7]
+      call ESMF_TimeIntervalSet(interval, yy=units(1), mm=units(2), d=units(3), &
+         & h=units(4), m=units(5), s=units(6), _RC)
+      has_units = units_in(interval, _RC)
+      @assertEqual(units /= 0, has_units)
+
+   end subroutine test_units_in
+
+   @Test
+   subroutine test_can_compare_intervals()
+      type(ESMF_TimeInterval) :: interval1, interval2
+      integer :: status
+      logical :: can_compare
+
+      call ESMF_TimeIntervalSet(interval1, d=3, _RC)
+      call ESMF_TimeIntervalSet(interval2, h=7, _RC)
+      can_compare = can_compare_intervals(interval1, interval2, _RC)
+      @assertTrue(can_compare, 'The intervals can be compared.')
+
+      call ESMF_TimeIntervalSet(interval1, mm=2, _RC)
+      can_compare = can_compare_intervals(interval1, interval2, _RC)
+      @assertFalse(can_compare, 'The intervals cannot be compared.')
+
+      can_compare = can_compare_intervals(interval2, interval1, _RC)
+      @assertFalse(can_compare, 'The intervals cannot be compared.')
+
+      call ESMF_TimeIntervalSet(interval1, yy=2, _RC)
+      can_compare = can_compare_intervals(interval2, interval1, _RC)
+      @assertFalse(can_compare, 'The intervals cannot be compared.')
+
+   end subroutine test_can_compare_intervals
+
+   @Test
    subroutine test_get_zero()
       type(ESMF_TimeInterval) :: interval
       integer(ESMF_KIND_I4) :: ns
       integer(ESMF_KIND_I4), parameter :: EXPECTED_NS = 0
       integer(ESMF_KIND_I4), parameter :: INITIAL_NS = 1
+      integer :: status
 
       call ESMF_TimeIntervalSet(interval, ns=INITIAL_NS, _RC)
-      actual = zero_time_interval()
-      call ESMF_TimeIntervalGet(actual, ns=ns, _RC)
+      interval = zero_time_interval()
+      call ESMF_TimeIntervalGet(interval, ns=ns, _RC)
       @assertEqual(EXPECTED_NS, ns, 'Interval is not zero.')
 
    end subroutine test_get_zero
@@ -30,29 +70,66 @@ contains
       integer(kind=ESMF_KIND_I4), parameter :: DD = 3
       integer(kind=ESMF_KIND_I4), parameter :: H = 3
       logical :: compatible
+      integer :: status
 
-      call ESMF_TimeIntervalSet(larger, dd=3*DD, _RC)
-      call ESMF_TimeIntervalSet(smaller, dd=DD, _RC)
+      call ESMF_TimeIntervalSet(larger, d=3*DD, _RC)
+      call ESMF_TimeIntervalSet(smaller, d=DD, _RC)
       compatible = intervals_are_compatible(larger, smaller, _RC)
       @assertTrue(compatible, 'The intervals are compatible.')
 
-      call ESMF_TimeIntervalSet(smaller, dd=2*DD, _RC)
+      compatible = intervals_are_compatible(smaller, larger, _RC)
+      @assertFalse(compatible, 'The larger unit must come first.')
+
+      call ESMF_TimeIntervalSet(smaller, d=2*DD, _RC)
       compatible = intervals_are_compatible(larger, smaller, _RC)
       @assertFalse(compatible, 'The smaller interval does not divide the larger interval evenly.')
 
    end subroutine test_intervals_are_compatible
 
-   !@Test
+   @Test
    subroutine test_times_and_intervals_are_compatible()
-      integer(ESMF_KIND_I4), parameter :: YY = 3
-      integer(ESMF_KIND_I4), parameter :: MM = 3
-      integer(ESMF_KIND_I4), parameter :: DD = 3
-      integer(ESMF_KIND_I4), parameter :: H = 3
       type(ESMF_TimeInterval) :: larger
       type(ESMF_TimeInterval) :: smaller
       type(ESMF_Time) :: time1
       type(ESMF_Time) :: time2
       logical :: compatible
+      integer :: status
+
+      call ESMF_TimeSet(time1, yy=1582, mm=10, dd=16, h=7, _RC)
+      call ESMF_TimeSet(time2, yy=1582, mm=10, dd=15, h=19, _RC)
+      call ESMF_TimeIntervalSet(larger, d=1, _RC)
+      call ESMF_TimeIntervalSet(smaller, h = 6, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertTrue(compatible, 'The times and intervals are compatible.')
+
+      call ESMF_TimeSet(time2, yy=1582, mm=10, dd=15, h=18, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'The time difference is not evenly divisible by the smaller interval.')
+
+      call ESMF_TimeSet(time1, yy=1582, mm=10, dd=16, h=18, _RC)
+      call ESMF_TimeIntervalSet(larger, h=6, _RC)
+      call ESMF_TimeIntervalSet(smaller, h=4, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'The larger interval is not evenly divisible by the smaller interval.')
+      call ESMF_TimeIntervalSet(larger, mm=1, _RC)
+      call ESMF_TimeIntervalSet(smaller, d=1, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'Larger interval cannot include months.')
+
+      call ESMF_TimeIntervalSet(larger, d=90, _RC)
+      call ESMF_TimeIntervalSet(smaller, mm=1, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'Smaller interval cannot include months.')
+
+      call ESMF_TimeIntervalSet(larger, yy=1, _RC)
+      call ESMF_TimeIntervalSet(smaller, d=1, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'Larger interval cannot include years.')
+
+      call ESMF_TimeIntervalSet(larger, d=365, _RC)
+      call ESMF_TimeIntervalSet(smaller, yy=1, _RC)
+      compatible = times_and_intervals_are_compatible(time1, time2, larger, smaller, _RC)
+      @assertFalse(compatible, 'Smaller interval cannot include years.')
 
    end subroutine test_times_and_intervals_are_compatible
 

--- a/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
+++ b/esmf_utils/tests/Test_ESMF_Time_Utilities.pf
@@ -7,7 +7,7 @@ module Test_ESMF_Time_Utilities
 
 contains
 
-   !@Test
+   @Test
    subroutine test_get_zero()
       type(ESMF_TimeInterval) :: interval
       integer(ESMF_KIND_I4) :: ns
@@ -21,159 +21,22 @@ contains
 
    end subroutine test_get_zero
 
-   !@Test
-   subroutine test_get_interval_type_yearly()
-      type(ESMF_TimeInterval) :: interval
-      integer :: interval_type
-
-      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertEqual(YEARLY, interval_type, 'The interval should be yearly.')
-      
-      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(interval_type == YEARLY, 'The interval should not be yearly.')
-      
-      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(interval_type == YEARLY, 'The interval should not be yearly.')
-
-   end subroutine test_get_interval_type_yearly
-
-   !@Test
-   subroutine test_get_interval_type_monthly()
-      type(ESMF_TimeInterval) :: interval
-      integer :: interval_type
-
-      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertEqual(MONTHLY, interval_type, 'The interval should be monthly.')
-
-      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertTrue(MONTHLY, interval_type, 'The interval should be monthly.')
-
-      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(MONTHLY, interval_type, 'The interval should not be monthly.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(MONTHLY, interval_type, 'The interval should not be monthly.')
-
-   end subroutine test_get_interval_type_monthly
-
-   !@Test
-   subroutine test_get_interval_type_uniform()
-      type(ESMF_TimeInterval) :: interval
-      integer :: interval_type
-
-      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertEqual(UNIFORM, interval_type, 'The interval should be uniform.')
-
-      call ESMF_TimeIntervalSet(interval, dd=3, h=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertEqual(UNIFORM, interval_type, 'The interval should be uniform.')
-
-      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, dd=3, _RC)
-      interval_type = get_interval_type(interval, _RC)
-      @assertFalse(UNIFORM, interval_type, 'The interval should not be uniform.')
-
-   end subroutine test_get_interval_type_uniform
-
-   !@Test
-   subroutine test_interval_is_uniform()
-      type(ESMF_TimeInterval) :: interval
-      logical :: is_uniform
-
-      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
-      is_uniform = interval_is_uniform(interval, _RC)
-      @assertTrue(is_uniform, 'The interval is uniform.')
-
-      call ESMF_TimeIntervalSet(interval, dd=3, h=3, _RC)
-      is_uniform = interval_is_uniform(interval, _RC)
-      @assertTrue(is_uniform, 'The interval is uniform.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, dd=3, _RC)
-      is_uniform = interval_is_uniform(interval, _RC)
-      @assertFalse(is_uniform, 'The interval is not uniform.')
-
-      call ESMF_TimeIntervalSet(interval, mm=3, dd=3, _RC)
-      is_uniform = interval_is_uniform(interval, _RC)
-      @assertFalse(is_uniform, 'The interval is not uniform.')
-
-   end subroutine test_interval_is_uniform
-
-   !@Test
-   subroutine test_interval_is_yearly()
-      type(ESMF_TimeInterval) :: interval
-      logical :: is_yearly
-
-      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
-      is_yearly = interval_is_yearly(interval, _RC)
-      @assertTrue(is_yearly, 'The interval is yearly.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
-      is_yearly = interval_is_yearly(interval, _RC)
-      @assertTrue(is_yearly, 'The interval is yearly.')
-
-      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
-      is_yearly = interval_is_yearly(interval, _RC)
-      @assertFalse(is_yearly, 'The interval is not yearly.')
-
-   end subroutine test_interval_is_yearly
-   
-   !@Test
-   subroutine test_interval_is_monthly()
-      type(ESMF_TimeInterval) :: interval
-      logical :: is_monthly
-
-      call ESMF_TimeIntervalSet(interval, mm=3, _RC)
-      is_monthly = interval_is_monthly(interval, _RC)
-      @assertTrue(is_monthly, 'The interval is monthly.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, mm=3, _RC)
-      is_monthly = interval_is_monthly(interval, _RC)
-      @assertTrue(is_monthly, 'The interval is monthly.')
-
-      call ESMF_TimeIntervalSet(interval, yy=3, _RC)
-      is_monthly = interval_is_monthly(interval, _RC)
-      @assertFalse(is_monthly, 'The interval is not monthly.')
-
-      call ESMF_TimeIntervalSet(interval, dd=3, _RC)
-      is_monthly = interval_is_monthly(interval, _RC)
-      @assertFalse(is_monthly, 'The interval is not monthly.')
-
-   end subroutine test_interval_is_monthly
-
-   !@Test
+   @Test
    subroutine test_intervals_are_compatible()
       type(ESMF_TimeInterval) :: larger
       type(ESMF_TimeInterval) :: smaller
+      integer(kind=ESMF_KIND_I4), parameter :: YY = 3
+      integer(kind=ESMF_KIND_I4), parameter :: MM = 3
+      integer(kind=ESMF_KIND_I4), parameter :: DD = 3
+      integer(kind=ESMF_KIND_I4), parameter :: H = 3
       logical :: compatible
 
-      call ESMF_TimeIntervalSet(larger, yy=9, _RC)
-      call ESMF_TimeIntervalSet(smaller, yy=3, _RC)
+      call ESMF_TimeIntervalSet(larger, dd=3*DD, _RC)
+      call ESMF_TimeIntervalSet(smaller, dd=DD, _RC)
       compatible = intervals_are_compatible(larger, smaller, _RC)
       @assertTrue(compatible, 'The intervals are compatible.')
 
-      compatible = intervals_are_compatible(smaller, larger, _RC)
-      @assertTrue(compatible, 'The intervals are compatible even when switched.')
-
-      call ESMF_TimeIntervalSet(smaller, mm=3, _RC)
-      compatible = intervals_are_compatible(larger, smaller, _RC)
-      @assertFalse(compatible, 'The intervals are different types.')
-
-      call ESMF_TimeIntervalSet(smaller, yy=6, _RC)
+      call ESMF_TimeIntervalSet(smaller, dd=2*DD, _RC)
       compatible = intervals_are_compatible(larger, smaller, _RC)
       @assertFalse(compatible, 'The smaller interval does not divide the larger interval evenly.')
 
@@ -190,7 +53,6 @@ contains
       type(ESMF_Time) :: time1
       type(ESMF_Time) :: time2
       logical :: compatible
-
 
    end subroutine test_times_and_intervals_are_compatible
 

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -56,7 +56,7 @@ endif ()
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.regridder_mgr MAPL.geom_mgr MAPL.GeomIO MAPL.esmf_utils MAPL.field MAPL.state MAPL.shared MAPL.profiler MAPL.base MAPL.hconfig_utils
-               ESMF::ESMF NetCDF::NetCDF_Fortran udunits2f PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2
+  ESMF::ESMF NetCDF::NetCDF_Fortran udunits2f PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2 MAPL.esmf_utils
   TYPE SHARED
   )
 

--- a/generic3g/OuterMetaComponent/SetServices.F90
+++ b/generic3g/OuterMetaComponent/SetServices.F90
@@ -46,15 +46,8 @@ contains
            timeStep=timestep, reference_time=reference_time, _RC)
       user_gridcomp = this%user_gc_driver%get_gridcomp()
       user_clock = this%user_gc_driver%get_clock()
-      call ESMF_ClockGet(user_clock, refTime=user_reference_time, timeStep=user_timestep, _RC)
-
-      if (allocated(this%component_spec%timestep)) then
-         call ESMF_ClockSet(user_clock, timeStep=timestep, _RC)
-      end if
-
-      if (allocated(this%component_spec%reference_time)) then
-         call ESMF_ClockSet(user_clock, refTime=reference_time, _RC)
-      end if
+      call ESMF_ClockSet(user_clock, timeStep=timestep, _RC)
+      call ESMF_ClockSet(user_clock, refTime=reference_time, _RC)
 
       call set_run_user_alarm(this, outer_clock, user_clock, _RC)
 

--- a/generic3g/OuterMetaComponent/SetServices.F90
+++ b/generic3g/OuterMetaComponent/SetServices.F90
@@ -155,7 +155,7 @@ contains
       integer :: status
       character(len=*), parameter :: ERRMSG = 'Timesteps are not compatible.'
       
-      call timesteps_are_same_duration_type(timestep1, timestep2, _RC)
+      call get_duration_type(timestep1, timestep2, _RC)
       _ASSERT(mod(timestep2, timestep1) == ZERO, ERRMSG)
       _ASSERT(mod(timestep1, timestep2) == ZERO, ERRMSG)
       _RETURN(_SUCCESS)
@@ -189,7 +189,7 @@ contains
 
       yearly = timestep_is_yearly(timestep, _RC)
       call ESMF_TimeIntervalGet(timestep, mm=mm, _RC)
-      timestep_is_monthly = mm /= 0 .and. .not. yearly
+      timestep_is_monthly = .not. yearly .and. mm /= 0
       _RETURN(_SUCCESS)
 
    end function timestep_is_monthly(timestep, rc)
@@ -206,7 +206,7 @@ contains
 
    end function timestep_is_yearly(timestep, rc)
 
-   subroutine timesteps_are_same_duration_type(timestep, timestep2, rc)
+   subroutine get_duration_type(timestep, timestep2, rc)
       type(ESMF_TimeInterval), intent(in) :: timestep
       type(ESMF_TimeInterval), intent(in) :: timestep2
       integer, optional, intent(out) :: rc 
@@ -224,6 +224,6 @@ contains
       lval2 = timestep_is_yearly(timestep2, _RC)
       _ASSERT(lval .eqv. lval2, ERRMSG)
       
-   end subroutine timesteps_are_same_duration_type
+   end subroutine get_duration_type
 
 end submodule SetServices_smod


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
As explained in #3357, the timestep and reference time for the user component, and therefore all the user alarms, must be compatible with the timestep and reference time for the OuterMetaComponent. Because the reference times may not be the same, it is insufficient to check the timesteps. This PR checks all user alarms, as determined by the user timestep and reference time, are compatible with the timestep and reference time of the OuterMetaComponent. It closes #3357.

## Related Issue
#3357
