### PR TITLE
Fixed #3624. Add logger print to MAPL_read_bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added logging prints for `MAPL_read_bundle`
+
 ### Changed
 
 ### Removed

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -10,7 +10,10 @@ set (srcs
         TileIO.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio
+if (BUILD_WITH_PFLOGGER)
+  find_package(PFLOGGER REQUIRED)
+endif ()
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio PFLOGGER::pflogger
          MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -14,9 +14,12 @@ if (BUILD_WITH_PFLOGGER)
   find_package(PFLOGGER REQUIRED)
 endif ()
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio PFLOGGER::pflogger
-         MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
-target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
+esma_add_library (${this}
+  SRCS ${srcs}
+  DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio MAPL_cfio_r4
+  TYPE ${MAPL_LIBRARY_TYPE})
+
+target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared PFLOGGER::pflogger ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -13,6 +13,7 @@ set (srcs
 if (BUILD_WITH_PFLOGGER)
   find_package(PFLOGGER REQUIRED)
 endif ()
+
 esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio PFLOGGER::pflogger
          MAPL_cfio_r4  TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran

--- a/griddedio/FieldBundleRead.F90
+++ b/griddedio/FieldBundleRead.F90
@@ -22,6 +22,7 @@ module MAPL_ESMFFieldBundleRead
    use MAPL_StringTemplate
    use gFTL_StringVector
    use MAPL_RegridMethods
+   use pFlogger, only: logging, Logger
    use, intrinsic :: iso_fortran_env, only: REAL32
    implicit none
    private
@@ -175,6 +176,14 @@ module MAPL_ESMFFieldBundleRead
          type(GriddedIOItemVector)            :: items
          character(len=ESMF_MAXSTR), allocatable :: field_names(:)
          type(GriddedIOitem) :: item
+
+         class(Logger), pointer :: lgr
+         character(len=ESMF_MAXSTR) :: timestring
+
+         lgr => logging%get_logger('MAPL.GRIDDEDIO')
+
+         call ESMF_TimeGet(time, timeString=timestring, _RC)
+         call lgr%info('MAPL_read_bundle: Reading file '//trim(file_tmpl)//' for time '//trim(timestring))
 
          call fill_grads_template(file_name,file_tmpl,time=time,rc=status)
          _VERIFY(status)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

As described in #3624, `MAPL_CFIORead` outputs a nice print:
```
MAPL_CFIOReadBundle: Reading ana/MERRA2_all/Y2000/M04/MERRA2.ana.eta.20000415_00z.nc4 at 20000415      0
```

But `MAPL_read_bundle` does not. This PR adds a logger print that looks like:
```
      GRIDDEDIO: INFO: MAPL_read_bundle: Reading file /css/era5/replay_data/L137/Y2019/M04/era5-L137.ana.eta.20190415_00z.nc4 for time 2019-04-15T00:00:00
```

Let me know if someone has better thoughts on how to format that print.

## Related Issue

Closes #3624 

