### PR TITLE
some cleanup

### DIFF
--- a/gridcomps/ExtData3G/AbstractDataSetFileSelector.F90
+++ b/gridcomps/ExtData3G/AbstractDataSetFileSelector.F90
@@ -8,16 +8,15 @@ module mapl3g_AbstractDataSetFileSelector
    use mapl_StringTemplate
    use mapl_FileMetadataUtilsMod
    use mapl3g_geomio
+   use mapl3g_ExtDataConstants
    implicit none
    private
 
    public AbstractDataSetFileSelector
-   public file_not_found
    public NUM_SEARCH_TRIES
 
    integer, parameter :: MAX_TRIALS = 10
    integer, parameter :: NUM_SEARCH_TRIES = 1
-   character(len=*), parameter :: file_not_found = "NONE"
  
    type, abstract :: AbstractDataSetFileSelector
       character(:), allocatable :: file_template

--- a/gridcomps/ExtData3G/CMakeLists.txt
+++ b/gridcomps/ExtData3G/CMakeLists.txt
@@ -9,11 +9,15 @@ set(srcs
  NonClimDataSetFileSelector.F90
  ExtDataUtilities.F90
  ExtDataCollection.F90
+ ExtDataCollectionMap.F90
  ExtDataConfig.F90
  ExtDataConstants.F90
  ExtDataDerived.F90
+ ExtDataDerivedMap.F90
  ExtDataRule.F90
+ ExtDataRuleMap.F90
  ExtDataSample.F90
+ ExtDataSampleMap.F90
  PrimaryExport.F90
  PrimaryExportVector.F90
  )

--- a/gridcomps/ExtData3G/DataSetBracket.F90
+++ b/gridcomps/ExtData3G/DataSetBracket.F90
@@ -115,9 +115,7 @@ contains
          weights(2) = 0.0
          _RETURN_IF(this%disable_interpolation) 
          time1 = this%left_node%get_interp_time()
-         call ESMF_TimePrint(time1, options='String', preString='bmma left: ')
          time2 = this%right_node%get_interp_time()
-         call ESMF_TimePrint(time2, options='String', preString='bmma right: ')
          tinv1 = time - time1
          tinv2 = time2 - time1
          alpha = tinv1/tinv2

--- a/gridcomps/ExtData3G/ExtDataCollection.F90
+++ b/gridcomps/ExtData3G/ExtDataCollection.F90
@@ -218,23 +218,3 @@ contains
    end function is_valid_range_allocated
 
 end module mapl3g_ExtDataCollection
-
-module mapl3g_ExtDataCollectionMap
-   use mapl3g_ExtDataCollection
-
-#include "types/key_deferredLengthString.inc"
-#define _value type(ExtDataCollection)
-#define _alt
-
-#define _map ExtDataCollectionMap
-#define _iterator ExtDataCollectionMapIterator
-
-#include "templates/map.inc"
-
-#undef _iterator
-#undef _map
-
-#undef _alt
-#undef _value
-
-end module mapl3g_ExtDataCollectionMap

--- a/gridcomps/ExtData3G/ExtDataCollectionMap.F90
+++ b/gridcomps/ExtData3G/ExtDataCollectionMap.F90
@@ -1,0 +1,18 @@
+module mapl3g_ExtDataCollectionMap
+   use mapl3g_ExtDataCollection
+
+#define Key __CHARACTER_DEFERRED
+#define T ExtDataCollection
+#define Map ExtDataCollectionMap
+#define MapIterator ExtDataCollectionMapIterator
+#define Pair ExtDataCollectionPair
+
+#include "map/template.inc"
+
+#undef Pair
+#undef MapIterator
+#undef Map
+#undef T
+#undef Key
+
+end module mapl3g_ExtDataCollectionMap

--- a/gridcomps/ExtData3G/ExtDataConfig.F90
+++ b/gridcomps/ExtData3G/ExtDataConfig.F90
@@ -179,7 +179,7 @@ contains
       rule_iterator = this%rule_map%begin()
       number_of_rules = 0
       do while(rule_iterator /= this%rule_map%end())
-         key => rule_iterator%key()
+         key => rule_iterator%first()
          idx = index(key,rule_sep)
          if (idx > 0) then
             if (trim(item_name)==key(1:idx-1)) number_of_rules = number_of_rules + 1
