### PR TITLE
Fix to allocate non-connected import items 

### DIFF
--- a/generic3g/specs/StateItemSpec.F90
+++ b/generic3g/specs/StateItemSpec.F90
@@ -294,9 +294,14 @@ contains
 
       integer :: status
       class(ClassAspect), pointer :: class_aspect
+      logical, allocatable :: active, not_connected
 
-      ! Kludge to prevent allocation of import items
-      _RETURN_IF(this%state_intent == ESMF_STATEINTENT_IMPORT)
+      if (this%state_intent == ESMF_STATEINTENT_IMPORT) then
+         ! Allow allocation of non-connected imports to support some testing modes
+         active = (this%allocation_status >= STATEITEM_ALLOCATION_ACTIVE)
+         not_connected = (this%allocation_status < STATEITEM_ALLOCATION_CONNECTED)
+         _RETURN_UNLESS(active .and. not_connected)
+      end if
 
       class_aspect => to_ClassAspect(this%aspects, _RC)
 


### PR DESCRIPTION
Added a fix that allows allocation of non-connected imports to support testing mode where all imports are activated

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

