### PR TITLE
Fixes #3646 - fixed a bug that was calculating num_vgrid_levels wrong

### DIFF
--- a/field/FieldInfo.F90
+++ b/field/FieldInfo.F90
@@ -113,7 +113,7 @@ contains
                call MAPL_InfoSet(info, namespace_ // "/vertical_grid/num_levels", 0, _RC)
             else if (vert_staggerLoc == VERTICAL_STAGGER_EDGE) then
                call MAPL_InfoSet(info, namespace_ // "/vertical_dim/vloc", "VERTICAL_DIM_EDGE", _RC)
-               call MAPL_InfoSet(info, namespace_ // "/vertical_grid/num_levels", num_levels+1, _RC)
+               call MAPL_InfoSet(info, namespace_ // "/vertical_grid/num_levels", num_levels-1, _RC)
             else if (vert_staggerLoc == VERTICAL_STAGGER_CENTER) then
                call MAPL_InfoSet(info, namespace_ // "/vertical_dim/vloc", "VERTICAL_DIM_CENTER", _RC)
                call MAPL_InfoSet(info, namespace_ // "/vertical_grid/num_levels", num_levels, _RC)
@@ -189,7 +189,7 @@ contains
          if (vert_staggerloc_ == VERTICAL_STAGGER_NONE) then
             num_vgrid_levels = 0
          else if (vert_staggerloc_ == VERTICAL_STAGGER_EDGE) then
-            num_vgrid_levels = num_levels_ + 1
+            num_vgrid_levels = num_levels_ - 1
          else if (vert_staggerloc_ == VERTICAL_STAGGER_CENTER) then
             num_vgrid_levels = num_levels_
          else


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

Fixes #3646 