### PR TITLE
Fixes #3673 - remove vert_only from field's internal info 

### DIFF
--- a/field/FieldCreate.F90
+++ b/field/FieldCreate.F90
@@ -116,7 +116,6 @@ contains
            ungridded_dims=ungridded_dims, &
            num_levels=num_levels, &
            vert_staggerloc=vert_staggerloc_, &
-           grid_to_field_map=grid_to_field_map, &
            units=units, &
            standard_name=standard_name, &
            long_name=long_name, &

--- a/field/FieldInfo.F90
+++ b/field/FieldInfo.F90
@@ -43,7 +43,6 @@ module mapl3g_FieldInfo
    character(*), parameter :: KEY_STANDARD_NAME = "/standard_name"
    character(*), parameter :: KEY_NUM_LEVELS = "/num_levels"
    character(*), parameter :: KEY_VERT_STAGGERLOC = "/vert_staggerloc"
-   character(*), parameter :: KEY_VERT_ONLY = "/vert_only"
    character(*), parameter :: KEY_UNGRIDDED_DIMS = "/ungridded_dims"
    character(*), parameter :: KEY_IS_ACTIVE = "/is_active"
 
@@ -57,7 +56,6 @@ contains
         namespace, &
         num_levels, vert_staggerloc, &
         ungridded_dims, &
-        grid_to_field_map, &
         units, long_name, standard_name, &
         is_active, &
         rc)
@@ -68,7 +66,6 @@ contains
       integer, optional, intent(in) :: num_levels
       type(VerticalStaggerLoc), optional, intent(in) :: vert_staggerloc
       type(UngriddedDims), optional, intent(in) :: ungridded_dims
-      integer, optional, intent(in) :: grid_to_field_map(:)
       character(*), optional, intent(in) :: units
       character(*), optional, intent(in) :: long_name
       character(*), optional, intent(in) :: standard_name
@@ -78,7 +75,6 @@ contains
       integer :: status
       type(ESMF_Info) :: ungridded_info
       character(:), allocatable :: namespace_
-      logical :: vert_only
 
       namespace_ = INFO_INTERNAL_NAMESPACE
       if (present(namespace)) then
@@ -88,12 +84,6 @@ contains
       if (present(ungridded_dims)) then
          ungridded_info = ungridded_dims%make_info(_RC)
          call MAPL_InfoSet(info, namespace_ // KEY_UNGRIDDED_DIMS, ungridded_info, _RC)
-      end if
-
-      if (present(grid_to_field_map)) then
-         vert_only = .false.
-         if (all(grid_to_field_map==0)) vert_only = .true.
-         call MAPL_InfoSet(info, namespace_ // KEY_VERT_ONLY, vert_only, _RC)
       end if
 
       if (present(units)) then
@@ -147,7 +137,6 @@ contains
         num_levels, vert_staggerloc, num_vgrid_levels, &
         units, long_name, standard_name, &
         ungridded_dims, &
-        vert_only, &
         is_active, &
         rc)
 
@@ -161,7 +150,6 @@ contains
       character(:), optional, allocatable, intent(out) :: long_name
       character(:), optional, allocatable, intent(out) :: standard_name
       type(UngriddedDims), optional, intent(out) :: ungridded_dims
-      logical, optional, intent(out) :: vert_only
       logical, optional, intent(out) :: is_active
       integer, optional, intent(out) :: rc
 
@@ -219,10 +207,6 @@ contains
 
       if (present(standard_name)) then
          call MAPL_InfoGet(info, namespace_ // KEY_STANDARD_NAME, standard_name, _RC)
-      end if
-
-      if (present(vert_only)) then
-         call MAPL_InfoGet(info, namespace_ // KEY_VERT_ONLY, vert_only, _RC)
       end if
 
       if (present(is_active)) then

--- a/field/tests/Test_FieldCreate.pf
+++ b/field/tests/Test_FieldCreate.pf
@@ -3,14 +3,14 @@
 
 module Test_FieldCreate
 
-   use mapl3g_Field_API, only: MAPL_FieldCreate, MAPL_FieldEmptyComplete, MAPL_FieldGet, MAPL_FieldInfoGetInternal
+   use mapl3g_Field_API, only: MAPL_FieldCreate, MAPL_FieldEmptyComplete, MAPL_FieldGet
    use mapl3g_VerticalStaggerLoc, only: VERTICAL_STAGGER_EDGE, VERTICAL_STAGGER_CENTER
    use mapl3g_FieldCondensedArray, only: assign_fptr_condensed_array
    use funit
    use ESMF_TestMethod_mod
    use esmf
 
-   implicit none(type, external)
+   implicit none(type,external)
 
 contains
 
@@ -50,10 +50,8 @@ contains
       type(ESMF_Field) :: field
       type(ESMF_Geom) :: geom
       type(ESMF_Grid) :: grid
-      type(ESMF_Info) :: field_info
       real(kind=ESMF_KIND_R4), pointer :: farray(:, :, :)
       integer, parameter :: num_vgrid_levels = 5
-      logical :: vert_only
       integer :: num_levels, status
 
       field = ESMF_FieldEmptyCreate(_RC)
@@ -72,9 +70,6 @@ contains
       @assertEqual(num_levels, num_vgrid_levels+1)
       call assign_fptr_condensed_array(field, farray, _RC)
       @assertEqual(shape(farray), [1, num_vgrid_levels+1, 1])
-      call ESMF_InfoGetFromHost(field, field_info, _RC)
-      call MAPL_FieldInfoGetInternal(field_info, vert_only=vert_only, _RC)
-      @assertTrue(vert_only)
 
       call ESMF_FieldDestroy(field, _RC)
       call ESMF_GeomDestroy(geom, _RC)
@@ -90,10 +85,8 @@ contains
       type(ESMF_Field) :: field
       type(ESMF_Geom) :: geom
       type(ESMF_Grid) :: grid
-      type(ESMF_info) :: field_info
       real(kind=ESMF_KIND_R4), pointer :: farray(:, :, :)
       integer, parameter :: num_vgrid_levels = 5
-      logical :: vert_only
       integer :: num_levels, status
 
       field = ESMF_FieldEmptyCreate(_RC)
@@ -111,9 +104,6 @@ contains
       @assertEqual(num_levels, num_vgrid_levels)
       call assign_fptr_condensed_array(field, farray, _RC)
       @assertEqual(shape(farray), [6, num_vgrid_levels, 1])
-      call ESMF_InfoGetFromHost(field, field_info, _RC)
-      call MAPL_FieldInfoGetInternal(field_info, vert_only=vert_only, _RC)
-      @assertFalse(vert_only)
 
       call ESMF_FieldDestroy(field, _RC)
       call ESMF_GeomDestroy(geom, _RC)


### PR DESCRIPTION
This reverts commit cbb6f71f94d92afc4dd905c1676386ec34345cf8.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Undid a commit that added the key `vert_only` to a field's internal info. This was redundant since we can query a field for its `GridToFieldMap` and check if it is vertical only.

## Related Issue

Fixes #3673 