### PR TITLE
Fixes #3693. Unit test fix for GCC 15

### DIFF
--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -104,7 +104,7 @@ contains
       params = [params, add_params('field exists', check_field_rank)]
 
       ! Service oriented tests
-      params = [params, ScenarioDescription('service_service', 'parent.yaml', 'field count', check_fieldcount)]
+      params = [params, add_params('field count', check_fieldCount)]
 
    contains
 
@@ -132,7 +132,7 @@ contains
               ScenarioDescription('vertical_regridding',     'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('vertical_regridding_2',   'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('vertical_regridding_3',   'AGCM.yaml',        check_name, check_stateitem), &
-              ScenarioDescription('expression',              'parent.yaml',      check_name, check_stateitem), & 
+              ScenarioDescription('expression',              'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('expression_defer_geom',   'parent.yaml',      check_name, check_stateitem)  &
               ]
       end function add_params

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -92,6 +92,7 @@ contains
    function get_parameters() result(params)
 
       type(ScenarioDescription), allocatable :: params(:)
+      type(ScenarioDescription) :: p
 
       params = [ScenarioDescription:: ]
 
@@ -104,7 +105,8 @@ contains
       params = [params, add_params('field exists', check_field_rank)]
 
       ! Service oriented tests
-      params = [params, add_params('field count', check_fieldCount)]
+      p = ScenarioDescription('service_service', 'parent.yaml', 'field count', check_fieldcount)
+      params = [params, p]
 
    contains
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR fixes an issue with GCC 15. For some reason, GCC 15 didn't like:

```fortran
      params = [params, ScenarioDescription('service_service', 'parent.yaml', 'field count', check_fieldcount)]
```
but does like what seems to be the equivalent:
```fortran
      type(ScenarioDescription) :: p
...
      p = ScenarioDescription('service_service', 'parent.yaml', 'field count', check_fieldcount)
      params = [params, p]
```

Why? 🤷🏼 

## Related Issue

Closes #3693 
