### PR TITLE
Fixes #4176 (missing TARGET)

### DIFF
--- a/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
@@ -43,7 +43,7 @@ contains
    end subroutine initialize_modify_advertised
    
    subroutine process_connections(this, rc)
-      class(OuterMetaComponent), intent(inout) :: this
+      class(OuterMetaComponent), target, intent(inout) :: this
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/include/MAPL_ErrLog.h
+++ b/include/MAPL_ErrLog.h
@@ -109,6 +109,7 @@
 #       define _RETURN_UNLESS(cond)     if(.not.(cond))then;_RETURN(_SUCCESS);endif
 #       define _VERIFY(A)     if(MAPL_Verify(A,_FILE_,__LINE__ __rc(rc))) __return
 #    endif
+#    define _ESTOP(status)  if (status /= 0) error stop				
 #    define _RC_(rc,status) rc=status);_VERIFY(status
 #    define _USERRC userRC=user_status, rc=status); _VERIFY(status); _VERIFY(user_status
 #    define _RC _RC_(rc,status)


### PR DESCRIPTION
Also added an option to change calls to MAPL_Verify into ERROR STOP, which may help in exotic debugging situations.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

