### PR TITLE
Fix NAG tests on release/MAPL-v3

### DIFF
--- a/generic3g/tests/Test_ConvertUnitsTransform.pf
+++ b/generic3g/tests/Test_ConvertUnitsTransform.pf
@@ -47,7 +47,7 @@ contains
       integer :: status
       type(ESMF_Field) :: field
       real(kind=ESMF_KIND_R4), pointer :: fptr(:)
-      real(kind=ESMF_KIND_R4), parameter :: UPDATE = 100000_R4
+      real(kind=ESMF_KIND_R4), parameter :: UPDATE = 100000.0_R4
 
       _UNUSED_DUMMY(this)
       states = [importState, exportState]
@@ -67,7 +67,7 @@ contains
       integer :: status
       type(ESMF_Field) :: field
       real(kind=ESMF_KIND_R8), pointer :: fptr(:)
-      real(kind=ESMF_KIND_R8), parameter :: UPDATE = 100000_R8
+      real(kind=ESMF_KIND_R8), parameter :: UPDATE = 100000.0_R8
 
       _UNUSED_DUMMY(this)
       states = [importState, exportState]


### PR DESCRIPTION
I just tried release/MAPL-v3 with nag. NAG was not happy. This fixed it.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

