### PR TITLE
Fixes #3488 - Control timestep of collection

### DIFF
--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -23,6 +23,8 @@ module mapl3g_HistoryCollectionGridComp
       class(GeomPFIO), allocatable :: writer
       type(ESMF_Time) :: start_stop_times(2)
       type(ESMF_Time) :: initial_file_time
+      type(ESMF_TimeInterval) :: timeStep
+      type(ESMF_TimeInterval) :: time_offstep
       character(len=:), allocatable :: template
       character(len=:), allocatable :: current_file
    end type HistoryCollectionGridComp
@@ -69,7 +71,6 @@ contains
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       type(ESMF_HConfig) :: hconfig
       type(ESMF_Geom) :: geom
-      type(ESMF_Alarm) :: alarm
       character(len=ESMF_MAXSTR) :: name
       type(FileMetadata) :: metadata
       type(MaplGeom), pointer :: mapl_geom
@@ -87,7 +88,6 @@ contains
       _VERIFY(STATUS)
       call collection_gridcomp%writer%initialize(metadata, mapl_geom, _RC)
 
-      call create_output_alarm(clock, hconfig, trim(name), _RC)
       collection_gridcomp%start_stop_times = set_start_stop_time(clock, hconfig, _RC)
 
       collection_gridcomp%current_file = null_file
@@ -128,16 +128,13 @@ contains
       character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       logical :: time_to_write, run_collection
       type(ESMF_Time) :: current_time
-      type(ESMF_TimeInterval) :: write_frequency
-      type(ESMF_Alarm) :: write_alarm
       character(len=ESMF_MAXSTR) :: name
       character(len=128) :: current_file
 
       call ESMF_GridCompGet(gridcomp, name=name, _RC)
       call ESMF_ClockGet(clock, currTime=current_time, _RC)
-      call ESMF_ClockGetAlarm(clock, trim(name)//"_write_alarm", write_alarm, _RC)
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
-      time_to_write = ESMF_AlarmIsRinging(write_alarm, _RC)
+
       run_collection = (current_time >= collection_gridcomp%start_stop_times(1)) .and. &
                            (current_time <= collection_gridcomp%start_stop_times(2))
 
@@ -145,7 +142,6 @@ contains
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
 
-      call ESMF_AlarmGet(write_alarm, ringInterval=write_frequency, _RC)
       call fill_grads_template_esmf(current_file, collection_gridcomp%template, collection_id=name, time=current_time, _RC)
       if (trim(current_file) /= collection_gridcomp%current_file) then
          collection_gridcomp%current_file = current_file
@@ -153,7 +149,7 @@ contains
          collection_gridcomp%initial_file_time = current_time
       end if
 
-      time_index = get_current_time_index(collection_gridcomp%initial_file_time, current_time, write_frequency)
+      time_index = get_current_time_index(collection_gridcomp%initial_file_time, current_time, collection_gridcomp%timeStep)
       call collection_gridcomp%writer%stage_data_to_file(collection_gridcomp%output_bundle, collection_gridcomp%current_file, time_index, _RC)
       _RETURN(_SUCCESS)
 

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -126,7 +126,7 @@ contains
       integer :: status, time_index
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
-      logical :: time_to_write, run_collection
+      logical :: run_collection
       type(ESMF_Time) :: current_time
       character(len=ESMF_MAXSTR) :: name
       character(len=128) :: current_file
@@ -138,7 +138,7 @@ contains
       run_collection = (current_time >= collection_gridcomp%start_stop_times(1)) .and. &
                            (current_time <= collection_gridcomp%start_stop_times(2))
 
-      _RETURN_UNLESS(run_collection .and. time_to_write)
+      _RETURN_UNLESS(run_collection)
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryCollectionGridComp, PRIVATE_STATE, collection_gridcomp)
 

--- a/gridcomps/History3G/HistoryCollectionGridComp_private.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp_private.F90
@@ -19,7 +19,6 @@ module mapl3g_HistoryCollectionGridComp_private
    public :: make_geom
    public :: register_imports
    public :: create_output_bundle
-   public :: create_output_alarm
    public :: set_start_stop_time
    public :: get_current_time_index
    ! These are public for testing.
@@ -114,52 +113,6 @@ contains
 
       _RETURN(_SUCCESS)
    end function create_output_bundle
