### PR TITLE
v2: Try and repeat failed ctest

### DIFF
--- a/.github/actions/ci-build-and-test-mapl/action.yml
+++ b/.github/actions/ci-build-and-test-mapl/action.yml
@@ -59,4 +59,4 @@ runs:
       run: |
         cmake --build build --target build-tests --parallel 4
         cmake --build build --parallel 4 --target tests
-        ctest --test-dir build --parallel 1 --output-on-failure -L 'ESSENTIAL'
+        ctest --test-dir build --parallel 1 --output-on-failure -L 'ESSENTIAL' || ( echo "Re-running only failing tests..." && ctest --test-dir build --parallel 1 --output-on-failure --rerun-failed )


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Every so often, we get a weird spurious failure in our CI and if you re-run, it works! 

This edit is one try at mitigating that by having `ctest` just try a re-run of failed tests to see if things are a real failure or not.

## Related Issue

