### PR TITLE
Fix NAG issue with StateMasking

### DIFF
--- a/state/StateMasking.F90
+++ b/state/StateMasking.F90
@@ -373,10 +373,10 @@ module MAPL_StateMaskMod
        end if
 
        if (rank == 2) then
-          call ESMF_FieldGet(field,0,farrayPtr=var2d,_RC)
+          call ESMF_FieldGet(field,0,farrayPtr=out_var2d,_RC)
           call MAPL_GetPointer(state,var2d, vartomask, _RC)
        else if (rank == 3) then
-          call ESMF_FieldGet(field,0,farrayPtr=var3d,_RC)
+          call ESMF_FieldGet(field,0,farrayPtr=out_var3d,_RC)
           call MAPL_GetPointer(state,var3d, vartomask, _RC)
        else
           _FAIL('Rank must be 2 or 3')


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This fixes a small bug that NAG found with develop (based on #3715). Interestingly, both Intel and GNU were fine, so I'm guessing they would have seen this at run-time, but I guess we don't actually go into `evaluate_box_mask` in a "normal" GEOS run?

I'll keep draft for now until @bena-nasa can review.

## Related Issue

