### PR TITLE
Fixed: added missing initialization for num_levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - define `comp_name` in `MAPL_GridCreate` when GC is not present
 - Fixed bug in profiler demo
+- Fixed uninitialized num_levels bug causing gcc14 to crash a node due to alloting enormous amount of memory
 
 ### Added
 

--- a/vertical/VerticalCoordinate.F90
+++ b/vertical/VerticalCoordinate.F90
@@ -68,6 +68,7 @@ contains
       type(NETCDF4_FileFormatter) :: file_formatter
       real, allocatable :: temp_ak(:,:), temp_bk(:,:)
    
+      vertical_coord%num_levels = 0 ! initialze
       var => metadata%get_variable(var_name, _RC)
       dimensions => var%get_dimensions()
       lev_name = ''


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
This fixes a "memory explosion" issue that takes a node down when compiled with gfortran. The issue was due to unititialized num_levels
## Related Issue

