### PR TITLE
v3: Fixes for easy tests

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -24,6 +24,9 @@ if (BUILD_WITH_FARGPARSE)
   target_compile_definitions (ExtDataDriver.x PRIVATE $<$<BOOL:${USE_EXTDATA2G}>:BUILD_WITH_EXTDATA2G>)
   add_subdirectory(ExtData_Testing_Framework EXCLUDE_FROM_ALL)
 
+  # ExtDataDriver.x is needed for 'make tests'
+  add_dependencies(build-tests ExtDataDriver.x)
+
   ecbuild_add_executable (TARGET pfio_MAPL_demo.x SOURCES pfio_MAPL_demo.F90)
   target_link_libraries (pfio_MAPL_demo.x PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF OpenMP::OpenMP_Fortran)
   set_target_properties(pfio_MAPL_demo.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})

--- a/Tests/GetHorzIJIndex/CMakeLists.txt
+++ b/Tests/GetHorzIJIndex/CMakeLists.txt
@@ -10,6 +10,9 @@ ecbuild_add_executable (
   SOURCES ${SRCS} )
 target_link_libraries(GetHorzIJIndexDriver.x  PRIVATE MAPL FARGPARSE::fargparse ESMF::ESMF  OpenMP::OpenMP_Fortran)
 
+# GetHorzIJIndexDriver.x is needed for 'make tests'
+add_dependencies(build-tests GetHorzIJIndexDriver.x)
+
 # Detect if we are using Open MPI and add oversubscribe
 string(REPLACE " " ";" MPI_Fortran_LIBRARY_VERSION_LIST ${MPI_Fortran_LIBRARY_VERSION_STRING})
 list(GET MPI_Fortran_LIBRARY_VERSION_LIST 0 MPI_Fortran_LIBRARY_VERSION_FIRSTWORD)
@@ -17,7 +20,7 @@ if(MPI_Fortran_LIBRARY_VERSION_FIRSTWORD MATCHES "Open")
   list(APPEND MPIEXEC_PREFLAGS "-oversubscribe")
 endif()
 
-set (TEST_CASES 
+set (TEST_CASES
   NO_OMP
   OMP_1_thread
   OMP_4_thread

--- a/mapl3g/CMakeLists.txt
+++ b/mapl3g/CMakeLists.txt
@@ -19,3 +19,6 @@ target_include_directories (${this} PUBLIC
 
 ecbuild_add_executable(TARGET GEOS.x SOURCES GEOS.F90 DEPENDS MAPL.generic3g MAPL.cap3g ESMF::ESMF)
 target_link_libraries(GEOS.x PRIVATE ${this})
+
+# GEOS.x is needed for 'make tests'
+add_dependencies(build-tests GEOS.x)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

As discovered by @darianboggs, if you checkout MAPL2 or MAPL3 and run CMake and then just run `make tests` without running `make install`, some of the tests crash. The reason is that CMake didn't know to build some of the executables needed for the tests.

So here we add the needed CMake to make that happen.

## Related Issue

Closes #3443 