### PR TITLE
fixes #3562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug that broke SCM model in GEOS
 - Fix ExtData2G unit test for GNU on Discover
 - Fixed nesting of internal timers (issue #3412)
 - Fixed issue of `make tests` not building all needed executables

--- a/base/MAPL_AbstractGridFactory.F90
+++ b/base/MAPL_AbstractGridFactory.F90
@@ -323,25 +323,32 @@ contains
 
    end function clone
 
-   function make_grid(this, unusable, rc) result(grid)
+   function make_grid(this, unusable, force_new_grid, rc) result(grid)
       use esmf
       use MAPL_KeywordEnforcerMod
       type (ESMF_Grid) :: grid
       class (AbstractGridFactory), intent(inout) :: this
       class (KeywordEnforcer), optional, intent(in) :: unusable
+      logical, optional, intent(in)  :: force_new_grid
       integer, optional, intent(out) :: rc
       
       integer :: status
       character(len=*), parameter :: Iam= MOD_NAME // 'make_grid'
+      logical :: new_grid
 
       _UNUSED_DUMMY(unusable)
-
-      if (allocated(this%grid)) then
-         grid = this%grid
+     
+      new_grid = .false.
+      if (present(force_new_grid)) new_grid = force_new_grid
+      if (new_grid) then
+         grid = this%make_new_grid(_RC)
       else
-         this%grid = this%make_new_grid(rc=status)
-         _VERIFY(status)
-         grid = this%grid
+         if (allocated(this%grid)) then
+            grid = this%grid
+         else
+            this%grid = this%make_new_grid(_RC)
+            grid = this%grid
+         end if
       end if
 
       _RETURN(_SUCCESS)

--- a/base/MAPL_GridManager.F90
+++ b/base/MAPL_GridManager.F90
@@ -607,11 +607,13 @@ module MAPL_GridManagerMod
    public :: get_instance
    public :: get_factory_id
    public :: get_factory
+   public :: factory_id_attribute_public
 
    ! singleton instance
    type (GridManager), target, save :: grid_manager
 
    character(len=*), parameter :: MOD_NAME = 'MAPL_GridManager::'
+   character(len=*), parameter :: factory_id_attribute_public = 'MAPL_grid_factory_id'
 
 contains
 

--- a/gridcomps/ExtData2G/ExtDataGridCompNG.F90
+++ b/gridcomps/ExtData2G/ExtDataGridCompNG.F90
@@ -637,7 +637,7 @@ CONTAINS
       if (item%vartype == MAPL_VectorField) then
          call item%filestream%get_file_bracket(use_time,item%source_time, item%modelGridFields%comp2, item%fail_on_missing_file,_RC)
       end if
-      call create_bracketing_fields(item,self%ExtDataState,cf_master, _RC)
+      call create_bracketing_fields(item,self%ExtDataState, _RC)
       call IOBundle_Add_Entry(IOBundles,item,idx)
       useTime(i)=use_time
 
@@ -1077,70 +1077,24 @@ CONTAINS
 
   end subroutine MAPL_ExtDataVerticalInterpolate
 
-  function MAPL_ExtDataGridChangeLev(Grid,CF,lm,rc) result(NewGrid)
+  function MAPL_ExtDataGridChangeLev(Grid,lm,rc) result(NewGrid)
 
      type(ESMF_Grid), intent(inout) :: Grid
-     type(ESMF_Config), intent(inout) :: CF
      integer,         intent(in)    :: lm
      integer, optional, intent(out) :: rc
 
      integer :: status
 
-     character(len=ESMF_MAXSTR) :: gname, comp_name
-     integer :: counts(3)
-     integer :: NX,NY
      type(ESMF_Grid)           :: newGrid
-     type(ESMF_Config)         :: cflocal
-     character(len=*), parameter :: CF_COMPONENT_SEPARATOR = '.'
-     real :: temp_real
-     logical :: isPresent
      type(ESMF_Info) :: infoh
+     class (AbstractGridFactory), pointer :: factory
+     integer :: factory_id
 
-     call MAPL_GridGet(grid,globalCellCountPerDim=counts,_RC)
-     call ESMF_GridGet(grid,name=gName,_RC)
-     call ESMF_ConfigGetAttribute(CF, value = NX, Label="NX:", _RC)
-     call ESMF_ConfigGetAttribute(CF, value = NY, Label="NY:", _RC)
-
-     comp_name = "ExtData"
-     cflocal = MAPL_ConfigCreate(_RC)
-     call MAPL_ConfigSetAttribute(cflocal,value=NX, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"NX:",_RC)
-     call MAPL_ConfigSetAttribute(cflocal,value=lm, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"LM:",_RC)
-
-     if (counts(2) == 6*counts(1)) then
-        call MAPL_ConfigSetAttribute(cflocal,value="Cubed-Sphere", label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"GRID_TYPE:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=6, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"NF:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=counts(1), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"IM_WORLD:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=ny/6, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"NY:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=trim(gname), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"GRIDNAME:",_RC)
-
-        call ESMF_InfoGetFromHost(grid,infoh,_RC)
-        isPresent = ESMF_InfoIsPresent(infoh,'STRETCH_FACTOR',_RC)
-        if (isPresent) then
-           call ESMF_InfoGet(infoh,'STRETCH_FACTOR',temp_real,_RC)
-           call MAPL_ConfigSetAttribute(cflocal,value=temp_real, label=trim(COMP_Name)//MAPL_CF_COMPONENT_SEPARATOR//"STRETCH_FACTOR:",_RC)
-        endif
-
-        isPresent = ESMF_InfoIsPresent(infoh,'TARGET_LON',_RC)
-        if (isPresent) then
-           call ESMF_InfoGet(infoh,'TARGET_LON',temp_real,_RC)
-           call MAPL_ConfigSetAttribute(cflocal,value=temp_real*MAPL_RADIANS_TO_DEGREES, label=trim(COMP_Name)//MAPL_CF_COMPONENT_SEPARATOR//"TARGET_LON:",_RC)
-        endif
-
-        isPresent = ESMF_InfoIsPresent(infoh,'TARGET_LAT',_RC)
-        if (isPresent) then
-           call ESMF_InfoGet(infoh,'TARGET_LAT',temp_real,_RC)
-           call MAPL_ConfigSetAttribute(cflocal,value=temp_real*MAPL_RADIANS_TO_DEGREES, label=trim(COMP_Name)//MAPL_CF_COMPONENT_SEPARATOR//"TARGET_LAT:",_RC)
-        endif
-     else
-        call MAPL_ConfigSetAttribute(cflocal,value=counts(1), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"IM_WORLD:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=counts(2), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"JM_WORLD:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=ny, label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"NY:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value=trim(gname), label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"GRIDNAME:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value='LatLon', label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"GRID_TYPE:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value='PC', label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"POLE:",_RC)
-        call MAPL_ConfigSetAttribute(cflocal,value='DC', label=trim(COMP_Name)//CF_COMPONENT_SEPARATOR//"DATELINE:",_RC)
-     end if
-     newgrid = grid_manager%make_grid(cflocal, prefix=trim(COMP_Name)//".", _RC)
+     factory => get_factory(grid, _RC)
+     NewGrid = factory%make_grid(force_new_grid=.true., _RC)
+     call ESMF_AttributeSet(NewGrid, name='GRID_LM', value=lm, _RC)
+     call ESMF_AttributeGet(Grid, name=factory_id_attribute_public,value=factory_id,_RC)
+     call ESMF_AttributeSet(NewGrid, name=factory_id_attribute_public,value=factory_id,_RC)
 
      _RETURN(ESMF_SUCCESS)
 
@@ -1489,10 +1443,9 @@ CONTAINS
      _RETURN(_SUCCESS)
   end subroutine set_constant_field
 
-  subroutine create_bracketing_fields(item,ExtDataState,cf,rc)
+  subroutine create_bracketing_fields(item,ExtDataState,rc)
      type(PrimaryExport), intent(inout) :: item
      type(ESMF_State), intent(inout) :: extDataState
-     type(ESMF_Config), intent(inout) :: cf
      integer, intent(out), optional :: rc
 
      integer :: status,lm,fieldRank
@@ -1547,7 +1500,7 @@ CONTAINS
               item%do_Fill = .true.
            end if
 
-           bracket_grid = MAPL_ExtDataGridChangeLev(grid,cf,item%vcoord%num_levels,_RC)
+           bracket_grid = MAPL_ExtDataGridChangeLev(grid,item%vcoord%num_levels,_RC)
            left_field = MAPL_FieldCreate(field,bracket_grid,lm=item%vcoord%num_levels,newName=trim(item%fcomp1),_RC)
            call set_field_units(left_field, item%units, _RC)
            call set_mw(left_field, item, _RC)
@@ -1583,7 +1536,7 @@ CONTAINS
               item%do_Fill = .true.
            end if
 
-           bracket_grid = MAPL_ExtDataGridChangeLev(grid,cf,item%vcoord%num_levels,_RC)
+           bracket_grid = MAPL_ExtDataGridChangeLev(grid,item%vcoord%num_levels,_RC)
            left_field = MAPL_FieldCreate(field,bracket_grid,lm=item%vcoord%num_levels,newName=trim(item%fcomp1),_RC)
            call set_field_units(left_field, item%units, _RC)
            _HERE


### PR DESCRIPTION
fixes #3562 
Confirmed 0 diff and that SCM works again
Basically added option to force a factory to make a new grid, rather than the cached grid so I can modify  the `GRID_LM` attribute without breaking the original grid.

And results in much cleaner code in the procedure in ExtData to make the new grid. Might use more memory but hopefully many of these grids being created are small.

I could not figure out another way to do what I needed to do given the limitations of our grid factory and grid manager API's.

## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [X] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

