### PR TITLE
Added gridcomp_set_geometry_from_hconfig

### DIFF
--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -38,6 +38,7 @@ module mapl3g_Generic
    use mapl3g_ESMF_Interfaces, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
    use mapl3g_hconfig_get
    use mapl3g_RestartModes, only: RestartMode
+   use mapl3g_ComponentSpecParser, only: parse_geometry_spec
    use mapl_InternalConstantsMod
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
@@ -169,6 +170,7 @@ module mapl3g_Generic
 
    interface MAPL_GridCompSetGeometry
       procedure :: gridcomp_set_geometry
+      procedure :: gridcomp_set_geometry_from_hconfig
    end interface MAPL_GridCompSetGeometry
 
    interface MAPL_GridCompSetEntryPoint
@@ -1032,6 +1034,24 @@ contains
       _RETURN(_SUCCESS)
    end subroutine gridcomp_set_geometry
 
+   subroutine gridcomp_set_geometry_from_hconfig(gridcomp, rc)
+      type(ESMF_GridComp), intent(inout) :: gridcomp
+      integer, optional, intent(out) :: rc
+
+      type(ComponentSpec), pointer :: component_spec
+      type(ESMF_HConfig) :: hconfig
+      type(OuterMetaComponent), pointer :: outer_meta
+      type(StateRegistry), pointer :: registry
+      integer :: status
+
+      call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
+      call MAPL_GridCompGetOuterMeta(gridcomp, outer_meta, _RC)
+      component_spec => outer_meta%get_component_spec()
+      call MAPL_GridCompGetRegistry(gridcomp, registry=registry, _RC)
+      component_spec%geometry_spec = parse_geometry_spec(hconfig, registry, _RC)
+
+      _RETURN(_SUCCESS)
+   end subroutine gridcomp_set_geometry_from_hconfig
 
    ! Use "<SELF>" to indicate connection to gridcomp.
    ! src_name and dst_name can be comma-delimited strings for multiple connection


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Added `MAPL_GridCompSetGeometry` that enables a gridcomp to set an ESMF Geom and vertical grid. It does so by creating a `GeometrySpec` which is subsequently used by the `geom_a` phase of initialize to create an `ESMF_Geom` and `VerticalGrid`.

## Related Issue

#4213 