### PR TITLE
v2: Fix issue with NVHPC and halting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `mapl_acg.cmake` to allow for more than one StateSpecs file per target
+- Fix NVHPC issue with IEEE halting code
 
 ### Added
 

--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -478,11 +478,7 @@ contains
       integer :: npes_world
       logical :: halting_mode(5)
 
-      logical :: set_halting_allowed = ieee_support_halting(ieee_invalid) .and. &
-         ieee_support_halting(ieee_overflow) .and. &
-         ieee_support_halting(ieee_divide_by_zero) .and. &
-         ieee_support_halting(ieee_underflow) .and. &
-         ieee_support_halting(ieee_inexact)
+      logical :: set_halting_allowed
 
       _UNUSED_DUMMY(unusable)
 
@@ -491,6 +487,12 @@ contains
 
       if (.not. this%mpi_already_initialized) then
          call ESMF_InitializePreMPI(_RC)
+
+         set_halting_allowed = ieee_support_halting(ieee_invalid) .and. &
+            ieee_support_halting(ieee_overflow) .and. &
+            ieee_support_halting(ieee_divide_by_zero) .and. &
+            ieee_support_halting(ieee_underflow) .and. &
+            ieee_support_halting(ieee_inexact)
 
          ! Testing with GCC 14 + MVAPICH 4 found that it was failing with
          ! a SIGFPE in MPI_Init_thread(). Turning off ieee halting


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

In testing with NVHPC 25.9, an [issue was found](https://forums.developer.nvidia.com/t/nvfortran-fails-on-valid-fortran/346679/1) with the set-at-compile-time of `set_halting_allowed` from #4007. The simple fix is to set `set_halting_allowed` at run-time.

## Related Issue

https://forums.developer.nvidia.com/t/nvfortran-fails-on-valid-fortran/346679/1