### PR TITLE
v2: Fix minor bug in Test_Client.pf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed 0d string reading and writing
+- Minor bug fix in pfio `test_prefetch_data` test
 
 ### Added
 
@@ -38,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added tests to read and write 0d and 1d string to and from netcdf files 
+- Added tests to read and write 0d and 1d string to and from netcdf files
 - Added new markup link checker based on [mlc](https://github.com/becheran/mlc)
 
 ### Changed

--- a/pfio/tests/Test_Client.pf
+++ b/pfio/tests/Test_Client.pf
@@ -58,9 +58,9 @@ contains
       handle_foo = c%add_ext_collection(template='foo')
       handle_bar = c%add_ext_collection(template='bar')
       @assertFalse(handle_foo == handle_bar)
-      
+
    end subroutine test_addExtCollection_unique_handle
-   
+
    @test
    subroutine test_prefetch_data()
       type (MockClientThread) :: c
@@ -72,6 +72,7 @@ contains
       character(len=:), allocatable :: expected_log
       type (MockSocketLog), target :: log
 
+      q = 17
       call c%set_connection(MockSocket(log))
       connection => c%get_connection()
       select type (connection)
@@ -91,9 +92,9 @@ contains
       type is (MockSocket)
          @assertEqual(expected_log, log%log)
       end select
-         
+
    end subroutine test_prefetch_data
-   
+
    @test
    subroutine test_wait()
       type (MockClientThread), target :: c
@@ -152,7 +153,7 @@ contains
 
       @assertEqual(q1_expected, q1)
       @assertEqual(q2_expected, q2)
-         
+
    end subroutine test_wait
-   
+
 end module test_Client


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is a minor bugfix to a pfio unit test. Technically, this bug was only ever triggered in MAPL3, but it is technically present in MAPL2.

Namely, the variable `q` is first used on the right side in `test_prefetch_data`. This PR initializes it (thanks to @tclune).

## Related Issue

