### PR TITLE
Fixes #3528 - Added an option to mapl_acg to use ACG v3 instead of ACG

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -5,11 +5,13 @@
 # used.
 
 file (COPY MAPL_GridCompSpecs_ACG.py DESTINATION ${esma_etc}/MAPL)
+file (COPY MAPL_GridCompSpecs_ACGv3.py DESTINATION ${esma_etc}/MAPL)
 file (COPY mapl_acg.pl DESTINATION ${esma_etc}/MAPL)
 file (COPY mapl_stub.pl DESTINATION ${esma_etc}/MAPL)
 
 install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
+  MAPL_GridCompSpecs_ACGv3.py
   combine_restarts.py
   split_restart.py
   mapl_acg.pl

--- a/cmake/mapl_acg.cmake
+++ b/cmake/mapl_acg.cmake
@@ -21,7 +21,7 @@
 
 
 function (mapl_acg target specs_file)
-  set (options)
+  set (options 3g)
   set (oneValueArgs  IMPORT_SPECS EXPORT_SPECS INTERNAL_SPECS GET_POINTERS DECLARE_POINTERS)
   # This list must align with oneValueArgs above (for later ZIP_LISTS)
   set (flags         -i           -x           -p             -g           -d)
@@ -84,7 +84,12 @@ function (mapl_acg target specs_file)
   else ()
     set (_generator_dir ${esma_etc}/MAPL)
   endif ()
-  set(generator ${_generator_dir}/MAPL_GridCompSpecs_ACG.py)
+
+  if (ARGS_3g)
+    set(generator ${_generator_dir}/MAPL_GridCompSpecs_ACGv3.py)
+  else ()
+    set(generator ${_generator_dir}/MAPL_GridCompSpecs_ACG.py)
+  endif ()
 
   add_custom_command (
     OUTPUT ${generated}


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Added the option `3g` for the cmake function `mapl_acg`. With this, one should be able to run `MAPL_GridCompSpecs_ACGv3.py`.


## Related Issue

#3528 
