### PR TITLE
Replacing MPI_THREAD_MULTIPLE with MPI_THREAD_SINGLE everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace MPI_THREAD_MULTIPLE with MPI_THREAD_SINGLE. This is done to address https://github.com/ufs-community/ufs-weather-model/issues/2637#issuecomment-2722008171. This replacement appears not to cause any problem with the the different thread scenarios and the use of PFIO
+
 ### Fixed
 
 - Fixed problem related to stale pointers to temp copies of dummy arguments in MAPL_Cap.F90.  Fix is to add TARGET attributein select locations.

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -480,9 +480,9 @@ contains
       if (.not. this%mpi_already_initialized) then
 
          call ESMF_InitializePreMPI(_RC)
-         call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierror)
+         call MPI_Init_thread(MPI_THREAD_SINGLE, provided, ierror)
          _VERIFY(ierror)
-         _ASSERT(provided == MPI_THREAD_MULTIPLE, 'MPI_THREAD_MULTIPLE not supported by this MPI.')
+         _ASSERT(provided == MPI_THREAD_SINGLE, 'MPI_THREAD_SINGLE not supported by this MPI.')
       else
          ! If we are here, then MPI has already been initialized by the user
          ! and we are just using it. But we need to make sure that the user
@@ -490,7 +490,7 @@ contains
          call MPI_Query_thread(provided, ierror)
          _VERIFY(ierror)
       end if
-      _ASSERT(provided == MPI_THREAD_MULTIPLE, 'MPI_THREAD_MULTIPLE not supported by this MPI.')
+      _ASSERT(provided == MPI_THREAD_SINGLE, 'MPI_THREAD_SINGLE not supported by this MPI.')
 
       call MPI_Comm_rank(this%comm_world, this%rank, status)
       _VERIFY(status)

--- a/pfio/pfio_collective_demo.F90
+++ b/pfio/pfio_collective_demo.F90
@@ -322,7 +322,7 @@ program main
 !$   integer :: num_threads
    type (FakeExtData), target :: extData
 
-   required = MPI_THREAD_MULTIPLE
+   required = MPI_THREAD_SINGLE
    call MPI_init_thread(required, provided,  ierror)
    _VERIFY(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank,  ierror)

--- a/pfio/pfio_server_demo.F90
+++ b/pfio/pfio_server_demo.F90
@@ -291,7 +291,7 @@ program main
    type (FakeExtData), target :: extData
    class(AbstractDirectoryService), pointer :: d_s=>null()
 
-   call MPI_init_thread(MPI_THREAD_MULTIPLE, provided, ierror)
+   call MPI_init_thread(MPI_THREAD_SINGLE, provided, ierror)
    _VERIFY(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
    _VERIFY(ierror)

--- a/pfio/tests/pfio_ctest_io.F90
+++ b/pfio/tests/pfio_ctest_io.F90
@@ -480,7 +480,7 @@ program main
    integer,allocatable :: local_comm_world(:), app_comms(:)
    integer :: md_id, exit_code
    
-   required = MPI_THREAD_MULTIPLE
+   required = MPI_THREAD_SINGLE
    !call MPI_init_thread(required, provided, ierror)
    call MPI_init(ierror)
    call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue). Technically not a bug, rather a deficiency in the particular MPI implementation
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [X] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description
Replace MPI_THREAD_MULTIPLE with MPI_THREAD_SINGLE. This is done to address https://github.com/ufs-community/ufs-weather-model/issues/2637#issuecomment-2722008171. This replacement appears not to cause any problem with the the different thread scenarios and the use of PFIO

## Related Issue
Closes #3487
