### PR TITLE
Feature/acg extra rm brackets 1750

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -28,9 +28,9 @@ RANKS = dict([(entry, rank) for entry, rank, _ in DIMS_OPTIONS])
 
 
 ############################### HELPER FUNCTIONS ###############################
-rm_quotes = lambda s: s.__str__().strip().strip('"\'').strip()
-add_quotes = lambda s: "'" + s.__str__() + "'"
-mk_array = lambda s: '[ ' + s.__str__() + ']'
+rm_quotes = lambda s: str(s).strip().strip('"\'').strip()
+add_quotes = lambda s: "'" + str(s) + "'"
+mk_array = lambda s: '[ ' + str(s).strip().strip('[]') + ']'
 
 def make_string_array(s):
     """ Returns a string representing a Fortran character array """

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `run_dt` to `timestep`
 - Add checks for compatibility between `timestep` and `reference_time` for OuterMetaComponent and user component.
 - Changed `refTime` (`reference_time`) to `offset` and runTime = refTime + offset
+- Added handling of array brackets in array-valued columns for ACG3
 
 ### Changed
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
When a column in a StateSpecs file is array-valued, and the user mistakenly puts array brackets (`[` and `]`) around the column value. The resulting include file is double brackets (`[[` and `]]`) which is wrong. This PR handles this more gracefully. With it, the column value can have array brackets, but they are not required. In the resulting include file, ACG writes a single set of array brackets. Because this problem has not been reported, I did not make it to ACG for MAPL2. It is worth correcting it in ACG3.

## Related Issue
#1750
