### PR TITLE
Fix bug in profiler demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug in profiler demo
+
 ### Added
 
 ### Changed

--- a/profiler/demo/demo.F90
+++ b/profiler/demo/demo.F90
@@ -1,5 +1,5 @@
 #define I_AM_MAIN
-638 #include "MAPL_ErrLog.h"
+#include "MAPL_ErrLog.h"
 program main
    use MPI
    use MAPL_Profiler
@@ -24,7 +24,7 @@ program main
    lap_prof = TimeProfiler('Lap')
    call lap_prof%start()
    !mem_prof = MemoryProfiler('TOTAL')
-   
+
    call main_prof%start('init reporter')
    call reporter%add_column(NameColumn(20))
    call reporter%add_column(FormattedTextColumn('#-cycles','(i5.0)', 5, NumCyclesColumn()))


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR fixes a bug found in testing the new [CMake Parallel Install](https://cmake.org/cmake/help/latest/prop_gbl/INSTALL_PARALLEL.html#prop_gbl:INSTALL_PARALLEL) capability.

For some reason, `ninja install/parallel` tried to build the `profiler/demo/demo.F90` code and found a rather obvious bug. 

As this has been there for 9 months, we obviously do not build it in our normal build process but `install/parallel` found it.

## Related Issue

