### PR TITLE
Port ESMF_PINFLAG change from 2.53 work into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a new `StateFilterItem` funtion to apply a mask or extra using a combination of variables from a state and return an array with the result
+- Implemented a new feature in to allow users to select the appropriate [`ESMF_PIN`](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node6.html#const:pin_flag) values. Users control this via `CAP.rc` and the choices are:
+  - `ESMF_PINFLAG: PET` --> `ESMF_PIN_DE_TO_PET`
+  - `ESMF_PINFLAG: VAS` --> `ESMF_PIN_DE_TO_VAS`
+  - `ESMF_PINFLAG: SSI` --> `ESMF_PIN_DE_TO_SSI`
+  - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
+
 
 ### Changed
 
@@ -98,15 +104,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CI to use Baselibs 7.31.0
   - Updates to GFE v1.18.0
 - Use oserver for Mask sampler
+
 ## [2.53.3] - 2025-05-02
 
 ### Added
 
 - Implemented a new feature in to allow users to select the appropriate [`ESMF_PIN`](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node6.html#const:pin_flag) values. Users control this via `CAP.rc` and the choices are:
-  - `ESMF_PIN: PET` --> `ESMF_PIN_DE_TO_PET`
-  - `ESMF_PIN: VAS` --> `ESMF_PIN_DE_TO_VAS`
-  - `ESMF_PIN: SSI` --> `ESMF_PIN_DE_TO_SSI`
-  - `ESMF_PIN: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
+  - `ESMF_PINFLAG: PET` --> `ESMF_PIN_DE_TO_PET`
+  - `ESMF_PINFLAG: VAS` --> `ESMF_PIN_DE_TO_VAS`
+  - `ESMF_PINFLAG: SSI` --> `ESMF_PIN_DE_TO_SSI`
+  - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
 
 ## [2.53.2] - 2025-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ESMF_PINFLAG: PET` --> `ESMF_PIN_DE_TO_PET`
   - `ESMF_PINFLAG: VAS` --> `ESMF_PIN_DE_TO_VAS`
   - `ESMF_PINFLAG: SSI` --> `ESMF_PIN_DE_TO_SSI`
-  - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
+  - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG` (default with no setting)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ESMF_PINFLAG: SSI` --> `ESMF_PIN_DE_TO_SSI`
   - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
 
-
 ### Changed
 
 - Update `components.yaml`
@@ -106,22 +105,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated CI to use Baselibs 7.31.0
   - Updates to GFE v1.18.0
 - Use oserver for Mask sampler
-
-## [2.53.3] - 2025-05-02
-
-### Added
-
-- Implemented a new feature in to allow users to select the appropriate [`ESMF_PIN`](https://earthsystemmodeling.org/docs/release/latest/ESMF_refdoc/node6.html#const:pin_flag) values. Users control this via `CAP.rc` and the choices are:
-  - `ESMF_PINFLAG: PET` --> `ESMF_PIN_DE_TO_PET`
-  - `ESMF_PINFLAG: VAS` --> `ESMF_PIN_DE_TO_VAS`
-  - `ESMF_PINFLAG: SSI` --> `ESMF_PIN_DE_TO_SSI`
-  - `ESMF_PINFLAG: SSI_CONTIG` --> `ESMF_PIN_DE_TO_SSI_CONTIG`
-
-## [2.53.2] - 2025-03-20
-
-### Changed
-
-- Relaxed the MPI thread levels to MPI_THREAD_SERIALIZED required by ESMF
 
 ## [2.53.1] - 2025-01-29
 

--- a/base/ApplicationSupport.F90
+++ b/base/ApplicationSupport.F90
@@ -8,7 +8,7 @@ module MAPL_ApplicationSupport
  use udunits2f, initialize_udunits => initialize, finalize_udunits => finalize
  use MAPL_Profiler, initialize_profiler =>initialize, finalize_profiler =>finalize
  use ESMF
- 
+
  implicit none
  private
 
@@ -17,11 +17,10 @@ module MAPL_ApplicationSupport
 
  contains
 
-   subroutine MAPL_Initialize(unusable,comm,logging_config,pinflag,rc)
+   subroutine MAPL_Initialize(unusable,comm,logging_config,rc)
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(in) :: comm
       character(len=*), optional,intent(in) :: logging_config
-      type(ESMF_PIN_Flag), optional, intent(in) :: pinflag
       integer, optional, intent(out) :: rc
 
       character(:), allocatable :: logging_configuration_file
@@ -48,11 +47,6 @@ module MAPL_ApplicationSupport
       _VERIFY(status)
       call initialize_udunits(_RC)
       _RETURN(_SUCCESS)
-
-      if (present(pinflag)) then
-         ! call pinflag setter
-         call MAPL_PinFlagSet(pinflag)
-      end if
 
    end subroutine MAPL_Initialize
 

--- a/base/ApplicationSupport.F90
+++ b/base/ApplicationSupport.F90
@@ -7,7 +7,6 @@ module MAPL_ApplicationSupport
  use pflogger, only: Logger
  use udunits2f, initialize_udunits => initialize, finalize_udunits => finalize
  use MAPL_Profiler, initialize_profiler =>initialize, finalize_profiler =>finalize
- use ESMF
 
  implicit none
  private

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -265,7 +265,7 @@ contains
 
    subroutine run_model(this, comm, unusable, rc)
       use pFlogger, only: logging, Logger
-      class (MAPL_Cap), intent(inout) :: this
+      class (MAPL_Cap), target, intent(inout) :: this
       integer, intent(in) :: comm
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) ::rc
@@ -394,7 +394,7 @@ contains
    end subroutine run_model
 
    subroutine initialize_cap_gc(this, unusable, n_run_phases, rc)
-     class(MAPL_Cap), intent(inout) :: this
+     class(MAPL_Cap), target, intent(inout) :: this
      class (KeywordEnforcer), optional, intent(in) :: unusable
      integer, optional, intent(in) :: n_run_phases
      integer, optional, intent(out) :: rc

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -86,7 +86,6 @@ contains
       type ( MAPL_CapOptions), optional, intent(in) :: cap_options
       integer, optional, intent(out) :: rc
       integer :: status
-      type(ESMF_PIN_Flag) :: pinflag
 
       cap%name = name
       cap%set_services => set_services
@@ -125,7 +124,6 @@ contains
       type ( MAPL_CapOptions), optional, intent(in) :: cap_options
       integer, optional, intent(out) :: rc
       integer :: status
-      type(ESMF_PIN_Flag) :: pinflag
 
       cap%name = name
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -265,7 +265,7 @@ contains
 
    subroutine run_model(this, comm, unusable, rc)
       use pFlogger, only: logging, Logger
-      class (MAPL_Cap), target, intent(inout) :: this
+      class (MAPL_Cap), intent(inout) :: this
       integer, intent(in) :: comm
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) ::rc
@@ -278,7 +278,6 @@ contains
       type (ESMF_VM) :: vm
       character(len=:), allocatable :: esmfComm, esmfConfigFile
       integer :: esmfConfigFileLen
-      type(ESMF_PIN_Flag) :: pinflag
 
       _UNUSED_DUMMY(unusable)
 
@@ -341,8 +340,7 @@ contains
 
       call lgr%info("Running with MOAB library for ESMF Mesh: %l1", this%cap_options%with_esmf_moab)
 
-      pinflag = GetPinFlagFromConfig(this%cap_options%cap_rc_file, _RC)
-      call this%initialize_cap_gc(pinflag=pinflag, rc=status)
+      call this%initialize_cap_gc(rc=status)
       _VERIFY(status)
 
       call this%cap_gc%set_services(rc = status)
@@ -395,21 +393,19 @@ contains
 
    end subroutine run_model
 
-   subroutine initialize_cap_gc(this, unusable, n_run_phases, pinflag, rc)
-     class(MAPL_Cap), target, intent(inout) :: this
+   subroutine initialize_cap_gc(this, unusable, n_run_phases, rc)
+     class(MAPL_Cap), intent(inout) :: this
      class (KeywordEnforcer), optional, intent(in) :: unusable
      integer, optional, intent(in) :: n_run_phases
-     type(ESMF_PIN_Flag), optional, intent(in) :: pinflag
      integer, optional, intent(out) :: rc
 
      integer :: status
+     type(ESMF_PIN_Flag) :: pinflag
 
      _UNUSED_DUMMY(unusable)
 
-     if (present(pinflag)) then
-        ! call pinflag setter
+     pinflag = GetPinFlagFromConfig(this%cap_options%cap_rc_file, _RC)
         call MAPL_PinFlagSet(pinflag)
-     end if
 
      if (this%non_dso) then
         call MAPL_CapGridCompCreate(this%cap_gc, this%get_cap_rc_file(), &


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is port of the changes being made in [MAPL 2.53.3](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.53.3) for the UFS folks.

By default, we keep the `SSI_CONTIG` setting current MAPL has.

Testing shows it is zero-diff, though we have not tested if the SSI work of @aoloso still works.

## Related Issue

