### PR TITLE
Initialize field to zero

### DIFF
--- a/field/FieldCreate.F90
+++ b/field/FieldCreate.F90
@@ -73,7 +73,7 @@ contains
       _UNUSED_DUMMY(unusable)
    end function field_create
 
-   subroutine field_empty_complete( field, &
+   subroutine field_empty_complete(field, &
         typekind, unusable, &
         gridToFieldMap, ungridded_dims, &
         num_levels, vert_staggerloc, &
@@ -115,6 +115,9 @@ contains
            ungriddedLBound=bounds%lower, &
            ungriddedUBound=bounds%upper, &
            _RC)
+
+      ! Initialize field to zero
+      call ESMF_FieldFill(field, dataFillScheme="const", const1=0.d0, _RC)
 
       call ESMF_InfoGetFromHost(field, field_info, _RC)
       vert_staggerloc_ = VERTICAL_STAGGER_NONE

--- a/generic3g/specs/FieldClassAspect.F90
+++ b/generic3g/specs/FieldClassAspect.F90
@@ -249,8 +249,6 @@ contains
       call ESMF_FieldGet(this%payload, status=fstatus, _RC)
       _ASSERT(fstatus == ESMF_FIELDSTATUS_COMPLETE, 'ESMF field status problem.')
 
-      ! Set field to zero, override with default_value, if provided
-      call FieldSet(this%payload, 0., _RC)
       if (allocated(this%default_value)) then
          call FieldSet(this%payload, this%default_value, _RC)
       end if


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Instead of initializing the field in `FieldClassAspect::allocate`, we initialize the field right after its completed, in `MAPL_FieldEmptyComplete`
## Related Issue

