### PR TITLE
v2: Add support for more than one StateSpecs per target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `mapl_acg.cmake` to allow for more than one StateSpecs file per target
+
 ### Added
 
 ### Changed


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

As found by @pchakraborty, if you have a scenario where two StateSpecs files are used in two separate Gridded Components, but have the same target they eventually point to (e.g., AdvCore and DynCore in FV3 GC), the current `mapl_acg` macro fails.

This PR updates the macro to allow for multiple StateSpecs per overall target.

## Related Issue