@@ -208,11 +208,11 @@ contains
 
       rule_iterator = this%rule_map%begin()
       do while(rule_iterator /= this%rule_map%end())
-         key => rule_iterator%key()
+         key => rule_iterator%first()
          idx = index(key,rule_sep)
          if (idx > 0) then
             if (key(1:idx-1) == trim(item_name)) then
-               rule => rule_iterator%value()
+               rule => rule_iterator%second()
                call start_times%push_back(rule%start_time)
             end if
          end if
@@ -286,12 +286,12 @@ contains
       logical :: found_rule
 
       _UNUSED_DUMMY(unusable)
-      item_type=ExtData_not_found
+      item_type=EXTDATA_NOT_FOUND
 
       found_rule = .false.
       rule_iterator = this%rule_map%begin()
       do while(rule_iterator /= this%rule_map%end())
-         key => rule_iterator%key()
+         key => rule_iterator%first()
          if (index(key,trim(item_name))/=0) then
             found_rule = .true.
             found_key = key
@@ -305,12 +305,12 @@ contains
          if (associated(rule)) then
             if (allocated(rule%vector_component)) then
                if (rule%vector_component=='EW') then
-                  item_type=Primary_Type_Vector_comp1
+                  item_type=PRIMARY_TYPE_VECTOR_COMP1
                else if (rule%vector_component=='NS') then
-                  item_type=Primary_Type_Vector_comp2
+                  item_type=PRIMARY_TYPE_VECTOR_COMP2
                end if
             else
-               item_type=Primary_Type_scalar
+               item_type=PRIMARY_TYPE_SCALAR
             end if
          end if
       end if
@@ -428,9 +428,10 @@ contains
       integer :: rule_sep_loc
 
       found_rule = .false.
-      iter = this%rule_map%begin()
-      do while(iter /= this%rule_map%end())
-         key => iter%key()
+      iter = this%rule_map%ftn_begin()
+      do while(iter /= this%rule_map%ftn_end())
+         call iter%next()
+         key => iter%first()
          rule_sep_loc = index(key,rule_sep)
          if (rule_sep_loc/=0) then
             found_rule = (key(:rule_sep_loc-1) == base_name)
@@ -438,7 +439,6 @@ contains
             found_rule = (key == base_name)
          end if
          if (found_rule) exit
-         call iter%next()
       enddo
       _RETURN(_SUCCESS)
    end function

--- a/gridcomps/ExtData3G/ExtDataConstants.F90
+++ b/gridcomps/ExtData3G/ExtDataConstants.F90
@@ -2,12 +2,11 @@ module mapl3g_ExtDataConstants
 implicit none
 private
 
-  integer, parameter, public    :: ExtData_Not_Found         = 0
-  integer, parameter, public    :: Primary_Type_Scalar = 1
-  integer, parameter, public    :: Primary_Type_Vector_comp1 = 2
-  integer, parameter, public    :: Primary_Type_Vector_comp2 = 3
-  integer, parameter, public    :: Derived_TYpe      = 4
-  integer, parameter, public    :: time_not_found = -1
-  character(len=14), parameter, public :: file_not_found = "file_not_found"
+  integer, parameter, public    :: EXTDATA_NOT_FOUND         = 0
+  integer, parameter, public    :: PRIMARY_TYPE_SCALAR = 1
+  integer, parameter, public    :: PRIMARY_TYPE_VECTOR_COMP1 = 2
+  integer, parameter, public    :: PRIMARY_TYPE_VECTOR_COMP2 = 3
+  integer, parameter, public    :: DERIVED_TYPE      = 4
+  character(len=14), parameter, public :: FILE_NOT_FOUND = "file_not_found"
 
 end module mapl3g_ExtDataConstants

--- a/gridcomps/ExtData3G/ExtDataDerived.F90
+++ b/gridcomps/ExtData3G/ExtDataDerived.F90
@@ -87,23 +87,3 @@ contains
    end subroutine display
 
 end module mapl3g_ExtDataDerived
-
-module mapl3g_ExtDataDerivedMap
-   use mapl3g_ExtDataDerived
-
-#include "types/key_deferredLengthString.inc"
-#define _value type(ExtDataDerived)
-#define _alt
-
-#define _map ExtDataDerivedMap
-#define _iterator ExtDataDerivedMapIterator
-
-#include "templates/map.inc"
-
-#undef _iterator
-#undef _map
-
-#undef _alt
-#undef _value
-
-end module mapl3g_ExtDataDerivedMap

