### PR TITLE
v3: Add missing ESSENTIAL label to some tests

### DIFF
--- a/field/tests/CMakeLists.txt
+++ b/field/tests/CMakeLists.txt
@@ -26,3 +26,7 @@ add_pfunit_ctest(MAPL.field.test_utils
                 MAX_PES 4
                 )
 add_dependencies(build-tests MAPL.field.test_fieldcreate MAPL.field.test_fieldreset MAPL.field.test_utils)
+
+set_target_properties(MAPL.field.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.field.tests PROPERTIES LABELS "ESSENTIAL")
+

--- a/field_bundle/tests/CMakeLists.txt
+++ b/field_bundle/tests/CMakeLists.txt
@@ -8,3 +8,7 @@ add_pfunit_ctest(MAPL.field_bundle.tests
                 MAX_PES 4
                 )
 add_dependencies(build-tests MAPL.field_bundle.tests)
+
+set_target_properties(MAPL.field_bundle.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+set_tests_properties(MAPL.field_bundle.tests PROPERTIES LABELS "ESSENTIAL")
+


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

A survey of the unit tests in MAPL3 shows that some were not labeled `ESSENTIAL` and so were being skipped.

NOTE: Per @tclune one of these should fail!

## Related Issue

Closes #3632 
