### PR TITLE
Make ExtensionTransform ESMF_Field names public character parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add validation for VariableSpec
 - Add a common set of string functions (StringCommon) in shared to consolidate
 - Add a new implementation of MAPL_HConfigGet that does not require a HConfigParams object
+- Add and use character parameters for `ESMF_Field` names in ExtensionTransform subclasses
 
 ### Changed
 

--- a/generic3g/transforms/ConvertUnitsTransform.F90
+++ b/generic3g/transforms/ConvertUnitsTransform.F90
@@ -13,6 +13,8 @@ module mapl3g_ConvertUnitsTransform
    private
 
    public :: ConvertUnitsTransform
+   public :: IMPORT_FIELD_NAME
+   public :: EXPORT_FIELD_NAME
 
    type, extends(ExtensionTransform) :: ConvertUnitsTransform
       private
@@ -30,6 +32,8 @@ module mapl3g_ConvertUnitsTransform
       procedure new_converter
    end interface ConvertUnitsTransform
 
+   character(len=*), parameter :: IMPORT_FIELD_NAME = 'import[1]'
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 
 contains
 
@@ -78,8 +82,8 @@ contains
       real(kind=ESMF_KIND_R8), pointer :: x8_in(:)
       real(kind=ESMF_KIND_R8), pointer :: x8_out(:)
 
-      call ESMF_StateGet(importState, itemName='import[1]', field=f_in, _RC)
-      call ESMF_StateGet(exportState, itemName='export[1]', field=f_out, _RC)
+      call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, field=f_in, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=f_out, _RC)
 
       call ESMF_FieldGet(f_in, typekind=typekind, _RC)
       if (typekind == ESMF_TYPEKIND_R4) then

--- a/generic3g/transforms/CopyTransform.F90
+++ b/generic3g/transforms/CopyTransform.F90
@@ -10,6 +10,11 @@ module mapl3g_CopyTransform
    use MAPL_FieldUtils
    implicit none
 
+   private
+   public :: CopyTransform
+   public :: IMPORT_FIELD_NAME
+   public :: EXPORT_FIELD_NAME
+
    type, extends(ExtensionTransform) :: CopyTransform
       private
       type(ESMF_TypeKind_Flag) :: src_typekind
@@ -24,6 +29,9 @@ module mapl3g_CopyTransform
    interface CopyTransform
        module procedure new_CopyTransform
    end interface CopyTransform
+
+   character(len=*), parameter :: IMPORT_FIELD_NAME = 'import[1]'
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 
 contains
 
@@ -68,8 +76,8 @@ contains
       integer :: status
       type(ESMF_Field) :: f_in, f_out
 
-      call ESMF_StateGet(importState, itemName='import[1]', field=f_in, _RC)
-      call ESMF_StateGet(exportState, itemName='export[1]', field=f_out, _RC)
+      call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, field=f_in, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=f_out, _RC)
 
       call FieldCopy(f_in, f_out, _RC)
 

--- a/generic3g/transforms/EvalTransform.F90
+++ b/generic3g/transforms/EvalTransform.F90
@@ -15,6 +15,7 @@ module mapl3g_EvalTransform
    private
 
    public :: EvalTransform
+   public :: EXPORT_FIELD_NAME
 
    type, extends(ExtensionTransform) :: EvalTransform
       private
@@ -31,6 +32,7 @@ module mapl3g_EvalTransform
       procedure :: new_EvalTransform
    end interface EvalTransform
 
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 contains
 
    function new_EvalTransform(expression, input_state, input_couplers) result(transform)
@@ -102,7 +104,7 @@ contains
 
       call update_with_target_attr(this, importState, exportState, clock, _RC)
 
-      call ESMF_StateGet(exportState, itemName='export[1]', field=f, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=f, _RC)
 
       call MAPL_StateEval(this%input_state, this%expression, f, _RC)
 

--- a/generic3g/transforms/RegridTransform.F90
+++ b/generic3g/transforms/RegridTransform.F90
@@ -15,6 +15,8 @@ module mapl3g_RegridTransform
    private
 
    public :: RegridTransform
