### PR TITLE
v3: Updates to allow Intel MPI tests to succeed on discover

### DIFF
--- a/GeomIO/tests/CMakeLists.txt
+++ b/GeomIO/tests/CMakeLists.txt
@@ -22,5 +22,9 @@ else()
 endif ()
 #set_property(TEST MAPL.GeomIO.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:$ENV{${LD_PATH}}")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.GeomIO.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests MAPL.GeomIO.tests)
 

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -47,6 +47,10 @@ add_pfunit_ctest(MAPL.base.tests
 set_target_properties(MAPL.base.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.base.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.base.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests MAPL.base.tests)
 
 set(TESTIO mapl_bundleio_test.x)

--- a/esmf_utils/tests/CMakeLists.txt
+++ b/esmf_utils/tests/CMakeLists.txt
@@ -22,6 +22,13 @@ if (APPLE)
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.esmf_utils.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/esmf_utils:$ENV{${LD_PATH}}")
+
+set(TEST_ENV "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/esmf_utils:$ENV{${LD_PATH}}")
+
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  list(APPEND TEST_ENV "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
+set_property(TEST MAPL.esmf_utils.tests PROPERTY ENVIRONMENT "${TEST_ENV}")
 
 add_dependencies(build-tests MAPL.esmf_utils.tests)

--- a/field/tests/CMakeLists.txt
+++ b/field/tests/CMakeLists.txt
@@ -24,3 +24,7 @@ set_tests_properties(MAPL.field.test_utils PROPERTIES LABELS "ESSENTIAL")
 
 add_dependencies(build-tests MAPL.field.test_fieldcreate MAPL.field.test_utils)
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.field.test_fieldcreate PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+  set_tests_properties(MAPL.field.test_utils PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()

--- a/field_bundle/tests/CMakeLists.txt
+++ b/field_bundle/tests/CMakeLists.txt
@@ -12,3 +12,6 @@ add_dependencies(build-tests MAPL.field_bundle.tests)
 set_target_properties(MAPL.field_bundle.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.field_bundle.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.field_bundle.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()

--- a/generic/tests/CMakeLists.txt
+++ b/generic/tests/CMakeLists.txt
@@ -17,4 +17,8 @@ add_pfunit_ctest(MAPL.generic.tests
 set_target_properties(MAPL.generic.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.generic.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.generic.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests MAPL.generic.tests)

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -68,10 +68,13 @@ endif ()
 # This test also requires UDUNITS2_XML_PATH to be set to the location of the udunits2.xml file
 # This is found by Findudunits.cmake and stored in the variable udunits_XML_PATH
 
-set_tests_properties(
-  MAPL.generic3g.tests
-  PROPERTIES ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}};UDUNITS2_XML_PATH=${udunits_XML_PATH}"
-)
+set(TEST_ENV "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:${CMAKE_BINARY_DIR}/lib:$ENV{${LD_PATH}};UDUNITS2_XML_PATH=${udunits_XML_PATH}")
+
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  list(APPEND TEST_ENV "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
+set_tests_properties(MAPL.generic3g.tests PROPERTIES ENVIRONMENT "${TEST_ENV}")
 
 add_dependencies(build-tests MAPL.generic3g.tests)
 

--- a/geom/tests/CMakeLists.txt
+++ b/geom/tests/CMakeLists.txt
@@ -21,6 +21,10 @@ add_pfunit_ctest(MAPL.geom.tests
 set_target_properties(MAPL.geom.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.geom.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.geom.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests MAPL.geom.tests)
 
 

--- a/gridcomps/ExtData2G/tests/CMakeLists.txt
+++ b/gridcomps/ExtData2G/tests/CMakeLists.txt
@@ -21,4 +21,8 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" AND NOT APPLE)
   target_link_libraries(MAPL.ExtData2G.tests ${CMAKE_DL_LIBS})
 endif ()
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.ExtData2G.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests MAPL.ExtData2G.tests)

--- a/gridcomps/ExtData3G/tests/CMakeLists.txt
+++ b/gridcomps/ExtData3G/tests/CMakeLists.txt
@@ -25,6 +25,13 @@ if (APPLE)
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.extdata3g.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:$ENV{${LD_PATH}}")
+
+set(TEST_ENV "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:$ENV{${LD_PATH}}")
+
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  list(APPEND TEST_ENV "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
+set_property(TEST MAPL.extdata3g.tests PROPERTY ENVIRONMENT "${TEST_ENV}")
 
 add_dependencies(build-tests MAPL.extdata3g.tests)

--- a/gridcomps/History3G/tests/CMakeLists.txt
+++ b/gridcomps/History3G/tests/CMakeLists.txt
@@ -21,7 +21,14 @@ if (APPLE)
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.history3g.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:$ENV{${LD_PATH}}")
+
+set(TEST_ENV "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/gridcomps:$ENV{${LD_PATH}}")
+
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  list(APPEND TEST_ENV "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
+set_property(TEST MAPL.history3g.tests PROPERTY ENVIRONMENT "${TEST_ENV}")
 
 add_dependencies(build-tests MAPL.history3g.tests)
 

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -47,6 +47,10 @@ add_pfunit_ctest(MAPL.pfio.tests
 set_target_properties(MAPL.pfio.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.pfio.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.pfio.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 include_directories(
    ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/pfio/tests/Test_Client.pf
+++ b/pfio/tests/Test_Client.pf
@@ -73,6 +73,7 @@ contains
       character(len=:), allocatable :: expected_log
       type (MockSocketLog), target :: log
 
+      q = 17
       call c%set_connection(MockSocket(log))
       connection => c%get_connection()
       select type (connection)

--- a/profiler/tests/CMakeLists.txt
+++ b/profiler/tests/CMakeLists.txt
@@ -24,5 +24,9 @@ add_pfunit_ctest (
 set_target_properties(MAPL.profiler.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.profiler.tests PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.profiler.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies (build-tests MAPL.profiler.tests)
 

--- a/regridder_mgr/tests/CMakeLists.txt
+++ b/regridder_mgr/tests/CMakeLists.txt
@@ -17,6 +17,10 @@ add_pfunit_ctest(${this}
 set_target_properties(${this} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(${this} PROPERTIES LABELS "ESSENTIAL")
 
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  set_tests_properties(MAPL.regridder_mgr.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
 add_dependencies(build-tests ${this})
 
 

--- a/state/tests/CMakeLists.txt
+++ b/state/tests/CMakeLists.txt
@@ -23,7 +23,14 @@ if (APPLE)
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.state.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/state:$ENV{${LD_PATH}}")
+
+set(TEST_ENV "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/state:$ENV{${LD_PATH}}")
+
+if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
+  list(APPEND TEST_ENV "I_MPI_OFI_PROVIDER=psm3")
+endif()
+
+set_property(TEST MAPL.state.tests PROPERTY ENVIRONMENT "${TEST_ENV}")
 
 add_dependencies(build-tests MAPL.state.tests)
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR adds code like:
```
if(${GEOS_SITE} STREQUAL "NCCS" AND ${MPI_STACK} STREQUAL "intelmpi")
  set_tests_properties(MAPL.generic.tests PROPERTIES ENVIRONMENT "I_MPI_OFI_PROVIDER=psm3")
endif()
```
in many places. Testing on discover found that without that Intel MPI setting, the MAPL tests would just fail at finalize.

## Related Issue

