### PR TITLE
Closes #4024. Change History to default VERSION: 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the default `VERSION` in History to `1` (which has been the effective default in `HISTORY.rc` for some time)
+
 ### Removed
 
 ### Deprecated

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -548,7 +548,7 @@ contains
     call ESMF_ConfigGetAttribute(config, value=snglcol,          &
                                          label='SINGLE_COLUMN:', default=0, _RC)
     call ESMF_ConfigGetAttribute(config, value=intstate%version,          &
-                                         label='VERSION:', default=0, _RC)
+                                         label='VERSION:', default=1, _RC)
     if( MAPL_AM_I_ROOT() ) then
        print *
        print *, 'EXPSRC:',trim(INTSTATE%expsrc)
@@ -1189,7 +1189,7 @@ contains
 
        if (list(n)%extrap_below_surf) then
           phis_in_collection = .false.
-          do i=1,list(n)%field_set%nfields 
+          do i=1,list(n)%field_set%nfields
              if (trim(fields(1,i)) == 'PHIS') phis_in_collection = .true.
           enddo
 
@@ -1213,7 +1213,7 @@ contains
           end if
 
           ts_in_collection = .false.
-          do i=1,list(n)%field_set%nfields 
+          do i=1,list(n)%field_set%nfields
              if (trim(fields(1,i)) == 'TS') ts_in_collection = .true.
           enddo
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates the default version of History to 1. The old default was 0 which used the old `resolution:` keyword which hasn't been used in a looooong time. All modern `HISTORY.rc` that are used with MAPL now use the `grid_label:` keyword.

CC @bena-nasa as I think I did this right...

## Related Issue

Closes #4024 

