### PR TITLE
v2: Prepare for 2.60 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.60.0] - 2025-09-11
+
+### Fixed
+
 - Fix NRL Solar Constant read routine for cycle-Cycle24 option
 - Change a few keyword names in sampler for consistency with HISTORY
 - Fixes for NVHPC: Move some subroutines in `MAPL_MaskMod` from submodule to module
@@ -34,11 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Add `FindISSM.cmake`
 - Update CI to use Baselibs 8.18.0
 - Allow row lookups to return key if key in values (ACG2)
-
-### Removed
-
-### Deprecated
-
 ## [2.59.0] - 2025-08-06
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.59.0
+  VERSION 2.60.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is a gitflow PR to prepare for a 2.60 release.

NOTE to self. This is "zero-diff" but #4040 by @darianboggs fixed a bug which presents in a difference in `ss_internal_rst`. I'll explain more in the release notes.

## Related Issue

