### PR TITLE
v3: Turn off ifx in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -87,26 +87,30 @@ jobs:
           cmake-generator: ${{ matrix.cmake-generator }}
           fortran-compiler: ifort
 
-  build_test_mapl_ifx:
-    name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
-    runs-on: ubuntu-latest
-    container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1
-    strategy:
-      fail-fast: false
-      matrix:
-        cmake-build-type: [Debug, Release]
-        cmake-generator: [Unix Makefiles]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          filter: blob:none
-
-      - name: Build and Test MAPL
-        uses: ./.github/actions/ci-build-and-test-mapl
-        with:
-          cmake-build-type: ${{ matrix.cmake-build-type }}
-          cmake-generator: ${{ matrix.cmake-generator }}
-          fortran-compiler: ifx
+  # The following job is for Intel Fortran Compiler (ifx) builds.
+  # At the moment, ifx seems to have random issues with MAPL3
+  ################################################################################
+  # build_test_mapl_ifx:                                                         #
+  #   name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
+  #   runs-on: ubuntu-latest                                                     #
+  #   container:                                                                 #
+  #     image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1        #
+  #   strategy:                                                                  #
+  #     fail-fast: false                                                         #
+  #     matrix:                                                                  #
+  #       cmake-build-type: [Debug, Release]                                     #
+  #       cmake-generator: [Unix Makefiles]                                      #
+  #   steps:                                                                     #
+  #     - name: Checkout                                                         #
+  #       uses: actions/checkout@v4                                              #
+  #       with:                                                                  #
+  #         fetch-depth: 1                                                       #
+  #         filter: blob:none                                                    #
+  #                                                                              #
+  #     - name: Build and Test MAPL                                              #
+  #       uses: ./.github/actions/ci-build-and-test-mapl                         #
+  #       with:                                                                  #
+  #         cmake-build-type: ${{ matrix.cmake-build-type }}                     #
+  #         cmake-generator: ${{ matrix.cmake-generator }}                       #
+  #         fortran-compiler: ifx                                                #
+  ################################################################################


### PR DESCRIPTION
This PR turns of ifx use in CI. It seems to be very twitchy and we know the latest version doesn't build Baselibs at the moment.
