### PR TITLE
v2: Turn on NAG build CI on PRs

### DIFF
--- a/.github/workflows/nag_build_discover.yml
+++ b/.github/workflows/nag_build_discover.yml
@@ -1,11 +1,26 @@
 name: NAG Build on Discover
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Do not run if the only files changed cannot affect the build
+    paths-ignore:
+      - "**.md"
+      - "**.pro"
+      - "**.sh"
+      - "**.perl"
+      - ".github/CODEOWNERS"
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # This example runs at 4 am every day
     - cron: '0 4 * * *'
+
+concurrency:
+  # For PRs: one slot per PR number.
+  # For non-PR events (schedule, workflow_dispatch): one slot per ref.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update CI to use Baselibs 8.20.0
-- Add gcc15 test
-- Update CI to use organization reusable workflows
-- Update README_ACG_WRITER.md.
+- Update CI
+  - Use Baselibs 8.20.0
+  - Add gcc15 test
+  - Use organization reusable workflows
+  - Run CI build test with NAG on PRs
+- Update `README_ACG_WRITER.md`
 - Update `components.yaml`
   - `ESMA_env` v5.16.0
     - Update to Baselibs 8.20.0


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR updates the CI to run NAG build tests with each PR. It seems to work pretty well. We might have to revisit it if we start overwhelming NCCS with SLURM requests.

## Related Issue

