### PR TITLE
Update to use Baselibs 7.33.0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `components.yaml`
-  - `ESMA_cmake` v3.58.2
+  - `ESMA_env` v4.37.0
+    - Update to Baselibs 7.33.0
+      - ESMF 8.8.1 (needed for MAPL3)
+      - Fixes for CMake 4
+  - `ESMA_cmake` v3.59.0
     - Fix for XCode 16.3
+    - Fixes for f2py with MPT
 
 ### Removed
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.36.0
+  tag: v4.37.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.58.2
+  tag: v3.59.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates the `components.yaml` to use Baselibs 7.33.0 which gets us ESMF 8.8.1 (needed for MAPL3, see #3639 by @pchakraborty).

I'm doing this in MAPL2 first because no reason to be out of sync with MAPL3 yet.

## Related Issue