--- a/gridcomps/ExtData3G/ExtDataDerivedMap.F90
+++ b/gridcomps/ExtData3G/ExtDataDerivedMap.F90
@@ -1,0 +1,18 @@
+module mapl3g_ExtDataDerivedMap
+   use mapl3g_ExtDataDerived
+
+#define Key __CHARACTER_DEFERRED
+#define T ExtDataDerived
+#define Map ExtDataDerivedMap
+#define MapIterator ExtDataDerivedMapIterator
+#define Pair ExtDataDerivedPair
+
+#include "map/template.inc"
+
+#undef Pair
+#undef MapIterator
+#undef Map
+#undef T
+#undef Key
+
+end module mapl3g_ExtDataDerivedMap

--- a/gridcomps/ExtData3G/ExtDataGridComp.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp.F90
@@ -25,7 +25,7 @@ module mapl3g_ExtDataGridComp
    public :: setServices
 
    ! Private state
-   character(*), parameter :: PRIVATE_STATE = "ExtDataGridComp"
+   character(*), parameter :: PRIVATE_STATE = "ExtData"
    type :: ExtDataGridComp
       type(PrimaryExportVector) :: export_vector
    end type ExtDataGridComp
@@ -82,8 +82,9 @@ contains
       call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
       active_items = get_active_items(exportState, _RC)
       call new_ExtDataConfig_from_yaml(config, hconfig, current_time,  _RC)
