### PR TITLE
Prefix public EASE routines with MAPL_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added functions to read and write 0d string to nc4 file.
 - Added EASE grid Factory so the regridder can use it easily
-  - NOTE: This must be taken with a matching `GEOSgcm_GridComp` (v2.7.5) as the routines moved from there to here.
+  - NOTE: This must be taken with a matching `GEOSgcm_GridComp` (v2.7.5) as the routines moved from there to here and public routines were prefixed by `MAPL_`
 - Added new option to History, if you specify xlevels instead of levels, it will perform extrapolation below the surface, using ECMWF formulas for height and temperature, otherwise use lowest model level
 - Added `_USERRC` macro for use with ESMF commands that return both `rc` and `userrc`
 - Added new option for `raw_bw.x` to use netcdf rather than binary

--- a/base/MAPL_EASEConversion.F90
+++ b/base/MAPL_EASEConversion.F90
@@ -1,40 +1,40 @@
 #include "MAPL_ErrLog.h"
 
 module MAPL_EASEConversion
-  
+
   ! =====================================================================================
-  ! This file is moved from 
+  ! This file is moved from
   ! GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/makebcs/EASE_conv.F90
   !  - Fortran routines for conversion of Equal-Area Scalable Earth (EASE)
   !    grid coordinates (lat/lon <--> row/col indices)
-  !    Implemented for global cylindrical ('Mxx') EASE grids only. 
+  !    Implemented for global cylindrical ('Mxx') EASE grids only.
   !
-  !    Works for EASE[v1] and EASEv2 grids. 
-  ! 
+  !    Works for EASE[v1] and EASEv2 grids.
+  !
   ! -------------------------------------------------------------------------------------
-  ! 
+  !
   ! CHANGELOG (easeV1_conv.F90):
   ! ============================
   !
-  ! easeV1_conv.F90 - Fortran routines for conversion of azimuthal 
+  ! easeV1_conv.F90 - Fortran routines for conversion of azimuthal
   !                   equal area and equal area cylindrical grid coordinates
-  ! 
+  !
   ! 30-Jan-1992 H.Maybee
   ! 20-Mar-1992 Ken Knowles  303-492-0644  knowles@kryos.colorado.edu
   ! 16-Dec-1993 MJ Brodzik   303-492-8263  brodzik@jokull.colorado.edu
-  !              Copied from nsmconv.f, changed resolutions from 
+  !              Copied from nsmconv.f, changed resolutions from
   !              40-20-10 km to 25-12.5 km
   ! 21-Dec-1993 MJ Brodzik   303-492-8263  brodzik@jokull.colorado.edu
-  !              Fixed sign of Southern latitudes in ease_inverse.
+  !              Fixed sign of Southern latitudes in MAPL_ease_inverse.
   ! 12-Sep-1994 David Hoogstrate 303-492-4116 hoogstra@jokull.colorado.edu
   ! 	       Changed grid cell size. Changed "c","f" to "l","h"
   ! 25-Oct-1994 David Hoogstrate 303-492-4116 hoogstra@jokull.colorado.edu
   ! 	       Changed row size from 587 to 586 for Mercator projection
-  ! 11-May-2011 reichle: Changed "smap" to "easeV1".  
+  ! 11-May-2011 reichle: Changed "smap" to "easeV1".
   !                      Added SSM/I and AMSR-E "M25" grid.
   !                      So far ONLY for cylindrical grids.
   !                      Converted from *.f to *.F90 module
-  ! 
+  !
   ! $Log$
   ! Revision 1.1  2011-05-11 21:58:46  rreichle
   ! Adding utilities to map between EASE grids and lat/lon coordinates.
@@ -53,9 +53,9 @@ module MAPL_EASEConversion
   !
   !    ***** ONLY cylindrical ('M') projection implemented *****
   !
-  ! Ported from Steven Chan's matlab code (smapease2inverse.m, 
+  ! Ported from Steven Chan's matlab code (smapease2inverse.m,
   ! smapease2forward.m), which has been ported from NSIDC's IDL code
-  ! (wgs84_convert.pro, wgs84_inverse.pro) available from  
+  ! (wgs84_convert.pro, wgs84_inverse.pro) available from
   ! ftp://sidads.colorado.edu/pub/tools/easegrid/geolocation_tools/
   !
   ! Official references:
@@ -63,15 +63,15 @@ module MAPL_EASEConversion
   !  doi:10.3390/ijgi3031154 -- correction of M25 "map_scale_m" parameters!
   !
   ! 04-Apr-2013 - reichle
-  ! 11-Sep-2018 - reichle, mgirotto -- added 'M25' grid parameters 
+  ! 11-Sep-2018 - reichle, mgirotto -- added 'M25' grid parameters
   !
   !
   ! CHANGELOG (EASE_conv.F90):
   ! ==========================
   !
-  ! 2022-09-13, wjiang+reichle: 
+  ! 2022-09-13, wjiang+reichle:
   !   merged easeV1_conv.F90 and easeV2_conv.F90 into EASE_conv.F90
-  !   - using different values for PI in easeV1 and easeV2 calcs as in old easeV[x]_conv.F90 modules; 
+  !   - using different values for PI in easeV1 and easeV2 calcs as in old easeV[x]_conv.F90 modules;
   !       in contrast, LDAS_EASE_conv.F90 in GEOSldas used only a single value for PI.
   !   - bug fix in easeV2_get_params() for EASEv2/M25 (to compute s0, divide by 2.0 not by integer 2)
   !
@@ -81,13 +81,13 @@ module MAPL_EASEConversion
   use mapl_ErrorHandlingMod
 
   implicit none
-  
+
   private
 
-  public :: ease_convert
-  public :: ease_inverse
-  public :: ease_extent
-  public :: get_ease_gridname_by_cols
+  public :: MAPL_ease_convert
+  public :: MAPL_ease_inverse
+  public :: MAPL_ease_extent
+  public :: MAPL_get_ease_gridname_by_cols
 
   ! =======================================================================
   !
@@ -96,56 +96,56 @@ module MAPL_EASEConversion
   ! ***NEVER*** change these constants to GEOS MAPL constants!!!!
   !
   ! These values are from the original definition of the EASE grids by NSIDC.
-  
-  ! radius of the earth (km), authalic sphere based on International datum 
-  
+
+  ! radius of the earth (km), authalic sphere based on International datum
+
   real(kind=REAL64), parameter :: easeV1_RE_km                    = 6371.228
-  
+
   ! scale factor for standard paralles at +/-30.00 degrees
-  
+
   real(kind=REAL64), parameter :: easeV1_COS_PHI1                 = .866025403
