### PR TITLE
Let logger print the gridcomp name, instead of mapl.generic

### DIFF
--- a/generic3g/OuterMetaComponent/init_meta.F90
+++ b/generic3g/OuterMetaComponent/init_meta.F90
@@ -21,7 +21,7 @@ contains
       user_gc_name = this%user_gc_driver%get_name(_RC)
       this%registry = StateRegistry(user_gc_name)
 
-      this%lgr => logging%get_logger('mapl.generic')
+      this%lgr => logging%get_logger(user_gc_name)
 
       _RETURN(_SUCCESS)
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

