### PR TITLE
StateFilterItem => MAPL_StateFilterItem in ACG

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACG.py
+++ b/Apps/MAPL_GridCompSpecs_ACG.py
@@ -365,7 +365,7 @@ class MAPL_DataSpec:
         other_args = [(option.name, self.spec_values[option]) for option in other_options]
         args.extend(other_args)
         delimiter = MAPL_DataSpec.DELIMITER
-        procedure_call = make_procedure_call("StateFilterItem", delimiter=delimiter,
+        procedure_call = make_procedure_call("MAPL_StateFilterItem", delimiter=delimiter,
             terminator=MAPL_DataSpec.TERMINATOR, **dict(args))
         return ''.join([self.emit_header(), procedure_call, self.emit_trailer()])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `StateFilterItem` => `MAPL_StateFilterItem` in **ACG**
 
 ### Added
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Peter Colarco is using the new `MAPL_StateFilterItem` feature with ACG. MAPL failed to compile. This PR fixes this by changing `StateFilterItem` to `MAPL_StateFilterItem` in ACG.

## Related Issue