-  
+
   real(kind=REAL64), parameter :: easeV2_PI                       = 3.14159265358979323846
   real(kind=REAL64), parameter :: easeV1_PI                       = 3.141592653589793
- 
+
   ! =======================================================================
   !
   ! EASEv2 global constants
 
   ! ***NEVER*** change these constants to GEOS MAPL constants!!!!
-  
+
   ! radius of the earth (m) and map eccentricity
-  
-  real(kind=REAL64), parameter :: map_equatorial_radius_m         = 6378137.0 
-  
+
+  real(kind=REAL64), parameter :: map_equatorial_radius_m         = 6378137.0
+
   real(kind=REAL64), parameter :: map_eccentricity                = 0.081819190843
-  
-  
+
+
   real(kind=REAL64), parameter :: e2      = map_eccentricity * map_eccentricity
   real(kind=REAL64), parameter :: e4      = e2 * e2
   real(kind=REAL64), parameter :: e6      = e2 * e4
-  
-  
+
+
   real(kind=REAL64), parameter :: map_reference_longitude         =   0.0  ! 'M', 'N', 'S'
-  
+
   ! constants for 'N' and 'S' (azimuthal) projections
-  
+
   real(kind=REAL64), parameter :: N_map_reference_latitude        =  90.0
   real(kind=REAL64), parameter :: S_map_reference_latitude        = -90.0
-  
+
   ! constants for 'M' (cylindrical) projection
-  
+
   real(kind=REAL64), parameter :: M_map_reference_latitude        =   0.0
   real(kind=REAL64), parameter :: M_map_second_reference_latitude =  30.0
-  
+
   real(kind=REAL64), parameter :: M_sin_phi1 = sin(M_map_second_reference_latitude*easeV2_PI/180.0)
   real(kind=REAL64), parameter :: M_cos_phi1 = cos(M_map_second_reference_latitude*easeV2_PI/180.0)
-  
+
   real(kind=REAL64), parameter :: M_kz = M_cos_phi1/sqrt(1.0-e2*M_sin_phi1*M_sin_phi1)
-  
- 
-contains  
-  
+
+
+contains
+
   ! *******************************************************************
   !
   !   GENERIC routines (public interface)
@@ -155,10 +155,10 @@ contains
   !   EASELabel = *EASEv[x]_[p][yy]*    (e.g., EASEv2_M09)
   !
   !     version:     x  = {  1,  2             }
-  !     projection:  p  = {  M                 }    ! only cylindrical ("M") implemented     
+  !     projection:  p  = {  M                 }    ! only cylindrical ("M") implemented
   !     resolution:  yy = { 01, 03, 09, 25, 36 }    ! 12.5 km not yet implemented
   !
-  !   Coordinate arguments for ease_convert() and ease_inverse():
+  !   Coordinate arguments for MAPL_ease_convert() and MAPL_ease_inverse():
   !
   !     |    map coords    |  0-based index   |   # grid cells   |
   !     |                  |  (real numbers!) |                  |
@@ -170,15 +170,15 @@ contains
   !
   ! --------------------------------------------------------------------
 
-  subroutine ease_convert (EASELabel, lat, lon, r, s, rc)   ! note odd/reversed order of (lat,lon) and (r,s)
-    
+  subroutine MAPL_ease_convert (EASELabel, lat, lon, r, s, rc)   ! note odd/reversed order of (lat,lon) and (r,s)
+
     character*(*),     intent(in)  :: EASELabel
     real,              intent(in)  :: lat, lon
     real,              intent(out) :: r, s         ! r = lon index,  s = lat index
     integer, optional, intent(out) :: rc
     integer :: status
     character(3)  :: grid
-    
+
     if (     index(EASELabel,'M36') /=0 ) then
        grid='M36'
     else if (index(EASELabel,'M25') /=0 ) then
@@ -190,36 +190,36 @@ contains
     else if (index(EASELabel,'M01') /=0 ) then
        grid='M01'
     else
