### PR TITLE
Check that the Fortran pointer type and kind match the ESMF_Field typekind in assign_fptr 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added constructor for DSO_SetServicesWrapper
 - Change macro in field/undo_function_overload.macro
 - Fixed bug with AccumulatorAction and subtypes
+- Added a check to assign_fptr that verifies that the pointer type/kind matches the Field typekind
 
 ## [Unreleased]
 

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -1094,25 +1094,12 @@ contains
       type(ESMF_TypeKind_Flag), intent(in) :: typekind
       integer, optional, intent(out) :: rc
       integer :: status
-      logical :: matches
-
-      matches = typekind_matches(field, typekind, _RC)
-      _ASSERT(matches, 'Field typekind does not match pointer type and kind.')
-      _RETURN(_SUCCESS)
-
-   end subroutine check_typekind
-
-   logical function typekind_matches(field, typekind, rc)
-      type(ESMF_Field), intent(in) :: field
-      type(ESMF_TypeKind_Flag), intent(in) :: typekind
-      integer, optional, intent(out) :: rc
-      integer :: status
       type(ESMF_TypeKind_Flag) :: actual_typekind
 
       call ESMF_FieldGet(field, typekind=actual_typekind, rc=status)
-      typekind_matches = actual_typekind == typekind
-      _RETURN(status)
+      _ASSERT(actual_typekind == typekind, 'Field typekind does not match pointer type and kind.')
+      _RETURN(_SUCCESS)
 
-   end function typekind_matches
+   end subroutine check_typekind
 
 end module MAPL_FieldPointerUtilities

--- a/field/FieldPointerUtilities.F90
+++ b/field/FieldPointerUtilities.F90
@@ -96,6 +96,7 @@ contains
       integer(ESMF_KIND_I8) :: local_size
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R4, _RC)
       local_size = FieldGetLocalSize(x, _RC)
       fp_shape = [ local_size ]
       call FieldGetCptr(x, cptr, _RC)
@@ -115,6 +116,7 @@ contains
       integer(ESMF_KIND_I8) :: local_size
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R8, _RC)
       local_size = FieldGetLocalSize(x, _RC)
       fp_shape = [ local_size ]
       call FieldGetCptr(x, cptr, _RC)
@@ -133,6 +135,7 @@ contains
       type(c_ptr) :: cptr
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R4, _RC)
       _ASSERT(size(fp_shape) == rank(fptr), 'Shape size must match pointer rank.')
       call FieldGetCptr(x, cptr, _RC)
       call c_f_pointer(cptr, fptr, fp_shape)
@@ -150,6 +153,7 @@ contains
       type(c_ptr) :: cptr
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R8, _RC)
       _ASSERT(size(fp_shape) == rank(fptr), 'Shape size must match pointer rank.')
       call FieldGetCptr(x, cptr, _RC)
       call c_f_pointer(cptr, fptr, fp_shape)
@@ -167,6 +171,7 @@ contains
       type(c_ptr) :: cptr
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R4, _RC)
       _ASSERT(size(fp_shape) == rank(fptr), 'Shape size must match pointer rank.')
       call FieldGetCptr(x, cptr, _RC)
       call c_f_pointer(cptr, fptr, fp_shape)
@@ -184,6 +189,7 @@ contains
       type(c_ptr) :: cptr
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_R8, _RC)
       _ASSERT(size(fp_shape) == rank(fptr), 'Shape size must match pointer rank.')
       call FieldGetCptr(x, cptr, _RC)
       call c_f_pointer(cptr, fptr, fp_shape)
@@ -1054,6 +1060,7 @@ contains
       integer(ESMF_KIND_I8) :: local_size
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_I4, _RC)
       local_size = FieldGetLocalSize(x, _RC)
       fp_shape = [ local_size ]
       call FieldGetCptr(x, cptr, _RC)
@@ -1073,6 +1080,7 @@ contains
       integer(ESMF_KIND_I8) :: local_size
       integer :: status
 
+      call check_typekind(x, ESMF_TYPEKIND_I8, _RC)
       local_size = FieldGetLocalSize(x, _RC)
       fp_shape = [ local_size ]
       call FieldGetCptr(x, cptr, _RC)
@@ -1080,5 +1088,31 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine assign_fptr_i8_rank1
+
+   subroutine check_typekind(field, typekind, rc)
+      type(ESMF_Field), intent(in) :: field
+      type(ESMF_TypeKind_Flag), intent(in) :: typekind
+      integer, optional, intent(out) :: rc
+      integer :: status
+      logical :: matches
+
+      matches = typekind_matches(field, typekind, _RC)
+      _ASSERT(matches, 'Field typekind does not match pointer type and kind.')
+      _RETURN(_SUCCESS)
+
+   end subroutine check_typekind
+
+   logical function typekind_matches(field, typekind, rc)
+      type(ESMF_Field), intent(in) :: field
+      type(ESMF_TypeKind_Flag), intent(in) :: typekind
+      integer, optional, intent(out) :: rc
+      integer :: status
+      type(ESMF_TypeKind_Flag) :: actual_typekind
+
+      call ESMF_FieldGet(field, typekind=actual_typekind, rc=status)
+      typekind_matches = actual_typekind == typekind
+      _RETURN(status)
+
+   end function typekind_matches
 
 end module MAPL_FieldPointerUtilities

--- a/generic3g/tests/Test_MeanTransform.pf
+++ b/generic3g/tests/Test_MeanTransform.pf
@@ -40,9 +40,9 @@ contains
 
       ! counter 0 at one point
       call FieldSet(acc%accumulation_field, COUNTER*MEAN, _RC)
-      call assign_fptr(acc%counter_field, fptr, _RC)
-      fptr(n) = 0
-      mask = fptr /= 0
+      call assign_fptr(acc%counter_field, ifptr, _RC)
+      ifptr(n) = 0
+      mask = ifptr /= 0
       call assign_fptr(acc%accumulation_field, fptr, _RC)
       call acc%calculate_mean_R4(_RC)
       @assertTrue(all(pack(fptr, mask) == MEAN), 'Some valid points not equal to MEAN')


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
**assign_fptr** does not check that the type and kind of the Fortran pointer match the typekind of the **ESMF_Field**, and this can result in incorrect casts. This PR adds a check to guarantee that the pointer and field are consistent so there is no casting.

## Related Issue
3492
