### PR TITLE
v2: Update to ESMA_env 5.13.0, ESMA_cmake 3.64.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v7.33.0
+baselibs_version: &baselibs_version v8.18.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v7.33.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.18.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
     name: ifort / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +91,7 @@ jobs:
     name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v7.33.0-intelmpi_2021.15-ifx_2025.1
+      image: gmao/ubuntu24-geos-env:v8.18.0-intelmpi_2021.15-ifx_2025.1
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `components.yaml`
+  - `ESMA_env` v5.13.0
+    - Update to Baselibs 8.18.0
+      - ESMF 8.9.0
+      - curl 8.15.0
+      - NCO 5.3.4
+      - CDO 2.5.3
+      - nccmp 1.10.0.0
+      - *Removed* szip, *added* libaec
+        - Note: To use libaec correctly, users should use `ESMA_cmake` v3.63.0/v4.20.0 or higher
+  - `ESMA_cmake` v3.64.0
+    - Support for libaec
+    - Add `FindISSM.cmake`
+- Update CI to use Baselibs 8.18.0
+
 ### Removed
 
 ### Deprecated

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v4.38.0
+  tag: v5.13.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.62.1
+  tag: v3.64.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates MAPL2 to use ESMA_env v5.13.0 and ESMA_cmake v3.64.0.

This adds ESMF 8.9.0 support as well as other updates to Baselibs (including moving from szip to libaec). The ESMA_cmake update is paired with this Baselibs.

It also updates the CI to use the same Baselibs version.

NOTE: At the moment we do not *require* ESMF 8.9.0

## Related Issue

