### PR TITLE
Kludge to prevent crashes on NAG + OSX

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_read_restart.F90
+++ b/generic3g/OuterMetaComponent/initialize_read_restart.F90
@@ -26,6 +26,7 @@ contains
       character(:), allocatable :: filename
       type(esmf_Time) :: currTime
       integer :: status
+      class(Logger), pointer :: user_logger
 
       call recurse(this, phase_idx=GENERIC_INIT_READ_RESTART, _RC)
       _RETURN_UNLESS(this%has_geom())
@@ -33,11 +34,12 @@ contains
       driver => this%get_user_gc_driver()
       call esmf_ClockGet(driver%get_clock(), currTime=currTime, _RC)
 
+      user_logger => this%get_logger()
       restart_handler = RestartHandler( &
            driver%get_name(), &
            this%get_geom(), &
            currTime, &
-           this%get_logger())
+           user_logger)
 
       states = driver%get_states()
       subdir = get_checkpoint_subdir(this%hconfig, currTime, _RC)

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -342,17 +342,8 @@ contains
       expected_itemtype = get_expected_itemtype(expectations, _RC)
 
       itemtype = get_itemtype(state, short_name, _RC)
-      block
-        integer :: itemCount
-        character(len=ESMF_MAXSTR), allocatable :: names(:)
-        if (expected_itemtype%ot /= itemtype%ot) then
-           call ESMF_StateGet(state, itemcount=itemcount, _RC)
-           allocate(names(itemCount))
-           call ESMF_StateGet(state, itemNameList=names, _RC)
-        end if
-      end block
-      @assert_that(msg // ':: check item type of '//short_name, expected_itemtype == itemtype, is(true()))
-
+      msg = msg // ':: check item type of '//short_name
+      @assert_that(msg, expected_itemtype == itemtype, is(true()))
 
       rc = 0
 
@@ -471,7 +462,8 @@ contains
 
       call ESMF_StateGet(state, short_name, field, _RC)
       call ESMF_FieldGet(field, typekind=found_field_typekind, _RC)
-      @assert_that(msg // ' field typekind: ',expected_field_typekind == found_field_typekind, is(true()))
+      msg = msg // ' field typekind: '
+      @assert_that(msg, expected_field_typekind == found_field_typekind, is(true()))
 
       rc = 0
    end subroutine check_field_typekind

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -121,7 +121,7 @@ contains
               ScenarioDescription('scenario_reexport_twice', 'grandparent.yaml', check_name, check_stateitem), &
               ScenarioDescription('history_1',               'cap.yaml',         check_name, check_stateitem), &
               ScenarioDescription('history_wildcard',        'cap.yaml',         check_name, check_stateitem), &
-!#              ScenarioDescription('extdata_1',               'cap.yaml',         check_name, check_stateitem), &
+              ScenarioDescription('extdata_1',               'cap.yaml',         check_name, check_stateitem), &
               ScenarioDescription('precision_extension',     'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('precision_extension_3d',  'parent.yaml',      check_name, check_stateitem), &
               ScenarioDescription('3d_specs',                'parent.yaml',      check_name, check_stateitem), &


### PR DESCRIPTION
Clearly memory is corrupted, but the problems sometimes go away with mere print statements.

Typical error messages were:

```
Runtime Error:
/Users/tclune/swdev/GEOS-ESM/MAPL3/shared/ErrorHandling.F90, line 117:
Incorrect interface block - Function MAPL_ERRORHANDLING:MAPL_VERIFY
does not return a POINTER
```

Failing tests were scenarios:
  - history_wildcard
  - extdata_1
  - statistics

No idea what the actual underlying problem is after days of investigating.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

