### PR TITLE
Prepare for MAPL 2.59.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed 0d string reading and writing
-- Minor bug fix in pfio `test_prefetch_data` test
-- Fixed stretched grid target lat/lon unit conversion in ExtData
-
 ### Added
 
 ### Changed
@@ -20,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Deprecated
+
+## [2.59.0] - 2025-08-06
+
+### Fixed
+
+- Fixed 0d string reading and writing
+- Minor bug fix in pfio `test_prefetch_data` test
+- Fixed stretched grid target lat/lon unit conversion in ExtData
+- Fix a typo in trajectory sampler
+
+### Added
+
+- Added tests to read and write 0d and 1d string to and from netcdf files
 
 ## [2.58.1] - 2025-07-19
 
@@ -36,12 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix some incorrect links in the documentation
-- Fix a typo in trajectory sampler
 
 ### Added
 
-- Added tests to read and write 0d and 1d string to and from netcdf files
-- Added new markup link checker based on [mlc](https://github.com/becheran/mlc)
+- Add new markup link checker based on [mlc](https://github.com/becheran/mlc)
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.58.1
+  VERSION 2.59.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR is to prepare for a release of MAPL 2.59. The main reason is to get fixes needed by our GCHP colleagues (see #3926). Per @lizziel:

> Tests look good. GCHP stretched grid is zero diff with develop relative to the prior MAPL version we were using (based off of MAPL 2.26). You can release any time. Thanks!

My nightly tests also show `develop` as working and zero-diff to MAPL 2.58

## Related Issue

