### PR TITLE
Added optional argument `add2export` for MAPL_GridCompAddFieldSpec

### DIFF
--- a/generic3g/ESMF_Utilities.F90
+++ b/generic3g/ESMF_Utilities.F90
@@ -9,6 +9,7 @@ module mapl3g_ESMF_Utilities
    public :: write(formatted)
    public :: get_substate
    public :: to_esmf_state_intent
+   public :: esmf_state_intent_to_string
    public :: MAPL_TYPEKIND_MIRROR
 
    type(ESMF_TypeKind_Flag), parameter :: MAPL_TYPEKIND_MIRROR = ESMF_TypeKind_Flag(200)
@@ -198,5 +199,22 @@ contains
       _RETURN(_SUCCESS)
    end function to_esmf_state_intent
 
+   function esmf_state_intent_to_string(state_intent, rc) result(state_intent_str)
+      type(ESMF_StateIntent_Flag), intent(in) :: state_intent
+      integer, optional, intent(out) :: rc
+      character(:), allocatable :: state_intent_str ! result
+
+      if (state_intent==ESMF_STATEINTENT_IMPORT) then
+         state_intent_str = "import"
+      else if (state_intent==ESMF_STATEINTENT_EXPORT) then
+         state_intent_str = "export"
+      else if (state_intent==ESMF_STATEINTENT_INTERNAL) then
+         state_intent_str = "internal"
+      else
+         _FAIL("invalid state intent")
+      end if
+
+      _RETURN(_SUCCESS)
+   end function esmf_state_intent_to_string
 
 end module mapl3g_ESMF_Utilities


### PR DESCRIPTION
…added the optional argument add2export, with code for the case when an internal var gets exported

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Fixes #3773 - added optional argument `add2export` and code for the case when `add2export` is present and true.

Also, made item_type user specifiable, in preparation for #3774 

## Related Issue

#3773 
#3774 