### PR TITLE
avoid using undefined comp_name in MAPL_GridCreate when gc is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- define comp_name in MAPL_GridCrate when GC is not present
+- define `comp_name` in `MAPL_GridCreate` when GC is not present
 - Fixed bug in profiler demo
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug in MAPL_GridCreate to set "NX" and clean up when GC is not present
 - Fixed bug in profiler demo
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix a bug in MAPL_GridCreate to set "NX" and clean up when GC is not present
+- define comp_name in MAPL_GridCrate when GC is not present
 - Fixed bug in profiler demo
 
 ### Added

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -10098,8 +10098,9 @@ contains
       nn = len_trim(gridname)
       dateline = gridname(nn-1:nn)
       if (dateline == 'CF') then
+         ! convert global NY to a local NY for each face
          call ESMF_ConfigGetAttribute(state%CF,ny,label=trim(Prefix)//'NY:', _RC)
-         call MAPL_ConfigSetAttribute(state%CF, value=ny/6, label=trim(Prefix)//'NX:', _RC)
+         call MAPL_ConfigSetAttribute(state%CF, value=ny/6, label=trim(Prefix)//'NY:', _RC)
       end if
 
       grid = grid_manager%make_grid(state%CF, prefix=trim(Prefix), _RC)

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -10052,24 +10052,20 @@ contains
       !---------
 
       Iam='MAPL_GridCreate'
+      Prefix = ''
       if(present(GC)) then
-         call ESMF_GridCompGet( GC, name=Comp_Name,   rc = status )
-         _VERIFY(status)
+         call ESMF_GridCompGet( GC, name=Comp_Name,   _RC)
          Iam = trim(Comp_Name)//Iam
          Prefix = trim(comp_name)//MAPL_CF_COMPONENT_SEPARATOR
-      else
-         Prefix = ''
       endif
 
       ! New option to get grid from existing component
       !-----------------------------------------------
 
       if(present(srcGC)) then
-         call ESMF_GridCompGet ( srcGC, grid=Grid, RC=status )
-         _VERIFY(status)
+         call ESMF_GridCompGet ( srcGC, grid=Grid, _RC)
          if(present(GC)) then
-            call ESMF_GridCompSet(GC, GRID=GRID, RC=status)
-            _VERIFY(status)
+            call ESMF_GridCompSet(GC, GRID=GRID, _RC)
          end if
          if(present(ESMFGRID)) then
             ESMFGRID=GRID
@@ -10079,16 +10075,14 @@ contains
 
 
 
-      call ESMF_VMGetCurrent(vm, rc=status)
-      _VERIFY(status)
+      call ESMF_VMGetCurrent(vm, _RC)
 
       ! Get MAPL object
       !----------------
 
       if(present(GC)) then
          _ASSERT(.not. present(MAPLOBJ),'needs informative message')
-         call MAPL_InternalStateGet(GC, STATE, RC=status)
-         _VERIFY(status)
+         call MAPL_InternalStateGet(GC, STATE, _RC)
       elseif(present(MAPLOBJ)) then
          STATE => MAPLOBJ
       else
@@ -10096,31 +10090,24 @@ contains
       endif
 
       if (trim(Prefix) /= '') then
-         call MAPL_ConfigPrepend(state%cf,trim(comp_name),MAPL_CF_COMPONENT_SEPARATOR,'NX:',rc=status)
-         _VERIFY(status)
-         call MAPL_ConfigPrepend(state%cf,trim(comp_name),MAPL_CF_COMPONENT_SEPARATOR,'NY:',rc=status)
-         _VERIFY(status)
+         call MAPL_ConfigPrepend(state%cf,trim(comp_name),MAPL_CF_COMPONENT_SEPARATOR,'NX:', _RC)
+         call MAPL_ConfigPrepend(state%cf,trim(comp_name),MAPL_CF_COMPONENT_SEPARATOR,'NY:', _RC)
       endif
 
-      call ESMF_ConfigGetAttribute(state%cf,gridname,label=trim(Prefix)//'GRIDNAME:',rc=status)
-      _VERIFY(status)
+      call ESMF_ConfigGetAttribute(state%cf,gridname,label=trim(Prefix)//'GRIDNAME:', _RC)
       nn = len_trim(gridname)
       dateline = gridname(nn-1:nn)
       if (dateline == 'CF') then
-         call ESMF_ConfigGetAttribute(state%CF,ny,label=trim(Prefix)//'NY:',rc=status)
-         _VERIFY(status)
-         call MAPL_ConfigSetAttribute(state%CF, value=ny/6, label=trim(Prefix)//'NX:',rc=status)
-         _VERIFY(status)
+         call ESMF_ConfigGetAttribute(state%CF,ny,label=trim(Prefix)//'NY:', _RC)
+         call MAPL_ConfigSetAttribute(state%CF, value=ny/6, label=trim(Prefix)//'NX:', _RC)
       end if
 
-      grid = grid_manager%make_grid(state%CF, prefix=trim(Prefix), rc=status)
-      _VERIFY(status)
+      grid = grid_manager%make_grid(state%CF, prefix=trim(Prefix), _RC)
 
       call state%grid%set(grid, _RC)
 
       if(present(GC)) then
-         call ESMF_GridCompSet(GC, GRID=GRID, RC=status)
-         _VERIFY(status)
+         call ESMF_GridCompSet(GC, GRID=GRID, _RC)
       end if
 
       if(present(ESMFGRID)) then
@@ -10144,10 +10131,8 @@ contains
 
          call ESMF_ConfigGetAttribute( cf, val, label=trim(comp_name)//trim(separator)//trim(label), rc = status )
          if (status /= ESMF_SUCCESS) then
-            call ESMF_ConfigGetAttribute(CF,val,label=trim(label),rc=status)
-            _VERIFY(status)
-            call MAPL_ConfigSetAttribute(CF, val, label=trim(comp_name)//trim(separator)//trim(label),rc=status)
-            _VERIFY(status)
+            call ESMF_ConfigGetAttribute(CF,val,label=trim(label), _RC)
+            call MAPL_ConfigSetAttribute(CF, val, label=trim(comp_name)//trim(separator)//trim(label), _RC)
          end if
 
          _RETURN(ESMF_SUCCESS)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

When argument gc is not present, comp_name is not defined but used. That leads to unwanted label. Also,  there is typo in setting  prefix//NX:  

## Related Issue

