### PR TITLE
Fixes #3831 - bug in MAPL_ClockGet

### DIFF
--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -48,7 +48,8 @@ module mapl3g_Generic
    use esmf, only: ESMF_StateIntent_Flag, ESMF_STATEINTENT_INTERNAL
    use esmf, only: ESMF_KIND_I4, ESMF_KIND_I8, ESMF_KIND_R4, ESMF_KIND_R8
    use esmf, only: ESMF_KIND_R8, ESMF_KIND_R4
-   use esmf, only: ESMF_Time, ESMF_TimeInterval, ESMF_TimeIntervalGet, ESMF_Clock, ESMF_ClockGet
+   use esmf, only: ESMF_Time, ESMF_TimeInterval, ESMF_TimeIntervalGet, ESMF_Clock
+   use esmf, only: MAPL_ClockGet => ESMF_ClockGet
    use esmf, only: ESMF_State, ESMF_StateItem_Flag, ESMF_STATEITEM_FIELD
    use esmf, only: operator(==)
    use mapl3g_hconfig_get
@@ -201,7 +202,6 @@ module mapl3g_Generic
 
    interface MAPL_ClockGet
       procedure :: clock_get
-      procedure :: ESMF_ClockGet
    end interface MAPL_ClockGet
 
 contains
@@ -992,6 +992,7 @@ contains
    end subroutine gridcomp_reexport
 
    subroutine clock_get(clock, dt, rc)
+      use esmf, only: ESMF_ClockGet
       type(ESMF_Clock), intent(in) :: clock
       real(ESMF_KIND_R4), intent(out) :: dt ! timestep in seconds
       integer, optional, intent(out) :: rc


### PR DESCRIPTION
Trivial bug - possibly only detected by NAG.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

I was wrong about whether ESMF_ClockGet was a generic name or a specific feature.   Possibly other compilers accept the situation, but NAG actually hangs.   (Too burned out to pursue a reproducer at the moment.)

## Related Issue

