### PR TITLE
v2: Fix for NAG halting on macOS Arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Change a few keyword names in sampler for consistency with HISTORY
+- Fix for NAG + macOS Arm which does not support IEEE halting properly
+
 ### Added
 
 ### Changed
@@ -25,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor bug fix in pfio `test_prefetch_data` test
 - Fixed stretched grid target lat/lon unit conversion in ExtData
 - Fix a typo in trajectory sampler
-- Change a few keyword names in sampler for consistency with HISTORY
 
 ### Added
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Per Malcolm Cohen of NAG, NAG + Apple Arm does not properly support IEEE halting. The solution he provided was to use the inquiry function `ieee_support_halting()`.[^1] 

My tests with NAG on macOS show this to fix it.

## Related Issue

Closes #4006 

[^1]: Unfortunately, `ieee_support_halting()` does not support the named constant `ieee_all` (which is a convenience `ieee_flag_type` for many calls, but not `ieee_support_halting()`) so we need a crazy long logical expression!
