### PR TITLE
Fix binary writes/reads in simulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - `StateFilterItem` => `MAPL_StateFilterItem` in **ACG**
+- Fix binary writes and reads in benchmark simulators
 
 ### Added
 

--- a/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
+++ b/benchmarks/io/checkpoint_simulator/checkpoint_simulator.F90
@@ -614,6 +614,9 @@ contains
               write(fc,'(I0.3)')writer_rank
               fname = "checkpoint_"//fc//".bin"
               open(file=fname,newunit=this%ncid,status='replace',form='unformatted',access='sequential')
+           else
+              fname = "checkpoint.bin"
+              open(file=fname,newunit=this%ncid,status='replace',form='unformatted',access='sequential')
            end if
         end if
      end if

--- a/benchmarks/io/restart_simulator/restart_simulator.F90
+++ b/benchmarks/io/restart_simulator/restart_simulator.F90
@@ -575,6 +575,9 @@ contains
               write(fc,'(I0.3)')writer_rank
               fname = "checkpoint_"//fc//".bin"
               open(file=fname,newunit=this%ncid,status='old',form='unformatted',access='sequential')
+           else
+              fname = "checkpoint.bin"
+              open(file=fname,newunit=this%ncid,status='old',form='unformatted',access='sequential')
            end if
         end if
      end if


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This fixes a bug in the benchmark simulators. Turns out non-split binary was broken.

## Related Issue

