### PR TITLE
fixes #4118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed test case12
+
 ### Added
 
 ### Changed

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -1276,6 +1276,7 @@ contains
     character(len=ESMF_MAXSTR) :: newName_
     character(len=ESMF_MAXSTR), parameter :: Iam='MAPL_FieldCreateNewgrid'
     real, pointer :: ptr1d(:)
+    logical :: has_de
 
     call ESMF_FieldGet(FIELD, grid=fgrid, _RC)
 
@@ -1361,8 +1362,11 @@ contains
     ! otherwise we will overwrite it
     call ESMF_AttributeSet(F, NAME='DIMS', VALUE=DIMS, _RC)
 
-    call assign_fptr(f, ptr1d, _RC)
-    ptr1d = 0.0    
+    has_de = MAPL_GridHasDe(grid, _RC)
+    if (has_de) then
+       call assign_fptr(f, ptr1d, _RC)
+       ptr1d = 0.0
+    end if
 
     _RETURN(ESMF_SUCCESS)
   end function MAPL_FieldCreateNewgrid


### PR DESCRIPTION
Fixes #4118 
Test case 12 of the ExtData/History tests was broken. Need to guard a spot where there be no DE's
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

