### PR TITLE
Fixes #3781 - Rename MAPL_GridCompAddFieldSpec -> MAPL_GridCompAddSpec

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -78,7 +78,7 @@ GC_VARIABLE = 'gridcomp_variable'
 GC_VARIABLE_DEFAULT = 'gc'
 STANDARD_NAME_PREFIX = "standard_name_prefix"
 # procedure names
-ADDSPEC = "MAPL_GridCompAddFieldSpec"
+ADDSPEC = "MAPL_GridCompAddSpec"
 GETPOINTER = "MAPL_StateGetPointer"
 TO_STRING_VECTOR = "toStringVector"
 # Fortran keywords

--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -50,6 +50,7 @@ STRING = 'string'
 VALUES_NOT_FOUND = 'values_not_found'
 
 #could be read from YAML list
+ADD_TO_EXPORT = 'add_to_export'
 ALIAS = 'alias'
 ALLOC = 'alloc'
 ARRAY = 'array'
@@ -147,17 +148,19 @@ def get_options(args):
              'N': 'VERTICAL_STAGGER_NONE'}},
         ALIAS: {FLAGS: {STORE}}, 
         ALLOC: {FLAGS: {STORE}}, 
-        'add2export': {MAPPING: LOGICAL},
+        ADD_TO_EXPORT: {MAPPING: LOGICAL},
         'attributes' : {MAPPING: STRINGVECTOR}, 
         CONDITION: {FLAGS: {STORE}}, 
         'dependencies': {MAPPING: STRINGVECTOR}, 
         'itemtype': {}, 
         'orientation': {}, 
         'regrid_method': {}, 
-        'restart': {MAPPING: dict(
-                [(b, TRUE_VALUE) for b in 'T t TRUE true True SKIP Skip skip'.split()] + 
-                [(b, FALSE_VALUE) for b in 'F FALSE false f False'.split()]
-            )},
+        'restart': {MAPPING: {
+            'OPTIONAL': 'MAPL_RESTART_OPTIONAL',
+            'SKIP': 'MAPL_RESTART_SKIP',
+            'REQUIRED': 'MAPL_RESTART_REQUIRED',
+            'BOOT': 'MAPL_RESTART_BOOT',
+            'SKIP_INITIAL': 'MAPL_RESTART_SKIP_INITIAL'}},
         STATE: {FLAGS: {MANDATORY, STORE}}, 
         'typekind': {MAPPING: { 
             'R4': 'ESMF_Typekind_R4',
@@ -177,7 +180,8 @@ def get_options(args):
         'name': SHORT_NAME,
         'prec': PRECISION,
         'vloc': VSTAGGER,
-        'vlocation': VSTAGGER
+        'vlocation': VSTAGGER,
+        'add2export': ADD_TO_EXPORT
     }
 
     options[CONTROLS] = {MAKE_BLOCK: {MAPPING: MAKE_BLOCK, FLAGS: CONTROL, FROM: CONDITION}} 

--- a/Apps/tests/acg3/ACG3.F90
+++ b/Apps/tests/acg3/ACG3.F90
@@ -3,7 +3,7 @@
 #define _SUCCESS ESMF_SUCCESS
 #define _FAILURE _SUCCESS-1
 module mapl3g_acg3
-   use mapl3g_Generic, only: MAPL_GridCompAddFieldSpec
+   use mapl3g_Generic, only: MAPL_GridCompAddSpec
    use mapl3g_State_API, only: MAPL_StateGetPointer
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unit tests for ACG3
 - Add enumerators for RESTART setting
 - Add `add2export` to ACG3
+- Changed `MAPL_GridCompAddFieldSpec` and ACG3 to use new RESTART enum
 
 ### Changed
 

--- a/field_bundle/FieldBundleInfo.F90
+++ b/field_bundle/FieldBundleInfo.F90
@@ -86,8 +86,9 @@ contains
            num_levels=num_levels, vert_staggerloc=vert_staggerloc, num_vgrid_levels=num_vgrid_levels, &
            units=units, long_name=long_name, standard_name=standard_name, is_active=is_active, _RC)
 
-
       _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+
    contains
 
       function to_TypeKind(typekind_str) result(typekind)
@@ -110,7 +111,7 @@ contains
 
    subroutine fieldbundle_set_internal(info, unusable, &
         namespace, &
-         geom, &
+        geom, &
         fieldBundleType, typekind, interpolation_weights, &
         ungridded_dims, &
         num_levels, vert_staggerloc, &
@@ -164,7 +165,8 @@ contains
            units=units, long_name=long_name, standard_name=standard_name, &
            is_active=is_active, _RC)
 
-      _RETURN(_SUCCESS)
+       _RETURN(_SUCCESS)
+       _UNUSED_DUMMY(unusable)
 
    contains
 

