### PR TITLE
Feature/wdboggs/add alias to acg3

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -191,7 +191,7 @@ Option = Enum(value = 'Option', names = {
         'VLOCATION': ('vlocation', VLOCATION_EMIT),
         'VLOC': ('vlocation', VLOCATION_EMIT),
 # these are Options that are not output but used to write 
-        'ALIAS': {'writer': identity_writer, 'mandatory': False, 'output': False},
+        'ALIAS': ('alias', identity_writer, False, False),
         'CONDITION': ('condition', identity_writer, False, False),
         'COND': ('condition', identity_writer, False, False),
         'ALLOC': ('alloc', identity_writer, False, False),

--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -551,12 +551,8 @@ def emit_values(specs, args):
     if f_get_pointers:
         f_get_pointers.close()
 
-
-#############################################
-# MAIN program begins here
-#############################################
-
-if __name__ == "__main__":
+# Main Procedure (Added to facilitate testing.)
+def main():
 # Process command line arguments
     args = get_args()
 
@@ -573,5 +569,12 @@ if __name__ == "__main__":
 # Emit values
     emit_values(specs, args)
 
+#############################################
+# MAIN program begins here
+#############################################
+
+if __name__ == "__main__":
+    main()
 # FIN
     sys.exit(SUCCESS)
+

--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -191,6 +191,7 @@ Option = Enum(value = 'Option', names = {
         'VLOCATION': ('vlocation', VLOCATION_EMIT),
         'VLOC': ('vlocation', VLOCATION_EMIT),
 # these are Options that are not output but used to write 
+        'ALIAS': {'writer': identity_writer, 'mandatory': False, 'output': False},
         'CONDITION': ('condition', identity_writer, False, False),
         'COND': ('condition', identity_writer, False, False),
         'ALLOC': ('alloc', identity_writer, False, False),
@@ -460,6 +461,7 @@ def digest(specs, args):
         for spec in specs[state_intent]: # spec from list
             dims = None
             ungridded = None
+            alias = None
             option_values = dict() # dict of option values
             for column in spec: # for spec writer value
                 column_value = spec[column]
@@ -477,6 +479,10 @@ def digest(specs, args):
                     dims = option_value
                 elif option == Option.UNGRIDDED:
                     ungridded = option_value
+                elif option == Option.ALIAS:
+                    alias = option_value
+            if alias:
+                option_values[Option.INTERNAL_NAME] = alias
 # MANDATORY
             for option in mandatory_options:
                 if option not in option_values:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `run_dt` to `timestep`
 - Add checks for compatibility between `timestep` and `reference_time` for OuterMetaComponent and user component.
 - Changed `refTime` (`reference_time`) to `offset` and runTime = refTime + offset
+- Add ALIAS column for ACG for MAPL3
 
 ### Changed
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
In response to a user request, we added a column to ACG for MAPL2, ALIAS, that can be used to name the pointer variable for the field being added. The default name for the pointer variable is the value in the SHORT_NAME column. This PR adds the ALIAS column for ACG in MAPL3.