### PR TITLE
Fixes #3692 bracket-vs-vector

### DIFF
--- a/field_bundle/API.F90
+++ b/field_bundle/API.F90
@@ -1,8 +1,9 @@
 module mapl3g_FieldBundle_API
 
+   use mapl3g_FieldBundleType_Flag
+   use mapl3g_FieldBundleCreate, only: MAPL_FieldBundleCreate => FieldBundleCreate
    use mapl3g_FieldBundleGet, only: MAPL_FieldBundleGet => FieldBundleGet
    use mapl3g_FieldBundleSet, only: MAPL_FieldBundleSet => FieldBundleSet
-   use mapl3g_FieldBundleCreate, only: MAPL_FieldBundleCreate
    use mapl3g_FieldBundleInfo, only: MAPL_FieldBundleInfoGetInternal
    use mapl3g_FieldBundleInfo, only: MAPL_FieldBundleInfoSetInternal
 
@@ -16,6 +17,15 @@ module mapl3g_FieldBundle_API
    public :: MAPL_FieldBundleSet
    public :: MAPL_FieldBundleInfoGetInternal
    public :: MAPL_FieldBundleInfoSetInternal
+
+   public :: FieldBundleType_Flag
+   public :: FIELDBUNDLETYPE_INVALID
+   public :: FIELDBUNDLETYPE_BASIC
+   public :: FIELDBUNDLETYPE_VECTOR
+   public :: FIELDBUNDLETYPE_BRACKET
+
+   public :: operator(==)
+   public :: operator(/=)
 
    ! Used internally by MAPL
    ! Users shouldn't need these

--- a/field_bundle/FieldBundleCreate.F90
+++ b/field_bundle/FieldBundleCreate.F90
@@ -1,36 +1,64 @@
 #include "MAPL_Generic.h"
 
 module mapl3g_FieldBundleCreate
-
+   use mapl3g_FieldBundleType_Flag
+   use mapl3g_FieldBundleSet
    use mapl_ErrorHandling
+   use mapl_KeywordEnforcer
    use esmf
 
-   implicit none
+   implicit none(type,external)
 
    private
 
-   public :: MAPL_FieldBundleCreate
+   public :: FieldBundleCreate
 
-   interface MAPL_FieldBundleCreate
+   interface FieldBundleCreate
+      procedure create_bundle_empty
       procedure create_bundle_from_state
       procedure create_bundle_from_field_list
-   end interface MAPL_FieldBundleCreate
+   end interface FieldBundleCreate
 
 contains
 
-   function create_bundle_from_state(state, rc) result(bundle)
-      type(ESMF_State), intent(in) :: state
-      integer, optional, intent(out) :: rc
+   function create_bundle_empty(unusable, name, fieldBundleType, rc) result(bundle)
       type(ESMF_FieldBundle) :: bundle ! result
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      character(*), optional, intent(in) :: name
+      type(FieldBundleType_Flag), optional, intent(in) :: fieldBundleType
+      integer, optional, intent(out) :: rc
+
+      type(FieldBundleType_Flag) :: fieldbundletype_
+      integer :: status
+
+      bundle = ESMF_FieldBundleCreate(name=name, _RC)
+
+      fieldBundleType_ = FIELDBUNDLETYPE_BASIC
+      if (present(fieldBundleType)) fieldBundleType_ = fieldBundleType
+      call FieldBundleSet(bundle, fieldBundleType=fieldBundleType_)
+
+      _RETURN(_SUCCESS)
+   end function create_bundle_empty
+
+
+   function create_bundle_from_state(state, unusable, name, fieldBundleType, rc) result(bundle)
+      type(ESMF_FieldBundle) :: bundle ! result
+      type(ESMF_State), intent(in) :: state
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      character(*), optional, intent(in) :: name
+      type(FieldBundleType_Flag), optional, intent(in) :: fieldBundleType
+      integer, optional, intent(out) :: rc
 
       character(len=ESMF_MAXSTR), allocatable :: item_name(:)
       type (ESMF_StateItem_Flag), allocatable  :: item_type(:)
       type(ESMF_Field) :: field
       type(ESMF_FieldStatus_Flag) :: field_status
