### PR TITLE
fixes #3485

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed bug when proccessing history collection list identified by NAG
-
 ### Removed
 
 ### Deprecated
+
+## [2.54.2] - 2025-03-18
+
+### Fixed
+
+- Fixed bug when proccessing history collection list identified by NAG
 
 ## [2.54.1] - 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug when proccessing history collection list identified by NAG
+
 ### Removed
 
 ### Deprecated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.54.1
+  VERSION 2.54.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -577,7 +577,7 @@ contains
 
              nlist = nlist + 1
              allocate( list(nlist), _STAT )
-             list(1:nlist-1)=IntState%list
+             if (nlist > 1) list(1:nlist-1)=IntState%list
              list(nlist)%collection = tmpstring
              list(nlist)%filename = list(nlist)%collection
              deallocate(IntState%list)


### PR DESCRIPTION
Fixes #3485
This fixed the issue with the failing extdata tests on release/MAPL-v3 with NAG. Since it seemed like a bug @mathomp4 thought we should do this as a proper hot fix to get this propagated to the MAPL3 branch eventually

## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

