### PR TITLE
v2: ESMF 9 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added support for ESMF 9
+  - Requires `#ifdef` to support changes in deprecated `ESMF_Attribute` API in ESMF 9
+
 ### Added
 
 ### Changed

--- a/generic/CMakeLists.txt
+++ b/generic/CMakeLists.txt
@@ -71,6 +71,15 @@ target_include_directories (${this} PUBLIC
 target_link_libraries (${this} PUBLIC ESMF::ESMF NetCDF::NetCDF_Fortran
   PRIVATE OpenMP::OpenMP_Fortran)
 
+# ESMF 9 made internal changes to the Info object that underlies the (now deprecated)
+# Attribute API. So, to get attributes by index, we need to specify
+# the convention and purpose arguments. Once MAPL requires ESMF 9, remove this
+# ifdef. (Not applicable to MAPL3 which uses Info natively.)
+if (ESMF_VERSION VERSION_GREATER_EQUAL 9.0.0)
+  message(STATUS "ESMF 9 detected. Setting -DESMF_VER_GE_9")
+  target_compile_definitions(${this} PRIVATE ESMF_VER_GE_9)
+endif ()
+
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)
 endif ()

--- a/generic/MAPL_Generic.F90
+++ b/generic/MAPL_Generic.F90
@@ -448,7 +448,7 @@ module MAPL_GenericMod
       integer                        , pointer :: phase_coldstart(:)=> null()
       integer                        , pointer :: phase_refresh(:)=> null()
       procedure(i_run), public, nopass, pointer :: customRefresh => null()
-      
+
       ! Make accessors?
       type(ESMF_GridComp)                      :: RootGC
       type(ESMF_GridComp)            , pointer :: parentGC         => null()
@@ -6060,7 +6060,7 @@ contains
 
       nwrgt1 = (mpl%grid%num_readers > 1)
 
-      isNC4 = MAPL_FILETYPE_UNK 
+      isNC4 = MAPL_FILETYPE_UNK
       if (on_tiles) mpl%grid%split_restart = .false.
       if(INDEX(FNAME,'*') == 0) then
          if (AmIRoot) then
@@ -7855,18 +7855,26 @@ contains
       character(len=ESMF_MAXSTR)            :: NAME
       logical                               :: VALUE
 
-      call ESMF_AttributeGet(FIELDIN, count=NF, RC=status)
-      _VERIFY(status)
+      ! ESMF 9 made internal changes to the Info object that underlies the (now deprecated)
+      ! Attribute API. So, to get attributes by index, we need to specify
+      ! the convention and purpose arguments. Once MAPL requires ESMF 9, remove this
+      ! ifdef. (Not applicable to MAPL3 which uses Info natively.)
+#ifdef ESMF_VER_GE_9
+      call ESMF_AttributeGet(FIELDIN, count=NF, convention="ESMF", purpose="General", _RC)
+#else
+      call ESMF_AttributeGet(FIELDIN, count=NF, _RC)
+#endif
 
       do I=1,NF
-         call ESMF_AttributeGet(FIELDIN,attributeIndex=I,NAME=NAME,RC=status)
-         _VERIFY(status)
+#ifdef ESMF_VER_GE_9
+         call ESMF_AttributeGet(FIELDIN,attributeIndex=I,NAME=NAME,convention="ESMF", purpose="General",_RC)
+#else
+         call ESMF_AttributeGet(FIELDIN,attributeIndex=I,NAME=NAME,_RC)
+#endif
          NAME = trim(NAME)
          if(NAME(1:10)=='FriendlyTo') then
-            call ESMF_AttributeGet(FIELDIN , NAME=NAME, VALUE=VALUE, RC=status)
-            _VERIFY(status)
-            call ESMF_AttributeSet(FIELDOUT, NAME=NAME, VALUE=VALUE, RC=status)
-            _VERIFY(status)
+            call ESMF_AttributeGet(FIELDIN , NAME=NAME, VALUE=VALUE, _RC)
+            call ESMF_AttributeSet(FIELDOUT, NAME=NAME, VALUE=VALUE, _RC)
          end if
       end do
 


### PR DESCRIPTION
NOTE: This is the first step for moving our CI, etc to ESMF v9. But I don't want to break GEOSgcm first.

---

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR has fixes/workarounds for using ESMF v9 with MAPL2. 

Runs with GEOSgcm v11, MAPL2, and ESMF v9.0.0b03 found that the model was crashing on an `ESMF_AttributeGet` call in `MAPL_Generic` where we get the Attributes *by index*, see https://github.com/esmf-org/esmf/issues/493. This is the *only* place in MAPL2 we do this.

The issue is due to updates in ESMF v9 requested for NamedAlias support needed in MAPL3 (see
https://github.com/esmf-org/esmf/pull/488) but that change altered the underlying `ESMF_Info` object that the (deprecated) `ESMF_Attribute` calls interact with.

A [solution was found](https://github.com/esmf-org/esmf/issues/493#issuecomment-3304756874) by @theurich which uses a different interface to `ESMF_AttributeGet` which lets ESMF know where to "reach into" the Info object for the right bits.

Testing show this is zero-diff for GEOSgcm v11.

## Related Issue

https://github.com/esmf-org/esmf/issues/493