### PR TITLE
Update ESMA_cmake to v3.58.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `components.yaml`
+  - `ESMA_cmake` v3.58.2
+    - Fix for XCode 16.3
+
 ### Removed
 
 ### Deprecated

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.58.1
+  tag: v3.58.2
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates ESMA_cmake to v3.58.2 which has a fix to allow building on XCode 16.3 by removing the use of `-Wl,-ld_classic`

## Related Issue

https://github.com/GEOS-ESM/ESMA_cmake/issues/438
