### PR TITLE
Update to use ifx 2025.1 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,9 +201,9 @@ workflows:
           baselibs_version: *baselibs_version
           container_name: mapl
           mpi_name: intelmpi
-          mpi_version: "2021.14"
+          mpi_version: "2021.15"
           compiler_name: ifx
-          compiler_version: "2025.0"
+          compiler_version: "2025.1"
           image_name: geos-env
           tag_build_arg_name: *tag_build_arg_name
       - ci/publish_docker:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -91,7 +91,7 @@ jobs:
     name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.14-ifx_2025.0
+      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Fixes for f2py with MPT
 
 - Update documentation on ACG in repo
+- Update CI to use ifx 2025.1
 
 ### Removed
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates the MAPL2 CI to use ifx 2025.1. 

## Related Issue