-      iter = active_items%begin()
-      do while (iter /= active_items%end())
+      iter = active_items%ftn_begin()
+      do while (iter /= active_items%ftn_end())
+         call iter%next()
          item_name => iter%of()
          has_rule = config%has_rule_for(item_name, _RC)
          _ASSERT(has_rule, 'no rule for extdata item: '//item_name)
@@ -92,7 +93,6 @@ contains
          primary_export = config%make_PrimaryExport(item_name, _RC)
          call primary_export%complete_export_spec(item_name, exportState, _RC)
          call extdata_gridcomp%export_vector%push_back(primary_export)
-         call iter%next()
       end do
 
       call report_active_items(extdata_gridcomp%export_vector, lgr)
@@ -122,14 +122,14 @@ contains
       _GET_NAMED_PRIVATE_STATE(gridcomp, ExtDataGridComp, PRIVATE_STATE, extdata_gridcomp)
       call ESMF_ClockGet(clock, currTime=current_time, _RC) 
       call ESMF_TimePrint(current_time, options='string', preString='extdata timestep: ', _RC)
-      iter = extdata_gridcomp%export_vector%begin()
-      do while (iter /= extdata_gridcomp%export_vector%end())
+      iter = extdata_gridcomp%export_vector%ftn_begin()
+      do while (iter /= extdata_gridcomp%export_vector%ftn_end())
+         call iter%next()
          export_item => iter%of() 
          call export_item%update_my_bracket(current_time, weights, _RC)
          export_name = export_item%get_export_var_name()
          call set_weights(exportState, export_name, weights, _RC)
-         call export_item%append_read_state(exportState, read_state, alias_map, _RC)
-         call iter%next()
+         !call export_item%append_read_state(exportState, read_state, alias_map, _RC)
       end do
 
       _RETURN(_SUCCESS)

--- a/gridcomps/ExtData3G/ExtDataGridComp_private.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp_private.F90
@@ -11,7 +11,6 @@ module mapl3g_ExtDataGridComp_private
    implicit none
    private
 
-   public :: merge_config
    public :: add_var_specs
    public :: set_weights
    public :: get_active_items
@@ -25,89 +24,6 @@ module mapl3g_ExtDataGridComp_private
 
 contains
 
-   recursive subroutine merge_config(merged_hconfig, input_hconfig, rc)
-      type(ESMF_HConfig), intent(inout) :: merged_hconfig
-      type(ESMF_HConfig), intent(in) :: input_hconfig
-      integer, intent(out), optional :: rc
-
-      integer :: status
-
-      character(len=:), allocatable :: sub_configs(:)
-      type(ESMF_HConfig) :: sub_config
-      integer :: i
-      logical :: is_sequence
-    
-      if (ESMF_HConfigIsDefined(input_hconfig, keyString=SUBCONFIG_KEY)) then
-         is_sequence = ESMF_HConfigIsSequence(input_hconfig, keyString=SUBCONFIG_KEY, _RC)
-         _ASSERT(is_sequence, "subconfig list in extdata not a sequence")
-         sub_configs = ESMF_HConfigAsStringSeq(input_hconfig, ESMF_MAXPATHLEN, keyString=SUBCONFIG_KEY, _RC) 
-         do i=1,size(sub_configs)
-            sub_config = ESMF_HConfigCreate(filename=trim(sub_configs(i)), _RC)
-            call merge_config(merged_hconfig, sub_config, _RC)
-            call ESMF_HConfigDestroy(sub_config, _RC)
-         enddo
-      end if
-      call merge_map(merged_hconfig, input_hconfig, COLLECTIONS_KEY, _RC)
-      call merge_map(merged_hconfig, input_hconfig, SAMPLINGS_KEY, _RC)
-      call merge_map(merged_hconfig, input_hconfig, EXPORTS_KEY, _RC)
-      call merge_map(merged_hconfig, input_hconfig, DERIVED_KEY, _RC)
-
-      _RETURN(_SUCCESS)
-
-      contains
-
-      subroutine merge_map(hconfig_to, hconfig_from, key, rc)
-         type(ESMF_HConfig), intent(inout) :: hconfig_to
-         type(ESMF_HConfig), intent(in) :: hconfig_from
-         character(len=*), intent(in) :: key
-         integer, optional, intent(out) :: rc
-
-         integer :: status
-         type(ESMF_HConfig) :: hconfig_temp, hconfig_exist, hconfig_accum, iter_val
-         type(ESMF_HConfigIter) :: iter, iter_begin,iter_end
-         character(len=:), allocatable :: iter_key
-
-         if (ESMF_HConfigIsDefined(hconfig_from, keyString=key)) then
-            hconfig_temp = ESMF_HConfigCreateAt(hconfig_from, keyString=key, _RC)
-         else
-            _RETURN(_SUCCESS)
-         end if
-
-         if (ESMF_HConfigIsDefined(hconfig_to, keyString=key)) then
-            hconfig_accum = ESMF_HConfigCreate(_RC)
-
-            iter_begin = ESMF_HConfigIterBegin(hconfig_temp)
-            iter_end = ESMF_HConfigIterEnd(hconfig_temp)
-            iter = iter_begin
-            do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
-               _VERIFY(status)
-               iter_key = ESMF_HConfigAsStringMapKey(iter, _RC)
-               iter_val = ESMF_HConfigCreateAtMapVal(iter, _RC)
-               call ESMF_HConfigAdd(hconfig_accum, iter_val, addKeyString=iter_key, _RC)
-            enddo
-
-            hconfig_exist = ESMF_HConfigCreateAt(hconfig_to, keyString=key, _RC)
-            iter_begin = ESMF_HConfigIterBegin(hconfig_exist)
-            iter_end = ESMF_HConfigIterEnd(hconfig_exist)
-            iter = iter_begin
-            do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
-               _VERIFY(status)
-               iter_key = ESMF_HConfigAsStringMapKey(iter, _RC)
-               iter_val = ESMF_HConfigCreateAtMapVal(iter, _RC)
-               call ESMF_HConfigAdd(hconfig_accum, iter_val, addKeyString=iter_key, _RC)
-            enddo
-            call ESMF_HConfigSet(hconfig_to, hconfig_accum, keyString=key, _RC)
-
-         else
-            call ESMF_HConfigAdd(hconfig_to, hconfig_temp, addKeyString=key, _RC)
-         end if
-         _RETURN(_SUCCESS)
-
-      end subroutine
-   end subroutine merge_config
-
-   ! once we pass in the merged hconfig after bug is fixed
-   ! in ESMF this will no longer need to be recursive
    recursive subroutine add_var_specs(gridcomp, hconfig, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       type(ESMF_HConfig), intent(in) :: hconfig
@@ -203,14 +119,14 @@ contains
       call lgr%info('*******************************************************')
       call lgr%info('** Variables to be provided by the ExtData Component **')
       call lgr%info('*******************************************************')
-      iter = exports%begin()
+      iter = exports%ftn_begin()
       i=0
-      do while (iter /= exports%end())
+      do while (iter /= exports%ftn_end())
+         call iter%next()
          export => iter%of() 
          export_name = export%get_export_var_name() 
          i=i+1
          call lgr%info('---- %i0.5~: %a', i, export_name)
-         call iter%next()
       end do
 
    end subroutine

--- a/gridcomps/ExtData3G/ExtDataRule.F90
+++ b/gridcomps/ExtData3G/ExtDataRule.F90
@@ -166,23 +166,3 @@ contains
    end subroutine split_vector
 
 end module mapl3g_ExtDataRule
-
-module mapl3g_ExtDataRuleMap
-   use mapl3g_ExtDataRule
-
-#include "types/key_deferredLengthString.inc"
-#define _value type(ExtDataRule)
-#define _alt
-
-#define _map ExtDataRuleMap
-#define _iterator ExtDataRuleMapIterator
-
-#include "templates/map.inc"
-
-#undef _iterator
-#undef _map
-
-#undef _alt
-#undef _value
-
-end module mapl3g_ExtDataRuleMap

--- a/gridcomps/ExtData3G/ExtDataRuleMap.F90
+++ b/gridcomps/ExtData3G/ExtDataRuleMap.F90
@@ -1,0 +1,20 @@
+module mapl3g_ExtDataRuleMap
+   use mapl3g_ExtDataRule
+
+#define Key __CHARACTER_DEFERRED
+#define T ExtDataRule
+#define Map ExtDataRuleMap
+#define MapIterator ExtDataRuleMapIterator
+#define Pair ExtDataRulePair
+
+#include "map/template.inc"
+
+#undef Pair
+#undef MapIterator
+#undef Map
+#undef T
+#undef Key
+
+end module mapl3g_ExtDataRuleMap
+
+

--- a/gridcomps/ExtData3G/ExtDataSample.F90
+++ b/gridcomps/ExtData3G/ExtDataSample.F90
@@ -105,23 +105,3 @@ contains
    end subroutine set_defaults
 
 end module mapl3g_ExtDataSample
-
-module mapl3g_ExtDataSampleMap
-   use mapl3g_ExtDataSample
-
-#include "types/key_deferredLengthString.inc"
-#define _value type(ExtDataSample)
-#define _alt
-
-#define _map ExtDataSampleMap
-#define _iterator ExtDataSampleMapIterator
-
-#include "templates/map.inc"
-
-#undef _iterator
-#undef _map
-
-#undef _alt
-#undef _value
-
-end module mapl3g_ExtDataSampleMap

--- a/gridcomps/ExtData3G/ExtDataSampleMap.F90
+++ b/gridcomps/ExtData3G/ExtDataSampleMap.F90
@@ -1,0 +1,18 @@
+module mapl3g_ExtDataSampleMap
+   use mapl3g_ExtDataSample
+
+#define Key __CHARACTER_DEFERRED
+#define T ExtDataSample
+#define Map ExtDataSampleMap
+#define MapIterator ExtDataSampleMapIterator
+#define Pair ExtDataSamplePair
+
+#include "map/template.inc"
+
+#undef Pair
+#undef MapIterator
+#undef Map
+#undef T
+#undef Key
+
+end module mapl3g_ExtDataSampleMap

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -23,6 +23,7 @@ module mapl3g_HistoryCollectionGridComp
    end type HistoryCollectionGridComp
 
    character(len=*), parameter :: null_file = 'null_file'
+   character(*), parameter :: PRIVATE_STATE = "HistoryCollection"
 
 contains
 
@@ -31,7 +32,6 @@ contains
       integer, intent(out) :: rc
 
       type(ESMF_HConfig) :: hconfig
-      character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       integer :: status
 
       ! Set entry points
@@ -56,7 +56,6 @@ contains
       integer, intent(out)  :: rc
 
       integer :: status
-      character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       type(ESMF_HConfig) :: hconfig
       type(ESMF_Geom) :: geom
@@ -118,7 +117,6 @@ contains
 
       integer :: status, time_index
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
-      character(*), parameter :: PRIVATE_STATE = "HistoryCollectionGridComp"
       logical :: run_collection
       type(ESMF_Time) :: current_time
       character(len=ESMF_MAXSTR) :: name


### PR DESCRIPTION
Just some cosmetic changes after talking to @tclune yesterday.
Pulled map modules out
Capitalized constants in constants
changed name of grid comp private state
change iterators to use `ftn_begin` and `ftn_end`
changed from gftl1 to gftl2
Removed merge hconfig routine since we don't need it

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

