### PR TITLE
Fixes #3922 - checkpoint subdirs

### DIFF
--- a/generic3g/OuterMetaComponent.F90
+++ b/generic3g/OuterMetaComponent.F90
@@ -428,6 +428,14 @@ module mapl3g_OuterMetaComponent
          integer, optional, intent(out) ::rc
       end subroutine set_entry_point
 
+      ! Currently resides in write_restart_smod
+      module function get_checkpoint_subdir(hconfig, currTime, rc) result(subdir)
+         character(:), allocatable :: subdir
+         type(esmf_HConfig), intent(in) :: hconfig
+         type(esmf_Time), intent(in) :: currTime
+         integer, optional, intent(out) :: rc
+      end function get_checkpoint_subdir
+
    end interface
 
    interface OuterMetaComponent

--- a/generic3g/OuterMetaComponent/write_restart.F90
+++ b/generic3g/OuterMetaComponent/write_restart.F90
@@ -73,9 +73,11 @@ contains
       character(:), allocatable :: timestamp_dir
       type(esmf_HConfig) :: checkpointing_cfg
 
+      subdir = ''
+
       call esmf_TimeGet(currTime, timeStringISOFrac=iso_time, _RC)
       timestamp_dir = trim(iso_time)
-      
+
       checkpoint_dir = 'checkpoint'
       has_checkpointing = esmf_HConfigIsDefined(hconfig, keystring='checkpointing', _RC)
       if (has_checkpointing) then

--- a/generic3g/OuterMetaComponent/write_restart.F90
+++ b/generic3g/OuterMetaComponent/write_restart.F90
@@ -3,6 +3,7 @@
 submodule (mapl3g_OuterMetaComponent) write_restart_smod
    use mapl3g_MultiState
    use mapl3g_RestartHandler
+   use mapl_OS
    use mapl_ErrorHandling
    implicit none (type, external)
 
@@ -22,29 +23,74 @@ contains
       type(MultiState) :: states
       type(RestartHandler) :: restart_handler
       integer :: status
+      character(:), allocatable :: subdir
+      character(:), allocatable :: filename
+      type(esmf_Time) :: currTime
 
+      call recurse_write_restart_(this, _RC)
       _RETURN_UNLESS(this%has_geom())
       
       driver => this%get_user_gc_driver()
+      call esmf_ClockGet(driver%get_clock(), currTime=currTime, _RC)
+
+      restart_handler = RestartHandler( &
+           this%get_geom(), &
+           currTime, &
+           this%get_logger())
+
       states = driver%get_states()
-      restart_handler = RestartHandler(this%get_name(), this%get_geom(), driver%get_clock(), _RC)
-      
+      subdir = get_checkpoint_subdir(this%hconfig, currTime, _RC)
+
       if (this%component_spec%misc%checkpoint_controls%import) then
-         call restart_handler%write("import", states%importState, _RC)
+         filename = mapl_PathJoin(subdir, this%get_name() // '_import.nc')
+         call restart_handler%write(states%importState, filename, _RC)
       end if
       
       if (this%component_spec%misc%checkpoint_controls%internal) then
-         call restart_handler%write("internal", states%internalState, _RC)
+         filename = mapl_PathJoin(subdir, this%get_name() // '_internal.nc')
+         call restart_handler%write(states%internalState, filename, _RC)
       end if
       
       if (this%component_spec%misc%checkpoint_controls%export) then
-         call restart_handler%write("export", states%exportState, _RC)
+         filename = mapl_PathJoin(subdir, this%get_name() // '_export.nc')
+         call restart_handler%write(states%exportState, filename, _RC)
       end if
-   
-      call recurse_write_restart_(this, _RC)
 
       _RETURN(ESMF_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine write_restart
+
+   module function get_checkpoint_subdir(hconfig, currTime, rc) result(subdir)
+      character(:), allocatable :: subdir
+      type(esmf_HConfig), intent(in) :: hconfig
+      type(esmf_Time), intent(in) :: currTime
+      integer, optional, intent(out) :: rc
+      
+      integer :: status
+      character(ESMF_MAXSTR) :: iso_time
+      logical :: has_checkpointing, has_path
+      character(:), allocatable :: checkpoint_dir
+      character(:), allocatable :: timestamp_dir
+      type(esmf_HConfig) :: checkpointing_cfg
+
+      call esmf_TimeGet(currTime, timeStringISOFrac=iso_time, _RC)
+      timestamp_dir = trim(iso_time)
+      
+      checkpoint_dir = 'checkpoint'
+      has_checkpointing = esmf_HConfigIsDefined(hconfig, keystring='checkpointing', _RC)
+      if (has_checkpointing) then
+         checkpointing_cfg = esmf_HConfigCreateAt(hconfig, keystring='checkpointing', _RC)
+         has_path = esmf_HConfigIsDefined(checkpointing_cfg, keystring='path', _RC)
+         if (has_path) then
+            checkpoint_dir = esmf_HConfigAsString(checkpointing_cfg, keystring='path', _RC)
+         end if
+         call esmf_HConfigDestroy(checkpointing_cfg, _RC)
+      end if
+      
+      subdir = mapl_PathJoin(checkpoint_dir, iso_time)
+      
+      _RETURN(_SUCCESS)
+   end function get_checkpoint_subdir
+   
 
 end submodule write_restart_smod


### PR DESCRIPTION
This implementation still relies on coincidental logic for determining
the path for chekpoint files.   Write/read share a common
procedure (that needs a better home), but Cap.F90 repeats that logic.

Better would be to use a coherent templating mechanism in both locations.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

