### PR TITLE
Added tests for timestep propagation in hierarchy.

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_set_clock.F90
+++ b/generic3g/OuterMetaComponent/initialize_set_clock.F90
@@ -101,11 +101,9 @@ contains
       alarm = ESMF_AlarmCreate(outer_clock, &
            name = RUN_USER_ALARM, &
            ringInterval=user_timestep, &
-           refTime=user_refTime, &
+           ringTime=user_refTime, &
            sticky=.false., &
            _RC)
-
-      call ESMF_AlarmRingerOn(alarm, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine set_run_user_alarm

--- a/generic3g/OuterMetaComponent/run_clock_advance.F90
+++ b/generic3g/OuterMetaComponent/run_clock_advance.F90
@@ -24,20 +24,19 @@ contains
       logical :: is_ringing
       integer :: phase
 
+      call ESMF_ClockGetAlarm(clock, alarm=alarm, alarmName=RUN_USER_ALARM, _RC)
+      is_ringing = ESMF_AlarmIsRinging(alarm, _RC)
+      _RETURN_IF(.not. is_ringing)
 
       associate(e => this%children%ftn_end())
         iter = this%children%ftn_begin()
         do while (iter /= e)
            call iter%next()
            child => iter%second()
-           call child%clock_advance()
            call child%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+           call child%clock_advance()
         end do
       end associate
-
-      call ESMF_ClockGetAlarm(clock, alarm=alarm, alarmName=RUN_USER_ALARM, _RC)
-      is_ringing = ESMF_AlarmIsRinging(alarm, _RC)
-      _RETURN_IF(.not. is_ringing)
 
       call this%user_gc_driver%clock_advance(_RC)
 

--- a/generic3g/specs/ChildSpec.F90
+++ b/generic3g/specs/ChildSpec.F90
@@ -15,7 +15,7 @@ module mapl3g_ChildSpec
    
    type :: ChildSpec
       class(AbstractUserSetServices), allocatable :: user_setservices
-      type(ESMF_HConfig), allocatable :: hconfig
+      type(ESMF_HConfig) :: hconfig
       type(ESMF_TimeInterval), allocatable :: timeStep
       type(ESMF_Time), allocatable :: refTime
    contains
@@ -47,7 +47,11 @@ contains
       type(ESMF_Time), optional, intent(in) :: refTime
 
       spec%user_setservices = user_setservices
-      if (present(hconfig)) spec%hconfig = hconfig
+      if (present(hconfig)) then
+         spec%hconfig = hconfig
+      else
+         spec%hconfig = ESMF_HConfigCreate(content='{}')
+      end if
 
       if (present(timeStep)) spec%timeStep = timeStep
       if (present(refTime)) spec%refTime = refTime
@@ -63,7 +67,7 @@ contains
       equal = (a%user_setservices == b%user_setservices)
       if (.not. equal) return
       
-      equal = equal_alloc_hconfig(a%hconfig, b%hconfig)
+      equal = equal_hconfig(a%hconfig, b%hconfig)
       if (.not. equal) return
 
       equal = equal_timestep(a%timeStep, b%timestep)
@@ -74,22 +78,16 @@ contains
 
    contains
 
-      logical function equal_alloc_hconfig(a, b) result(equal)
-         type(ESMF_HConfig), allocatable, intent(in) :: a
-         type(ESMF_HConfig), allocatable, intent(in) :: b
-
+      logical function equal_hconfig(a, b) result(equal)
+         type(ESMF_HConfig), intent(in) :: a
+         type(ESMF_HConfig), intent(in) :: b
 
          type(ESMF_HConfigMatch_Flag) :: match_flag
          
-         equal = (allocated(a) .eqv. allocated(b))
-         if (.not. equal) return
+         match_flag = ESMF_HConfigMatch(a, b)
+         equal = (match_flag == ESMF_HCONFIGMATCH_EXACT)
 
-         if (allocated(a)) then
-            match_flag = ESMF_HConfigMatch(a, b)
-            equal = (match_flag == ESMF_HCONFIGMATCH_EXACT)
-         end if
-
-      end function equal_alloc_hconfig
+      end function equal_hconfig
 
       logical function equal_timestep(a, b) result(equal)
          type(ESMF_TimeInterval), allocatable, intent(in) :: a

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -38,6 +38,8 @@ set (test_srcs
   Test_MaxAction.pf
   Test_MinAction.pf
   Test_ExtensionAction.pf
+
+  Test_timestep_propagation.pf
 )
 
 add_pfunit_ctest(

--- a/generic3g/tests/Test_timestep_propagation.pf
+++ b/generic3g/tests/Test_timestep_propagation.pf
@@ -1,0 +1,265 @@
+#include "MAPL_TestErr.h"
+
+module Test_timestep_propagation
+   use mapl3g_Generic
+   use mapl3g_ComponentSpecParser
+   use mapl3g_ChildSpec
+   use mapl3g_GenericPhases
+   use mapl3g_GenericGridComp, generic_setservices => setServices
+   use mapl3g_ComponentDriver
+   use mapl3g_GriddedComponentDriver
+   use mapl3g_UserSetServices
+   use mapl3g_MultiState
+   use mapl_ErrorHandling
+   use esmf
+   use funit
+   implicit none
+
+   type(ESMF_TimeInterval) :: child_timeStep
+   type(ESMF_Time) :: child_refTime
+   integer :: child_run_count
+
+contains
+
+  @test
+   subroutine test_default_timeStep()
+
+      type(ESMF_Time) :: t0, t1, expected_refTime
+      type(ESMF_TimeInterval) :: timeStep, expected_timeStep
+      type(ESMF_Clock) :: clock
+      integer :: status, user_status
+      type(ESMF_HConfig) :: cap_hconfig
+      type(ESMF_GridComp) :: cap_gridcomp
+      type(GriddedComponentDriver) :: driver
+      
+      call ESMF_TimeSet(t0, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(t1, timeString="2000-04-03T22:00:00", _RC)
+      call ESMF_TimeIntervalSet(timestep, s=900)
+
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=t0, stoptime=t1, refTime=t0, _RC)
+      cap_hconfig = ESMF_HConfigCreate(content='{use_default_timestep: true}', _RC)
+
+      cap_gridcomp = MAPL_GridCompCreate('CAP', user_setservices(parent_ss), cap_hconfig, _RC)
+      call ESMF_GridCompSetServices(cap_gridcomp, generic_setservices, userRC=user_status, _RC)
+
+      driver = GriddedComponentDriver(cap_gridcomp, MultiState(), clock)
+      call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+
+      call ESMF_TimeIntervalSet(expected_timeStep, s=900)
+      expected_refTime = t0
+
+      @assert_that(child_timestep == expected_timestep, is(true()))
+      @assert_that(child_reftime == expected_reftime, is(true()))
+      
+   end subroutine test_default_timeStep
+
+   @test
+   subroutine test_double_timeStep()
+
+      type(ESMF_Time) :: t0, t1
+      type(ESMF_TimeInterval) :: timeStep, expected_timeStep
+      type(ESMF_Clock) :: clock
+      integer :: status, user_status
+      type(ESMF_HConfig) :: cap_hconfig
+      type(ESMF_GridComp) :: cap_gridcomp
+      type(GriddedComponentDriver) :: driver
+      
+      call ESMF_TimeSet(t0, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(t1, timeString="2000-04-03T22:00:00", _RC)
+      call ESMF_TimeIntervalSet(timestep, s=1800)
+
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=t0, stoptime=t1, refTime=t0, _RC)
+      cap_hconfig = ESMF_HConfigCreate(content='{use_default_timestep: true}', _RC)
+
+      cap_gridcomp = MAPL_GridCompCreate('CAP', user_setservices(parent_ss), cap_hconfig, _RC)
+      call ESMF_GridCompSetServices(cap_gridcomp, generic_setservices, userRC=user_status, _RC)
+
+      driver = GriddedComponentDriver(cap_gridcomp, MultiState(), clock)
+      call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+
+      call ESMF_TimeIntervalSet(expected_timeStep, s=1800)
+      @assert_that(child_timestep == expected_timestep, is(true()))
+      
+   end subroutine test_double_timeStep
+
+   @test
+   ! This test verifies that a child with a doubledtimestep only runs
+   ! on alternate timesteps of the parent.
+   subroutine test_child_call_frequency()
+
+      type(ESMF_Time) :: t0, t1
+      type(ESMF_TimeInterval) :: timeStep
+      type(ESMF_Clock) :: clock
+      integer :: status, user_status
+      type(ESMF_HConfig) :: cap_hconfig
+      type(ESMF_GridComp) :: cap_gridcomp
+      type(GriddedComponentDriver) :: driver
+      
+      call ESMF_TimeSet(t0, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(t1, timeString="2000-04-03T22:00:00", _RC)
+      call ESMF_TimeIntervalSet(timestep, s=900)
+
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=t0, stoptime=t1, refTime=t0, _RC)
+      cap_hconfig = ESMF_HConfigCreate(content='{use_default_timestep: false}', _RC)
+
+
+      cap_gridcomp = MAPL_GridCompCreate('CAP', user_setservices(parent_ss), cap_hconfig, _RC)
+      call ESMF_GridCompSetServices(cap_gridcomp, generic_setservices, userRC=user_status, _RC)
+
+      driver = GriddedComponentDriver(cap_gridcomp, MultiState(), clock)
+      call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
+
+      child_run_count = 0
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(1)))
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(1)))
+
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(2)))
+      
+   end subroutine test_child_call_frequency
+
+  @test
+   ! This test verifies that a child with a doubledtimestep only runs
+   ! on alternate timesteps of the parent.
+   subroutine test_child_call_frequency_with_offset()
+
+      type(ESMF_Time) :: t0, t1
+      type(ESMF_TimeInterval) :: timeStep
+      type(ESMF_Clock) :: clock
+      integer :: status, user_status
+      type(ESMF_HConfig) :: cap_hconfig
+      type(ESMF_GridComp) :: cap_gridcomp
+      type(GriddedComponentDriver) :: driver
+      
+      call ESMF_TimeSet(t0, timeString="2000-04-03T21:00:00", _RC)
+      call ESMF_TimeSet(t1, timeString="2000-04-03T22:00:00", _RC)
+      call ESMF_TimeIntervalSet(timestep, s=900)
+
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=t0, stoptime=t1, refTime=t0, _RC)
+      cap_hconfig = ESMF_HConfigCreate(content='{use_default_timestep: false, use_default_refTime: false}', _RC)
+
+
+      cap_gridcomp = MAPL_GridCompCreate('CAP', user_setservices(parent_ss), cap_hconfig, _RC)
+      call ESMF_GridCompSetServices(cap_gridcomp, generic_setservices, userRC=user_status, _RC)
+
+      driver = GriddedComponentDriver(cap_gridcomp, MultiState(), clock)
+      call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
+
+      child_run_count = 0
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(0)))
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(1)))
+
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(1)))
+      
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(2)))
+ 
+      call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+      call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+      @assert_that(child_run_count, is(equal_to(2)))
+ 
+ end subroutine test_child_call_frequency_with_offset
+
+   !-------------------------------
+   ! test gridcomps implementation
+   !-------------------------------
+
+
+   subroutine parent_ss(gridcomp, rc)
+      type(ESMF_Gridcomp) :: gridcomp
+      integer, intent(out) :: rc
+
+      type(ChildSpec) :: child_spec
+      integer :: status
+      logical :: use_default_timestep
+      logical :: use_default_refTime
+      type(ESMF_TimeInterval), allocatable :: timeStep
+      type(ESMF_Time), allocatable :: refTime
+      type(ESMF_HConfig) :: hconfig
+
+      rc=0
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, run_parent, _RC)
+
+      call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
+
+      call MAPL_ResourceGet(gridcomp, keystring='use_default_timestep', value=use_default_timestep, default=.true., _RC)
+      if (.not. use_default_timestep) then
+         allocate(timeStep)
+         call ESMF_TimeIntervalSet(timeStep, s=1800)
+      end if
+
+      call MAPL_ResourceGet(gridcomp, keystring='use_default_refTime', value=use_default_refTime, default=.true., _RC)
+      if (.not. use_default_refTime) then
+         allocate(refTime)
+         ! offset by 900 seconds
+         call ESMF_TimeSet(refTime, timeString="2000-04-03T21:15:00", _RC)
+      end if
+
+      child_spec = ChildSpec(user_SetServices(child_ss), timeStep=timeStep, refTime=refTime)
+      call MAPL_GridCompAddChild(gridcomp, 'child', child_spec, _RC)
+      
+   end subroutine parent_ss
+   
+  subroutine run_parent(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp)   :: gridcomp
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, intent(out)  :: rc
+
+      integer :: status
+      
+      rc=0
+      call MAPL_RunChild(gridcomp, 'child', _RC)
+
+   end subroutine run_parent
+
+   subroutine child_ss(gridcomp, rc)
+      type(ESMF_Gridcomp) :: gridcomp
+      integer, intent(out) :: rc
+
+      integer :: status
+
+      rc=0
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, run_child, _RC)
+      
+   end subroutine child_ss
+
+   subroutine run_child(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp)   :: gridcomp
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, intent(out)  :: rc
+
+      integer :: status
+      
+      rc=0
+      call ESMF_ClockGet(clock, timeStep=child_timeStep, refTime=child_refTime, _RC)
+
+      child_run_count = child_run_count + 1
+
+    end subroutine run_child
+
+end module Test_timestep_propagation


### PR DESCRIPTION
- Exposed at least one bug in MAPL3 logic (fixed)
- Exposed bug or weakness in documentation in ESMF alarms . ringtime must be start time or future time even for recurring alarm.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Added unit tests and fixed bugs that were exposed.
## Related Issue

