### PR TITLE
Initialize fields

### DIFF
--- a/field/FieldCreate.F90
+++ b/field/FieldCreate.F90
@@ -116,7 +116,7 @@ contains
            ungriddedUBound=bounds%upper, &
            _RC)
 
-      ! Initialize field to zero
+      ! Initialize field
       if (typekind==ESMF_TYPEKIND_I4) then
          call ESMF_FieldFill(field, dataFillScheme="const", param1I4=MAPL_UNDEFINED_INTEGER, _RC)
       else

--- a/field/FieldCreate.F90
+++ b/field/FieldCreate.F90
@@ -9,7 +9,7 @@ module mapl3g_FieldCreate
    use mapl3g_LU_Bound
    use mapl_KeywordEnforcer
    use mapl_ErrorHandling
-   use mapl_InternalConstantsMod, only: MAPL_UNDEFINED_REAL
+   use mapl_InternalConstantsMod, only: MAPL_UNDEFINED_INTEGER
    use esmf, MAPL_FieldEmptyCreate => ESMF_FieldEmptyCreate
 
    implicit none(type,external)
@@ -117,7 +117,11 @@ contains
            _RC)
 
       ! Initialize field to zero
-      call ESMF_FieldFill(field, dataFillScheme="const", const1=0.d0, _RC)
+      if (typekind==ESMF_TYPEKIND_I4) then
+         call ESMF_FieldFill(field, dataFillScheme="const", param1I4=MAPL_UNDEFINED_INTEGER, _RC)
+      else
+         call ESMF_FieldFill(field, dataFillScheme="nan", _RC)
+      end if
 
       call ESMF_InfoGetFromHost(field, field_info, _RC)
       vert_staggerloc_ = VERTICAL_STAGGER_NONE


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Instead of initializing to zero, we initialize the real fields to NaN, and integer (i4) fields to `MAPL_UNDEFINED_INTEGER`

**NOTE** DON’T MERGE as this breaks the test `MAPL3G_Comp_Test_case09` 

## Related Issue

