### PR TITLE
Fixes #3893. Fix for Wallclock print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated wallclock print to be more readable
+- Updated wallclock print to be more readable: `Wallclock: 2025/07/17 20:02`
 
 ## [2.58.0] - 2025-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [2.58.1] - 2025-07-19
+
+### Fixed
+
+- Fixed typo in wallclock print
+
+### Changed
+
+- Updated wallclock print to be more readable
+
 ## [2.58.0] - 2025-07-17
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.58.0
+  VERSION 2.58.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui

--- a/gridcomps/Cap/MAPL_CapGridComp.F90
+++ b/gridcomps/Cap/MAPL_CapGridComp.F90
@@ -1249,11 +1249,13 @@ contains
                                wallclock_values)
              write(6,1000) this%root_name, AGCM_YY,AGCM_MM,AGCM_DD,AGCM_H,AGCM_M,AGCM_S,&
                            LOOP_THROUGHPUT,INST_THROUGHPUT,RUN_THROUGHPUT,HRS_R,MIN_R,SEC_R,&
-                           mem_committed_percent,mem_used_percent,wallclock_date,wallclock_values(5),wallclock_values(6)
+                           mem_committed_percent,mem_used_percent,&
+                           wallclock_values(1),wallclock_values(2),wallclock_values(3), &
+                           wallclock_values(5),wallclock_values(6)
         endif
     1000 format(1x,a,1x,'Date: ',i4.4,'/',i2.2,'/',i2.2,2x,'Time: ',i2.2,':',i2.2,':',i2.2, &
                 2x,'Throughput(days/day)[Avg Tot Run]: ',f12.1,1x,f12.1,1x,f12.1,2x,'TimeRemaining(Est) ',i3.3,':',i2.2,':',i2.2,2x, &
-                f5.1,'% : ',f5.1,'% Mem Comm:Used ; ',A8,' ',i2.2,':'i2.2)
+                f5.1,'% : ',f5.1,'% Mem Comm:Used',2x,'Wallclock: ',i4.4,'/',i2.2,'/',i2.2,1x,i2.2,':',i2.2)
 
         _RETURN(_SUCCESS)
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

As detailed in #3893, NAG found a bug in the wallclock code (missing comma). I guess Intel and GNU didn't care. So, this fixes that.

I also decided to kill two birds with one stone and fix #3884 following the [@wmputman format](https://github.com/GEOS-ESM/MAPL/issues/3884#issuecomment-3085576800):
```
I think Wallclock: 2025/07/17 20:02 is good

```

## Related Issue

Closes #3893 
Closes #3884 