-       _FAIL("ease_convert(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_convert(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
     endif
-    
+
     if(     index(EASELabel,'EASEv2') /=0) then
        call easeV2_convert(grid,lat,lon,r,s)
     else if(index(EASELabel,'EASEv1') /=0) then
        call easeV1_convert(grid,lat,lon,r,s)
     else
-       _FAIL("ease_convert(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_convert(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
     endif
 
     _RETURN(_SUCCESS)
 
-  end subroutine ease_convert
-  
+  end subroutine MAPL_ease_convert
+
   ! *******************************************************************
-  
-  subroutine ease_inverse (EASELabel, r, s, lat, lon, rc)   ! note odd/reversed order of (r,s) and (lat,lon) 
-    
-    ! Note: Get lat/lon of grid cell borders by using fractional indices. 
+
+  subroutine MAPL_ease_inverse (EASELabel, r, s, lat, lon, rc)   ! note odd/reversed order of (r,s) and (lat,lon)
+
+    ! Note: Get lat/lon of grid cell borders by using fractional indices.
     !       E.g., s=-0.5 yields northern grid cell boundary of northernmost grid cells.
-    
+
     character*(*),     intent(in)  :: EASELabel
     real,              intent(in)  :: r, s         ! r = lon index,  s = lat index
     real,              intent(out) :: lat, lon
     integer, optional, intent(out) :: rc
-    
+
     character(3)  :: grid
-    integer       :: status   
- 
+    integer       :: status
+
     if (     index(EASELabel,'M36') /=0 ) then
        grid='M36'
     else if (index(EASELabel,'M25') /=0 ) then
@@ -231,29 +231,29 @@ contains
     else if (index(EASELabel,'M01') /=0 ) then
        grid='M01'
     else
-       _FAIL("ease_inverse(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_inverse(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
     endif
-    
+
     if(     index(EASELabel,'EASEv2') /=0) then
        call easeV2_inverse(grid,r,s,lat,lon, _RC)
     else if(index(EASELabel,'EASEv1') /=0) then
        call easeV1_inverse(grid,r,s,lat,lon, _RC)
     else
-       _FAIL("ease_inverse(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_inverse(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
     endif
 
     _RETURN(_SUCCESS)
 
-  end subroutine ease_inverse
-  
+  end subroutine MAPL_ease_inverse
+
   ! *******************************************************************
-  
-  subroutine ease_extent (EASELabel, cols, rows, cell_area, ll_lon, ll_lat, ur_lon, ur_lat, rc)
-    
-    ! get commonly used EASE grid parameters 
+
+  subroutine MAPL_ease_extent (EASELabel, cols, rows, cell_area, ll_lon, ll_lat, ur_lon, ur_lat, rc)
+
+    ! get commonly used EASE grid parameters
 
     character*(*),           intent(in)  :: EASELabel
-    integer,                 intent(out) :: cols, rows  ! number of grid cells in lon and lat direction, resp. 
+    integer,                 intent(out) :: cols, rows  ! number of grid cells in lon and lat direction, resp.
     real,          optional, intent(out) :: cell_area   ! [m^2]
     real,          optional, intent(out) :: ll_lon      ! lon of grid cell boundary in lower left  corner
     real,          optional, intent(out) :: ll_lat      ! lat of grid cell boundary in lower left  corner
@@ -266,7 +266,7 @@ contains
     real               :: tmplon
     character(3)       :: grid
     integer            :: status
-    
+
     if (     index(EASELabel,'M36') /=0 ) then
        grid='M36'
     else if (index(EASELabel,'M25') /=0 ) then
@@ -278,9 +278,9 @@ contains
     else if (index(EASELabel,'M01') /=0 ) then
        grid='M01'
     else
-       _FAIL("ease_extent(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_extent(): unknown grid projection and resolution: "//trim(EASELabel)//"  STOPPING.")
     endif
-    
+
     if(     index(EASELabel,'EASEv2') /=0) then
 
        call easeV2_get_params(grid, map_scale_m, cols, rows, r0, s0, _RC)
@@ -294,109 +294,109 @@ contains
        if(present(cell_area)) cell_area = CELL_km**2 * 1000. * 1000.
 
     else
-       _FAIL("ease_extent(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
+       _FAIL("MAPL_ease_extent(): unknown grid version: "//trim(EASELabel)//"  STOPPING.")
     endif
 
     ! get lat/lon of corner grid cells
-    ! 
+    !
     ! recall that EASE grid indexing is zero-based
 
-    if (present(ll_lat))  call ease_inverse(EASElabel, 0., rows-0.5, ll_lat, tmplon, _RC)     
-    if (present(ur_lat))  call ease_inverse(EASElabel, 0.,     -0.5, ur_lat, tmplon, _RC)     
-    
+    if (present(ll_lat))  call MAPL_ease_inverse(EASElabel, 0., rows-0.5, ll_lat, tmplon, _RC)
+    if (present(ur_lat))  call MAPL_ease_inverse(EASElabel, 0.,     -0.5, ur_lat, tmplon, _RC)
+
     if (present(ll_lon))  ll_lon = -180.
     if (present(ur_lon))  ur_lon =  180.
 
     _RETURN(_SUCCESS)
 
-  end subroutine ease_extent
+  end subroutine MAPL_ease_extent
 
   ! *******************************************************************
   !
   !   EASEv1 routines (private)
   !
   ! *******************************************************************
-  
+
   subroutine easeV1_convert (grid, lat, lon, r, s, rc)
-    
-    ! convert geographic coordinates (spherical earth) to 
+
+    ! convert geographic coordinates (spherical earth) to
     ! azimuthal equal area or equal area cylindrical grid coordinates
-    ! 
+    !
     ! status = easeV1_convert (grid, lat, lon, r, s)
-    ! 
+    !
     ! input : grid - projection name '[M][xx]'
     !            where xx = approximate resolution [km]
     !               ie xx = "01", "03", "09", "36"       (SMAP)
     !               or xx = "12", "25"                   (SSM/I, AMSR-E)
     ! 	    lat, lon = geo. coords. (decimal degrees)
-    ! 
+    !
     ! output: r, s - column, row coordinates
-    ! 
+    !
     ! result: status = 0 indicates normal successful completion
     ! 		-1 indicates error status (point not on grid)
-    ! 
+    !
     ! --------------------------------------------------------------------------
-        
+
     character*(*),     intent(in)  :: grid
     real,              intent(in)  :: lat, lon
     real,              intent(out) :: r, s
     integer, optional, intent(out) :: rc
 
     ! local variables
-    
+
     integer :: cols, rows, status
     real(kind=REAL64)  :: Rg, phi, lam, rho, CELL_km, r0, s0
-   
-    real(kind=REAL64), parameter :: PI = easeV1_PI 
+
+    real(kind=REAL64), parameter :: PI = easeV1_PI
     ! ---------------------------------------------------------------------
-    
+
     call easeV1_get_params( grid, CELL_km, cols, rows, r0, s0, Rg, _RC)
-    
+
     phi = lat*PI/180.   ! convert from degree to radians
     lam = lon*PI/180.   ! convert from degree to radians
-    
+
     if (grid(1:1).eq.'N') then
        rho = 2 * Rg * sin(PI/4. - phi/2.)
        r = r0 + rho * sin(lam)
        s = s0 + rho * cos(lam)
-       
+
     else if (grid(1:1).eq.'S') then
        rho = 2 * Rg * cos(PI/4. - phi/2.)
        r = r0 + rho * sin(lam)
        s = s0 - rho * cos(lam)
-       
+
     else if (grid(1:1).eq.'M') then
        r = r0 + Rg * lam * easeV1_COS_PHI1
        s = s0 - Rg * sin(phi) / easeV1_COS_PHI1
 
     else
-       _FAIL('Unsupported v1 convert')       
+       _FAIL('Unsupported v1 convert')
     endif
-        
+
     _RETURN(_SUCCESS)
 
   end subroutine easeV1_convert
-  
+
   ! *******************************************************************
-  
+
   subroutine easeV1_inverse (grid, r, s, lat, lon, rc)
-    
-    ! convert azimuthal equal area or equal area cylindrical 
+
+    ! convert azimuthal equal area or equal area cylindrical
     ! grid coordinates to geographic coordinates (spherical earth)
-    ! 
+    !
     ! status = easeV1_inverse (grid, r, s, lat, lon)
-    ! 
+    !
     ! input : grid - projection name '[M][xx]'
     !            where xx = approximate resolution [km]
     !               ie xx = "01", "03", "09", "36"       (SMAP)
     !               or xx = "12", "25"                   (SSM/I, AMSR-E)
     ! 	    r, s - column, row coordinates
-    ! 
+    !
     ! output: lat, lon = geo. coords. (decimal degrees)
-    ! 
+    !
     ! result: status = 0 indicates normal successful completion
     ! 		-1 indicates error status (point not on grid)
-    ! 
+    !
     ! --------------------------------------------------------------------------
 
     character*(*),     intent(in)  :: grid
@@ -404,7 +404,7 @@ contains
     real,              intent(out) :: lat, lon
     integer, optional, intent(out) :: rc
     ! local variables
-    
+
     integer :: cols, rows, status
     real(kind=REAL64)    :: Rg, phi, lam, rho, CELL_km, r0, s0
     real(kind=REAL64)    :: gamma, beta, epsilon, x, y, c
@@ -413,17 +413,17 @@ contains
     real(kind=REAL64), parameter :: PI = easeV1_PI
 
     ! ---------------------------------------------------------------------
-    
+
     call easeV1_get_params( grid, CELL_km, cols, rows, r0, s0, Rg, _RC)
-        
+
     x = r - r0
     y = -(s - s0)
-    
-    if ((grid(1:1).eq.'N').or.(grid(1:1).eq.'S')) then 
+
+    if ((grid(1:1).eq.'N').or.(grid(1:1).eq.'S')) then
        rho = sqrt(x*x + y*y)
        if (rho.eq.0.0) then
-          if (grid(1:1).eq.'N') lat = 90.0 
-          if (grid(1:1).eq.'S') lat = -90.0 
+          if (grid(1:1).eq.'N') lat = 90.0
+          if (grid(1:1).eq.'S') lat = -90.0
           lon = 0.0
        else
           if (grid(1:1).eq.'N') then
@@ -454,13 +454,13 @@ contains
           lat = phi*180./PI   ! convert from radians to degree
           lon = lam*180./PI   ! convert from radians to degree
        endif
-       
+
     else if (grid(1:1).eq.'M') then
-       
+
        ! 	  allow .5 cell tolerance in arcsin function
        ! 	  so that grid coordinates which are less than .5 cells
        ! 	  above 90.00N or below 90.00S are given a lat of 90.00
-       
+
        epsilon = 1 + 0.5/Rg
        beta = y*easeV1_COS_PHI1/Rg
        if (abs(beta).gt.epsilon) return
@@ -478,36 +478,36 @@ contains
        _FAIL('Unsupported v1 grid')
     endif
 
-    _RETURN(_SUCCESS)    
+    _RETURN(_SUCCESS)
 
   end subroutine easeV1_inverse
-  
+
   ! *******************************************************************
 
   subroutine easeV1_get_params( grid, CELL_km, cols, rows, r0, s0, Rg, rc )
-    
+
     implicit none
-    
+
     character*(*),    intent(in)  :: grid
     real(kind=REAL64),intent(out) :: CELL_km, r0, s0, Rg
     integer,          intent(out) :: cols, rows
     integer, optional,intent(out) :: rc
-    
+
     ! --------------------------------------------------------
     !
-    ! r0,s0 are defined such that cells at all scales have 
+    ! r0,s0 are defined such that cells at all scales have
     ! coincident center points
-    ! 
+    !
     !c        r0 = (cols-1)/2. * scale
     !c        s0 = (rows-1)/2. * scale
     !
     ! --------------------------------------------------------
-    integer :: status    
+    integer :: status
 
     if ((grid(1:1).eq.'N').or.(grid(1:1).eq.'S')) then
 
        _FAIL('easeV1_get_params(): polar projections not implemented yet')
-    
+
     else if (grid(1:1).eq.'M') then
 
        if      (grid .eq. 'M36') then ! SMAP 36 km grid
@@ -516,35 +516,35 @@ contains
           rows = 408
           r0 = 481.0
           s0 = 203.5
-       
+
        else if (grid .eq. 'M25') then ! SSM/I, AMSR-E 25 km grid
           CELL_km = 25.067525         ! nominal cell size in kilometers
           cols = 1383
           rows = 586
           r0 = 691.0
           s0 = 292.5
-       
+
        else if (grid .eq. 'M09') then ! SMAP  9 km grid
           CELL_km = 9.00010069766     ! nominal cell size in kilometers
           cols = 3852
           rows = 1632
           r0 = 1925.5
           s0 = 815.5
-       
+
        else if (grid .eq. 'M03') then ! SMAP  3 km grid
           CELL_km = 3.00003356589     ! nominal cell size in kilometers
           cols = 11556
           rows = 4896
           r0 = 5777.5
           s0 = 2447.5
-       
+
        else if (grid .eq. 'M01') then ! SMAP  1 km grid
           CELL_km = 1.00001118863     ! nominal cell size in kilometers
           cols = 34668
           rows = 14688
           r0 = 17333.5
           s0 = 7343.5
-       
+
        else
           _FAIL( 'easeV1_get_params(): unknown resolution: ' // grid)
        endif
@@ -552,120 +552,120 @@ contains
     else
        _FAIL('easeV1_get_params(): unknown projection: '// grid)
     endif
-        
+
     Rg = easeV1_RE_km/CELL_km
 
     _RETURN(_SUCCESS)
-    
+
   end subroutine easeV1_get_params
-  
+
 
   ! *******************************************************************
   !
   !   EASEv2 routines (private)
   !
   ! *******************************************************************
-  
+
   subroutine easeV2_convert (grid, lat, lon, col_ind, row_ind, rc)
-    
-    ! convert geographic coordinates (spherical earth) to 
+
+    ! convert geographic coordinates (spherical earth) to
     ! azimuthal equal area or equal area cylindrical grid coordinates
-    ! 
+    !
     ! *** NOTE order of calling arguments:  "lat-lon-lon-lat" ***
     !
     ! useage: call easeV2_convert (grid, lat, lon, r, s)
-    ! 
+    !
     ! input : grid - projection name '[M][xx]'
     !            where xx = approximate resolution [km]
     !               ie xx = "01", "03", "09", "36"       (SMAP)
     ! 	      lat, lon = geo. coords. (decimal degrees)
-    ! 
+    !
     ! output: col_ind, row_ind - column, row coordinates
-    ! 
+    !
     ! --------------------------------------------------------------------------
-        
+
     character*(*),     intent(in)  :: grid
     real,              intent(in)  :: lat, lon
     real,              intent(out) :: col_ind, row_ind
     integer, optional, intent(out) :: rc
     ! local variables
-    
+
     integer :: cols, rows, status
     real(kind=REAL64)  :: dlon, phi, lam, map_scale_m, r0, s0, ms, x, y, sin_phi, q
 
     real(kind=REAL64), parameter :: PI = easeV2_PI
- 
-    real :: epsilon 
+
+    real :: epsilon
 
     ! ---------------------------------------------------------------------
-    
+
     call easeV2_get_params( grid, map_scale_m, cols, rows, r0, s0, _RC)
 
     epsilon = 1.e-6
     dlon = lon
-    
+
     if (abs(map_reference_longitude)>epsilon) then
-       
+
        dlon = lon - map_reference_longitude
-       
+
     end if
 
     if (dlon .lt. -180.0) dlon = dlon + 360.0
     if (dlon .gt.  180.0) dlon = dlon - 360.0
-    
+
     phi =  lat*PI/180.0   ! convert from degree to radians
     lam = dlon*PI/180.0   ! convert from degree to radians
-    
+
     sin_phi = sin(phi)
-    
+
     ms      = map_eccentricity*sin_phi
-    
+
     q = (1. - e2)*                                                     &
          (                                                             &
          (sin_phi /(1. - e2*sin_phi*sin_phi))                          &
          -                                                             &
          .5/map_eccentricity*log((1.-ms)/(1.+ms))                      &
          )
-    
+
     ! note: "qp" only needed for 'N' and 'S' projections
-    
+
     if      (grid(1:1).eq.'M') then
-       
+
        x =  map_equatorial_radius_m*M_kz*lam
-       
+
        y = (map_equatorial_radius_m*q)/(2.*M_kz)
-       
+
     else
-       
+
        _FAIL('EASEv2_convert(): Polar projections not implemented yet')
-       
+
     endif
-    
+
     row_ind = s0 - (y/map_scale_m)
     col_ind = r0 + (x/map_scale_m)
 
     _RETURN(_SUCCESS)
-    
+
   end subroutine easeV2_convert
-  
+
   ! *******************************************************************
-  
+
   subroutine easeV2_inverse (grid, r, s, lat, lon, rc)
-    
-    ! convert azimuthal equal area or equal area cylindrical 
+
+    ! convert azimuthal equal area or equal area cylindrical
     ! grid coordinates to geographic coordinates (spherical earth)
-    ! 
+    !
     ! *** NOTE order of calling arguments:  "lon-lat-lat-lon" ***
     !
     ! useage: call easeV1_inverse (grid, r, s, lat, lon)
-    ! 
+    !
     ! input : grid - projection name '[M][xx]'
     !            where xx = approximate resolution [km]
     !               ie xx = "01", "03", "09", "36"       (SMAP)
     ! 	      r, s - column, row coordinates
-    ! 
+    !
     ! output: lat, lon = geo. coords. (decimal degrees)
-    ! 
+    !
     ! --------------------------------------------------------------------------
 
     character*(*),     intent(in)  :: grid
@@ -674,76 +674,76 @@ contains
     integer, optional, intent(out) :: rc
 
     ! local variables
-    
+
     integer                      :: cols, rows, status
     real(kind=REAL64)            :: phi, lam, map_scale_m, r0, s0, beta, x, y, qp
-    real(kind=REAL64), parameter :: PI = easeV2_PI   
- 
+    real(kind=REAL64), parameter :: PI = easeV2_PI
+
     ! ---------------------------------------------------------------------
-    
+
     call easeV2_get_params( grid, map_scale_m, cols, rows, r0, s0, _RC)
-    
+
     x =  (r - r0)*map_scale_m
     y = -(s - s0)*map_scale_m
-    
+
     qp = (1. - e2)*                                                           &
          (                                                                    &
          (1./(1.-e2))                                                         &
          -                                                                    &
          .5/map_eccentricity*log((1.-map_eccentricity)/(1.+map_eccentricity)) &
          )
-    
+
     if      (grid(1:1).eq.'M') then
-       
+
        beta = asin(2.*y*M_kz/(map_equatorial_radius_m*qp))
-       
+
        lam  = x/(map_equatorial_radius_m*M_kz)
-       
+
     else
-       
+
        _FAIL('EASEv2_inverse(): Polar projections not implemented yet')
-       
+
     endif
-    
+
     phi = beta                                                              &
          + ( ( e2/3.       + 31./180.*e4 + 517./ 5040.*e6 )*sin(2.*beta) )  &
          + ( (               23./360.*e4 + 251./ 3780.*e6 )*sin(4.*beta) )  &
          + ( (                             761./45360.*e6 )*sin(6.*beta) )
-    
+
     lat = phi*180./PI                            ! convert from radians to degree
     lon = lam*180./PI + map_reference_longitude  ! convert from radians to degree
-    
+
     if (lon .lt. -180.0) lon = lon + 360.0
     if (lon .gt.  180.0) lon = lon - 360.0
 
-    _RETURN(_SUCCESS)   
- 
+    _RETURN(_SUCCESS)
+
   end subroutine easeV2_inverse
-  
+
   ! *******************************************************************
-  
+
   subroutine easeV2_get_params( grid, map_scale_m, cols, rows, r0, s0, rc)
-    
+
     implicit none
-    
+
     character*(*),     intent(in)  :: grid
     real(kind=REAL64), intent(out) :: map_scale_m, r0, s0
     integer,           intent(out) :: cols, rows
     integer, optional, intent(out) :: rc
-    
+
     integer :: status
 
     if (grid(1:1).eq.'M') then
-       
+
        if      (grid .eq. 'M36') then      ! SMAP 36 km grid
-          
+
           map_scale_m = 36032.220840584   ! nominal cell size in meters
           cols = 964
           rows = 406
           r0 = (cols-1)/2.0
           s0 = (rows-1)/2.0
 
-       else if (grid .eq. 'M25') then      ! 25 km grid  
+       else if (grid .eq. 'M25') then      ! 25 km grid
 
           map_scale_m = 25025.2600000      ! nominal cell size in meters (see doi:10.3390/ijgi3031154)
           cols = 1388
@@ -758,7 +758,7 @@ contains
           rows = 1624
           r0 = (cols-1)/2.0
           s0 = (rows-1)/2.0
-          
+
        else if (grid .eq. 'M03') then      ! SMAP  3 km grid
 
           map_scale_m = 3002.6850700487    ! nominal cell size in meters
@@ -766,7 +766,7 @@ contains
           rows = 4872
           r0 = (cols-1)/2.0
           s0 = (rows-1)/2.0
-          
+
        else if (grid .eq. 'M01') then      ! SMAP  1 km grid
 
           map_scale_m = 1000.89502334956   ! nominal cell size in meters
@@ -774,34 +774,34 @@ contains
           rows = 14616
           r0 = (cols-1)/2.0
           s0 = (rows-1)/2.0
-       
+
        else
-          
+
           _FAIL('easeV2_get_params(): unknown resolution: '//grid)
-       
+
        endif
 
     else if ((grid(1:1).eq.'N').or.(grid(1:1).eq.'S')) then
-       
+
        _FAIL('easeV2_get_params(): Polar projections not implemented yet')
-       
+
     else
-       
+
        _FAIL('easeV2_get_params(): unknown projection: '// grid)
-       
+
     endif
 
-    _RETURN(_SUCCESS)       
+    _RETURN(_SUCCESS)
 
   end subroutine easeV2_get_params
 
-  function get_ease_gridname_by_cols(cols, rc) result(name)
+  function MAPL_get_ease_gridname_by_cols(cols, rc) result(name)
 
     ! Obtain EASE grid name based on number of columns (longitudes).
     !
     ! This inverts subroutines easeV[x]_get_params(), with which consistency
-    !   must be maintained manually if more EASE grids are added. 
-    
+    !   must be maintained manually if more EASE grids are added.
+
       integer,           intent(in) :: cols
       integer, optional, intent(out):: rc
 
@@ -819,7 +819,7 @@ contains
         name = 'EASEv2_M03'
       case (34704)
         name = 'EASEv2_M01'
-            
+
       case (963)
         name = 'EASEv1_M36'
       case (1383)
@@ -835,7 +835,7 @@ contains
       end select
       _RETURN(_SUCCESS)
   end function
-  
+
   ! *******************************************************************
 
 end module MAPL_EASEConversion

--- a/base/MAPL_EASEGridFactory.F90
+++ b/base/MAPL_EASEGridFactory.F90
@@ -1,7 +1,7 @@
 #include "MAPL_ErrLog.h"
 
 ! overload set interfaces in legacy
-! Document Pole :: XY 
+! Document Pole :: XY
 !          Date :: DE
 
 ! This module generates Equal Area Scalable Earth (EASE) grids as ESMF_Grids.
@@ -146,7 +146,7 @@ contains
       integer, optional, intent(out):: rc
 
       integer :: status, cols, rows
-      real    :: cell_area, ur_lat, ur_lon, ll_lat, ll_lon 
+      real    :: cell_area, ur_lat, ur_lon, ll_lat, ll_lon
 
       _UNUSED_DUMMY(unusable)
 
@@ -156,7 +156,7 @@ contains
       call set_with_default(factory%nx, nx, MAPL_UNDEFINED_INTEGER)
       call set_with_default(factory%ny, ny, MAPL_UNDEFINED_INTEGER)
 
-      call ease_extent(grid_name, cols, rows, cell_area=cell_area, ll_lon=ll_lon, ll_lat=ll_lat, ur_lon=ur_lon, ur_lat=ur_lat)
+      call MAPL_ease_extent(grid_name, cols, rows, cell_area=cell_area, ll_lon=ll_lon, ll_lat=ll_lat, ur_lon=ur_lon, ur_lat=ur_lat)
 
       call set_with_default(factory%im_world, cols, MAPL_UNDEFINED_INTEGER)
       call set_with_default(factory%jm_world, rows, MAPL_UNDEFINED_INTEGER)
@@ -218,7 +218,7 @@ contains
       _UNUSED_DUMMY(unusable)
 
       if (this%periodic) then
-         if (this%pole == "XY") then 
+         if (this%pole == "XY") then
             polekindflag = ESMF_POLEKIND_NONE
          else
             polekindflag = ESMF_POLEKIND_MONOPOLE
@@ -455,12 +455,12 @@ contains
 
       allocate(lat_centers(this%jm_world))
 
-      ! 
+      !
       ! EASE grid counting from North to South, and the index is based on 0
-      ! 
+      !
       do row = 0, this%jm_world-1
          s = row*1.0
-         call ease_inverse(this%grid_name, 0., s, lat, tmplon) 
+         call MAPL_ease_inverse(this%grid_name, 0., s, lat, tmplon)
          lat_centers(this%jm_world - row) = lat ! use lat-lon grid index to avoid confusion
       enddo
 
@@ -480,17 +480,17 @@ contains
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: rc
 
-      real(kind=REAL32) :: s, lat, tmplon 
+      real(kind=REAL32) :: s, lat, tmplon
 
       integer :: status, row
 
       _UNUSED_DUMMY(unusable)
 
       allocate(lat_corners(this%jm_world+1))
-     
+
       do row = 0, this%jm_world
          s = row - 0.5
-         call ease_inverse(this%grid_name, 0., s, lat, tmplon) 
+         call MAPL_ease_inverse(this%grid_name, 0., s, lat, tmplon)
          lat_corners(this%jm_world +1 -row) = lat
       enddo
 
@@ -602,7 +602,7 @@ contains
          use_file_coords = .false.
       end if
 
-      
+
       this%is_evenspaced = .false.
 
       lon_name = 'lon'
@@ -619,10 +619,10 @@ contains
         end if
       end if
 
-      grid_name = get_ease_gridname_by_cols(im)
+      grid_name = MAPL_get_ease_gridname_by_cols(im)
       this%grid_name = grid_name
-   
-      call ease_extent(grid_name, cols, rows, cell_area=cell_area, ll_lon=ll_lon, ll_lat=ll_lat, ur_lon=ur_lon, ur_lat=ur_lat)
+
+      call MAPL_ease_extent(grid_name, cols, rows, cell_area=cell_area, ll_lon=ll_lon, ll_lat=ll_lat, ur_lon=ur_lon, ur_lat=ur_lat)
 
       call set_with_default(this%im_world, cols, MAPL_UNDEFINED_INTEGER)
       call set_with_default(this%jm_world, rows, MAPL_UNDEFINED_INTEGER)
@@ -688,7 +688,7 @@ contains
 
       ! given grid_name, im_world and jm_world are comupted
 
-      call ease_extent(this%grid_name, this%im_world, this%jm_world, ll_lat=ll_lat, ur_lat=ur_lat)
+      call MAPL_ease_extent(this%grid_name, this%im_world, this%jm_world, ll_lat=ll_lat, ur_lat=ur_lat)
 
       call ESMF_ConfigGetAttribute(config, tmp, label=prefix//'IMS_FILE:', rc=status)
       if ( status == _SUCCESS ) then
@@ -1003,7 +1003,7 @@ contains
       integer :: status
       character(len=2) :: pole ,dateline
       character(len=:), allocatable :: grid_name
-     
+
       type (ESMF_Config) :: config
       type (ESMF_VM) :: vm
       integer :: nPet
@@ -1026,7 +1026,7 @@ contains
       call MAPL_ConfigSetAttribute(config, max_index(2,1), 'JM_WORLD:', _RC)
       call MAPL_ConfigSetAttribute(config, max_index(3,1), 'LM:', _RC)
 
-      grid_name = get_ease_gridname_by_cols(max_index(1,1))
+      grid_name = MAPL_get_ease_gridname_by_cols(max_index(1,1))
       call MAPL_ConfigSetAttribute(config, grid_name, 'GRIDNAME:', _RC)
 
       lon => null()
@@ -1155,9 +1155,9 @@ contains
    function generate_grid_name(this) result(name)
       character(len=:), allocatable :: name
       class (EASEGridFactory), intent(in) :: this
-      
-      name = get_ease_gridname_by_cols(this%im_world)
-   
+
+      name = MAPL_get_ease_gridname_by_cols(this%im_world)
+
    end function generate_grid_name
 
    function check_decomposition(this,unusable,rc) result(can_decomp)
@@ -1584,7 +1584,7 @@ contains
       type(FileMetadata), intent(in) :: metadata
       character(len=*), intent(in) :: coord_name
       integer, optional, intent(out) :: rc
-      
+
       type(Variable), pointer :: var
       integer :: status
 
@@ -1599,7 +1599,7 @@ contains
       type(FileMetadata), intent(in) :: metadata
       character(len=*), intent(in) :: coord_name
       integer, optional, intent(out) :: rc
-      
+
       type(Variable), pointer :: var
       type(Attribute), pointer :: attr
       integer :: status
@@ -1622,7 +1622,7 @@ contains
       type(FileMetadata), intent(in) :: metadata
       character(len=*), intent(in) :: coord_name
       integer, optional, intent(out) :: rc
-      
+
       type(Variable), pointer :: var
       type(Attribute), pointer :: attr
       integer :: status, im, i
@@ -1630,7 +1630,7 @@ contains
       character(len=:), allocatable :: bnds_name, source_file
       real(kind=REAL64), allocatable :: file_bounds(:,:)
       type(NetCDF4_FileFormatter) :: file_formatter
-      
+
 
       var => metadata%get_variable(coord_name, _RC)
       attr => var%get_attribute("bounds", _RC)
@@ -1644,7 +1644,7 @@ contains
       im = metadata%get_dimension(coord_name, _RC)
       allocate(coord_bounds(im+1), _STAT)
       allocate(file_bounds(2,im), _STAT)
-      source_file = metadata%get_source_file() 
+      source_file = metadata%get_source_file()
 
       call file_formatter%open(source_file, PFIO_READ, _RC)
       call file_formatter%get_var(bnds_name, file_bounds, _RC)

--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -17,7 +17,7 @@ module NCIOMod
   use MAPL_BaseMod
   use MAPL_CommsMod
   use MAPL_SortMod
-  use MAPL_EASEConversion, only:  get_ease_gridname_by_cols
+  use MAPL_EASEConversion, only:  MAPL_get_ease_gridname_by_cols
   !use MAPL_RangeMod
   use MAPL_ShmemMod
   use MAPL_ExceptionHandling
@@ -4186,7 +4186,7 @@ contains
 
     else
 
-       pfio_mode = PFIO_NOCLOBBER 
+       pfio_mode = PFIO_NOCLOBBER
        if (clobber) pfio_mode = PFIO_CLOBBER
        if (arrdes%writers_comm /= mpi_comm_null) then
           if (arrdes%num_writers == 1) then
@@ -5280,7 +5280,7 @@ contains
    end subroutine MAPL_ReadTilingNC4
 
    subroutine MAPL_WriteTilingNC4(File, GridName, im, jm, nx, ny, iTable, rTable, N_PfafCat, rc)
-   
+
      character(*),      intent(IN) :: File
      character(*),      intent(IN) :: GridName(:)
      integer,           intent(IN) :: IM(:), JM(:)
@@ -5289,9 +5289,9 @@ contains
      real(REAL64),      intent(IN) :: rTable(:,:)
      integer, optional, intent(in) :: N_PfafCat
      integer, optional, intent(out):: rc
-   
+
      integer                       :: k, ll, ng, ip, status, n_pfafcat_
-   
+
      character(len=:), allocatable :: attr
      type (Variable)               :: v
      type (NetCDF4_FileFormatter)  :: formatter
@@ -5302,31 +5302,31 @@ contains
      logical                       :: EASE
      integer, parameter            :: deflate_level = 1
      integer, parameter            :: SRTM_maxcat = 291284
- 
+
      ng  = size(GridName)
      ip  = size(iTable,1)
-   
+
      EASE = .false.
      if (index(GridName(1), 'EASE') /=0) EASE = .true.
      ! number of Pfafstetter catchments defined in underlying raster file
-   
+
      n_pfafcat_ = SRTM_maxcat
-   
+
      if (present(N_PfafCat)) n_pfafcat_ = N_PfafCat
-   
+
      call metadata%add_dimension('tile', ip)
-   
+
      ! -------------------------------------------------------------------
-     !  
+     !
      ! create nc4 variables and write metadata
-   
+
      do ll = 1, ng
        if (ll == 1) then
          ocn_str = ''
        else
          ocn_str = '_ocn'
        endif
-   
+
        attr = 'Grid'//trim(ocn_str)//'_Name'
        call metadata%add_attribute( attr, trim(GridName(ll)))
        attr = 'IM'//trim(ocn_str)
@@ -5334,7 +5334,7 @@ contains
        attr = 'JM'//trim(ocn_str)
        call metadata%add_attribute( attr, JM(ll))
      enddo
-   
+
      attr = 'raster_nx'
      call metadata%add_attribute( attr, nx)
      attr = 'raster_ny'
@@ -5343,13 +5343,13 @@ contains
      call metadata%add_attribute( attr, n_pfafcat_)
      attr = 'N_Grids'
      call metadata%add_attribute( attr, ng)
-   
+
      v = Variable(type=PFIO_INT32, dimensions='tile')
      call v%add_attribute('units', '1')
      call v%add_attribute('long_name', 'tile_type')
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('typ', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'radian2')
      call v%add_attribute('long_name', 'tile_area')
@@ -5357,7 +5357,7 @@ contains
      call v%add_attribute("_FillValue", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('area', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_center_of_mass_longitude')
@@ -5365,7 +5365,7 @@ contains
      call v%add_attribute("_FillValue", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('com_lon', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_center_of_mass_latitude')
@@ -5373,28 +5373,28 @@ contains
      call v%add_attribute("_FillValue", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('com_lat', v)
-   
+
      do ll = 1, ng
         if (ll == 1) then
            ocn_str = ''
         else
            ocn_str = '_ocn'
         endif
-   
+
         v = Variable(type=PFIO_INT32, dimensions='tile')
         call v%add_attribute('units', '1')
         call v%add_attribute('long_name', 'GRID'//trim(ocn_str)//'_i_index_of_tile_in_global_grid')
         call v%add_attribute("missing_value",   MAPL_UNDEFINED_INTEGER)
         call v%set_deflation(DEFLATE_LEVEL)
         call metadata%add_variable('i_indg'//trim(ocn_str), v)
-   
+
         v = Variable(type=PFIO_INT32, dimensions='tile')
         call v%add_attribute('units', '1')
         call v%add_attribute('long_name', 'GRID'//trim(ocn_str)//'_j_index_of_tile_in_global_grid')
         call v%set_deflation(DEFLATE_LEVEL)
         call v%add_attribute("missing_value",   MAPL_UNDEFINED_INTEGER)
         call metadata%add_variable('j_indg'//trim(ocn_str), v)
-   
+
         v = Variable(type=PFIO_REAL64, dimensions='tile')
         call v%add_attribute('units', '1')
         call v%add_attribute('long_name', 'GRID'//trim(ocn_str)//'_area_fraction_of_tile_in_grid_cell')
@@ -5402,7 +5402,7 @@ contains
         call v%add_attribute("_FillValue",    UNDEF_REAL64)
         call v%set_deflation(DEFLATE_LEVEL)
         call metadata%add_variable('frac_cell'//trim(ocn_str), v)
-   
+
         v = Variable(type=PFIO_INT32, dimensions='tile')
         call v%add_attribute('units', '1')
         call v%add_attribute('long_name', 'internal_dummy_index_of_tile')
@@ -5410,63 +5410,63 @@ contains
         call v%set_deflation(DEFLATE_LEVEL)
         call metadata%add_variable('dummy_index'//trim(ocn_str), v)
      enddo
-   
+
      v = Variable(type=PFIO_INT32, dimensions='tile')
      call v%add_attribute('units', '1')
      call v%add_attribute('long_name', 'Pfafstetter_index_of_tile')
      call v%add_attribute("missing_value",   MAPL_UNDEFINED_INTEGER)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('pfaf_index', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_minimum_longitude')
      call v%add_attribute("missing_value", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('min_lon', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_maximum_longitude')
      call v%add_attribute("missing_value", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('max_lon', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_minimum_latitude')
      call v%add_attribute("missing_value", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('min_lat', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'degree')
      call v%add_attribute('long_name', 'tile_maximum_latitude')
      call v%add_attribute("missing_value", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('max_lat', v)
-   
+
      v = Variable(type=PFIO_REAL64, dimensions='tile')
      call v%add_attribute('units', 'm')
      call v%add_attribute('long_name', 'tile_mean_elevation')
      call v%add_attribute("missing_value", UNDEF_REAL64)
      call v%set_deflation(DEFLATE_LEVEL)
      call metadata%add_variable('elev', v)
-   
+
      ! -------------------------------------------------------------------
-     !  
+     !
      ! write data into nc4 file
-   
+
      call formatter%create(File, mode=PFIO_NOCLOBBER, rc=status)
      call formatter%write(metadata,                   rc=status)
      call formatter%put_var('typ',     iTable(:,0),   rc=status)
      call formatter%put_var('area',    rTable(:,3),   rc=status)
      call formatter%put_var('com_lon', rTable(:,1),   rc=status)
      call formatter%put_var('com_lat', rTable(:,2),   rc=status)
-   
+
      allocate(fr(ip), pfaf(ip))
      fr = UNDEF_REAL64
-   
+
      do ll = 1, ng
         if (ng == 1) then
            if (EASE) then
@@ -5478,20 +5478,20 @@ contains
         else
            KK = iTable(:,5+ll)
         endif
-   
+
         II = iTable(:,ll*2    )
         JJ = iTable(:,ll*2 + 1)
-   
+
         where( rTable(:,3+ll) /=0.0)
            fr = rTable(:,3)/rTable(:,3+ll)
         endwhere
-   
+
         if (ll == 1) then
           ocn_str=''
         else
           ocn_str='_ocn'
         endif
-   
+
         if (ll == 2) then
           pfaf = MAPL_UNDEFINED_INTEGER
           where (iTable(:,0) == 100)
@@ -5503,28 +5503,28 @@ contains
           where (iTable(:,0) == 20)
             pfaf = 200000000
           endwhere
-   
+
           where (iTable(:,0) /=0 )
             II = MAPL_UNDEFINED_INTEGER
             JJ = MAPL_UNDEFINED_INTEGER
             fr = UNDEF_REAL64
           endwhere
         endif
-   
+
         call formatter%put_var('i_indg'    //trim(ocn_str), II, rc=status)
         call formatter%put_var('j_indg'    //trim(ocn_str), JJ, rc=status)
         call formatter%put_var('frac_cell' //trim(ocn_str), fr, rc=status)
         call formatter%put_var('dummy_index'//trim(ocn_str), KK, rc=status)
-   
+
         if (EASE .or. ll == 2) call formatter%put_var('pfaf_index', pfaf, rc=status)
      enddo
-   
+
      call formatter%put_var('min_lon', rTable(:, 6), rc=status)
      call formatter%put_var('max_lon', rTable(:, 7), rc=status)
      call formatter%put_var('min_lat', rTable(:, 8), rc=status)
      call formatter%put_var('max_lat', rTable(:, 9), rc=status)
      call formatter%put_var('elev',    rTable(:,10), rc=status)
-   
+
      call formatter%close(rc=status)
      _RETURN(_SUCCESS)
    end subroutine MAPL_WriteTilingNC4
@@ -5554,7 +5554,7 @@ contains
        _VERIFY(STATUS)
        NT        = hdr(1)
        N_PfafCat = hdr(2)
-       
+
       call READ_PARALLEL(layout, N_GRIDS, unit=UNIT, rc=status)
       _VERIFY(STATUS)
 
@@ -5573,7 +5573,7 @@ contains
           allocate(AVR_transpose(9,NT))
           ! In older tile files, EASE grid name convention is "SMAP-EASEvx-Mxx".
           ! Change her to revised convention "EASEvx_Mxx":
-          Correct_ease_name = get_ease_gridname_by_cols(IM(1))
+          Correct_ease_name = MAPL_get_ease_gridname_by_cols(IM(1))
           GridNAME(1) = Correct_ease_name
       else
          allocate(AVR(NT,NumGlobalVars+NumLocalVars*N_GRIDS), STAT=STATUS)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This is an update to the EASE routine brought over in #3698 . We update the public names to be prefixed with `MAPL_` (e.g., `MAPL_ease_convert`) to allow for a case where a code has MAPL 2.57 but still uses a GEOSgcm_GridComp where `ease_convert` still lives.

This will prevent duplicate routines.

## Related Issue

