### PR TITLE
Removed unused is_directory argument from MAPL_MakeSymbolicLink

### DIFF
--- a/Apps/MAPL_Component_Driver/DriverCap.F90
+++ b/Apps/MAPL_Component_Driver/DriverCap.F90
@@ -587,7 +587,7 @@ contains
 
       if (MAPL_AmIRoot()) then
          call MAPL_PushDirectory(checkpointing_path, _RC)
-         call MAPL_MakeSymbolicLink(src_path=target_name, link_path=LAST_CHECKPOINT, is_directory=.true., _RC)
+         call MAPL_MakeSymbolicLink(src_path=target_name, link_path=LAST_CHECKPOINT, _RC)
          path = MAPL_PopDirectory(_RC)
       end if
 

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -527,7 +527,7 @@ contains
 
       if (MAPL_AmIRoot()) then
          call MAPL_PushDirectory(checkpointing_path, _RC)
-         call MAPL_MakeSymbolicLink(src_path=target_name, link_path=LAST_CHECKPOINT, is_directory=.true., _RC)
+         call MAPL_MakeSymbolicLink(src_path=target_name, link_path=LAST_CHECKPOINT, _RC)
          path = MAPL_PopDirectory(_RC)
       end if
 

--- a/shared/OS.F90
+++ b/shared/OS.F90
@@ -305,10 +305,9 @@ contains
    end function path_join
 
 
-   subroutine make_symbolic_link(src_path, link_path, is_directory, rc)
+   subroutine make_symbolic_link(src_path, link_path, rc)
       character(*), intent(in) :: src_path
       character(*), intent(in) :: link_path
-      logical, optional, intent(in) :: is_directory
       integer, optional, intent(out) :: rc
 
       interface

--- a/shared/tests/test_OS.pf
+++ b/shared/tests/test_OS.pf
@@ -103,7 +103,7 @@ contains
       integer :: status
 
       call mapl_MakeDirectory(SUBDIR, _RC)
-      call mapl_MakeSymbolicLink(src_path=SUBDIR, link_path=SYMDIR, is_directory=.true., _RC)
+      call mapl_MakeSymbolicLink(src_path=SUBDIR, link_path=SYMDIR, _RC)
 
       @assert_that(mapl_DirectoryExists(SYMDIR), is(true()))
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Fixes #4170 - Argument is_directory in MAPL_MakeSymbolicLink is not used

## Related Issue

