### PR TITLE
Fix ExtData bug causing time interpolation to be skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed uninitialized num_levels bug causing gcc14 to crash a node due to allocating enormous amount of memory
 - Fix for GNU + MVAPICH 4 disabling ieee halting around `MPI_Init_thread()`
 - Test if `GridCornerLons:` and `GridCornerLats:` attributes are present before removing
+- Fixed ExtData bug causing time interpolation to be skipped if no current reads
 
 ### Added
 


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)
NOTE: I tested this fix with GCHP and not GEOSgcm

## Description

This PR fixes a bug introduced in GEOS-ESM/MAPL/pull/2619 that caused ExtData Run to exit early if IOBundles size was zero, thereby skipping time interpolation. In GCHP the time interpolation must run every heartbeat to interpolate certain meteorology fields from 3-hr time-averaged imports.

## Related Issue

None

