### PR TITLE
Feature/wdboggs/3402 test merge hconfig

### DIFF
--- a/hconfig_utils/CMakeLists.txt
+++ b/hconfig_utils/CMakeLists.txt
@@ -7,6 +7,7 @@ set(srcs
   hconfig_get_private.F90
   generalized_equality.F90
   get_hconfig.F90
+  HConfigUtilities.F90
   )
 
 if (BUILD_WITH_PFLOGGER)

--- a/hconfig_utils/HConfigUtilities.F90
+++ b/hconfig_utils/HConfigUtilities.F90
@@ -1,12 +1,16 @@
+#include "MAPL_Generic.h"
 module mapl3g_HConfigUtilities
    use esmf, only: ESMF_HConfig, ESMF_HConfigIter, ESMF_HConfigIterBegin
    use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop 
    use esmf, only: ESMF_HConfigCreate, ESMF_HConfigIsMap, ESMF_HConfigAsStringMapKey
    use esmf, only: ESMF_HConfigIsDefined, ESMF_HConfigCreateAtMapVal, ESMF_HConfigSet
+   use mapl_ErrorHandling
    implicit none(type,external)
    private
 
    public :: merge_hconfig
+
+   character(*), parameter :: MAPL_SECTION = 'mapl'
 
 contains
 
@@ -27,7 +31,6 @@ contains
 
       _ASSERT(ESMF_HConfigIsMap(parent_hconfig), 'parent hconfig must be a mapping.')
       _ASSERT(ESMF_HConfigIsMap(child_hconfig), 'child hconfig must be a mapping.')
-
       total_hconfig = ESMF_HConfigCreate(child_hconfig, _RC)
 
       iter_begin = ESMF_HConfigIterBegin(parent_hconfig, rc=rc)

--- a/hconfig_utils/HConfigUtilities.F90
+++ b/hconfig_utils/HConfigUtilities.F90
@@ -1,0 +1,55 @@
+module mapl3g_HConfigUtilities
+   use esmf, only: ESMF_HConfig, ESMF_HConfigIter, ESMF_HConfigIterBegin
+   use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop 
+   use esmf, only: ESMF_HConfigCreate, ESMF_HConfigIsMap, ESMF_HConfigAsStringMapKey
+   use esmf, only: ESMF_HConfigIsDefined, ESMF_HConfigCreateAtMapVal, ESMF_HConfigSet
+   implicit none(type,external)
+   private
+
+   public :: merge_hconfig
+
+contains
+
+   ! Merge two hconfigs
+   ! 1) Do not include parent `mapl` section
+   ! 2) Duplicate keys defer to those of the child
+   function merge_hconfig(parent_hconfig, child_hconfig, rc) result(total_hconfig)
+      type(ESMF_HConfig) :: total_hconfig
+      type(ESMF_HConfig), intent(in) :: parent_hconfig
+      type(ESMF_HConfig), intent(in) :: child_hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
+      character(:), allocatable :: key
+      type(ESMF_HConfig) :: val
+      logical :: duplicate_key
+
+      _ASSERT(ESMF_HConfigIsMap(parent_hconfig), 'parent hconfig must be a mapping.')
+      _ASSERT(ESMF_HConfigIsMap(child_hconfig), 'child hconfig must be a mapping.')
+
+      total_hconfig = ESMF_HConfigCreate(child_hconfig, _RC)
+
+      iter_begin = ESMF_HConfigIterBegin(parent_hconfig, rc=rc)
+      iter_end = ESMF_HConfigIterEnd(parent_hconfig, rc=rc)
+      iter = iter_begin
+      do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
+         _VERIFY(status)
+
+         ! ignore mapl section
+         key = ESMF_HConfigAsStringMapKey(iter, rc=rc)
+         if (key == MAPL_SECTION) cycle
+
+         ! ignore duplicate key
+         duplicate_key = ESMF_HConfigIsDefined(child_hconfig, keystring=key, _RC)
+         if (duplicate_key) cycle
+
+         val = ESMF_HConfigCreateAtMapVal(iter, _RC)
+         call ESMF_HConfigSet(child_hconfig, keystring=key, content=val, _RC)
+      end do
+
+      _RETURN(_SUCCESS)
+   end function merge_hconfig
+
+end module mapl3g_HConfigUtilities
+

