### PR TITLE
MAPL3: Updates for ESMF 8.9.0 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,9 @@ endif ()
 
 # There is an interface change in ESMF_HConfig in ESMF 8.9.0,
 # so we need to check the version and if it is 8.9.0 or later,
-# set a variable
+# set a variable.
+# NOTE: When we move to requiring ESMF 8.9.0 we can
+#       remove all this code and use the updated interface!
 if(ESMF_VERSION VERSION_GREATER_EQUAL 8.9.0)
   set (ESMF_HCONFIGSET_HAS_INTENT_INOUT TRUE)
   message(STATUS "ESMF_HConfig has intent(inout) in ESMF 8.9.0 or later")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ endif ()
 # set a variable
 if(ESMF_VERSION VERSION_GREATER_EQUAL 8.9.0)
   set (ESMF_HCONFIGSET_HAS_INTENT_INOUT TRUE)
+  message(STATUS "ESMF_HConfig has intent(inout) in ESMF 8.9.0 or later")
 else()
   set (ESMF_HCONFIGSET_HAS_INTENT_INOUT FALSE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,15 @@ else ()
   endif ()
 endif ()
 
+# There is an interface change in ESMF_HConfig in ESMF 8.9.0,
+# so we need to check the version and if it is 8.9.0 or later,
+# set a variable
+if(ESMF_VERSION VERSION_GREATER_EQUAL 8.9.0)
+  set (ESMF_HCONFIGSET_HAS_INTENT_INOUT TRUE)
+else()
+  set (ESMF_HCONFIGSET_HAS_INTENT_INOUT FALSE)
+endif()
+
 # We wish to add extra flags when compiling as Debug. We should only
 # do this if we are using esma_cmake since the flags are defined
 # there. Note that some flags like STANDARD_F18 might be available on

--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -104,12 +104,15 @@ esma_add_fortran_submodules(
   SOURCES initialize.F90 run.F90 finalize.F90 get_states.F90
           get_clock.F90 set_clock.F90 run_export_couplers.F90
           run_import_couplers.F90 clock_advance.F90
-          get_gridcomp.F90 get_name.F90 add_export_coupler.F90 
+          get_gridcomp.F90 get_name.F90 add_export_coupler.F90
           add_import_coupler.F90 read_restart.F90 write_restart.F90)
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
+if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+  target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+endif()
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -54,7 +54,7 @@ module mapl3g_Generic
    ! These should not be needed by users
    public :: MAPL_GridCompGetOuterMeta
    public :: MAPL_GridCompGetRegistry
-   
+
 
    ! These should be available to users
    public :: MAPL_GridCompAddVarSpec
@@ -201,13 +201,13 @@ contains
       type(ESMF_GridComp) function get_outer_gridcomp(gridcomp, rc) result(outer_gc)
          type(ESMF_GridComp), intent(inout) :: gridcomp
          integer, optional, intent(out) :: rc
-         
+
          integer :: status
          type(InnerMetaComponent), pointer :: inner_meta
 
          inner_meta => get_inner_meta(gridcomp, _RC)
          outer_gc = inner_meta%get_outer_gridcomp()
-         
+
          _RETURN(_SUCCESS)
       end function get_outer_gridcomp
 
@@ -226,7 +226,7 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine gridcomp_get_registry
-      
+
   subroutine gridcomp_get(gridcomp, unusable, &
         hconfig, &
         logger, &
@@ -246,7 +246,7 @@ contains
       type(OuterMetaComponent), pointer :: outer_meta_, outer_meta_from_inner_gc
 
       call MAPL_GridCompGetOuterMeta(gridcomp, outer_meta_, _RC)
-      
+
       if (present(hconfig)) hconfig = outer_meta_%get_hconfig()
       if (present(logger)) logger => outer_meta_%get_lgr()
       if (present(geom)) geom = outer_meta_%get_geom()
@@ -300,7 +300,11 @@ contains
    subroutine gridcomp_add_child_by_spec(gridcomp, child_name, child_spec, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       character(len=*), intent(in) :: child_name
+#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+      type(ChildSpec), intent(inout) :: child_spec
+#else
       type(ChildSpec), intent(in) :: child_spec
+#endif
       integer, optional, intent(out) :: rc
 
       integer :: status
@@ -502,7 +506,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -525,14 +529,14 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
 
    end subroutine gridcomp_resource_get_i8
-   
+
    subroutine gridcomp_resource_get_r4(gc, keystring, value, unusable, default, value_set, rc)
       real(kind=ESMF_KIND_R4), intent(inout) :: value
       real(kind=ESMF_KIND_R4), optional, intent(in) :: default
@@ -548,7 +552,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -571,7 +575,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -594,7 +598,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -617,7 +621,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger=logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -640,7 +644,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -663,7 +667,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -686,7 +690,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -709,7 +713,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -732,7 +736,7 @@ contains
 
       call MAPL_GridCompGet(gc, hconfig=hconfig, logger=logger, _RC)
       params = HConfigParams(hconfig, keystring, value_set, logger)
-      call MAPL_HConfigGet(params, value, default, _RC) 
+      call MAPL_HConfigGet(params, value, default, _RC)
       if(present(value_set)) value_set = params%value_set
 
       _RETURN(_SUCCESS)
@@ -786,7 +790,7 @@ contains
       type(ExtensionFamily), pointer :: family
       type(StateItemExtension), pointer :: primary
       class(StateItemSpec), pointer :: spec
-      
+
       call MAPL_GridCompGetRegistry(gridcomp, registry=registry, _RC)
       v_pt = VirtualConnectionPt(state_intent, short_name)
 

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -141,7 +141,11 @@ module mapl3g_OuterMetaComponent
       module recursive subroutine add_child_by_spec(this, child_name, child_spec, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          character(*), intent(in) :: child_name
+#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+         type(ChildSpec), intent(inout) :: child_spec
+#else
          type(ChildSpec), intent(in) :: child_spec
+#endif
          integer, optional, intent(out) :: rc
       end subroutine add_child_by_spec
 
@@ -152,19 +156,19 @@ module mapl3g_OuterMetaComponent
          class(AbstractUserSetServices), intent(in) :: user_setservices
          type(ESMF_HConfig), intent(in) :: hconfig
       end function new_outer_meta
-   
+
       module subroutine init_meta(this, rc)
          class(OuterMetaComponent), intent(inout) :: this
          integer, optional, intent(out) :: rc
       end subroutine init_meta
-   
+
       module function get_child_by_name(this, child_name, rc) result(child_component)
          type(GriddedComponentDriver) :: child_component
          class(OuterMetaComponent), intent(in) :: this
          character(len=*), intent(in) :: child_name
          integer, optional, intent(out) :: rc
       end function get_child_by_name
-   
+
       module recursive subroutine run_child_by_name(this, child_name, unusable, phase_name, rc)
          class(OuterMetaComponent), intent(inout) :: this
          character(len=*), intent(in) :: child_name
@@ -172,51 +176,51 @@ module mapl3g_OuterMetaComponent
          character(len=*), optional, intent(in) :: phase_name
          integer, optional, intent(out) :: rc
       end subroutine run_child_by_name
-   
+
       module recursive subroutine run_children_(this, unusable, phase_name, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          class(KE), optional, intent(in) :: unusable
          character(len=*), optional, intent(in) :: phase_name
          integer, optional, intent(out) :: rc
       end subroutine run_children_
-   
+
       module function get_outer_meta_from_outer_gc(gridcomp, rc) result(outer_meta)
          type(OuterMetaComponent), pointer :: outer_meta
          type(ESMF_GridComp), intent(inout) :: gridcomp
          integer, optional, intent(out) :: rc
       end function get_outer_meta_from_outer_gc
-   
+
       module subroutine attach_outer_meta(gridcomp, rc)
          type(ESMF_GridComp), intent(inout) :: gridcomp
          integer, optional, intent(out) :: rc
       end subroutine attach_outer_meta
-   
+
       module subroutine free_outer_meta(gridcomp, rc)
          type(ESMF_GridComp), intent(inout) :: gridcomp
          integer, optional, intent(out) :: rc
       end subroutine free_outer_meta
-   
+
       module function get_phases(this, method_flag) result(phases)
          type(StringVector), pointer :: phases
          class(OuterMetaComponent), target, intent(inout):: this
          type(ESMF_Method_Flag), intent(in) :: method_flag
       end function get_phases
-   
+
       module subroutine set_hconfig(this, hconfig)
          class(OuterMetaComponent), intent(inout) :: this
          type(ESMF_HConfig), intent(in) :: hconfig
       end subroutine set_hconfig
-   
+
       module function get_hconfig(this) result(hconfig)
          type(ESMF_Hconfig) :: hconfig
          class(OuterMetaComponent), intent(inout) :: this
       end function get_hconfig
-   
+
       module function get_geom(this) result(geom)
          type(ESMF_Geom) :: geom
          class(OuterMetaComponent), intent(inout) :: this
       end function get_geom
-   
+
       module recursive subroutine initialize_set_clock(this, outer_clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          type(ESMF_Clock), intent(in) :: outer_clock
@@ -224,14 +228,14 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_set_clock
-   
+
       module recursive subroutine initialize_advertise(this, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          ! optional arguments
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_advertise
-   
+
      module recursive subroutine initialize_modify_advertised(this, importState, exportState, clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          ! optional arguments
@@ -241,7 +245,7 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_modify_advertised
-   
+
      module recursive subroutine initialize_modify_advertised2(this, importState, exportState, clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          ! optional arguments
@@ -251,20 +255,20 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_modify_advertised2
-   
+
       module recursive subroutine initialize_realize(this, unusable, rc)
          class(OuterMetaComponent), intent(inout) :: this
          ! optional arguments
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_realize
-   
+
       module recursive subroutine recurse_(this, phase_idx, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          integer :: phase_idx
          integer, optional, intent(out) :: rc
       end subroutine recurse_
-   
+
       module recursive subroutine recurse_read_restart_(this, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          integer, optional, intent(out) :: rc
@@ -280,21 +284,21 @@ module mapl3g_OuterMetaComponent
          procedure(I_child_op) :: oper
          integer, optional, intent(out) :: rc
       end subroutine apply_to_children_custom
-   
+
       module recursive subroutine initialize_user(this, unusable, rc)
          class(OuterMetaComponent), intent(inout) :: this
          ! optional arguments
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine initialize_user
-   
+
       module subroutine run_custom(this, method_flag, phase_name, rc)
          class(OuterMetaComponent), intent(inout) :: this
          type(ESMF_METHOD_FLAG), intent(in) :: method_flag
          character(*), intent(in) :: phase_name
          integer, optional, intent(out) :: rc
       end subroutine run_custom
-   
+
       module recursive subroutine run_user(this, clock, phase_name, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          type(ESMF_Clock), intent(inout) :: clock
@@ -303,7 +307,7 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine run_user
-   
+
       module recursive subroutine run_clock_advance(this, clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          type(ESMF_Clock), intent(inout) :: clock
@@ -311,7 +315,7 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine run_clock_advance
-   
+
       module recursive subroutine finalize(this, importState, exportState, clock, unusable, rc)
          class(OuterMetaComponent), intent(inout) :: this
          type(ESMF_State) :: importState
@@ -321,7 +325,7 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine finalize
-   
+
       module recursive subroutine read_restart(this, importState, exportState, clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          type(ESMF_State) :: importState
@@ -331,7 +335,7 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine read_restart
-   
+
       module recursive subroutine write_restart(this, importState, exportState, clock, unusable, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          type(ESMF_State) :: importState
@@ -341,28 +345,28 @@ module mapl3g_OuterMetaComponent
          class(KE), optional, intent(in) :: unusable
          integer, optional, intent(out) :: rc
       end subroutine write_restart
-   
+
       module function get_name(this, rc) result(name)
          character(:), allocatable :: name
          class(OuterMetaComponent), intent(in) :: this
          integer, optional, intent(out) :: rc
       end function get_name
-   
+
       module function get_gridcomp(this) result(gridcomp)
          type(ESMF_GridComp) :: gridcomp
          class(OuterMetaComponent), intent(in) :: this
       end function get_gridcomp
-   
+
       module subroutine set_geom(this, geom)
          class(OuterMetaComponent), intent(inout) :: this
          type(ESMF_Geom), intent(in) :: geom
       end subroutine set_geom
-   
+
       module subroutine set_vertical_grid(this, vertical_grid)
          class(OuterMetaComponent), intent(inout) :: this
          class(VerticalGrid), intent(in) :: verticaL_grid
       end subroutine set_vertical_grid
-    
+
       module function get_vertical_grid(this) result(vertical_grid)
          class(VerticalGrid), allocatable :: verticaL_grid
          class(OuterMetaComponent), intent(inout) :: this
@@ -372,12 +376,12 @@ module mapl3g_OuterMetaComponent
          type(StateRegistry), pointer :: registry
          class(OuterMetaComponent), target, intent(in) :: this
       end function get_registry
-   
+
       module function get_component_spec(this) result(component_spec)
          type(ComponentSpec), pointer :: component_spec
          class(OuterMetaComponent), target, intent(in) :: this
       end function get_component_spec
-   
+
       module function get_internal_state(this) result(internal_state)
          type(ESMF_State) :: internal_state
          class(OuterMetaComponent), intent(in) :: this
@@ -387,19 +391,19 @@ module mapl3g_OuterMetaComponent
          class(Logger), pointer :: lgr
          class(OuterMetaComponent), target, intent(in) :: this
       end function get_lgr
-   
+
       module function get_user_gc_driver(this) result(user_gc_driver)
          type(GriddedComponentDriver), pointer :: user_gc_driver
          class(OuterMetaComponent), target, intent(in) :: this
       end function get_user_gc_driver
-   
+
       module subroutine connect_all(this, src_comp, dst_comp, rc)
          class(OuterMetaComponent), intent(inout) :: this
          character(*), intent(in) :: src_comp
          character(*), intent(in) :: dst_comp
          integer, optional, intent(out) :: rc
       end subroutine connect_all
-   
+
       module subroutine set_entry_point(this, method_flag, userProcedure, unusable, phase_name, rc)
          class(OuterMetaComponent), intent(inout) :: this
          type(ESMF_Method_Flag), intent(in) :: method_flag
@@ -408,7 +412,7 @@ module mapl3g_OuterMetaComponent
          character(len=*), optional, intent(in) :: phase_name
          integer, optional, intent(out) ::rc
       end subroutine set_entry_point
-   
+
    end interface
 
    interface OuterMetaComponent

--- a/generic3g/OuterMetaComponent/add_child_by_spec.F90
+++ b/generic3g/OuterMetaComponent/add_child_by_spec.F90
@@ -25,7 +25,7 @@ contains
       type(ESMF_GridComp) :: child_outer_gc
       type(OuterMetaComponent), pointer :: child_meta
       type(ESMF_HConfig) :: total_hconfig
-      
+
       _ASSERT(is_valid_name(child_name), 'Child name <' // child_name //'> does not conform to GEOS standards.')
       _ASSERT(this%children%count(child_name) == 0, 'duplicate child name: <'//child_name//'>.')
 
@@ -52,7 +52,11 @@ contains
    function merge_hconfig(parent_hconfig, child_hconfig, rc) result(total_hconfig)
       type(ESMF_HConfig) :: total_hconfig
       type(ESMF_HConfig), intent(in) :: parent_hconfig
+#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+      type(ESMF_HConfig), intent(inout) :: child_hconfig
+#else
       type(ESMF_HConfig), intent(in) :: child_hconfig
+#endif
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/generic3g/OuterMetaComponent/add_child_by_spec.F90
+++ b/generic3g/OuterMetaComponent/add_child_by_spec.F90
@@ -17,7 +17,11 @@ contains
    module recursive subroutine add_child_by_spec(this, child_name, child_spec, rc)
       class(OuterMetaComponent), target, intent(inout) :: this
       character(*), intent(in) :: child_name
+#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+      type(ChildSpec), intent(inout) :: child_spec
+#else
       type(ChildSpec), intent(in) :: child_spec
+#endif
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/gridcomps/ExtData3G/CMakeLists.txt
+++ b/gridcomps/ExtData3G/CMakeLists.txt
@@ -11,6 +11,10 @@ esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.generic3g MAPL.GeomIO PFLOGGER::pflogger TYPE SHARED)
 
+if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+  target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+endif()
+
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()

--- a/hconfig_utils/CMakeLists.txt
+++ b/hconfig_utils/CMakeLists.txt
@@ -26,6 +26,10 @@ target_link_libraries (${this} PUBLIC ESMF::ESMF)
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
+if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+  target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+endif()
+
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()

--- a/hconfig_utils/HConfigUtilities.F90
+++ b/hconfig_utils/HConfigUtilities.F90
@@ -1,7 +1,7 @@
 #include "MAPL_Generic.h"
 module mapl3g_HConfigUtilities
    use esmf, only: ESMF_HConfig, ESMF_HConfigIter, ESMF_HConfigIterBegin
-   use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop 
+   use esmf, only: ESMF_HConfigIterEnd, ESMF_HConfigIterLoop
    use esmf, only: ESMF_HConfigCreate, ESMF_HConfigIsMap, ESMF_HConfigAsStringMapKey
    use esmf, only: ESMF_HConfigIsDefined, ESMF_HConfigCreateAtMapVal, ESMF_HConfigSet
    use mapl_ErrorHandling
@@ -20,7 +20,11 @@ contains
    function merge_hconfig(parent_hconfig, child_hconfig, rc) result(total_hconfig)
       type(ESMF_HConfig) :: total_hconfig
       type(ESMF_HConfig), intent(in) :: parent_hconfig
+#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
+      type(ESMF_HConfig), intent(inout) :: child_hconfig
+#else
       type(ESMF_HConfig), intent(in) :: child_hconfig
+#endif
       integer, optional, intent(out) :: rc
 
       integer :: status


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This update is to allow for ESMF `develop` testing of MAPL. In such testing, it was found that ESMF in `develop` has changed the intents of (one of?) the inputs to `ESMF_HConfigSet`:

https://github.com/esmf-org/esmf/commit/403ed1e287cac15d9ca4bc60c0d88b59d6376238

As such, MAPL needs support for that change. We base off of the `ESMF_VERSION` if greater than or equal to 8.9.0

## Related Issue

