### PR TITLE
A MAPL3 Version of ExtDataDriver.x

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -4,6 +4,8 @@
 # in the other libaries, but this make it explicit which aspects are externally
 # used.
 
+add_subdirectory(MAPL_Component_Driver)
+
 file (COPY MAPL_GridCompSpecs_ACG.py DESTINATION ${esma_etc}/MAPL)
 file (COPY MAPL_GridCompSpecs_ACGv3.py DESTINATION ${esma_etc}/MAPL)
 file (COPY mapl_acg.pl DESTINATION ${esma_etc}/MAPL)

--- a/Apps/MAPL_Component_Driver/CMakeLists.txt
+++ b/Apps/MAPL_Component_Driver/CMakeLists.txt
@@ -2,10 +2,10 @@ esma_set_this (OVERRIDE root_gridcomp)
 find_package (MPI REQUIRED)
 
 esma_add_library(${this}
-  SRCS RootGridComp.F90
+  SRCS RootGridComp.F90 time_support.F90
   DEPENDENCIES mapl3g MAPL
   TYPE SHARED)
 
-ecbuild_add_executable(TARGET MAPL_Component_Driver.x SOURCES MAPL_Component_Driver.F90 DriverCap.F90 DriverCapGridComp.F90 time_support.F90 DEPENDS MAPL mapl3g ESMF::ESMF)
+ecbuild_add_executable(TARGET MAPL_Component_Driver.x SOURCES MAPL_Component_Driver.F90 DriverCap.F90 DriverCapGridComp.F90 DEPENDS MAPL mapl3g ESMF::ESMF)
 target_link_libraries(MAPL_Component_Driver.x PRIVATE ${this})
 target_include_directories (MAPL_Component_Driver.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/Apps/MAPL_Component_Driver/CMakeLists.txt
+++ b/Apps/MAPL_Component_Driver/CMakeLists.txt
@@ -1,0 +1,11 @@
+esma_set_this (OVERRIDE root_gridcomp)
+find_package (MPI REQUIRED)
+
+esma_add_library(${this}
+  SRCS RootGridComp.F90
+  DEPENDENCIES mapl3g MAPL
+  TYPE SHARED)
+
+ecbuild_add_executable(TARGET MAPL_Component_Driver.x SOURCES MAPL_Component_Driver.F90 DriverCap.F90 DriverCapGridComp.F90 time_support.F90 DEPENDS MAPL mapl3g ESMF::ESMF)
+target_link_libraries(MAPL_Component_Driver.x PRIVATE ${this})
+target_include_directories (MAPL_Component_Driver.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/Apps/MAPL_Component_Driver/CMakeLists.txt
+++ b/Apps/MAPL_Component_Driver/CMakeLists.txt
@@ -1,11 +1,6 @@
-esma_set_this (OVERRIDE root_gridcomp)
+
 find_package (MPI REQUIRED)
 
-esma_add_library(${this}
-  SRCS RootGridComp.F90 time_support.F90
-  DEPENDENCIES mapl3g MAPL
-  TYPE SHARED)
-
-ecbuild_add_executable(TARGET MAPL_Component_Driver.x SOURCES MAPL_Component_Driver.F90 DriverCap.F90 DriverCapGridComp.F90 DEPENDS MAPL mapl3g ESMF::ESMF)
-target_link_libraries(MAPL_Component_Driver.x PRIVATE ${this})
+ecbuild_add_executable(TARGET MAPL_Component_Driver.x SOURCES MAPL_Component_Driver.F90 DriverCap.F90 DriverCapGridComp.F90 RootGridComp.F90 time_support.F90 DEPENDS MAPL mapl3g ESMF::ESMF)
+target_link_libraries (MAPL_Component_Driver.x PRIVATE MAPL mapl3g MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (MAPL_Component_Driver.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/Apps/MAPL_Component_Driver/DriverCap.F90
+++ b/Apps/MAPL_Component_Driver/DriverCap.F90
@@ -1,0 +1,159 @@
+#include "MAPL_Generic.h"
+
+module mapl3g_DriverCap
+   use mapl3
+   use mapl3g_DriverCapGridComp, only: cap_setservices => setServices
+   use MAPL_TimeStringConversion, only: hconfig_to_esmf_timeinterval
+   use esmf, only: ESMF_GridCompSetServices
+   implicit none
+   private
+
+   public :: MAPL_run_driver_cap
+
+contains
+
+
+   subroutine MAPL_run_driver_cap(hconfig, is_model_pet, unusable, servers, rc)
+      USE MAPL_ApplicationSupport
+      type(ESMF_HConfig), intent(inout) :: hconfig
+      logical, intent(in) :: is_model_pet
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      type(ESMF_GridComp), optional, intent(in) :: servers(:)
+      integer, optional, intent(out) :: rc
+
+      type(GriddedComponentDriver) :: driver
+      integer :: status
+
+      driver = make_driver(hconfig, is_model_pet, _RC)
+
+      if (is_model_pet) then
+         call initialize_phases(driver, phases=GENERIC_INIT_PHASE_SEQUENCE, _RC)
+         call integrate(driver, _RC)
+         call driver%write_restart(_RC)
+         call driver%finalize(_RC)
+      end if
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine MAPL_run_driver_cap
+
+   function make_driver(hconfig, is_model_pet, rc) result(driver)
+      use mapl3g_GenericGridComp, only: generic_SetServices => setServices
+      type(GriddedComponentDriver) :: driver
+      type(ESMF_HConfig), intent(inout) :: hconfig
+      logical, intent(in) :: is_model_pet
+      integer, optional, intent(out) :: rc
+
+      type(ESMF_GridComp) :: cap_gridcomp
+      type(ESMF_Clock) :: clock
+      character(:), allocatable :: cap_name
+      integer :: status, user_status
+      type(ESMF_HConfig) :: cap_gc_hconfig
+      integer, allocatable :: petList(:)
+
+      cap_name = ESMF_HConfigAsString(hconfig, keystring='name', _RC)
+      clock = create_clock(hconfig, _RC)
+
+      cap_gc_hconfig = ESMF_HConfigCreateAt(hconfig, keystring='cap_gc', _RC)
+      petList = get_model_pets(is_model_pet, _RC)
+      cap_gridcomp = MAPL_GridCompCreate(cap_name, user_setservices(cap_setservices), cap_gc_hconfig, petList=petList, _RC)
+
+      call ESMF_GridCompSetServices(cap_gridcomp, generic_setServices, userRC=user_status, _RC)
+      _VERIFY(user_status)
+
+      driver = GriddedComponentDriver(cap_gridcomp, clock=clock)
+
+      _RETURN(_SUCCESS)
+   end function make_driver
+
+   ! Create function that accepts a logical flag returns list of mpi processes that have .true..
+   function get_model_pets(flag, rc) result(petList)
+      use mpi
+      integer, allocatable :: petList(:)
+      logical, intent(in) :: flag
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_VM) :: vm
+      logical, allocatable, target :: flags(:)
+      integer :: world_comm
+      integer :: i, petCount
+      
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, petCount=petCount, mpiCommunicator=world_comm, _RC)
+      allocate(flags(petCount))
+      call MPI_Allgather(flag, 1, MPI_LOGICAL, flags, 1, MPI_LOGICAL, world_comm, status)
+      _VERIFY(status)
+      petList = pack([(i, i=0,petCount-1)], flags)
+
+      _RETURN(_SUCCESS)
+   end function get_model_pets
+
+   function create_clock(hconfig, rc) result(clock)
+      type(ESMF_Clock) :: clock
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Time) :: startTime, stopTime, end_of_segment
+      type(ESMF_TimeInterval) :: timeStep, segment_duration
+      type(ESMF_HConfig) :: clock_config
+      
+      clock_config = ESMF_HConfigCreateAt(hconfig, keystring='clock', _RC)
+
+      call ESMF_CalendarSetDefault(ESMF_CALKIND_GREGORIAN,_RC)
+      call set_time(startTime, 'start', clock_config, _RC)
+      call ESMF_TimePrint(startTime, options='string', prestring='start time set: ' ,_RC)
+      call set_time(stopTime, 'stop', clock_config, _RC)
+      call ESMF_TimePrint(stopTime, options='string', prestring='stop time set: ', _RC)
+      timeStep = hconfig_to_esmf_timeinterval(clock_config, 'dt', _RC)
+      segment_duration = hconfig_to_esmf_timeinterval(clock_config, 'segment_duration', _RC)
+
+      end_of_segment = startTime + segment_duration
+      if (end_of_segment < stopTime) stopTime = end_of_segment
+      call ESMF_TimePrint(stopTime, options='string', prestring='actual stop time set: ', _RC)
+      clock = ESMF_ClockCreate(timeStep=timeStep, startTime=startTime, stopTime=stopTime, refTime=startTime, _RC)
+      
+      _RETURN(_SUCCESS)
+   end function create_clock
+
+   subroutine set_time(time, key, hconfig, rc)
+      type(ESMF_Time), intent(out) :: time
+      character(*), intent(in) :: key
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      character(:), allocatable :: iso_time
+      
+      iso_time = ESMF_HConfigAsString(hconfig, keystring=key, _RC)
+      call ESMF_TimeSet(time, timeString=iso_time, _RC)
+      
+      _RETURN(_SUCCESS)
+   end subroutine set_time
+
+   subroutine integrate(driver, rc)
+      type(GriddedComponentDriver), intent(inout) :: driver
+      integer, optional, intent(out) :: rc
+
+      integer :: status, hour, minute, second, year, month, day
+      type(ESMF_Clock) :: clock
+      type(ESMF_Time) :: currTime, stopTime
+
+      clock = driver%get_clock()
+      call ESMF_ClockGet(clock, currTime=currTime, stopTime=stopTime, _RC)
+      
+      do while (currTime < stopTime)
+         call ESMF_TimeGet(currTime, yy=year, mm=month, dd=day, h=hour, m=minute, s=second,  _RC)
+         call driver%run(phase_idx=GENERIC_RUN_USER, _RC)
+         call driver%run(phase_idx=GENERIC_RUN_CLOCK_ADVANCE, _RC)
+         call driver%clock_advance(_RC)
+         call ESMF_ClockGet(clock, currTime=currTime, _RC)
+      end do
+      call esmf_TimePrint(currTime, options='string', preString='Cap time after loop: ', _RC)
+
+      _RETURN(_SUCCESS)
+      
+   end subroutine integrate
+
+end module mapl3g_DriverCap

--- a/Apps/MAPL_Component_Driver/DriverCapGridComp.F90
+++ b/Apps/MAPL_Component_Driver/DriverCapGridComp.F90
@@ -1,0 +1,97 @@
+#include "MAPL_Generic.h"
+module mapl3g_DriverCapGridComp
+   use :: generic3g
+   use :: mapl_ErrorHandling 
+   implicit none
+
+   private
+
+   public :: setServices
+
+   type :: DriverCapGridComp
+      character(:), allocatable :: extdata_name
+      character(:), allocatable :: history_name
+      character(:), allocatable :: root_name
+      logical :: run_extdata
+      logical :: run_history
+   end type DriverCapGridComp
+
+   character(*), parameter :: PRIVATE_STATE = 'DriverCapGridComp'
+    
+contains
+   
+   subroutine setServices(gridcomp, rc)
+      type(ESMF_GridComp) :: gridcomp
+      integer, intent(out) :: rc
+
+      integer :: status
+      type(DriverCapGridComp), pointer :: cap
+      character(:), allocatable :: extdata, history
+      type(OuterMetaComponent), pointer :: outer_meta
+
+      ! Set entry points
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_INITIALIZE, init, phase_name='GENERIC::INIT_USER', _RC)
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, run, phase_name='run', _RC)
+
+      ! Attach private state
+      _SET_NAMED_PRIVATE_STATE(gridcomp, DriverCapGridComp, PRIVATE_STATE)
+      _GET_NAMED_PRIVATE_STATE(gridcomp, DriverCapGridComp, PRIVATE_STATE, cap)
+
+      ! Disable extdata or history
+      call MAPL_GridCompGetResource(gridcomp, keystring='run_extdata', value=cap%run_extdata, default=.true., _RC)
+      call MAPL_GridCompGetResource(gridcomp, keystring='run_history', value=cap%run_history, default=.true., _RC)
+
+      ! Get Names of children
+      call MAPL_GridCompGetResource(gridcomp, keystring='extdata_name', value=cap%extdata_name, default='EXTDATA', _RC)
+      call MAPL_GridCompGetResource(gridcomp, keystring='root_name', value=cap%root_name, _RC)
+      call MAPL_GridCompGetResource(gridcomp, keystring='history_name', value=cap%history_name, default='HIST', _RC)
+
+      if (cap%run_extdata) then 
+         call MAPL_GridCompConnectAll(gridcomp, src_comp=cap%extdata_name, dst_comp=cap%root_name, _RC)
+      end if
+      if (cap%run_history) then
+         call MAPL_GridCompConnectAll(gridcomp, src_comp=cap%root_name, dst_comp=cap%history_name, _RC)
+      end if
+      _RETURN(_SUCCESS)
+   end subroutine setServices
+
+   subroutine init(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp)   :: gridcomp
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, intent(out)  :: rc
+
+      integer :: status
+      type(DriverCapGridComp), pointer :: cap
+
+  _GET_NAMED_PRIVATE_STATE(gridcomp, DriverCapGridComp, PRIVATE_STATE, cap)
+
+      _RETURN(_SUCCESS)
+   end subroutine init
+
+
+   subroutine run(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp)   :: gridcomp
+      type(ESMF_State)      :: importState
+      type(ESMF_State)      :: exportState
+      type(ESMF_Clock)      :: clock      
+      integer, intent(out)  :: rc
+
+      integer :: status
+      type(DriverCapGridComp), pointer :: cap
+
+      _GET_NAMED_PRIVATE_STATE(gridcomp, DriverCapGridComp, PRIVATE_STATE, cap)
+
+      if (cap%run_extdata) then
+         call MAPL_GridCompRunChild(gridcomp, cap%extdata_name, _RC)
+      end if
+      call MAPL_GridCompRunChild(gridcomp, cap%root_name, _RC)
+      if (cap%run_history) then
+         call MAPL_GridCompRunChild(gridcomp, cap%history_name, phase_name='run', _RC)
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine run
+
+end module mapl3g_DriverCapGridComp

