### PR TITLE
Fix to allow refTime that is before currTime.

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_set_clock.F90
+++ b/generic3g/OuterMetaComponent/initialize_set_clock.F90
@@ -90,12 +90,12 @@ contains
       integer :: status
       type(ESMF_TimeInterval) :: outer_timestep, user_timestep, zero
       type(ESMF_Time) :: user_refTime
-      type(ESMF_Time) :: outer_refTime
+      type(ESMF_Time) :: currTime
       type(ESMF_Alarm) :: alarm
 
       call ESMF_TimeIntervalSet(zero, s=0, _RC)
 
-      call ESMF_ClockGet(outer_clock, timestep=outer_timestep, refTime=outer_refTime, _RC)
+      call ESMF_ClockGet(outer_clock, timestep=outer_timestep, currTime=currTime, _RC)
       call ESMF_ClockGet(user_clock, timestep=user_timestep, refTime=user_refTime, _RC)
 
       alarm = ESMF_AlarmCreate(outer_clock, &
@@ -104,6 +104,10 @@ contains
            ringTime=user_refTime, &
            sticky=.false., &
            _RC)
+
+      if (user_refTime < currTime) then
+         call ESMF_AlarmRingerOff(alarm, _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine set_run_user_alarm

--- a/generic3g/tests/Test_timestep_propagation.pf
+++ b/generic3g/tests/Test_timestep_propagation.pf
@@ -213,7 +213,7 @@ contains
       if (.not. use_default_refTime) then
          allocate(refTime)
          ! offset by 900 seconds
-         call ESMF_TimeSet(refTime, timeString="2000-04-03T21:15:00", _RC)
+         call ESMF_TimeSet(refTime, timeString="2000-04-03T20:45:00", _RC)
       end if
 
       child_spec = ChildSpec(user_SetServices(child_ss), timeStep=timeStep, refTime=refTime)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