--- a/hconfig_utils/tests/CMakeLists.txt
+++ b/hconfig_utils/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MODULE_DIRECTORY "${esma_include}/hconfig_utils/tests")
 
 set (test_srcs
   Test_hconfig_get_private.pf
+  Test_HConfigUtilities.pf
   )
 
 
@@ -12,6 +13,7 @@ add_pfunit_ctest(MAPL.hconfig_utils.tests
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 MAX_PES 4
                 )
+set_tests_properties(MAPL.hconfig_utils.tests PROPERTIES LABELS "ESSENTIAL")
 set_target_properties(MAPL.hconfig_utils.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 if (APPLE)

--- a/hconfig_utils/tests/Test_HConfigUtilities.pf
+++ b/hconfig_utils/tests/Test_HConfigUtilities.pf
@@ -3,7 +3,7 @@ module Test_HConfigUtilities
    use mapl3g_HConfigUtilities
    use esmf, only: ESMF_HConfig, ESMF_HConfigCreate, ESMF_HConfigDestroy
    use esmf, only: ESMF_HConfigAdd, ESMF_HConfigAsString
-   use esmf, only: ESMF_HConfigValidateMapKeys
+   use esmf, only: ESMF_HConfigIsDefined
    use mapl_ErrorHandling
    use pfunit
    implicit none(type, external)
@@ -18,8 +18,7 @@ module Test_HConfigUtilities
    character(len=*), parameter :: KEY3 = 'key3: '
    character(len=*), parameter :: KEY4 = 'key4: '
    character(len=*), parameter :: KEY5 = 'key5: '
-   character(len=len(KEY1)), parameter :: CHILD_KEYS(3) = &
-      & [character(len=len(KEY1)) :: KEY1, KEY2, KEY3]
+   integer, parameter :: KEYLEN = len(KEY1)
    character(len=*), parameter :: PVALUE1 = 'parent_value1'
    character(len=*), parameter :: PVALUE2 = 'parent_value2'
    character(len=*), parameter :: PVALUE4 = 'parent_value4'
@@ -67,9 +66,9 @@ contains
    @Test
    subroutine test_merge_hconfig_mapl_section()
       integer :: status
-      logical :: are_valid
-      character(len=:), allocatable :: badkey
-      character(len=:), allocatable :: msg
+      logical :: defined
+      character(len=80) :: msg
+
 
       call ESMF_HConfigAdd(hconfig_content, content=PVALUE1, addKeyString=KEY1, _RC)
       call ESMF_HConfigAdd(hconfig_content, content=PVALUE5, addKeyString=KEY5, _RC)
@@ -82,11 +81,6 @@ contains
 
       call check_match(merged, KEY1, CHVALUE1, _RC)
       call check_match(merged, KEY3, CHVALUE3, _RC)
-
-      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
-      msg = ''
-      if(.not. are_valid) msg = trim(badkey) // ' was found.'
-      @assertTrue(are_valid, msg)
 
    end subroutine test_merge_hconfig_mapl_section
 
@@ -115,9 +109,6 @@ contains
    @Test
    subroutine test_merge_hconfig_no_mapl()
       integer :: status
-      logical :: are_valid
-      character(len=:), allocatable :: badkey
-      character(len=:), allocatable :: msg
 
       call ESMF_HConfigAdd(parent, content=PVALUE4, addKeyString=KEY4, _RC)
       call ESMF_HConfigAdd(child, content=CHVALUE1, addKeyString=KEY1, _RC)
@@ -128,19 +119,11 @@ contains
       call check_match(merged, KEY1, CHVALUE1, _RC)
       call check_match(merged, KEY3, CHVALUE3, _RC)
 
-      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
-      msg = ''
-      if(.not. are_valid) msg = trim(badkey) // ' was found.'
-      @assertTrue(are_valid, msg)
-
    end subroutine test_merge_hconfig_no_mapl
 
    @Test
    subroutine test_merge_hconfig_duplicate()
       integer :: status
-      logical :: are_valid
-      character(len=:), allocatable :: badkey
-      character(len=:), allocatable :: msg
 
       call ESMF_HConfigAdd(hconfig_content, content=PVALUE1, addKeyString=KEY1, _RC)
       call ESMF_HConfigAdd(parent, content=hconfig_content, addKeyString=MAPLKEY, _RC)
@@ -155,11 +138,6 @@ contains
       call check_match(merged, KEY1, CHVALUE1, _RC)
       call check_match(merged, KEY2, CHVALUE2, _RC)
       call check_match(merged, KEY3, CHVALUE3, _RC)
-
-      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
-      msg = ''
-      if(.not. are_valid) msg = trim(badkey) // ' was found.'
-      @assertTrue(are_valid, msg)
 
    end subroutine test_merge_hconfig_duplicate
 

--- a/hconfig_utils/tests/Test_HConfigUtilities.pf
+++ b/hconfig_utils/tests/Test_HConfigUtilities.pf
@@ -1,0 +1,46 @@
+module Test_HConfigUtilities
+   use mapl3g_HConfigUtilities
+   use esmf, only: ESMF_HConfig, ESMF_HConfigIter, ESMF_HConfigIterBegin
+   use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop 
+   use esmf, only: ESMF_HConfigCreate, ESMF_HConfigIsMap, ESMF_HConfigAsStringMapKey
+   use esmf, only: ESMF_HConfigIsDefined, ESMF_HConfigCreateAtMapVal, ESMF_HConfigSet
+   use pfunit
+   implicit none(type, external)
+
+   type(ESMF_HConfig) :: parent
+   type(ESMF_HConfig) :: child
+
+contains
+
+   @Before
+   subroutine set_up()
+      call ESMF_HConfigCreate()
+   end subroutine set_up
+
+   @After
+   subroutine tear_down()
+      call ESMF_HConfigDestroy()
+   end subroutine tear_down
+
+   @Test
+   subroutine test_merge_hconfig_basic()
+
+   end subroutine test_merge_hconfig_basic
+
+   @Test
+   subroutine test_merge_hconfig_bad_parent()
+   end subroutine test_merge_hconfig_bad_parent
+
+   @Test
+   subroutine test_merge_hconfig_bad_child()
+   end subroutine test_merge_hconfig_bad_child
+
+   @Test
+   subroutine test_merge_hconfig_no_mapl()
+   end subroutine test_merge_hconfig_no_mapl
+
+   @Test
+   subroutine test_merge_hconfig_duplicate()
+   end subroutine test_merge_hconfig_duplicate
+
+end module Test_HConfigUtilities

--- a/hconfig_utils/tests/Test_HConfigUtilities.pf
+++ b/hconfig_utils/tests/Test_HConfigUtilities.pf
@@ -1,46 +1,166 @@
+#include "MAPL_TestErr.h"
 module Test_HConfigUtilities
    use mapl3g_HConfigUtilities
-   use esmf, only: ESMF_HConfig, ESMF_HConfigIter, ESMF_HConfigIterBegin
-   use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop 
-   use esmf, only: ESMF_HConfigCreate, ESMF_HConfigIsMap, ESMF_HConfigAsStringMapKey
-   use esmf, only: ESMF_HConfigIsDefined, ESMF_HConfigCreateAtMapVal, ESMF_HConfigSet
+   use esmf, only: ESMF_HConfig, ESMF_HConfigCreate, ESMF_HConfigDestroy
+   use esmf, only: ESMF_HConfigAdd, ESMF_HConfigAsString
+   use esmf, only: ESMF_HConfigValidateMapKeys
+   use mapl_ErrorHandling
    use pfunit
    implicit none(type, external)
 
    type(ESMF_HConfig) :: parent
    type(ESMF_HConfig) :: child
+   type(ESMF_HConfig) :: merged
+   type(ESMF_HConfig) :: hconfig_content
+   character(len=*), parameter :: MAPLKEY = 'mapl: '
+   character(len=*), parameter :: KEY1 = 'key1: '
+   character(len=*), parameter :: KEY2 = 'key2: '
+   character(len=*), parameter :: KEY3 = 'key3: '
+   character(len=*), parameter :: KEY4 = 'key4: '
+   character(len=*), parameter :: KEY5 = 'key5: '
+   character(len=len(KEY1)), parameter :: CHILD_KEYS(3) = &
+      & [character(len=len(KEY1)) :: KEY1, KEY2, KEY3]
+   character(len=*), parameter :: PVALUE1 = 'parent_value1'
+   character(len=*), parameter :: PVALUE2 = 'parent_value2'
+   character(len=*), parameter :: PVALUE4 = 'parent_value4'
+   character(len=*), parameter :: PVALUE5 = 'parent_value5'
+   character(len=*), parameter :: CHVALUE1 = 'child_value1'
+   character(len=*), parameter :: CHVALUE2 = 'child_value2'
+   character(len=*), parameter :: CHVALUE3 = 'child_value3'
 
 contains
 
    @Before
    subroutine set_up()
-      call ESMF_HConfigCreate()
+      integer :: status
+      parent = ESMF_HConfigCreate(_RC)
+      child = ESMF_HConfigCreate(_RC)
+      hconfig_content = ESMF_HConfigCreate(_RC)
    end subroutine set_up
 
    @After
    subroutine tear_down()
-      call ESMF_HConfigDestroy()
+      integer :: status
+      call ESMF_HConfigDestroy(parent, rc=status)
+      call ESMF_HConfigDestroy(child, rc=status)
+      call ESMF_HConfigDestroy(merged, rc=status)
+      call ESMF_HConfigDestroy(hconfig_content, rc=status)
    end subroutine tear_down
 
-   @Test
-   subroutine test_merge_hconfig_basic()
+   subroutine check_match(hconfig, key, expected, rc)
+      type(ESMF_HConfig), intent(in) :: hconfig
+      character(len=*), intent(in) :: key
+      character(len=*), intent(in) :: expected
+      integer, optional, intent(out) :: rc
+      integer :: status
+      character(len=:), allocatable :: strval
+      logical :: ok
 
-   end subroutine test_merge_hconfig_basic
+      strval = ESMF_HConfigAsString(hconfig, keyString=trim(key), asOkay=ok, _RC)
+      @assertTrue(ok, trim(key) // ' not found')
+      if(ok) then
+         @assertEqual(trim(expected), strval, 'Wrong value for ' // trim(key))
+      end if
+
+   end subroutine check_match
+     
+   @Test
+   subroutine test_merge_hconfig_mapl_section()
+      integer :: status
+      logical :: are_valid
+      character(len=:), allocatable :: badkey
+      character(len=:), allocatable :: msg
+
+      call ESMF_HConfigAdd(hconfig_content, content=PVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(hconfig_content, content=PVALUE5, addKeyString=KEY5, _RC)
+      call ESMF_HConfigAdd(parent, content=hconfig_content, addKeyString=MAPLKEY, _RC)
+      call ESMF_HConfigAdd(parent, content=PVALUE4, addKeyString=KEY4, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE3, addKeyString=KEY3, _RC)
+
+      merged = merge_hconfig(parent, child, _RC)
+
+      call check_match(merged, KEY1, CHVALUE1, _RC)
+      call check_match(merged, KEY3, CHVALUE3, _RC)
+
+      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
+      msg = ''
+      if(.not. are_valid) msg = trim(badkey) // ' was found.'
+      @assertTrue(are_valid, msg)
+
+   end subroutine test_merge_hconfig_mapl_section
 
    @Test
    subroutine test_merge_hconfig_bad_parent()
+      integer :: status
+
+      call ESMF_HConfigAdd(parent, content = "['A', 'B', 'C', 'D', 'E', 'F']", _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE1, addKeyString=KEY1, _RC)
+      merged = merge_hconfig(parent, child, rc=status)
+      @assertTrue(status /= 0, 'The return code should be nonzero.')
+
    end subroutine test_merge_hconfig_bad_parent
 
    @Test
-   subroutine test_merge_hconfig_bad_child()
-   end subroutine test_merge_hconfig_bad_child
+   subroutine test_merge_hconfig_problem_child()
+      integer :: status
+
+      call ESMF_HConfigAdd(parent, content=PVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(child, content = "['A', 'B', 'C', 'D', 'E', 'F']", _RC)
+      merged = merge_hconfig(parent, child, rc=status)
+      @assertTrue(status /= 0, 'The return code should be nonzero.')
+
+   end subroutine test_merge_hconfig_problem_child
 
    @Test
    subroutine test_merge_hconfig_no_mapl()
+      integer :: status
+      logical :: are_valid
+      character(len=:), allocatable :: badkey
+      character(len=:), allocatable :: msg
+
+      call ESMF_HConfigAdd(parent, content=PVALUE4, addKeyString=KEY4, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE3, addKeyString=KEY3, _RC)
+
+      merged = merge_hconfig(parent, child, _RC)
+
+      call check_match(merged, KEY1, CHVALUE1, _RC)
+      call check_match(merged, KEY3, CHVALUE3, _RC)
+
+      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
+      msg = ''
+      if(.not. are_valid) msg = trim(badkey) // ' was found.'
+      @assertTrue(are_valid, msg)
+
    end subroutine test_merge_hconfig_no_mapl
 
    @Test
    subroutine test_merge_hconfig_duplicate()
+      integer :: status
+      logical :: are_valid
+      character(len=:), allocatable :: badkey
+      character(len=:), allocatable :: msg
+
+      call ESMF_HConfigAdd(hconfig_content, content=PVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(parent, content=hconfig_content, addKeyString=MAPLKEY, _RC)
+      call ESMF_HConfigAdd(parent, content=PVALUE4, addKeyString=KEY4, _RC)
+      call ESMF_HConfigAdd(parent, content=PVALUE2, addKeyString=KEY2, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE1, addKeyString=KEY1, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE2, addKeyString=KEY2, _RC)
+      call ESMF_HConfigAdd(child, content=CHVALUE3, addKeyString=KEY3, _RC)
+
+      merged = merge_hconfig(parent, child, _RC)
+
+      call check_match(merged, KEY1, CHVALUE1, _RC)
+      call check_match(merged, KEY2, CHVALUE2, _RC)
+      call check_match(merged, KEY3, CHVALUE3, _RC)
+
+      are_valid = ESMF_HConfigValidateMapKeys(child, CHILD_KEYS, badKey=badkey, _RC)
+      msg = ''
+      if(.not. are_valid) msg = trim(badkey) // ' was found.'
+      @assertTrue(are_valid, msg)
+
    end subroutine test_merge_hconfig_duplicate
 
 end module Test_HConfigUtilities

--- a/hconfig_utils/tests/Test_hconfig_get_private.pf
+++ b/hconfig_utils/tests/Test_hconfig_get_private.pf
@@ -115,7 +115,7 @@ contains
       params = HConfigParams(hconfig, LABEL)
       call get_value(params, actual, rc=status_)
       found = params%value_set
-      @assertFalse(status_ == 0, 'get_value should have failed.')
+      @assertFalse(found, 'get_value should have failed.')
 
    end subroutine test_get_i4_not_found_no_default
 
@@ -540,7 +540,7 @@ contains
          hconfig = ESMF_HConfigCreate(rc=status)
          hconfig_is_created = (status == 0)
          call ESMF_HConfigAdd(hconfig, 0, addKeyString='null', rc=status)
-         @assertEqual(0, status, 'Failed to add null vallue')
+         @assertEqual(0, status, 'Failed to add null value')
       end if
       @assertTrue(hconfig_is_created, 'HConfig was not created.')
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This copies the **merge_hconfig** function from **add_child_by_spec.F90** in **generic3g/OuterMetaComponent/add_child_by_spec.F90** into a new module mapl3g_HConfigUtilities in **hconfig_utils*, makes necessary changes, and implements unit tests for the modified function.

## Related Issue
#3402
