### PR TITLE
Fixes #3579 - Query gridcomp for grid and num_levels

### DIFF
--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -224,9 +224,10 @@ module mapl3g_OuterMetaComponent
          class(OuterMetaComponent), intent(in) :: this
       end function has_geom
 
-      module function get_geom(this) result(geom)
+      module function get_geom(this, rc) result(geom)
          type(ESMF_Geom) :: geom
          class(OuterMetaComponent), intent(inout) :: this
+         integer, intent(out), optional :: rc
       end function get_geom
 
       module recursive subroutine initialize_set_clock(this, outer_clock, unusable, rc)

--- a/generic3g/OuterMetaComponent/get_geom.F90
+++ b/generic3g/OuterMetaComponent/get_geom.F90
@@ -1,16 +1,20 @@
 #include "MAPL_Generic.h"
 
 submodule (mapl3g_OuterMetaComponent) get_geom_smod
+
+   use mapl_ErrorHandling
    implicit none
 
 contains
 
-   module function get_geom(this) result(geom)
+   module function get_geom(this, rc) result(geom)
       type(ESMF_Geom) :: geom
       class(OuterMetaComponent), intent(inout) :: this
+      integer, intent(out), optional :: rc
 
       geom = this%geom
 
+      _RETURN(_SUCCESS)
    end function get_geom
 
 end submodule get_geom_smod


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

We can now retrieve `grid` and `num_levels` from a gridcomp via `MAPL_GridCompGet`
## Related Issue

#3579 
