### PR TITLE
Fixes #3905: fix 0d string read and write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed 0d string reading and writing
+
 ### Added
 
 ### Changed

--- a/pfio/NetCDF_Supplement.F90
+++ b/pfio/NetCDF_Supplement.F90
@@ -211,10 +211,14 @@ contains
       integer  :: size
       integer, target  :: length
 
-      allocate(dimids(1))
+      allocate(dimids(1), source = -9999) ! 
       status = nf90_inquire_variable(ncid,  varid, dimids=dimids)
-      status = nf90_inquire_dimension(ncid, dimids(1), len=size)
-      status = c_f_pfio_get_var_string_len(ncid, varid, c_loc(length), size)
+      if ( dimids(1) == -9999 ) then
+        size = 0 ! scalar string
+      else
+        status = nf90_inquire_dimension(ncid, dimids(1), len=size)
+      endif
+      status  = c_f_pfio_get_var_string_len(ncid, varid, c_loc(length), size)
       str_len = length
    end function pfio_nf90_get_var_string_len
 

--- a/pfio/tests/Test_NetCDF4_FileFormatter.pf
+++ b/pfio/tests/Test_NetCDF4_FileFormatter.pf
@@ -20,7 +20,6 @@ contains
 
       open(newunit=unit, file='test.nc', status='old')
       close(unit, status='delete')
-      
    end subroutine tearDown
 
    @test
@@ -32,7 +31,7 @@ contains
 
       call cf_expected%add_dimension('x',1)
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
       @assertEqual(NF90_NOERR, status)
       call formatter%write(cf_expected, rc=status)
       @assertEqual(0, NF90_NOERR)
@@ -60,7 +59,7 @@ contains
       call cf_expected%add_dimension('y',2)
       call cf_expected%add_variable('var', Variable(type=pFIO_INT32, dimensions='x,y'))
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
       @assertEqual(NF90_NOERR, status)
       call formatter%write(cf_expected, rc=status)
       @assertEqual(0, NF90_NOERR)
@@ -88,7 +87,7 @@ contains
       call cf_expected%add_dimension('y',2)
       call cf_expected%add_attribute('attr', [1,2])
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
       @assertEqual(NF90_NOERR, status)
       call formatter%write(cf_expected, rc=status)
       @assertEqual(0, NF90_NOERR)
@@ -120,7 +119,7 @@ contains
       call v%add_attribute('attr', [1.,2.,3.])
       call cf_expected%add_variable('var', v)
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
       @assertEqual(NF90_NOERR, status)
       call formatter%write(cf_expected, rc=status)
       @assertEqual(0, NF90_NOERR)
@@ -152,7 +151,7 @@ contains
       call v%add_attribute('attr', [1.,2.,3.])
       call cf_expected%add_variable('var', v)
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
       @assertEqual(NF90_NOERR, status)
       call formatter%write(cf_expected, rc=status)
       @assertEqual(0, NF90_NOERR)
@@ -190,12 +189,16 @@ contains
       call metadata%add_variable('new_char',v)
       char_write = "I am 0d String"
 
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%write(metadata, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%put_var('new_char', char_write)
       call formatter%close(rc=status)
+      @assertEqual(NF90_NOERR, status)
 
       call formatter%open('test.nc', PFIO_READ, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%inq_var_string_length('new_char',length)
       allocate(character(len=length):: char_read)
       call formatter%get_var('new_char', char_read)
@@ -223,12 +226,16 @@ contains
                     "a     ",  \
                     "1d    ",  \
                     "String"]
-      call formatter%create('test.nc', rc=status)
+      call formatter%create('test.nc', mode=PFIO_CLOBBER, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%write(metadata, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%put_var('new_char', char_write, start=[1], count=[Ydim])
       call formatter%close(rc=status)
+      @assertEqual(NF90_NOERR, status)
 
       call formatter%open('test.nc', PFIO_READ, rc=status)
+      @assertEqual(NF90_NOERR, status)
       call formatter%inq_var_string_length('new_char',length)
       metadata = formatter%read()
       my_dim = metadata%get_dimension('Ydim')


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR has a fix from @weiyuan-jiang for the 0d-string issue in #3905 

In my testing on bucy, it seems to fix it.

We also found a separate issue where if a `test.nc` existed, the first test could fail. This is probably *very* rare and might never happen in CI, but to make sure, we just create all the tests in CLOBBER mode. 

This should be safe since I think pFUnit always runs tests serially. (@tclune can let me know if that's true...). The other thought was we could have a "pre-routine" that could `inquire` for `test.nc` and remove if found?

I've also added some extra asserts (to match the other tests)

## Related Issue

Closes #3905 
