### PR TITLE
Feature/bmauer/raw netcdf for hoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added new option to History, if you specify xlevels instead of levels, it will perform extrapolation below the surface, using ECMWF formulas for height and temperature, otherwise use lowest model level
 - Added `_USERRC` macro for use with ESMF commands that return both `rc` and `userrc`
+- Added new option for `raw_bw.x` to use netcdf rather than binary
 
 
 ### Changed

--- a/benchmarks/io/raw_bw/BW_Benchmark.F90
+++ b/benchmarks/io/raw_bw/BW_Benchmark.F90
@@ -2,15 +2,24 @@
 
 module mapl_BW_Benchmark
    use mapl_ErrorHandlingMod
+   use netcdf
    use, intrinsic :: iso_fortran_env, only: INT64
    implicit none
    private
 
    public :: BW_Benchmark
+   public :: NETCDF_FILE
+   public :: BINARY_FILE
+
+   enum, bind(c)
+      enumerator :: NETCDF_FILE
+      enumerator :: BINARY_FILE
+   end enum
 
    type :: BW_Benchmark
       real, allocatable :: buffer(:)
       character(:), allocatable :: filename
+      integer :: file_type
    contains
       procedure :: run
    end type BW_Benchmark
@@ -28,15 +37,22 @@ contains
 
       integer :: status
       integer :: unit
+      integer :: var_id
 
-      unit = open_file(this%filename, _RC)
-      call write_file(this%buffer, unit, _RC)
-      call delete_file(this%filename, _RC)
+      if (this%file_type == BINARY_FILE) then
+         unit = open_bin_file(this%filename, _RC)
+         call write_bin_file(this%buffer, unit, _RC)
+         call delete_bin_file(this%filename, _RC)
+      else if (this%file_type == NETCDF_FILE) then
+         unit = open_netcdf_file(this%filename, this%buffer, var_id, _RC)
+         call write_netcdf_file(this%buffer, unit, var_id, _RC)
+         call delete_netcdf_file(this%filename, _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine run
 
-   function open_file(filename, rc) result(unit)
+   function open_bin_file(filename, rc) result(unit)
       integer :: unit
       character(*), intent(in) :: filename
       integer, optional, intent(out) :: rc
@@ -48,9 +64,9 @@ contains
            status='new', form='unformatted', access='sequential', _IOSTAT)
 
       _RETURN(_SUCCESS)
-   end function open_file
+   end function open_bin_file
 
-   subroutine write_file(buffer, unit, rc)
+   subroutine write_bin_file(buffer, unit, rc)
       real, intent(in) :: buffer(:)
       integer :: unit
       integer, optional, intent(out) :: rc
@@ -64,10 +80,10 @@ contains
       close(unit, _IOSTAT)
 
       _RETURN(_SUCCESS)
-   end subroutine write_file
+   end subroutine write_bin_file
       
 
-   subroutine delete_file(filename, rc)
+   subroutine delete_bin_file(filename, rc)
       character(*), intent(in) :: filename
       integer, optional, intent(out) :: rc
 
@@ -79,7 +95,56 @@ contains
       close(unit, status='delete', _IOSTAT)
 
       _RETURN(_SUCCESS)
