### PR TITLE
Fix issue with GNU and MVAPICH 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- define `comp_name` in `MAPL_GridCreate` when GC is not present
+- Define `comp_name` in `MAPL_GridCreate` when GC is not present
 - Fixed bug in profiler demo
+- Fix for GNU + MVAPICH 4 disabling ieee halting around `MPI_Init_thread()`
 
 ### Added
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -15,6 +15,7 @@ module MAPL_CapMod
    use MAPL_CapOptionsMod
    use MAPL_ServerManager
    use MAPL_ApplicationSupport
+   use ieee_arithmetic
    use, intrinsic :: iso_fortran_env, only: REAL64, INT64, OUTPUT_UNIT
    implicit none
    private
@@ -475,6 +476,7 @@ contains
       integer :: ierror, status
       integer :: provided
       integer :: npes_world
+      logical :: halting_mode(5)
 
       _UNUSED_DUMMY(unusable)
 
@@ -482,10 +484,17 @@ contains
       _VERIFY(ierror)
 
       if (.not. this%mpi_already_initialized) then
-
          call ESMF_InitializePreMPI(_RC)
+
+         ! Testing with GCC 14 + MVAPICH 4 found that it was failing with
+         ! a SIGFPE in MPI_Init_thread(). Turning off ieee halting
+         ! around the call seems to "fix" it
+         call ieee_get_halting_mode(ieee_all, halting_mode)
+         call ieee_set_halting_mode(ieee_all, .false.)
          call MPI_Init_thread(MPI_THREAD_MULTIPLE, provided, ierror)
          _VERIFY(ierror)
+         call ieee_set_halting_mode(ieee_all, halting_mode)
+
       else
          ! If we are here, then MPI has already been initialized by the user
          ! and we are just using it. But we need to make sure that the user


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

In trying to test GCC 14 with MVAPICH 4 on Discover, it was found that when you tried to run GEOS, the code would crash at `MPI_Init_thread()` with a SIGFPE. This is weird.

After talking with @FlorianDeconinck, he suggested something his group found which is that at times you have to turn off IEEE halting around a call. (I want to say @pchakraborty also mentioned something about this once...)

Should we need to do this? No. Can I run a simple `MPI_Init_thread()` example code with GCC 14 + MVAPICH 4? Yes. But this seems to be needed here.

I'm going to keep this as Draft until I can discuss with @tclune (and perhaps @FlorianDeconinck and @pchakraborty). I mean, it seems "harmless" but it is weird. I could (via CMake) make this an `#ifdef` sort of thing with the right detection...but is it worth it?

## Related Issue

