### PR TITLE
v2: Fixes for ifx 2025.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CMake workaround for ifx 2025.2
+  - NOTE: Still needs updates in GFE not yet in Baselibs
+
 ### Added
 
 ### Changed
+
+- Update `components.yaml`
+  - `ESMA_env` v5.14.0
+    - Update to Baselibs 8.19.0
+      - esmf 9.0.0b03
+      - curl 8.16.0
+  - `ESMA_cmake` v3.65.0
+    - Workaround for ifx 2025.2
 
 ### Removed
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v5.13.0
+  tag: v5.14.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v3.64.0
+  tag: v3.65.0
   develop: develop
 
 ecbuild:

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -41,7 +41,13 @@ target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
-target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+# We need to work around a bug in ifx 2025.2 where we have to use a different preprocesor
+# so here we need to escape the double quotes
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 2025.2 AND CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 2025.3)
+  target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX=\\"${CMAKE_SHARED_LIBRARY_SUFFIX}\\")
+else()
+  target_compile_definitions(${this} PRIVATE SYSTEM_DSO_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+endif()
 
 if (PFUNIT_FOUND)
   add_subdirectory (tests)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR has CMake fixes for ifx 2025.2 support. It first updates to ESMA_cmake v3.65.0 which as the "real" fix for the [ifx 2025.2 preprocessor bug](https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735) (which will be fixed in 2025.3).

Then, a workaround is needed in the Shared CMake due to a quoting issue.

Finally, we update to ESMA_env v5.14.0 which has ESMF v9.0.0b03. Not needed in MAPL2, but might as well keep up.

## Related Issue

