### PR TITLE
Fixed #3551 - add restart reading to one of the initialize phases

### DIFF
--- a/generic3g/CMakeLists.txt
+++ b/generic3g/CMakeLists.txt
@@ -73,7 +73,7 @@ esma_add_fortran_submodules(
   SOURCES SetServices.F90 add_child_by_spec.F90 new_outer_meta.F90 init_meta.F90
           get_child_by_name.F90 run_child_by_name.F90 run_children.F90
           get_outer_meta_from_outer_gc.F90 attach_outer_meta.F90 free_outer_meta.F90
-          get_phases.F90 set_hconfig.F90 get_hconfig.F90 get_geom.F90
+          get_phases.F90 set_hconfig.F90 get_hconfig.F90 has_geom.F90 get_geom.F90
           initialize_advertise.F90
 	  initialize_modify_advertised.F90 initialize_modify_advertised2.F90
           initialize_realize.F90 recurse.F90 apply_to_children_custom.F90

--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -58,6 +58,7 @@ module mapl3g_OuterMetaComponent
       procedure :: get_user_gc_driver
       procedure :: set_hconfig
       procedure :: get_hconfig
+      procedure :: has_geom
       procedure :: get_geom
       procedure :: get_registry
       procedure :: get_lgr
@@ -215,6 +216,11 @@ module mapl3g_OuterMetaComponent
          type(ESMF_Hconfig) :: hconfig
          class(OuterMetaComponent), intent(inout) :: this
       end function get_hconfig
+
+      module function has_geom(this)
+         logical :: has_geom
+         class(OuterMetaComponent), intent(in) :: this
+      end function has_geom
 
       module function get_geom(this) result(geom)
          type(ESMF_Geom) :: geom

--- a/generic3g/OuterMetaComponent/has_geom.F90
+++ b/generic3g/OuterMetaComponent/has_geom.F90
@@ -1,0 +1,17 @@
+#include "MAPL_Generic.h"
+
+submodule (mapl3g_OuterMetaComponent) has_geom_smod
+
+   implicit none
+
+contains
+
+   module function has_geom(this)
+      logical :: has_geom
+      class(OuterMetaComponent), intent(in) :: this
+
+      has_geom = .false.
+      if (allocated(this%geom)) has_geom = .true.
+   end function has_geom
+
+end submodule has_geom_smod

--- a/generic3g/OuterMetaComponent/initialize_realize.F90
+++ b/generic3g/OuterMetaComponent/initialize_realize.F90
@@ -18,6 +18,7 @@ contains
 
       call this%run_custom(ESMF_METHOD_INITIALIZE, PHASE_NAME, _RC)
       call recurse(this, phase_idx=GENERIC_INIT_REALIZE, _RC)
+      call recurse_read_restart(this, _RC)
       call this%registry%allocate(_RC)
 
       _RETURN(ESMF_SUCCESS)

--- a/generic3g/OuterMetaComponent/read_restart.F90
+++ b/generic3g/OuterMetaComponent/read_restart.F90
@@ -29,7 +29,7 @@ contains
       driver => this%get_user_gc_driver()
       name = driver%get_name()
       ! TODO: Need a better way of identifying a gridcomp that reads a restart
-      if ((name /= "cap") .and. (name /= "HIST") .and. (name /= "EXTDATA")) then
+      if (this%has_geom()) then
          geom = this%get_geom()
          states = driver%get_states()
          call states%get_state(import_state, "import", _RC)
@@ -38,9 +38,7 @@ contains
          call restart_handler%read("import", import_state, _RC)
          call restart_handler%read("internal", internal_state, _RC)
       end if
-      if (name /= "HIST") then
-         call recurse_read_restart(this, _RC)
-      end if
+      call recurse_read_restart(this, _RC)
 
       _RETURN(ESMF_SUCCESS)
       _UNUSED_DUMMY(unusable)

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -32,7 +32,6 @@ contains
 
       if (is_model_pet) then
          call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
-         call driver%read_restart(_RC)
          call integrate(driver, _RC)
          call driver%write_restart(_RC)
          call driver%finalize(_RC)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Added reading restart to the `GENERIC_INIT_REALIZE` phase of initialization. When restart is available (of the form `<gridcomp-name>_<state-intent>_rst.nc4`) it is read by each component that has an allocated `geom`. Also added the query method `OuterMetaComponent::has_geom`.

## Related Issue

#3551
