### PR TITLE
Fixed nesting of internal timers (see also commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+Fixed nesting of internal timers (issue #3412)
 
 ### Removed
 

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -1883,8 +1883,8 @@ contains
             call state%t_profiler%stop(trim(sbrtn),_RC)
             call state%t_profiler%stop(_RC)
          end if
-         call t_p%stop(trim(state%compname),_RC)
       endif
+      call t_p%stop(trim(state%compname),_RC)
 
 
       _RETURN(ESMF_SUCCESS)
@@ -2420,8 +2420,6 @@ contains
       if (.not. MAPL_ProfIsDisabled()) then
          call report_generic_profile()
       end if
-
-      call t_p%stop(trim(state%compname),_RC)
 
       ! Clean-up
       !---------


### PR DESCRIPTION
707681be4771158e250277f618158d1b098ae0c3)

## Types of change(s)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue
#3412 