-
-   subroutine create_output_alarm(clock, hconfig, comp_name, rc)
-      type(ESMF_Clock), intent(inout) :: clock
-      type(ESMF_HConfig), intent(in) :: hconfig
-      character(len=*), intent(in) :: comp_name
-      integer, intent(out), optional :: rc
-
-      type(ESMF_Alarm) :: alarm
-      integer :: status
-      type(ESMF_HConfig) :: time_hconfig
-      type(ESMF_TimeInterval) :: time_interval
-      character(len=:), allocatable :: iso_time
-      type(ESMF_Time) :: first_ring_time, currTime, startTime
-      integer :: int_time, yy, mm, dd, m, h, s
-      logical :: has_ref_time, has_frequency
-
-      call ESMF_ClockGet(clock, currTime=currTime, timeStep=time_interval, startTime = startTime, _RC)
-
-      time_hconfig = ESMF_HConfigCreateAt(hconfig, keyString='time_spec', _RC)
-
-      has_frequency = ESMF_HConfigIsDefined(time_hconfig, keyString='frequency', _RC)
-      if (has_frequency) then
-         time_interval = hconfig_to_esmf_timeinterval(time_hconfig, 'frequency', _RC)
-      end if
-
-      int_time = 0
-      has_ref_time = ESMF_HConfigIsDefined(time_hconfig, keyString='ref_time', _RC)
-      if (has_ref_time) then
-         iso_time = ESMF_HConfigAsString(time_hconfig, keyString='ref_time', _RC)
-         int_time = string_to_integer_time(iso_time, _RC)
-      end if
-
-      call MAPL_UnpackTime(int_time, h, m, s)
-      call ESMF_TimeGet(currTime, yy=yy, mm=mm, dd=dd, _RC)
-      call ESMF_TimeSet(first_ring_time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
-
-      ! These 2 lines are borrowed from old History. Unforunately until ESMF alarms
-      ! get fixed kluges like this are neccessary so alarms will acutally ring
-      if (first_ring_time == startTime) first_ring_time = first_ring_time + time_interval
-      if (first_ring_time < currTime) &
-           first_ring_time = first_ring_time +(INT((currTime - first_ring_time)/time_interval)+1)*time_interval
-
-      alarm = ESMF_AlarmCreate(clock=clock, RingInterval=time_interval, RingTime=first_ring_time, sticky=.false., name=comp_name//"_write_alarm",  _RC)
-
-      _RETURN(_SUCCESS)
-   end subroutine create_output_alarm
 
    function set_start_stop_time(clock, hconfig, rc) result(start_stop_time)
       type(ESMF_Time) :: start_stop_time(2)

--- a/gridcomps/History3G/HistoryGridComp.F90
+++ b/gridcomps/History3G/HistoryGridComp.F90
@@ -60,8 +60,9 @@ contains
          child_name = make_child_name(collection_name, _RC)
 
          call get_child_timestep(child_hconfig, timeStep, _RC)
-         child_spec = ChildSpec(user_setservices(collection_setServices), child_hconfig, timeStep, refTime)
+         child_spec = ChildSpec(user_setservices(collection_setServices), hconfig=child_hconfig, timeStep=timeStep, refTime=refTime)
          call MAPL_GridCompAddChild(gridcomp, child_name, child_spec,_RC)
+         _HERE
       end do
       
       _RETURN(_SUCCESS)

--- a/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
+++ b/gridcomps/History3G/tests/Test_HistoryCollectionGridComp.pf
@@ -199,42 +199,4 @@ contains
 
    end subroutine test_set_start_stop_time
 
-   @Test
-   subroutine test_create_output_alarm()
-      type(ESMF_HConfig) :: hconfig
-      type(ESMF_Time) :: time,start_stop_time(2)
-      integer :: status
-      type(ESMF_Time) :: start_time, stop_time
-      type(ESMF_TimeInterval) :: dt
-      type(ESMF_Clock) :: clock
-      type(ESMF_Alarm) :: alarm
-      logical :: is_ringing
-      type(ESMF_Time) currTime
-      character(len=:), allocatable :: comp_name
-
-      comp_name = "coll1"
-      call ESMF_TimeIntervalSet(dt, h=1, _RC)
-      call ESMF_TimeSet(start_time, timeString="2000-04-03T21:00:00", _RC)
-      call ESMF_TimeSet(stop_time, timeString="2000-04-22T21:00:00", _RC)
-      clock = ESMF_ClockCreate(timeStep=dt, startTime=start_time, stopTime=stop_time, _RC)
-      hconfig = ESMF_HConfigCreate(content = &
-        "{time_spec: {frequency: PT3H}}", _RC)
-
-      call create_output_alarm(clock, hconfig, comp_name, _RC)
-      call ESMF_ClockGetAlarm(clock, comp_name//"_write_alarm", alarm, _RC)
-     
-      call ESMF_ClockAdvance(clock, _RC)
-      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
-      @assert_that(is_ringing, is(false()))
-
-      call ESMF_ClockAdvance(clock, _RC)
-      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
-      @assert_that(is_ringing, is(false()))
-
-      call ESMF_ClockAdvance(clock, _RC) 
-      is_ringing = ESMF_AlarmIsRinging(alarm, _RC) 
-      @assert_that(is_ringing, is(true()))
- 
-   end subroutine test_create_output_alarm
-
 end module Test_HistoryCollectionGridComp


### PR DESCRIPTION
In MAPL3g, timestep of a component is specified by the parent. However the schema for History3g has the timestep being set by the collection as a "time_spec".  This adds a bit of extra logic to pull out timestep at the parent level.

We should consider whether the History schema should be modified to make this more natural.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

