### PR TITLE
Add markup link checker

### DIFF
--- a/.github/workflows/markup-link-checker.yml
+++ b/.github/workflows/markup-link-checker.yml
@@ -8,5 +8,10 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Markup Link Checker (mlc)
       uses: becheran/mlc@v0.22.0
+      with:
+        args: '.'

--- a/.github/workflows/markup-link-checker.yml
+++ b/.github/workflows/markup-link-checker.yml
@@ -1,0 +1,12 @@
+name: "Markup Link Checker"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces that all links in the documentation are valid.
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Markup Link Checker (mlc)
+      uses: becheran/mlc@v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix some incorrect links in the documentation
+
 ### Added
+
+- Add new markup link checker based on [mlc](https://github.com/becheran/mlc)
 
 ### Changed
 
-- Added RC for Timer call in MAPL_Generic.F90
+- Added RC for Timer call in `MAPL_Generic.F90`
 
 ### Removed
 

--- a/docs/user_guide/docs/mapl_Introduction.md
+++ b/docs/user_guide/docs/mapl_Introduction.md
@@ -2,9 +2,9 @@ The Earth System Modeling Framework (ESMF) is a suite of software tools for deve
 
 ESMF supports the development of these complex applications in a number of ways. It introduces a set of simple, consistent component interfaces that apply to all types of components, including couplers themselves. These interfaces expose in an obvious way the inputs and outputs of each component. It offers a variety of data structures for transferring data between components, and libraries for regridding, time advancement, and other common modeling functions. Finally, it provides a growing set of tools for using metadata to describe components and their input and output fields. This capability is important because components that are self-describing can be integrated more easily into automated workflows, model and dataset distribution and analysis portals, and other emerging “semantically enabled” computational environments.
 
-As ESMF has become available and has evolved to be a robust software framework, several groups have been involved in adopting its use in climate and weather prediction models and in data assimilation systems. Existing programs have been converted to use the superstructure of the framework at MIT, NCAR, GFDL, Goddard, NCEP and the DoD (see impacts). 
-One of the most complete attempts to use ESMF has been the development of the [GEOS Systems](https://gmao.gsfc.nasa.gov/GEOS_systems/), a model targeted by the [NASA MAP program](https://map.nasa.gov/models/GEOS-5.php). 
-The GEOS various applications have been built ‘from the ground up’ using the latest available versions of ESMF superstructure and infrastructure. 
+As ESMF has become available and has evolved to be a robust software framework, several groups have been involved in adopting its use in climate and weather prediction models and in data assimilation systems. Existing programs have been converted to use the superstructure of the framework at MIT, NCAR, GFDL, Goddard, NCEP and the DoD (see impacts).
+One of the most complete attempts to use ESMF has been the development of the [GEOS Systems](https://gmao.gsfc.nasa.gov/GEOS_systems/), a model targeted by the NASA MAP program.
+The GEOS various applications have been built ‘from the ground up’ using the latest available versions of ESMF superstructure and infrastructure.
 Figure 1 (below) represents a hierarchical (tree) implementation of the component-based GEOS-5 software where each box is an ESMF component performing some specific function and the root of the tree serves as the top level control point.
 
 
@@ -13,32 +13,32 @@ Figure 1 (below) represents a hierarchical (tree) implementation of the componen
 | Figure 1: _Structure of the GEOS-5 atmospheric general circulation model._ |
 
 
-All of these efforts have produced much constructive feedback to the ESMF core development team, 
-and have helped refine the design and improve the implementation of the framework. 
-They have also served to identify the most important directions for future extensions. 
-Comparing the various implementations led to two seemingly contradictory conclusions: all implementations 
-are different and much of what they do is the same. 
-Both conclusions were anticipated, since ESMF is a general framework designed to meet a wide variety of needs. 
-This generality is an important strength of the ESMF design, but it also implies that there are many different 
+All of these efforts have produced much constructive feedback to the ESMF core development team,
+and have helped refine the design and improve the implementation of the framework.
+They have also served to identify the most important directions for future extensions.
+Comparing the various implementations led to two seemingly contradictory conclusions: all implementations
+are different and much of what they do is the same.
+Both conclusions were anticipated, since ESMF is a general framework designed to meet a wide variety of needs.
+This generality is an important strength of the ESMF design, but it also implies that there are many different
 ways of using ESMF - even when performing very simi- lar tasks.
-Other observations from this early experience were that each group, within its own 
-implementations, repeatedly needed functions that provided higher level functionality than that provided by 
-the basic ESMF tools, and that the core methods of ESMF components (__Run__, __Initialize__, and __Finalize__) 
+Other observations from this early experience were that each group, within its own
+implementations, repeatedly needed functions that provided higher level functionality than that provided by
+the basic ESMF tools, and that the core methods of ESMF components (__Run__, __Initialize__, and __Finalize__)
 looked very similar in all their implementations.
 
 
-The MAPL package arose as a response to this early experience, particularly during the design and implementation of GEOS systems. 
-It is based on the observation that much of the work done in these initial implementations can be standardized; 
-thus, reducing the labor of constructing ESMF applications in the future, as well as increasing their interoperability. 
+The MAPL package arose as a response to this early experience, particularly during the design and implementation of GEOS systems.
+It is based on the observation that much of the work done in these initial implementations can be standardized;
+thus, reducing the labor of constructing ESMF applications in the future, as well as increasing their interoperability.
 In its initial implementation, MAPL provides:
 
 - Specific conventions and best practices for the utilization of ESMF in climate models
 - A middle-ware layer (between the model and ESMF) that facilitates the adoption of ESMF by climate models.
 
-This enhancement in usability of ESMF must come at the cost of reduced generality. 
-To make the framework more usable for our applications, we make assumptions and place requirements on 
-the applications that ESMF, with its goal of generality, could not. 
-MAPL does this ‘on top of’ ESMF and as a separate layer through which the application uses ESMF for 
-some of its functions (although for most things, applications will continue to use ESMF directly). 
-We feel that this middle-ware-layer approach is the right way to get the usability and interoperability 
+This enhancement in usability of ESMF must come at the cost of reduced generality.
+To make the framework more usable for our applications, we make assumptions and place requirements on
+the applications that ESMF, with its goal of generality, could not.
+MAPL does this ‘on top of’ ESMF and as a separate layer through which the application uses ESMF for
+some of its functions (although for most things, applications will continue to use ESMF directly).
+We feel that this middle-ware-layer approach is the right way to get the usability and interoperability
 that climate model components require of the framework, without sacrificing ESMF’s generality and extensibility.

--- a/docs/user_guide/docs/mapl_cap.md
+++ b/docs/user_guide/docs/mapl_cap.md
@@ -1,9 +1,9 @@
 ## MAPL Cap
 
-The main program (or, in ESMF lingo, the Cap) of any ESMF application is 
+The main program (or, in ESMF lingo, the Cap) of any ESMF application is
 provided by the user. In MAPL, it initiates the execution of each of the
 sub-hierarchies of the application (`SetServices`, `Initialize`, `Run`,
-`Finalize`, and the new `Record`). 
+`Finalize`, and the new `Record`).
 Usually, each of these, except `Run` and `Record`, is executed only once.
 
  In MAPL applications, the Cap contains the time loop.
@@ -83,5 +83,5 @@ probably easier to look at its full code than to try to describe its
 functioning in detail. Studying this code should also be useful if one
 decides to write a more specialized custom version to replace it.
 
-For additional information, please consult the document 
-[CapGridComp.md](../../gridcomps/Cap/CapGridComp.md).
+For additional information, please consult the document
+[CapGridComp.md](../../../gridcomps/Cap/CapGridComp.md).


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR adds a new markup link checker based on [mlc](https://github.com/becheran/mlc).

Running it found two issues:

1. A bad link to a Cap Grid Comp markdown file
2. A link that no longer exists to a NASA MAP website: https://map.nasa.gov/models/GEOS-5.php 

I couldn't find a good replacement for the second one.

## Related Issue