+   public :: IMPORT_FIELD_NAME
+   public :: EXPORT_FIELD_NAME
 
    type, extends(ExtensionTransform) :: ScalarRegridTransform
       type(ESMF_Geom) :: src_geom
@@ -34,6 +36,8 @@ module mapl3g_RegridTransform
       module procedure :: new_ScalarRegridTransform
    end interface RegridTransform
 
+   character(len=*), parameter :: IMPORT_FIELD_NAME = 'import[1]'
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 contains
 
    function new_ScalarRegridTransform(src_geom, dst_geom, dst_param) result(transform)
@@ -73,8 +77,8 @@ contains
 
       regridder_manager => get_regridder_manager()
 
-      this%src_geom = get_geom(importState, 'import[1]')
-      this%dst_geom = get_geom(exportState, 'export[1]')
+      this%src_geom = get_geom(importState, IMPORT_FIELD_NAME)
+      this%dst_geom = get_geom(exportState, EXPORT_FIELD_NAME)
       spec = RegridderSpec(this%dst_param, this%src_geom, this%dst_geom)
       this%regrdr => regridder_manager%get_regridder(spec, _RC)
 
@@ -124,21 +128,21 @@ contains
       type(ESMF_StateItem_Flag) :: itemType_in, itemType_out
       type(ESMF_Geom) :: geom_in, geom_out
 
-      call ESMF_StateGet(importState, itemName='import[1]', itemType=itemType_in, _RC)
-      call ESMF_StateGet(exportState, itemName='export[1]', itemType=itemType_out, _RC)
+      call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, itemType=itemType_in, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, itemType=itemType_out, _RC)
 
       _ASSERT(itemType_in == itemType_out, 'Regridder requires same itemType for input and output.')
 
       if (itemType_in == MAPL_STATEITEM_FIELD) then
-         call ESMF_StateGet(importState, itemName='import[1]', field=f_in, _RC)
-         call ESMF_StateGet(exportState, itemName='export[1]', field=f_out, _RC)
+         call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, field=f_in, _RC)
+         call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=f_out, _RC)
          call ESMF_FieldGet(f_in, geom=geom_in, _RC)
          call ESMF_FieldGet(f_out, geom=geom_out, _RC)
          call this%update_transform(geom_in, geom_out)
          call this%regrdr%regrid(f_in, f_out, _RC)
       else ! bundle case
-         call ESMF_StateGet(importState, itemName='import[1]', fieldBundle=fb_in, _RC)
-         call ESMF_StateGet(exportState, itemName='export[1]', fieldBundle=fb_out, _RC)
+         call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, fieldBundle=fb_in, _RC)
+         call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, fieldBundle=fb_out, _RC)
          call MAPL_FieldBundleGet(fb_in, geom=geom_in, _RC)
          call MAPL_FieldBundleGet(fb_out, geom=geom_out, _RC)
          call this%update_transform(geom_in, geom_out)

--- a/generic3g/transforms/TimeInterpolateTransform.F90
+++ b/generic3g/transforms/TimeInterpolateTransform.F90
@@ -15,6 +15,8 @@ module mapl3g_TimeInterpolateTransform
    private
 
    public :: TimeInterpolateTransform
+   public :: IMPORT_FIELD_NAME
+   public :: EXPORT_FIELD_NAME
 
    type, extends(ExtensionTransform) :: TimeInterpolateTransform
    contains
@@ -26,6 +28,9 @@ module mapl3g_TimeInterpolateTransform
    interface TimeInterpolateTransform
       module procedure :: new_TimeInterpolateTransform
    end interface TimeInterpolateTransform
+
+   character(len=*), parameter :: IMPORT_FIELD_NAME = 'import[1]'
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 
 contains
 
@@ -58,14 +63,14 @@ contains
       type(ESMF_Field) :: field_out
       type(ESMF_TypeKind_Flag) :: typekind
 