--- a/generic3g/Generic3g.F90
+++ b/generic3g/Generic3g.F90
@@ -9,4 +9,6 @@ module Generic3g
    use mapl3g_GriddedComponentDriver
    use mapl3g_UserSetServices
    use mapl3g_ESMF_HConfigUtilities, only: MAPL_HConfigMatch
+   use mapl3g_RestartHandler, only: MAPL_RESTART, MAPL_RESTART_OPTIONAL, MAPL_RESTART_SKIP
+   use mapl3g_RestartHandler, only: MAPL_RESTART_REQUIRED, MAPL_RESTART_BOOT, MAPL_RESTART_SKIP_INITIAL
 end module Generic3g

--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -52,6 +52,7 @@ module mapl3g_Generic
    use esmf, only: ESMF_State, ESMF_StateItem_Flag, ESMF_STATEITEM_FIELD
    use esmf, only: operator(==)
    use mapl3g_hconfig_get
+   use mapl3g_RestartHandler
    use pflogger, only: logger_t => logger
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
@@ -463,7 +464,7 @@ contains
       class(KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(in) :: ungridded_dims(:)
       character(*), optional, intent(in) :: units
-      logical, optional, intent(in) :: restart
+      integer(kind=kind(MAPL_RESTART)), optional, intent(in) :: restart
       type(ESMF_StateItem_Flag), optional, intent(in) :: itemType
       logical, optional, intent(in) :: add2export
       integer, optional, intent(out) :: rc

--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -67,7 +67,7 @@ module mapl3g_Generic
 
    ! These should be available to users
    public :: MAPL_GridCompAddVarSpec
-   public :: MAPL_GridCompAddFieldSpec
+   public :: MAPL_GridCompAddSpec
    public :: MAPL_GridCompIsGeneric
    public :: MAPL_GridCompIsUser
 
@@ -83,7 +83,7 @@ module mapl3g_Generic
 
    public :: MAPL_GridCompSetGeometry
 
-    public :: MAPL_GridcompGetResource
+   public :: MAPL_GridcompGetResource
 
    ! Accessors
 !!$   public :: MAPL_GetOrbit
@@ -100,6 +100,9 @@ module mapl3g_Generic
 
    ! Spec types
    public :: MAPL_STATEITEM_STATE, MAPL_STATEITEM_FIELDBUNDLE
+
+   ! Restart types
+   public :: MAPL_RESTART, MAPL_RESTART_SKIP
 
    ! Interfaces
 
@@ -148,9 +151,9 @@ module mapl3g_Generic
       procedure :: gridcomp_add_varspec_basic
    end interface MAPL_GridCompAddVarSpec
 
-   interface MAPL_GridCompAddFieldSpec
-      procedure :: gridcomp_add_fieldspec
-   end interface MAPL_GridCompAddFieldSpec
+   interface MAPL_GridCompAddSpec
+      procedure :: gridcomp_add_spec
+   end interface MAPL_GridCompAddSpec
 
    interface MAPL_GridCompSetGeometry
       procedure :: gridcomp_set_geometry
@@ -439,7 +442,7 @@ contains
       _RETURN(_SUCCESS)
    end subroutine gridcomp_add_varspec_basic
 
-   subroutine gridcomp_add_fieldspec( &
+   subroutine gridcomp_add_spec( &
         gridcomp, &
         state_intent, &
         short_name, &
@@ -452,7 +455,7 @@ contains
         units, &
         restart, &
         itemType, &
-        add2export, &
+        add_to_export, &
         rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       type(ESMF_StateIntent_Flag), intent(in) :: state_intent
@@ -466,7 +469,7 @@ contains
       character(*), optional, intent(in) :: units
       integer(kind=kind(MAPL_RESTART)), optional, intent(in) :: restart
       type(ESMF_StateItem_Flag), optional, intent(in) :: itemType
-      logical, optional, intent(in) :: add2export
+      logical, optional, intent(in) :: add_to_export
       integer, optional, intent(out) :: rc
 
       type(VariableSpec) :: var_spec
@@ -500,8 +503,8 @@ contains
       component_spec => outer_meta%get_component_spec()
       call component_spec%var_specs%push_back(var_spec)
 
-      if (present(add2export)) then
-         if (add2export) then
+      if (present(add_to_export)) then
+         if (add_to_export) then
             _ASSERT((state_intent==ESMF_STATEINTENT_INTERNAL), "cannot reexport a non-internal spec")
             call gridcomp_reexport( &
                  gridcomp=gridcomp, &
@@ -515,7 +518,7 @@ contains
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
       _UNUSED_DUMMY(restart)
-   end subroutine gridcomp_add_fieldspec
+   end subroutine gridcomp_add_spec
 
    subroutine MAPL_GridCompSetVerticalGrid(gridcomp, vertical_grid, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Renamed `MAPL_GridCompAddFieldSpec` -> `MAPL_GridCompAddSpec`. Includes @darianboggs's edits to `MAPL_GridCompSpecs_ACGv3.py`

## Related Issue

#3781 