-   end subroutine delete_file
+   end subroutine delete_bin_file
+
+   function open_netcdf_file(filename, buffer, varid, rc) result(unit)
+      integer :: unit
+      character(*), intent(in) :: filename
+      real, intent(in) :: buffer(:)
+      integer, intent(inout) :: varid
+      integer, optional, intent(out) :: rc
+
+      integer :: status, dimid
+
+      status = NF90_Create(filename, IOR(NF90_CLOBBER, NF90_NETCDF4), unit)
+      _VERIFY(status)
+      status = NF90_def_dim(unit, "dim1", size(buffer), dimid) 
+      _VERIFY(status)
+      status = NF90_def_var(unit, 'var1', NF90_FLOAT, [dimid], varid)
+      _VERIFY(status)
+      status = NF90_EndDef(unit)
+      _VERIFY(status)
+
+      _RETURN(_SUCCESS)
+   end function open_netcdf_file
+
+   subroutine write_netcdf_file(buffer, unit, varid, rc)
+      real, intent(in) :: buffer(:)
+      integer :: unit
+      integer :: varid
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      status = nf90_put_var(unit, varid, buffer)
+      _VERIFY(status)
+
+      ! Without the close, maybe the writing is not done?
+      status = nf90_close(unit)
+      _VERIFY(status)
+
+      _RETURN(_SUCCESS)
+   end subroutine write_netcdf_file
+      
+
+   subroutine delete_netcdf_file(filename, rc)
+      character(*), intent(in) :: filename
+      integer, optional, intent(out) :: rc
+
+      call SYSTEM('rm '//filename)
+      
+      _RETURN(_SUCCESS)
+   end subroutine delete_netcdf_file
 
 end module mapl_BW_Benchmark
 

--- a/benchmarks/io/raw_bw/BW_BenchmarkSpec.F90
+++ b/benchmarks/io/raw_bw/BW_BenchmarkSpec.F90
@@ -18,6 +18,7 @@ module mapl_BW_BenchmarkSpec
       integer :: n_levs
       integer :: n_writers
       integer :: n_tries
+      character(len=:), allocatable :: file_type
    end type BW_BenchmarkSpec
 
 contains
@@ -53,6 +54,10 @@ contains
       _ASSERT(associated(option), 'n_tries not found')
       call cast(option, spec%n_tries, _RC)
 
+      option => options%at('file_type')
+      _ASSERT(associated(option), 'file_type not found')
+      call cast(option, spec%file_type)
+
       _RETURN(_SUCCESS)
    end function make_BW_BenchmarkSpec
 
@@ -80,6 +85,12 @@ contains
            default=1, &
            action='store')
 
+      call parser%add_argument('--file_type', &
+           help='type of file, options netcdf or binary', &
+           type='string', &
+           action='store', &
+           default='binary')
+
    end subroutine add_cli_options
 
 
@@ -102,6 +113,8 @@ contains
       call MPI_Comm_rank(comm, rank, status)
       _VERIFY(status)
       benchmark%filename = make_filename(base='scratch.', rank=rank, width=5, _RC)
+      if (spec%file_type == 'binary') benchmark%file_type = BINARY_FILE
+      if (spec%file_type == 'netcdf') benchmark%file_type = NETCDF_FILE
 
       _RETURN(_SUCCESS)
    end function make_BW_Benchmark

--- a/benchmarks/io/raw_bw/CMakeLists.txt
+++ b/benchmarks/io/raw_bw/CMakeLists.txt
@@ -5,6 +5,6 @@ ecbuild_add_executable (
   SOURCES BW_Benchmark.F90 BW_BenchmarkSpec.F90 driver.F90
   DEFINITIONS USE_MPI)
 
-target_link_libraries (raw_bw.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse OpenMP::OpenMP_Fortran)
+target_link_libraries (raw_bw.x PRIVATE MAPL.shared MPI::MPI_Fortran FARGPARSE::fargparse OpenMP::OpenMP_Fortran NetCDF::NetCDF_Fortran)
 target_include_directories (raw_bw.x PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 set_target_properties (raw_bw.x PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})

--- a/benchmarks/io/raw_bw/driver.F90
+++ b/benchmarks/io/raw_bw/driver.F90
@@ -63,7 +63,7 @@ contains
 
       benchmark = make_BW_Benchmark(spec, writer_comm, _RC)
 
-      call write_header(writer_comm, _RC)
+      call write_header(writer_comm, spec%file_type, _RC)
 
       tot_time = 0
       tot_time_sq = 0
@@ -111,8 +111,9 @@ contains
    end function time
 
 
-   subroutine write_header(comm, rc)
+   subroutine write_header(comm, file_type, rc)
       integer, intent(in) :: comm
+      character(len=*), intent(in) :: file_type
       integer, optional, intent(out) :: rc
 
       integer :: status
@@ -122,6 +123,7 @@ contains
       _VERIFY(status)
       _RETURN_UNLESS(rank == 0)
 
+      write(*,*)'Tested with file type: '//trim(file_type)
       write(*,'(3(a10,","),6(a15,:,","))',iostat=status) &
            'NX', '# levs', '# writers', 'write (GB)', 'packet (GB)', &
            'Time (s)', 'Eff. BW (GB/s)', 'Avg. BW (GB/s)', 'Rel. Std. Dev.'


### PR DESCRIPTION
I did this, so might as well save it...
Add an option to the `raw_bw.x` code to use netcdf files rather than Fortran binary.
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

