### PR TITLE
Fixes #3554 Set gridToFieldMap in FieldClassAspect::allocate

### DIFF
--- a/generic3g/specs/GeomAspect.F90
+++ b/generic3g/specs/GeomAspect.F90
@@ -36,6 +36,7 @@ module mapl3g_GeomAspect
       procedure :: supports_conversion_specific
       procedure :: set_geom
       procedure :: get_geom
+      procedure :: get_horizontal_dims_spec
       procedure, nopass :: get_aspect_id
    end type GeomAspect
 
@@ -144,6 +145,16 @@ contains
 
       _RETURN(_SUCCESS)
    end function get_geom
+
+   function get_horizontal_dims_spec(this, rc) result(horizontal_dims_spec)
+      class(GeomAspect), intent(in) :: this
+      integer, optional, intent(out) :: rc
+      type(HorizontalDimsSpec) :: horizontal_dims_spec
+
+      horizontal_dims_spec = this%horizontal_dims_spec
+
+      _RETURN(_SUCCESS)
+   end function get_horizontal_dims_spec
 
    subroutine connect_to_export(this, export, actual_pt, rc)
       class(GeomAspect), intent(inout) :: this


### PR DESCRIPTION
…y variables) based on GeomAspect's horizontal_dims_spc

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Set gridToFieldMap in FieldClassAspect::allocate (to identify VertOnly variables) based on GeomAspect's horizontal_dims_spec

## Related Issue

#3554 