+      type(FieldBundleType_Flag) :: fieldbundletype_
       integer :: item_count, idx, status
 
       ! bundle to pack fields in
-      bundle = ESMF_FieldBundleCreate(_RC)
+      bundle = FieldBundleCreate(name=name, fieldBundleType=fieldBundleType, _RC)
+
       call ESMF_StateGet(state, itemCount=item_count, _RC)
       allocate(item_name(item_count), _STAT)
       allocate(item_type(item_count), _STAT)
@@ -45,17 +73,25 @@ contains
             call ESMF_FieldBundleAdd(bundle, [field], _RC)
          end if
       end do
+
       deallocate(item_name, item_type, _STAT)
 
       _RETURN(_SUCCESS)
    end function create_bundle_from_state
 
-   function create_bundle_from_field_list(field_list, rc) result(bundle)
-      type(ESMF_Field), intent(in) :: field_list(:)
-      integer, optional, intent(out) :: rc
+   function create_bundle_from_field_list(fieldList, unusable, name, fieldBundleType, rc) result(bundle)
       type(ESMF_FieldBundle) :: bundle ! result
+      type(ESMF_Field), intent(in) :: fieldList(:)
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      character(*), optional, intent(in) :: name
+      type(FieldBundleType_Flag), optional, intent(in) :: fieldBundleType
+      integer, optional, intent(out) :: rc
 
-      _FAIL("not implemented yet")
+      integer :: status
+      bundle = FieldBundleCreate(name=name, fieldBundleType=fieldBundleType, _RC)
+      call ESMF_FieldBundleAdd(bundle, fieldList=fieldList, _RC)
+
+      _RETURN(_SUCCESS)
    end function create_bundle_from_field_list
 
 end module mapl3g_FieldBundleCreate

--- a/field_bundle/FieldBundleGet.F90
+++ b/field_bundle/FieldBundleGet.F90
@@ -20,8 +20,6 @@ module mapl3g_FieldBundleGet
       procedure bundle_get
    end interface FieldBundleGet
 
-   character(*), parameter :: KEY_FIELD_BUNDLE_TYPE = '/fieldBundleType'
-
 contains
 
    ! Supplement ESMF FieldBundleGet

--- a/field_bundle/FieldBundleInfo.F90
+++ b/field_bundle/FieldBundleInfo.F90
@@ -25,6 +25,8 @@ module mapl3g_FieldBundleInfo
       procedure fieldbundle_set_internal
    end interface
 
+   character(*), parameter :: KEY_FIELDBUNDLETYPE_FLAG = '/FieldBundleType_Flag'
+
 
 contains
 
@@ -64,7 +66,7 @@ contains
       end if
 
       if (present(fieldBundleType)) then
