### PR TITLE
fix because nag didn't like `%l`...

### DIFF
--- a/gridcomps/ExtData3G/DataSetNode.F90
+++ b/gridcomps/ExtData3G/DataSetNode.F90
@@ -252,7 +252,7 @@ contains
       end if
       call ESMF_TimeGet(this%interp_time, timeString=interp_time_string)
 
-      call lgr%info('node status side %a at time %a time index %i0.5 updated %l enabled %l', node_side, interp_time_string, this%time_index, this%update, this%enabled)
+      call lgr%info('node status side %a at time %a time index %i0.5 updated %g0 enabled %g0', node_side, interp_time_string, this%time_index, this%update, this%enabled)
   end subroutine
 
 end module mapl3g_DataSetNode


### PR DESCRIPTION
Really small change. NAG seemed unhappy with `%l`, changed to `%g0` to write a logical through pflogger. I had added an info print via pflogger in ExtData3G via the last PR I made and Matt's nightly NAG test failed.
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

