### PR TITLE
Add ALIAS column to ACG StateSpec files

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -200,6 +200,7 @@ Option = Enum(value = 'Option', names = {
         'VLOCATION': ('vlocation', VLOCATION_EMIT),
         'VLOC': ('vlocation', VLOCATION_EMIT),
 # these are Options that are not output but used to write 
+        'ALIAS': ('alias', identity_emit, False, False),
         'CONDITION': ('condition', identity_emit, False, False),
         'COND': ('condition', identity_emit, False, False),
         'ALLOC': ('alloc', identity_emit, False, False),
@@ -463,6 +464,7 @@ def digest(specs, args):
         for spec in specs[category]: # spec from list
             dims = None
             ungridded = None
+            alias = None
             option_values = dict() # dict of option values
             for column in spec: # for spec emit value
                 column_value = spec[column]
@@ -480,6 +482,10 @@ def digest(specs, args):
                     dims = option_value
                 elif option == Option.UNGRIDDED:
                     ungridded = option_value
+                elif option == Option.ALIAS:
+                    alias = Option.ALIAS(column_value)
+            if alias:
+                option_values[Option.INTERNAL_NAME] = alias
 # MANDATORY
             for option in mandatory_options:
                 if option not in option_values:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Add column for ACG (ALIAS) that set the pointer variable to a different name than the `short_name`
 
 ### Fixed
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
This PR adds the capability to the automatic code generator (ACG) to give an alternate name to the pointer variable in the pointer declaration and `MAPL_GetPointer` call for a variable spec. The default behavior is to create a pointer variable `FOO` for a variable spec with `short_name=FOO`. If the `ALIAS` column is added to the ACG StateSpec file and the value for a row is not blank, that value is used for the pointer variable if the `-d` and/or `-g` options are included in the ACG call.

This PR was created in response to variable specs that include the same `NAME` (`short_name`) for variables in two categories (eg. `IMPORT` and `EXPORT`). It creates a more general capability to name the pointer variable.