### PR TITLE
v3: Enable ifx CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort]
+              compiler: [gfortran, ifort, ifx]
               cmake_generator: ['Unix Makefiles']
               build_type: ['Debug']
           baselibs_version: *baselibs_version
@@ -93,7 +93,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              # ifx cannot build FMS
+              # ifx 2025.1 cannot build FMS, 2025.2 can, but fails with yafyaml
               #compiler: [gfortran, ifort, ifx]
               compiler: [gfortran, ifort]
           baselibs_version: *baselibs_version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake-build-type: [Debug, Release]
-        cmake-generator: [Unix Makefiles]
+        cmake-generator: [Unix Makefiles, Ninja]
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         cmake-build-type: [Debug, Release]
-        cmake-generator: [Unix Makefiles]
+        cmake-generator: [Unix Makefiles, Ninja]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -87,30 +87,26 @@ jobs:
           cmake-generator: ${{ matrix.cmake-generator }}
           fortran-compiler: ifort
 
-  # The following job is for Intel Fortran Compiler (ifx) builds.
-  # At the moment, ifx seems to have random issues with MAPL3
-  ################################################################################
-  # build_test_mapl_ifx:                                                         #
-  #   name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
-  #   runs-on: ubuntu-latest                                                     #
-  #   container:                                                                 #
-  #     image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1        #
-  #   strategy:                                                                  #
-  #     fail-fast: false                                                         #
-  #     matrix:                                                                  #
-  #       cmake-build-type: [Debug, Release]                                     #
-  #       cmake-generator: [Unix Makefiles]                                      #
-  #   steps:                                                                     #
-  #     - name: Checkout                                                         #
-  #       uses: actions/checkout@v4                                              #
-  #       with:                                                                  #
-  #         fetch-depth: 1                                                       #
-  #         filter: blob:none                                                    #
-  #                                                                              #
-  #     - name: Build and Test MAPL                                              #
-  #       uses: ./.github/actions/ci-build-and-test-mapl                         #
-  #       with:                                                                  #
-  #         cmake-build-type: ${{ matrix.cmake-build-type }}                     #
-  #         cmake-generator: ${{ matrix.cmake-generator }}                       #
-  #         fortran-compiler: ifx                                                #
-  ################################################################################
+  build_test_mapl_ifx:
+    name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
+    runs-on: ubuntu-latest
+    container:
+      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type: [Debug, Release]
+        cmake-generator: [Unix Makefiles, Ninja]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          filter: blob:none
+
+      - name: Build and Test MAPL
+        uses: ./.github/actions/ci-build-and-test-mapl
+        with:
+          cmake-build-type: ${{ matrix.cmake-build-type }}
+          cmake-generator: ${{ matrix.cmake-generator }}
+          fortran-compiler: ifx


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

As both @bena-nasa and myself have seen, MAPL3 does build with `ifx` just fine on bucy. So, let's turn it on in CI. 

I'm also trying turning on the Ninja builds in Github CI. Just to see.

## Related Issue