--- a/Apps/MAPL_Component_Driver/MAPL_Component_Driver.F90
+++ b/Apps/MAPL_Component_Driver/MAPL_Component_Driver.F90
@@ -1,0 +1,44 @@
+#define I_AM_MAIN
+#include "MAPL_Generic.h"
+
+program mapl_component_driver
+   use mapl3
+   use mapl3g_DriverCap
+   use esmf
+   implicit none
+
+   integer :: status
+   type(ESMF_HConfig) :: hconfig
+   logical :: is_model_pet
+   type(ESMF_GridComp), allocatable :: servers(:)
+
+   call MAPL_Initialize(hconfig=hconfig, is_model_pet=is_model_pet, servers=servers, configFileNameFromArgNum=1, _RC)
+   call run_driver(hconfig, is_model_pet=is_model_pet, servers=servers, _RC)
+   call MAPL_Finalize(_RC)
+
+contains
+
+#undef I_AM_MAIN
+#include "MAPL_Generic.h"
+
+   subroutine run_driver(hconfig, is_model_pet, servers, rc)
+      type(ESMF_HConfig), intent(inout) :: hconfig
+      logical, intent(in) :: is_model_pet
+      type(ESMF_GridComp), optional, intent(in) :: servers(:)
+      integer, optional, intent(out) :: rc
+
+      logical :: has_cap_hconfig
+      type(ESMF_HConfig) :: cap_hconfig
+      integer :: status
+
+      has_cap_hconfig = ESMF_HConfigIsDefined(hconfig, keystring='cap', _RC)
+      _ASSERT(has_cap_hconfig, 'No cap section found in configuration file')
+      cap_hconfig = ESMF_HConfigCreateAt(hconfig, keystring='cap', _RC)
+
+      call MAPL_run_driver_cap(cap_hconfig, is_model_pet=is_model_pet, servers=servers, _RC)
+      call ESMF_HConfigDestroy(cap_hconfig, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine run_driver
+
+end program mapl_component_driver

--- a/Apps/MAPL_Component_Driver/RootGridComp.F90
+++ b/Apps/MAPL_Component_Driver/RootGridComp.F90
@@ -1,0 +1,286 @@
+#include "MAPL_Generic.h"
+
+module mapl3g_RootgGridComp
+
+   use mapl_ErrorHandling
+   use mapl3
+   use mapl, only: MAPL_GetPointer
+   use esmf
+   use gFTL2_StringStringMap
+   use MAPL_StateUtils
+   use timeSupport
+
+   implicit none
+   private
+
+   public :: setServices
+
+   type :: Comp_Driver_Support
+      type(StringStringMap) :: fillDefs
+      character(len=:), allocatable :: runMode
+      type(timeVar) :: tFunc
+      real :: delay ! in seconds
+   end type Comp_Driver_Support 
+
+   character(*), parameter :: PRIVATE_STATE = "Comp_Driver_Support"
+   character(*), parameter :: MAPL_SECTION = "mapl"
+   character(*), parameter :: COMPONENT_STATES_SECTION = "states"
+   character(*), parameter :: COMPONENT_EXPORT_STATE_SECTION = "export"
+   character(*), parameter :: KEY_DEFAULT_VERT_PROFILE = "default_vertical_profile"
+   character(len=*), parameter :: runModeGenerateExports = "GenerateExports"
+
+contains
+
+   subroutine setServices(gridcomp, rc)
+      type(ESMF_GridComp) :: gridcomp
+      integer, intent(out) :: rc
+
+      integer :: status
+
+       
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_INITIALIZE, init, _RC)
+      call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, run, phase_name="run", _RC)
+            ! Attach private state
+      _SET_NAMED_PRIVATE_STATE(gridcomp, Comp_Driver_Support, PRIVATE_STATE)
+      call add_internal_specs(gridcomp, _RC)
+
+      _RETURN(_SUCCESS)
+      contains
+
+         subroutine add_internal_specs(gridcomp, rc)
+            type(ESMF_GridComp), intent(inout) :: gridcomp
+            integer, intent(out), optional :: rc
+            type(VariableSpec) :: varspec
+            integer :: status
+            varspec = make_VariableSpec(state_intent=ESMF_STATEINTENT_INTERNAL, &
+                                        short_name='time_interval' , & 
+                                        standard_name='unknown', &
+                                        units='unknown', &
+                                        vertical_stagger=VERTICAL_STAGGER_NONE, &
+                                        default_value=0.0, _RC)
+            call MAPL_GridCompAddVarSpec(gridcomp, varspec, _RC)
+            varspec = make_VariableSpec(state_intent=ESMF_STATEINTENT_INTERNAL, &
+                                        short_name='rand' , & 
+                                        standard_name='randomnumber', &
+                                        units='unknown', &
+                                        vertical_stagger=VERTICAL_STAGGER_NONE, &
+                                        default_value=0.0, _RC)
+            call MAPL_GridCompAddVarSpec(gridcomp, varspec, _RC)
+            varspec = make_VariableSpec(state_intent=ESMF_STATEINTENT_INTERNAL, &
+                                        short_name='grid_lons' , & 
+                                        standard_name='longitude', &
+                                        units='degrees_east', &
+                                        vertical_stagger=VERTICAL_STAGGER_NONE, &
+                                        default_value=0.0, _RC)
+            call MAPL_GridCompAddVarSpec(gridcomp, varspec, _RC)
+            varspec = make_VariableSpec(state_intent=ESMF_STATEINTENT_INTERNAL, &
+                                        short_name='grid_lats' , & 
+                                        standard_name='latitude', &
+                                        units='degrees_north', &
+                                        vertical_stagger=VERTICAL_STAGGER_NONE, &
+                                        default_value=0.0, _RC)
+            call MAPL_GridCompAddVarSpec(gridcomp, varspec, _RC)
+            _RETURN(_SUCCESS)
+
+         end subroutine
+   end subroutine setServices
+
+   subroutine init(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp) :: gridcomp
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
+
+      character(:), allocatable :: field_name
+      type(ESMF_HConfig) :: hconfig, mapl_cfg, states_cfg, export_cfg, field_cfg, fill_def
+      logical :: has_export_section, has_default_vert_profile
+      real(kind=ESMF_KIND_R4), allocatable :: default_vert_profile(:)
+      real(kind=ESMF_KIND_R4), pointer :: ptr3d(:, :, :)
+      integer :: ii, jj, shape_(3), status
+      type(ESMF_State) :: internal_state
+      type(Comp_Driver_Support), pointer :: support
+      type(ESMF_HConfigIter) :: iter, e, b
+      logical :: is_present
+      character(len=:), allocatable :: key, keyVal
+      type(ESMF_Time) :: current_time
+
+      _GET_NAMED_PRIVATE_STATE(gridcomp, Comp_Driver_Support, PRIVATE_STATE, support)
+      call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
+      ! ASSUME: mapl and states sections always exist
+      mapl_cfg = ESMF_HConfigCreateAt(hconfig, keyString=MAPL_SECTION, _RC)
+      states_cfg = ESMF_HConfigCreateAt(mapl_cfg, keyString=COMPONENT_STATES_SECTION, _RC)
+      has_export_section = ESMF_HConfigIsDefined(states_cfg, keyString=COMPONENT_EXPORT_STATE_SECTION, _RC)
+      _RETURN_UNLESS(has_export_section)
+
+      ! For each field getting 'export'ed, check hconfig and use default_vert_profile if specified
+      export_cfg = ESMF_HConfigCreateAt(states_cfg, keyString=COMPONENT_EXPORT_STATE_SECTION, _RC)
+      b = ESMF_HConfigIterBegin(export_cfg, _RC)
+      e = ESMF_HConfigIterEnd(export_cfg, _RC)
+      iter = b
+      do while (ESMF_HConfigIterLoop(iter, b, e))
+         field_name = ESMF_HConfigAsStringMapKey(iter, _RC)
+         ! print *, "FIELD: ", field_name
+         field_cfg = ESMF_HConfigCreateAtMapVal(iter, _RC)
+         has_default_vert_profile = ESMF_HConfigIsDefined(field_cfg, keyString=KEY_DEFAULT_VERT_PROFILE, _RC)
+         if (has_default_vert_profile) then
+            default_vert_profile = ESMF_HConfigAsR4Seq(field_cfg, keyString=KEY_DEFAULT_VERT_PROFILE, _RC)
+            call MAPL_GetPointer(exportState, ptr3d, trim(field_name), _RC)
+            shape_ = shape(ptr3d)
+            _ASSERT(shape_(3) == size(default_vert_profile), "incorrect size of vertical profile")
+            do concurrent(ii = 1:shape_(1), jj=1:shape_(2))
+               ptr3d(ii, jj, :) = default_vert_profile
+            end do
+         end if
+      end do
+
+      support%runMode = ESMF_HConfigAsString(hconfig, keyString='RUN_MODE', _RC)
+      support%delay = -1.0
+      is_present = ESMF_HConfigIsDefined(hconfig, keyString='delay', _RC)
+      if (is_present) then
+         support%delay = ESMF_HConfigAsR4(hconfig, keyString='delay', _RC)
+      end if
+      fill_def = ESMF_HConfigCreateAt(hconfig, keyString='FILL_DEF', _RC)
+      b = ESMF_HConfigIterBegin(fill_def, _RC)
+      e = ESMF_HConfigIterEnd(fill_def, _RC)
+      iter = b
+      do while (ESMF_HConfigIterLoop(iter, b, e))
+         key = ESMF_HConfigAsStringMapKey(iter, _RC)
+         keyVal = ESMF_HConfigAsStringMapVal(iter, _RC)
+         call support%fillDefs%insert(key, keyVal) 
+      enddo 
+      call ESMF_ClockGet(clock, currTime=current_time, _RC)
+      call support%tFunc%init_time(hconfig, current_time, _RC)
+      
+      call MAPL_GridCompGetInternalState(gridcomp, internal_state, _RC) 
+      call initialize_internal_state(internal_state, support, _RC)
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(importState)
+      _UNUSED_DUMMY(clock)
+   end subroutine init
+
+   recursive subroutine run(gridcomp, importState, exportState, clock, rc)
+      type(ESMF_GridComp) :: gridcomp
+      type(ESMF_State) :: importState
+      type(ESMF_State) :: exportState
+      type(ESMF_Clock) :: clock
+      integer, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_State) :: internal_state
+      type(Comp_Driver_Support), pointer :: support
+      type(ESMF_Time) :: current_time
+
+      _GET_NAMED_PRIVATE_STATE(gridcomp, Comp_Driver_Support, PRIVATE_STATE, support)
+      call ESMF_ClockGet(clock, currTime=current_time, _RC)
+      call MAPL_GridCompGetInternalState(gridcomp, internal_state, _RC) 
+      call update_internal_state(internal_state, current_time, support, _RC)
+
+      if (support%runMode == "GenerateExports") then
+         call fill_state_from_internal(exportState, internal_state, support, _RC)
+      else
+         _FAIL("no run mode selected")
+      end if
+      _UNUSED_DUMMY(importState)
+      _UNUSED_DUMMY(exportState)
+      _UNUSED_DUMMY(clock)
+      _RETURN(_SUCCESS)
+
+   end subroutine run
+
+   subroutine initialize_internal_state(internal_state, support, rc)
+      type(ESMF_State), intent(inout) :: internal_state
+      type(Comp_Driver_Support), intent(inout) :: support
+      integer, optional, intent(out) :: rc
+
+      real, pointer :: ptr_2d(:,:)
+      real(ESMF_KIND_R8), pointer :: coords(:,:)
+      integer :: status, seed_size, mypet
+      integer, allocatable :: seeds(:)
+      type(ESMF_Field) :: field
+      type(ESMF_Grid) :: grid
+      type(ESMF_VM) :: vm
+
+      ! rand
+      call MAPL_StateGetPointer(internal_state, ptr_2d, 'rand', _RC)
+      call random_seed(size=seed_size)
+      allocate(seeds(seed_size))
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, localPet=mypet, _RC)
+      seeds = mypet
+      call random_seed(put=seeds)
+      call random_number(ptr_2d)
+      ! lons and lats
+      call MAPL_StateGetPointer(internal_state, ptr_2d, 'grid_lons', _RC)
+      call ESMF_StateGet(internal_state, 'grid_lons', field, _RC)
+      call ESMF_FieldGet(field, grid=grid, _RC)
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+                             staggerloc=ESMF_STAGGERLOC_CENTER, &
+                             farrayPtr=coords, _RC)
+      ptr_2d = coords
+      call MAPL_StateGetPointer(internal_state, ptr_2d, 'grid_lats', _RC)
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+                             staggerloc=ESMF_STAGGERLOC_CENTER, &
+                             farrayPtr=coords, _RC)
+      ptr_2d = coords
+
+      _RETURN(_SUCCESS)
+
+   end subroutine initialize_internal_state
+
+   subroutine update_internal_state(internal_state, current_time, support, rc)
+      type(ESMF_State), intent(inout) :: internal_state
+      type(ESMF_Time), intent(inout) :: current_time
+      type(Comp_Driver_Support), intent(inout) :: support
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      real, pointer :: ptr_2d(:,:)
+
+      call MAPL_StateGetPointer(internal_state, ptr_2d, 'time_interval', _RC)
+      ptr_2d = support%tFunc%evaluate_time(current_time, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end subroutine update_internal_state
+
+   subroutine fill_state_from_internal(state, internal_state, support, rc)
+      type(ESMF_State), intent(inout) :: state
+      type(ESMF_State), intent(inout) :: internal_state
+      type(Comp_Driver_Support), intent(inout) :: support
+      integer, optional, intent(out) :: rc
+     
+      integer :: status, item_count, i
+      character(len=ESMF_MAXSTR), allocatable :: name_list(:)
+      type(ESMF_Field) :: field
+      character(len=:), pointer :: expression
+    
+      call ESMF_StateGet(state, itemCount=item_count, _RC) 
+      allocate(name_list(item_count), _STAT)
+      call ESMF_StateGet(state, itemNameList=name_list, _RC)
+      do i=1,item_count
+         call ESMF_StateGet(state, trim(name_list(i)), field, _RC)
+         expression => support%fillDefs%at(trim(name_list(i)))
+         _ASSERT(associated(expression), "no expression for item "//trim(name_list(i)))
+         call MAPL_StateEval(internal_state, expression, field, _RC)
+      enddo
+      
+      _RETURN(_SUCCESS)
+
+   end subroutine fill_state_from_internal 
+
+end module Mapl3g_RootgGridComp
+
+subroutine setServices(gridcomp, rc)
+   use ESMF
+   use MAPL_ErrorHandlingMod
+   use mapl3g_RootgGridComp, only: Root_setServices => SetServices
+   type(ESMF_GridComp)  :: gridcomp
+   integer, intent(out) :: rc
+
+   integer :: status
+
+   call Root_setServices(gridcomp, _RC)
+
+   _RETURN(_SUCCESS)
+end subroutine setServices

--- a/Apps/MAPL_Component_Driver/time_support.F90
+++ b/Apps/MAPL_Component_Driver/time_support.F90
@@ -1,0 +1,144 @@
+#include "MAPL_Generic.h"
+module timeSupport
+   use mapl_ErrorHandling
+   use ESMF
+   use MAPL_TimeStringConversion, only: hconfig_to_esmf_timeinterval
+   implicit none
+
+   public timeVar
+
+   type :: timeVar
+      type(ESMF_Time) :: refTime
+      character(len=10) :: timeUnits
+      integer :: climYear
+      logical :: have_offset
+      integer :: update_ref_time
+      type(ESMF_TimeInterval) :: update_offset
+   contains
+      procedure :: init_time
+      procedure :: evaluate_time
+      procedure :: set_time_for_date
+   end type timeVar
+
+contains
+
+   subroutine init_time(this,hconfig,currTime,rc)
+      class(timeVar), intent(inout) :: this
+      type(ESMF_HConfig), intent(inout) :: hconfig
+      type(ESMF_Time), intent(inout) :: currTime
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      logical :: isPresent
+
+      character(len=:), allocatable :: iso_time
+
+      isPresent = ESMF_HConfigIsDefined(hconfig, keyString='REF_TIME', _RC)
+      if (isPresent) then
+         iso_time = ESMF_HConfigAsString(Hconfig, keyString='REF_TIME', _RC)
+         call ESMF_TimeSet(this%refTime, timeString=iso_time, _RC)
+      else
+         this%refTime=currTime
+      end if
+      
+      this%timeUnits = 'days'
+      isPresent = ESMF_HConfigIsDefined(hconfig, keyString='TIME_UNITS', _RC)
+      if (isPresent) then
+         this%timeUnits = ESMF_HConfigAsString(hconfig, keyString='TIME_UNITS', _RC)
+      end if
+
+      this%climYear = -1
+      isPresent = ESMF_HConfigIsDefined(hconfig, keyString='CLIM_YEAR', _RC)
+      if (isPresent) then
+         this%climYear = ESMF_HConfigAsI4(hconfig, keyString='CLIM_YEAR', _RC)
+      end if
+
+      this%have_offset = .false.
+      this%update_ref_time = -1
+      isPresent = ESMF_HConfigIsDefined(hconfig, keyString='UPDATE_OFFSET', _RC)
+      if (isPresent) then
+         this%update_offset = hconfig_to_esmf_timeinterval(hconfig, 'UPDATE_OFFSET', _RC)
+         this%have_offset = .true.
+      end if
+      
+      isPresent = ESMF_HConfigIsDefined(hconfig, keyString='UPDATE_REF_TIME', _RC)
+      if (isPresent) then
+         this%update_ref_time = ESMF_HConfigAsI4(hconfig, keyString='UPDATE_REF_TIME', _RC) 
+      end if
+      _RETURN(_SUCCESS)
+
+   end subroutine init_time
+
+   function evaluate_time(this,currTime,rc) result(dt)
+      class(timeVar), intent(in) :: this
+      type(ESMF_Time), intent(in) :: currTime
+      integer, optional, intent(out) :: rc
+      real(kind=ESMF_KIND_R8) :: dt
+
+      integer :: status
+
+      type(ESMF_TimeInterval) :: timeInterval, yearInterval
+      integer :: ycurr,yint
+      type(ESMF_Time) :: periodic_time, temp_time
+
+      temp_time = currTime
+      if (this%climYear > 0) then
+         call ESMF_TimeGet(currTime,yy=ycurr,_RC)
+         yint=this%climYear-ycurr
+         call ESMF_TimeIntervalSet(yearInterval,yy=yint,_RC)
+         temp_time = temp_time+yearInterval
+      end if
+      periodic_time = this%set_time_for_date(temp_time,_RC)
+      if (this%have_offset) then
+         timeInterval = periodic_time + this%update_offset - this%refTime
+      else
+         timeInterval = periodic_time - this%refTime
+      end if
+      select case(trim(this%timeUnits))
+      case ('days')
+         call ESMF_TimeIntervalGet(timeInterval,d_r8=dt,_RC)
+      case ('hours')
+         call ESMF_TimeIntervalGet(timeInterval,h_r8=dt,_RC)
+      case ('minutes')
+         call ESMF_TimeIntervalGet(timeInterval,m_r8=dt,_RC)
+      case ('seconds')
+         call ESMF_TimeIntervalGet(timeInterval,s_r8=dt,_RC)
+      case default
+         _FAIL("Unsupported time units specify for interval")
+      end select
+      _RETURN(_SUCCESS)
+
+   end function evaluate_time
+
+   function set_time_for_date(this,input_time,rc) result(returned_time)
+      type(ESMF_Time) :: returned_time
+
+      class(timeVar), intent(in) :: this
+      type(ESMF_Time), intent(inout) :: input_time
+      integer, optional, intent(out) :: rc
+
+      integer :: hour,minute,second,year,month,day,status
+      type(ESMF_Time) :: new_time
+
+      if (this%update_ref_time /= -1) then
+         call ESMF_TimeGet(input_time,yy=year,mm=month,dd=day,_RC)
+         hour = this%update_ref_time/10000
+         minute = mod(this%update_ref_time/100,100)
+         second = mod(this%update_ref_time,100) 
+         call ESMF_TimeSet(new_time,yy=year,mm=month,dd=day,h=hour,m=minute,s=second,_RC)
+         if (new_time == input_time) then
+            returned_time = input_time
+         else if (new_time < input_time) then
+            returned_time = new_time
+         else if (new_time > input_time) then
+            call ESMF_TimeSet(new_time,yy=year,mm=month,dd=day-1,h=hour,m=minute,s=second,_RC)
+            returned_time = new_time
+         end if
+      else
+         returned_time = input_time
+      end if
+      _RETURN(_SUCCESS)
+   end function
+
+end module timeSupport
+


### PR DESCRIPTION
This is my first attempt at a mapl3 version of ExtDataDriver.x

Some background and things I've changed/need to still be done.
I have moved this to the Apps directory, and renamed it `MAPL_Component_Driver` because that is what is really is, a driver to exercise ExtData and/or History so that is a better name does not single out ExtData.

This is by no means complete but a start. I started with one of the Cap test components as the base and went from there to add some of the functionality in ExtDataDriver.x. There was some stuff about setting a default vertical profile in the template I started from, not sure what that is about but left it for now.

Since there is no functional ExtData3G yet I have not bothered with all the the run modes in the original. For now it can exercise History3G and fill in the exports from a "menu" of fields that are set in the internal state.
The "menu" of functions available to use to fill exports is not quite as many so far as in the MAPL2 ExtDataDriver.x
For now it is a time interval relative to a reference, the lats of the grid, the Lons of the grid, and random numbers.

I have changed it to use HCONFIG
Now that MAPL3 can dynamically create import and export variables at runtime from the component input file, I don't have to support this via a custom layer as I did in MAPL2.

For now I have made copies of the cap and capGridComp in the application directory. Future work will be to adapt those in the way I adapted the MAPL2 version for greater functionality in these layers. If this proves not necessary we can always revert to use the "stock" cap.

I have confirmed I can exercise History3G with this.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

