### PR TITLE
Fixes #3548 - Calling make_VariableSpec with UngriddedDims

### DIFF
--- a/esmf_utils/UngriddedDims.F90
+++ b/esmf_utils/UngriddedDims.F90
@@ -38,6 +38,7 @@ module mapl3g_UngriddedDims
       module procedure new_UngriddedDims_empty
       module procedure new_UngriddedDims_vec
       module procedure new_UngriddedDims_arr
+      module procedure new_UngriddedDims_extent_arr
    end interface UngriddedDims
 
    interface operator(==)
@@ -79,6 +80,18 @@ contains
 
    end function new_UngriddedDims_arr
 
+   function new_UngriddedDims_extent_arr(extent_arr) result(spec)
+      type(UngriddedDims) :: spec
+      integer, intent(in) :: extent_arr(:)
+
+      integer :: i
+      type(UngriddedDim) :: dim_spec
+
+      do i = 1, size(extent_arr)
+         dim_spec = UngriddedDim(extent_arr(i))
+         call spec%dim_specs%push_back(dim_spec)
+      end do
+   end function new_UngriddedDims_extent_arr
 
    ! Note: Ensure that vertical is the first ungridded dimension.
    subroutine add_dim(this, dim_spec, rc)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Calling `make_VariableSpec` with `UngriddedDims`. Also added an `UngriddedDims` constructor that takes an array of extents as an argument.

## Related Issue

Fixes #3548 