### PR TITLE
v2: Add NAG CI Runner

### DIFF
--- a/.github/workflows/nag_build_discover.yml
+++ b/.github/workflows/nag_build_discover.yml
@@ -1,0 +1,16 @@
+name: NAG Build on Discover
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # This example runs at midnight every day
+    - cron:  '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  run-nag-build-discover:
+    uses: GEOS-ESM/CI-workflows/.github/workflows/nag-build.yml@project/mapl

--- a/.github/workflows/nag_build_discover.yml
+++ b/.github/workflows/nag_build_discover.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # This example runs at midnight every day
-    - cron:  '0 0 * * *'
+    # This example runs at 4 am every day
+    - cron: '0 4 * * *'
 
 defaults:
   run:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR adds a preliminary attempt to get a working NAG CI running on discover. I have to make this PR into `main` as to do more testing, it needs to be on the default branch.

At the moment it's only triggered by hand or at 4 am every day. This is mainly because the speed of MAPL development might (currently) overwhelm SLURM. Once this is in, then we can experiment turning it on for every pull request and see what happens.

I am also in talks with NCCS to provide a higher priority QOS which might be useful once this goes into full use.

## Related Issue

