### PR TITLE
Prepare for 2.53.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed but with MAPL_GetHorzijIndex from previous release when not points are passed on a processor causing a deadlock
-
 ### Removed
 
 ### Deprecated
+
+## [2.53.1] - 2025-01-29
+
+### Fixed
+
+- Fixed bug with `MAPL_GetHorzijIndex` when not points are passed on a processor causing a deadlock
 
 ## [2.53.0] - 2025-01-24
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.53.0
+  VERSION 2.53.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
Preparing for a release due to hotfix.

I have tested and it is zero-diff for AMIP.