### PR TITLE
v2: Fix misspelled MAPL_LIBRARY_TYPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix a memory leak in trajectory sampler due to misuage of FieldRegrid which should be FieldRedist
 - Fixed `mapl_acg.cmake` to allow for more than one StateSpecs file per target
 - Fix NVHPC issue with IEEE halting code
+- Fix a misspelled `MAPL_LIBRARY_TYPE` in `vertical`
 
 ### Added
 

--- a/vertical/CMakeLists.txt
+++ b/vertical/CMakeLists.txt
@@ -1,7 +1,7 @@
 esma_set_this (OVERRIDE MAPL.vertical)
 
 set (srcs
-     Eta2Eta.F90  
+     Eta2Eta.F90
      VerticalCoordinate.F90
 	  VerticalRegridConserveInterface.F90
 	  VerticalRegridUtilities.F90
@@ -10,7 +10,7 @@ set (srcs
 esma_add_library(${this}
     SRCS ${srcs}
     DEPENDENCIES MAPL.shared MAPL.base MAPL.pfio PFLOGGER::pflogger
-    TYPE ${MAPL_LIBARRY_TYPE}
+    TYPE ${MAPL_LIBRARY_TYPE}
     )
 
 target_include_directories (${this} PUBLIC


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This is a bug fix for MAPL v2. There was a misspelled `MAPL_LIBRARY_TYPE` in `vertical`. As such, it was *always* built as a `STATIC` library. This is not what we expect.

I'm going to CC in @bena-nasa as he might be able to test this library to make sure all works still? Unless there is a unit test for it?

## Related Issue