-         call ESMF_InfoGet(info, key=namespace_//KEY_FIELDBUNDLETYPE, value=fieldBundleType_str, _RC)
+         call ESMF_InfoGetCharAlloc(info, key=namespace_//KEY_FIELDBUNDLETYPE_FLAG, value=fieldBundleType_str, _RC)
          fieldBundleType = FieldBundleType_Flag(fieldBundleType_str)
       end if
 
@@ -149,7 +151,7 @@ contains
 
       if (present(fieldBundleType)) then
          fieldBundleType_str = fieldBundleType%to_string()
-         call ESMF_InfoSet(info, key=namespace_ // KEY_FIELDBUNDLETYPE, value=fieldBundleType_str, _RC)
+         call ESMF_InfoSet(info, key=namespace_ // KEY_FIELDBUNDLETYPE_FLAG, value=fieldBundleType_str, _RC)
       end if
 
       if (present(interpolation_weights)) then

--- a/field_bundle/FieldBundleSet.F90
+++ b/field_bundle/FieldBundleSet.F90
@@ -20,8 +20,6 @@ module mapl3g_FieldBundleSet
       procedure bundle_set
    end interface FieldBundleSet
 
-   character(*), parameter :: KEY_FIELD_BUNDLE_TYPE = '/fieldBundleType'
-
 contains
 
   subroutine bundle_set(fieldBundle, unusable, &

--- a/field_bundle/FieldBundleType_Flag.F90
+++ b/field_bundle/FieldBundleType_Flag.F90
@@ -4,7 +4,9 @@ module mapl3g_FieldBundleType_Flag
 
    public :: FieldBundleType_Flag
    public :: FIELDBUNDLETYPE_BASIC
+   public :: FIELDBUNDLETYPE_VECTOR
    public :: FIELDBUNDLETYPE_BRACKET
+   public :: FIELDBUNDLETYPE_VECTOR_BRACKET
    public :: FIELDBUNDLETYPE_INVALID
 
    public :: operator(==)
@@ -31,7 +33,9 @@ module mapl3g_FieldBundleType_Flag
    end interface operator(/=)
 
    type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_BASIC = FieldBundleType_Flag(1, "FIELDBUNDLETYPE_BASIC")
-   type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_BRACKET = FieldBundleType_Flag(2, "FIELDBUNDLETYPE_BRACKET")
+   type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_VECTOR = FieldBundleType_Flag(2, "FIELDBUNDLETYPE_VECTOR")
+   type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_BRACKET = FieldBundleType_Flag(3, "FIELDBUNDLETYPE_BRACKET")
+   type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_VECTOR_BRACKET = FieldBundleType_Flag(4, "FIELDBUNDLETYPE_VECTOR_BRACKET")
    type(FieldBundleType_Flag), parameter :: FIELDBUNDLETYPE_INVALID = FieldBundleType_Flag(-1, "FIELDBUNDLETYPE_INVALID")
 
 contains
@@ -43,6 +47,8 @@ contains
       select case (name)
       case ("FIELDBUNDLETYPE_BASIC")
          type_flag = FIELDBUNDLETYPE_BASIC
+      case ("FIELDBUNDLETYPE_VECTOR")
+         type_flag = FIELDBUNDLETYPE_VECTOR
       case ("FIELDBUNDLETYPE_BRACKET")
          type_flag = FIELDBUNDLETYPE_BRACKET
       case default

--- a/field_bundle/tests/Test_FieldBundleDelta.pf
+++ b/field_bundle/tests/Test_FieldBundleDelta.pf
@@ -102,7 +102,7 @@ contains
       type(UngriddedDims) :: ungridded_dims
       type(VerticalStaggerLoc) :: vert_staggerloc
 
-      bundle = ESMF_FieldBundleCreate()
+      bundle = MAPL_FieldBundleCreate()
       call MAPL_FieldBundleSet(bundle, geom=geom)
       fieldCount = size(weights) - 1
       do i = 1, fieldCount
@@ -421,6 +421,7 @@ contains
       character(:), allocatable :: new_units
       real(kind=ESMF_KIND_R4), allocatable :: weights(:)
       real(kind=ESMF_KIND_R4), parameter :: new_weights(*) = [0.,0.25,0.75]
+      type(ESMF_Grid) :: grid, tmp_grid
 
       call setup_geom(geom, 4)
       call setup_bundle(bundle, weights=[5.], geom=geom, typekind=ESMF_TYPEKIND_R4, units='km')
@@ -439,7 +440,9 @@ contains
          @assertEqual('km', new_units)
 
          call ESMF_FieldGet(fieldList(i), geom=tmp_geom, _RC)
-         @assert_that(tmp_geom == geom, is(true()))
+         call ESMF_GeomGet(geom, grid=grid, _RC)
+         call ESMF_GeomGet(tmp_geom, grid=tmp_grid, _RC)
+         @assert_that(tmp_grid == grid, is(true()))
       end do
 
       call MAPL_FieldBundleGet(bundle, interpolation_weights=weights, _RC)
@@ -472,6 +475,7 @@ contains
       real(kind=ESMF_KIND_R4), parameter :: new_weights(*) = [0.,0.25,0.75]
       integer :: nlevels
       type(UngriddedDims) :: ungridded_dims
+      type(ESMF_Grid) :: grid, tmp_grid
 
       call setup_geom(geom, 4)
       call setup_bundle(bundle, weights=[5.], geom=geom, typekind=ESMF_TYPEKIND_R4, units='km', &
@@ -491,7 +495,9 @@ contains
          @assertEqual('km', new_units)
 
          call ESMF_FieldGet(fieldList(i), geom=tmp_geom, _RC)
-         @assert_that(tmp_geom == geom, is(true()))
+         call ESMF_GeomGet(geom, grid=grid, _RC)
+         call ESMF_GeomGet(tmp_geom, grid=tmp_grid, _RC)
+         @assert_that(tmp_grid == grid, is(true()))
 
          call MAPL_FieldGet(fieldList(i), ungridded_dims=ungridded_dims, _RC)
          @assert_that(ungridded_dims%get_num_ungridded(), is(1))

--- a/generic3g/specs/BracketClassAspect.F90
+++ b/generic3g/specs/BracketClassAspect.F90
@@ -122,7 +122,7 @@ contains
 
       integer :: status
 
-      this%payload = ESMF_FieldBundleCreate(_RC)
+      this%payload = MAPL_FieldBundleCreate(fieldBundleType=FIELDBUNDLETYPE_BRACKET, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine create

--- a/generic3g/specs/VectorClassAspect.F90
+++ b/generic3g/specs/VectorClassAspect.F90
@@ -117,7 +117,7 @@ contains
 
       integer :: status
 
-      this%payload = ESMF_FieldBundleCreate(_RC)
+      this%payload = MAPL_FieldBundleCreate(fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
 
       _RETURN(ESMF_SUCCESS)
    end subroutine create

--- a/regridder_mgr/EsmfRegridder.F90
+++ b/regridder_mgr/EsmfRegridder.F90
@@ -33,7 +33,7 @@ module mapl3g_EsmfRegridder
       type(EsmfRegridderParam) :: regridder_param
       type(ESMF_Routehandle) :: routehandle
    contains
-      procedure :: regrid_scalar
+      procedure :: regrid_field
    end type EsmfRegridder
 
 
@@ -102,7 +102,7 @@ contains
 
    end function new_EsmfRegridder
 
-   subroutine regrid_scalar(this, f_in, f_out, rc)
+   subroutine regrid_field(this, f_in, f_out, rc)
       class(EsmfRegridder), intent(inout) :: this
       type(ESMF_Field), intent(inout) :: f_in, f_out
       integer, optional, intent(out) :: rc
@@ -141,7 +141,7 @@ contains
              _RC)
       end associate
       _RETURN(_SUCCESS)
-   end subroutine regrid_scalar
+   end subroutine regrid_field
 
    subroutine regrid_ungridded(this, mask, f_in, f_out, n, rc)
       class(EsmfRegridder), intent(inout) :: this

--- a/regridder_mgr/NullRegridder.F90
+++ b/regridder_mgr/NullRegridder.F90
@@ -13,7 +13,7 @@ module mapl3g_NullRegridder
    type, extends(Regridder) :: NullRegridder
       private
    contains
-      procedure :: regrid_scalar
+      procedure :: regrid_field
    end type NullRegridder
 
    type(NullRegridder), protected :: NULL_REGRIDDER
@@ -25,13 +25,13 @@ contains
       
    end function new_NullRegridder
 
-   subroutine regrid_scalar(this, f_in, f_out, rc)
+   subroutine regrid_field(this, f_in, f_out, rc)
       class(NullRegridder), intent(inout) :: this
       type(ESMF_Field), intent(inout) :: f_in, f_out
       integer, optional, intent(out) :: rc
 
       _FAIL('Null regridder')
-   end subroutine regrid_scalar
+   end subroutine regrid_field
 
 end module mapl3g_NullRegridder
       

--- a/regridder_mgr/tests/Test_RegridderManager.pf
+++ b/regridder_mgr/tests/Test_RegridderManager.pf
@@ -6,6 +6,7 @@ module Test_RegridderManager
    use mapl3g_VerticalStaggerLoc
    use mapl3g_regridder_mgr
    use mapl3g_Geom_API
+   use mapl3g_FieldBundle_API
    use mapl_BaseMod, only: MAPL_UNDEF
    use esmf_TestMethod_mod ! mapl
    use esmf
@@ -291,7 +292,7 @@ contains
       ! North-east field
       f1 = make_field(geom_1, 'u', value=2._ESMF_KIND_R4, _RC)
       f2 = make_field(geom_1, 'v', value=2._ESMF_KIND_R4, _RC)
-      uv1 = ESMF_FieldBundleCreate(name='[u,v]', fieldList=[f1,f2], _RC)
+      uv1 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f1,f2], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
 
       call ESMF_FieldGet(f1, farrayptr=u1, _RC)
       u1(::4,6) = MAPL_UNDEF ! checkerboard
@@ -301,7 +302,7 @@ contains
       
       f3 = make_field(geom_2, 'u', value=0._ESMF_KIND_R4, _RC)
       f4 = make_field(geom_2, 'v', value=0._ESMF_KIND_R4, _RC)
-      uv2 = ESMF_FieldBundleCreate(name='[u,v]', fieldList=[f3,f4], _RC)
+      uv2 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f3,f4], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
 
       call my_regridder%regrid(uv1, uv2, _RC)
 
@@ -317,5 +318,61 @@ contains
    end subroutine test_regrid_2d_vector
 
 
-end module Test_RegridderManager
+   @test(type=ESMF_TestMethod, npes=[1])
+   ! Test that regridder distinguishes flavors of FieldBundle
+   subroutine test_regrid_bracket(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(GeomManager), target :: geom_mgr
+      type(RegridderManager), target :: regridder_mgr
+      type(RegridderSpec) :: spec
+      integer :: status
+      class(Regridder), pointer :: my_regridder
+      type(ESMF_Geom) :: geom_1, geom_2
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Field) :: f1, f2, f3, f4
+      type(ESMF_Fieldbundle) :: xy1, xy2
+      real(kind=ESMF_KIND_R4), pointer :: x1(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: y1(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: x2(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: y2(:,:)
 
+      type(DynamicMask) :: dyn_mask
+      
+      geom_mgr = GeomManager()
+      regridder_mgr = RegridderManager(geom_mgr)
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 12, jm_world: 13, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      geom_1 = make_geom(geom_mgr, hconfig, _RC)
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 6, jm_world: 5, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      geom_2 = make_geom(geom_mgr, hconfig, _RC) ! variant of geom_1
+
+      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=real(MAPL_UNDEF,kind=ESMF_KIND_R8), handleAllElements=.true.,_RC)
+      
+      spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dyn_mask=dyn_mask), geom_1, geom_2)
+      my_regridder => regridder_mgr%get_regridder(spec, _RC)
+
+      ! North-east field
+      f1 = make_field(geom_1, 'x', value=1._ESMF_KIND_R4, _RC)
+      f2 = make_field(geom_1, 'y', value=10._ESMF_KIND_R4, _RC)
+      xy1 = MAPL_FieldBundleCreate(name='[x,y]', fieldList=[f1,f2], fieldBundleType=FIELDBUNDLETYPE_BRACKET, _RC)
+
+      call ESMF_FieldGet(f1, farrayptr=x1, _RC)
+      call ESMF_FieldGet(f2, farrayptr=y1, _RC)
+      
+      f3 = make_field(geom_2, 'x', value=0._ESMF_KIND_R4, _RC)
+      f4 = make_field(geom_2, 'y', value=0._ESMF_KIND_R4, _RC)
+      xy2 = MAPL_FieldBundleCreate(name='[x,y]', fieldList=[f3,f4], fieldBundleType=FIELDBUNDLETYPE_BRACKET, _RC)
+
+      call my_regridder%regrid(xy1, xy2, _RC)
+
+      call ESMF_FieldGet(f3, farrayptr=x2, _RC)
+      call ESMF_FieldGet(f4, farrayptr=y2, _RC)
+
+      ! If treated as vector, the components would mix.  We check here that they do not.
+      @assert_that(x2, every_item(is(near(1._ESMF_KIND_R4, 1.e-5))))
+      @assert_that(y2, every_item(is(near(10._ESMF_KIND_R4, 1.e-5))))
+
+   end subroutine test_regrid_bracket
+
+end module Test_RegridderManager


### PR DESCRIPTION
This change ensures that vector FieldBundles are regridded differently than ordinary flat FieldBundles.  This includes bracket FieldBundles. Added one unit test to verify.

Most of the changes are simply updating conventions and such while I was in there makking changes.

Sort of a bug fix, but was not exercised yet.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