-      call ESMF_StateGet(importState, 'import[1]', itemType=itemType, _RC)
+      call ESMF_StateGet(importState, IMPORT_FIELD_NAME, itemType=itemType, _RC)
       _ASSERT(itemType == ESMF_STATEITEM_FIELDBUNDLE, 'Expected FieldBundle in importState.')
 
-      call ESMF_StateGet(exportState, 'export[1]', itemType=itemType, _RC)
+      call ESMF_StateGet(exportState, EXPORT_FIELD_NAME, itemType=itemType, _RC)
       _ASSERT(itemType == ESMF_STATEITEM_FIELD, 'Expected Field in exportState.')
 
-      call ESMF_StateGet(importState, itemName='import[1]', fieldbundle=bundle_in, _RC)
-      call ESMF_StateGet(exportState, itemName='export[1]', field=field_out, _RC)
+      call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, fieldbundle=bundle_in, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=field_out, _RC)
       call ESMF_FieldGet(field_out, typekind=typekind, _RC)
 
 

--- a/generic3g/transforms/VerticalRegridTransform.F90
+++ b/generic3g/transforms/VerticalRegridTransform.F90
@@ -22,6 +22,8 @@ module mapl3g_VerticalRegridTransform
    public :: VERTICAL_REGRID_LINEAR
    public :: VERTICAL_REGRID_CONSERVATIVE
    public :: operator(==), operator(/=)
+   public :: IMPORT_FIELD_NAME
+   public :: EXPORT_FIELD_NAME
 
    type, extends(ExtensionTransform) :: VerticalRegridTransform
       type(ESMF_Field) :: v_in_coord, v_out_coord
@@ -40,6 +42,9 @@ module mapl3g_VerticalRegridTransform
    interface VerticalRegridTransform
       procedure :: new_VerticalRegridTransform
    end interface VerticalRegridTransform
+
+   character(len=*), parameter :: IMPORT_FIELD_NAME = 'import[1]'
+   character(len=*), parameter :: EXPORT_FIELD_NAME = 'export[1]'
 
 contains
 
@@ -101,17 +106,17 @@ contains
 
       call compute_interpolation_matrix_(this%v_in_coord, this%v_out_coord, this%matrix, _RC)
 
-      call ESMF_StateGet(importState, itemName="import[1]", itemtype=itemtype_in, _RC)
-      call ESMF_StateGet(exportState, itemName="export[1]", itemtype=itemtype_out, _RC)
+      call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, itemtype=itemtype_in, _RC)
+      call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, itemtype=itemtype_out, _RC)
       _ASSERT(itemtype_out == itemtype_in, "Mismathed item types.")
 
       if (itemtype_in == MAPL_STATEITEM_FIELD) then
-         call ESMF_StateGet(importState, itemName="import[1]", field=f_in, _RC)
-         call ESMF_StateGet(exportState, itemName="export[1]", field=f_out, _RC)
+         call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, field=f_in, _RC)
+         call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, field=f_out, _RC)
          call regrid_field_(this%matrix, f_in, f_out, _RC)
       elseif (itemtype_in == MAPL_STATEITEM_FIELDBUNDLE) then
-         call ESMF_StateGet(importState, itemName="import[1]", fieldBundle=fb_in, _RC)
-         call ESMF_StateGet(exportState, itemName="export[1]", fieldBundle=fb_out, _RC)
+         call ESMF_StateGet(importState, itemName=IMPORT_FIELD_NAME, fieldBundle=fb_in, _RC)
+         call ESMF_StateGet(exportState, itemName=EXPORT_FIELD_NAME, fieldBundle=fb_out, _RC)
          call MAPL_FieldBundleGet(fb_in, fieldlist=fieldlist_in, _RC)
          call MAPL_FieldBundleGet(fb_out, fieldlist=fieldlist_out, _RC)
          do i = 1, size(fieldlist_in)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
The names of the `ESMF_Field` objects in the `ESMF_State` objects in subclasses of `ExtensionTransform` were previously private. This made it difficult to test the subclasses. This PR adds public `character` parameters for the names.

