### PR TITLE
Fixes #4224

### DIFF
--- a/field/FieldGet.F90
+++ b/field/FieldGet.F90
@@ -7,6 +7,7 @@ module mapl3g_FieldGet
    use mapl_KeywordEnforcer
    use mapl_ErrorHandling
    use mapl3g_UngriddedDims
+   use mapl3g_VerticalGridManager
    use esmf
 
    implicit none (type,external)
@@ -22,7 +23,7 @@ contains
 
    subroutine field_get(field, unusable, &
         short_name, typekind, &
-        geom, &
+        geom, vgrid, &
         num_levels, vert_staggerloc, num_vgrid_levels, &
         ungridded_dims, &
         units, standard_name, long_name, &
@@ -31,6 +32,7 @@ contains
       type(ESMF_Field), intent(in) :: field
       class(KeywordEnforcer), optional, intent(in) :: unusable
       type(ESMF_Geom), allocatable, optional, intent(out) :: geom
+      class(VerticalGrid), pointer, optional, intent(out) :: vgrid
       character(len=:), optional, allocatable, intent(out) :: short_name
       type(ESMF_TypeKind_Flag), optional, intent(out) :: typekind
       integer, optional, intent(out) :: num_levels
@@ -47,6 +49,8 @@ contains
       type(ESMF_Info) :: field_info
       character(len=ESMF_MAXSTR) :: fname
       type(ESMF_FieldStatus_Flag) :: fstatus
+      integer, allocatable :: vgrid_id
+      type(VerticalGridManager), pointer :: vgrid_manager
 
       if (present(short_name)) then
          call ESMF_FieldGet(field, name=fname, _RC)
@@ -64,6 +68,10 @@ contains
          end if
       end if
 
+      if (present(vgrid)) then
+         allocate(vgrid_id) ! trigger "is present"
+      end if
+
       if (present(typekind)) then
          call ESMF_FieldGet(field, typekind=typekind, _RC)
       end if
@@ -76,7 +84,13 @@ contains
            ungridded_dims=ungridded_dims, &
            units=units, standard_name=standard_name, long_name=long_name, &
            allocation_status=allocation_status, &
+           vgrid_id=vgrid_id, &
            _RC)
+
+      if (present(vgrid)) then
+         vgrid_manager => get_vertical_grid_manager()
+         vgrid => vgrid_manager%get_grid(id=vgrid_id, _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end subroutine field_get

--- a/field/FieldInfo.F90
+++ b/field/FieldInfo.F90
@@ -5,7 +5,6 @@ module mapl3g_FieldInfo
    use mapl3g_esmf_info_keys, only: INFO_SHARED_NAMESPACE
    use mapl3g_esmf_info_keys, only: INFO_INTERNAL_NAMESPACE
    use mapl3g_esmf_info_keys, only: INFO_PRIVATE_NAMESPACE
-   use mapl3g_VerticalGrid
    use mapl3g_InfoUtilities
    use mapl3g_UngriddedDims
    use mapl3g_VerticalStaggerLoc
@@ -48,7 +47,7 @@ module mapl3g_FieldInfo
       procedure :: field_info_copy_shared
    end interface FieldInfoCopyShared
 
-   character(*), parameter :: KEY_VERTICAL_GRID = "/vertical_grid"
+   character(*), parameter :: KEY_VGRID_ID = "/vgrid_id"
    character(*), parameter :: KEY_TYPEKIND = "/typekind"
    character(*), parameter :: KEY_UNITS = "/units"
    character(*), parameter :: KEY_ATTRIBUTES = "/attributes"
@@ -68,26 +67,22 @@ module mapl3g_FieldInfo
    character(*), parameter :: KEY_SPEC_HANDLE = "/spec_handle"
    character(*), parameter :: KEY_RESTART_MODE = "/restart_mode"
 
-   type :: VGridWrapper
-      class(VerticalGrid), pointer :: ptr
-   end type VGridWrapper
-
 contains
 
    subroutine field_info_set_internal(info, unusable, &
         namespace, &
-        vertical_grid, &
         typekind, &
         num_levels, vert_staggerloc, &
         ungridded_dims, &
         units, long_name, standard_name, &
         allocation_status, &
+        vgrid_id, &
         spec_handle, &
         rc)
       type(ESMF_Info), intent(inout) :: info
       class(KeywordEnforcer), optional, intent(in) :: unusable
       character(*), optional, intent(in) :: namespace
-      class(VerticalGrid), optional, target, intent(in) :: vertical_grid
+      integer, optional, intent(in) :: vgrid_id
       type(esmf_typekind_Flag), optional, intent(in) :: typekind
       integer, optional, intent(in) :: num_levels
       type(VerticalStaggerLoc), optional, intent(in) :: vert_staggerloc
@@ -103,18 +98,14 @@ contains
       type(ESMF_Info) :: ungridded_info
       character(:), allocatable :: namespace_
       character(:), allocatable :: str
-      type(VGridWrapper) :: vgrid_wrapper
-      integer, allocatable :: encoded_vgrid(:)
 
       namespace_ = INFO_INTERNAL_NAMESPACE
       if (present(namespace)) then
          namespace_ = namespace
       end if
 
-      if (present(vertical_grid)) then
-         vgrid_wrapper%ptr => vertical_grid
-         encoded_vgrid = transfer(vgrid_wrapper, [1])
-         call mapl_InfoSet(info, namespace_ // KEY_VERTICAL_GRID, encoded_vgrid, _RC)
+      if (present(vgrid_id)) then
+         call mapl_InfoSet(info, namespace_ // KEY_VGRID_ID, vgrid_id, _RC)
       end if
 
       if (present(typekind)) then
@@ -180,7 +171,7 @@ contains
 
    subroutine field_info_get_internal(info, unusable, &
         namespace, &
-        vertical_grid, &
+        vgrid_id, &
         typekind, &
         num_levels, vert_staggerloc, num_vgrid_levels, &
         units, &
@@ -192,7 +183,7 @@ contains
       type(ESMF_Info), intent(in) :: info
       class(KeywordEnforcer), optional, intent(in) :: unusable
       character(*), optional, intent(in) :: namespace
-      class(VerticalGrid), optional, allocatable, intent(out) :: vertical_grid
+      integer, optional, intent(out) :: vgrid_id
       type(esmf_TypeKind_Flag), optional, intent(out) :: typekind
       integer, optional, intent(out) :: num_levels
       type(VerticalStaggerLoc), optional, intent(out) :: vert_staggerloc
@@ -213,8 +204,6 @@ contains
       character(:), allocatable :: namespace_ 
       character(:), allocatable :: str
       logical :: key_is_present
-      integer, allocatable :: encoded_vgrid(:)
-      type(VGridWrapper) :: vgrid_wrapper
       logical :: is_present
       
       namespace_ = INFO_INTERNAL_NAMESPACE
@@ -222,15 +211,10 @@ contains
          namespace_ = namespace
       end if
 
-      if (present(vertical_grid)) then
-         
-         is_present= esmf_InfoIsPresent(info, namespace_ // KEY_VERTICAL_GRID, _RC)
-         if (is_present) then
-            call mapl_InfoGet(info, namespace_ //KEY_VERTICAL_GRID, encoded_vgrid, _RC)
-            vgrid_wrapper = transfer(encoded_vgrid, vgrid_wrapper)
-            vertical_grid = vgrid_wrapper%ptr
-         end if
+      if (present(vgrid_id)) then
+         call mapl_InfoGet(info, namespace_ // KEY_VGRID_ID, vgrid_id, _RC)
       end if
+
       if (present(typekind)) then
          call mapl_InfoGet(info, namespace_ // KEY_TYPEKIND, str, _RC)
          typekind = to_Typekind(str)

--- a/field/FieldSet.F90
+++ b/field/FieldSet.F90
@@ -23,7 +23,7 @@ contains
 
 subroutine field_set(field, &
         geom, &
-        vertical_grid, &
+        vgrid, &
         vert_staggerloc, &
         typekind, &
         unusable, &
@@ -37,7 +37,7 @@ subroutine field_set(field, &
       type(ESMF_Field), intent(inout) :: field
       class(KeywordEnforcer), optional, intent(in) :: unusable
       type(ESMF_Geom), optional, intent(in) :: geom
-      class(VerticalGrid), optional, target, intent(in) :: vertical_grid
+      class(VerticalGrid), optional, intent(in) :: vgrid
       type(VerticalStaggerLoc), optional, intent(in) :: vert_staggerloc
       type(esmf_TypeKind_Flag), optional, intent(in) :: typekind
       integer, optional, intent(in) :: num_levels
@@ -50,6 +50,7 @@ subroutine field_set(field, &
       type(ESMF_Info) :: field_info
       type(FieldDelta) :: field_delta
       type(esmf_FieldStatus_Flag) :: fstatus
+      integer, allocatable :: vgrid_id
 
       call esmf_FieldGet(field, status=fstatus, _RC)
       if (fstatus == ESMF_FIELDSTATUS_COMPLETE) then
@@ -57,9 +58,13 @@ subroutine field_set(field, &
          call field_delta%update_field(field, _RC)
       end if
 
+      if (present(vgrid)) then
+         vgrid_id = vgrid%get_id() ! allocate so "present" below
+      end if
+
       call esmf_InfoGetFromHost(field, field_info, _RC)
       call FieldInfoSetInternal(field_info, &
-           vertical_grid=vertical_grid, &
+           vgrid_id=vgrid_id, &
            vert_staggerloc=vert_staggerloc, &
            typekind=typekind, units=units, &
            ungridded_dims=ungridded_dims, _RC)

--- a/field_bundle/FieldBundleGet.F90
+++ b/field_bundle/FieldBundleGet.F90
@@ -28,7 +28,7 @@ contains
    ! For "bracket" bundles, additional metadata is stored in the info object
 
    subroutine bundle_get(fieldBundle, unusable, &
-        fieldCount, fieldList, geom, &
+        fieldCount, fieldList, geom, vgrid, &
         fieldBundleType, &
         ! Bracket specific items
         typekind, interpolation_weights, &
@@ -44,6 +44,7 @@ contains
       integer, optional, intent(out) :: fieldCount
       type(ESMF_Field), optional, allocatable, intent(out) :: fieldList(:)
       type(ESMF_Geom), allocatable, optional, intent(out) :: geom
+      class(VerticalGrid), pointer, optional, intent(out) :: vgrid
       type(FieldBundleType_Flag), optional, intent(out) :: fieldBundleType
       type(ESMF_TypeKind_Flag), optional, intent(out) :: typekind
       real(ESMF_KIND_R4), optional, allocatable, intent(out) :: interpolation_weights(:)
@@ -62,6 +63,8 @@ contains
       integer :: fieldCount_
       type(ESMF_Info) :: bundle_info
       logical :: has_geom
+      integer, allocatable :: vgrid_id
+      type(VerticalGridManager), pointer :: vgrid_manager
 
       if (present(fieldCount) .or. present(fieldList)) then
          call ESMF_FieldBundleGet(fieldBundle, fieldCount=fieldCount_, _RC)
@@ -75,7 +78,11 @@ contains
          call ESMF_FieldBundleGet(fieldBundle, fieldList=fieldList, itemOrderflag=ESMF_ITEMORDER_ADDORDER, _RC)
       end if
 
-      ! Get these from FieldBundleInfo
+       if (present(vgrid)) then
+         allocate(vgrid_id) ! trigger "is present"
+      end if
+
+     ! Get these from FieldBundleInfo
       call ESMF_InfoGetFromHost(fieldBundle, bundle_info, _RC)
       call FieldBundleInfoGetInternal(bundle_info, &
            fieldBundleType=fieldBundleType, &
@@ -86,6 +93,7 @@ contains
            allocation_status=allocation_status, &
            bracket_updated=bracket_updated, &
            has_geom=has_geom, &
+           vgrid_id=vgrid_id, &
            _RC)
 
       if (present(geom) .and. has_geom) then

--- a/field_bundle/FieldBundleInfo.F90
+++ b/field_bundle/FieldBundleInfo.F90
@@ -34,6 +34,7 @@ contains
 
    subroutine fieldbundle_get_internal(info, unusable, &
         namespace, &
+        vgrid_id, &
         fieldBundleType, &
         typekind, interpolation_weights, &
         ungridded_dims, num_levels, vert_staggerloc, num_vgrid_levels, &
@@ -46,6 +47,7 @@ contains
 
       type(ESMF_Info), intent(in) :: info
       class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: vgrid_id
       character(*), optional, intent(in) :: namespace
       type(FieldBundleType_Flag), optional, intent(out) :: fieldBundleType
       type(ESMF_TypeKind_Flag), optional, intent(out) :: typekind
@@ -73,7 +75,7 @@ contains
          namespace_ = namespace
       end if
 
-      if (present(fieldBundleType)) then
+     if (present(fieldBundleType)) then
          call ESMF_InfoGetCharAlloc(info, key=namespace_//KEY_FIELDBUNDLETYPE_FLAG, value=fieldBundleType_str, _RC)
          fieldBundleType = FieldBundleType_Flag(fieldBundleType_str)
       end if
@@ -105,7 +107,9 @@ contains
       call FieldInfoGetInternal(info, namespace = namespace_//KEY_FIELD_PROTOTYPE, &
            ungridded_dims=ungridded_dims, &
            num_levels=num_levels, vert_staggerloc=vert_staggerloc, num_vgrid_levels=num_vgrid_levels, &
-           units=units, long_name=long_name, standard_name=standard_name, spec_handle=spec_handle, _RC)
+           units=units, long_name=long_name, standard_name=standard_name, spec_handle=spec_handle, &
+           vgrid_id=vgrid_id, &
+           _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -137,6 +141,7 @@ contains
         num_levels, vert_staggerloc, &
         units, standard_name, long_name, &
         allocation_status, &
+        vgrid_id, &
         spec_handle, &
         bracket_updated, &
         has_geom, &
@@ -155,6 +160,7 @@ contains
       character(*), optional, intent(in) :: standard_name
       character(*), optional, intent(in) :: long_name
       type(StateItemAllocation), optional, intent(in) :: allocation_status
+      integer, optional, intent(in) :: vgrid_id
       integer, optional, intent(in) :: spec_handle(:)
       logical, optional, intent(in) :: bracket_updated
       logical, optional, intent(in) :: has_geom
@@ -200,6 +206,7 @@ contains
            ungridded_dims=ungridded_dims, &
            num_levels=num_levels, vert_staggerloc=vert_staggerloc, &
            units=units, long_name=long_name, standard_name=standard_name, &
+           vgrid_id=vgrid_id, &
            spec_handle=spec_handle, _RC)
 
        _RETURN(_SUCCESS)

--- a/field_bundle/FieldBundleSet.F90
+++ b/field_bundle/FieldBundleSet.F90
@@ -30,7 +30,7 @@ module mapl3g_FieldBundleSet
 contains
 
   subroutine bundle_set(fieldBundle, unusable, &
-        geom, &
+        geom, vgrid, &
         fieldBundleType, typekind, interpolation_weights, &
         ungridded_dims, &
         num_levels, vert_staggerloc, &
@@ -42,6 +42,7 @@ contains
       type(ESMF_FieldBundle), intent(inout) :: fieldBundle
       class(KeywordEnforcer), optional, intent(in) :: unusable
       type(ESMF_Geom), optional, intent(in) :: geom
+      class(VerticalGrid), optional, intent(in) :: vgrid
       type(FieldBundleType_Flag), optional, intent(in) :: fieldBundleType
       type(ESMF_TypeKind_Flag), optional, intent(in) :: typekind
       real(ESMF_KIND_R4), optional, intent(in) :: interpolation_weights(:)
@@ -62,6 +63,7 @@ contains
       integer :: i
       type(ESMF_Field), allocatable :: fieldList(:)
       logical, allocatable :: has_geom
+      integer, allocatable :: vgrid_id
 
       if (present(geom)) then
          ! ToDo - update when ESMF makes this interface public.
@@ -81,6 +83,10 @@ contains
          end if
 
       end if
+
+      if (present(vgrid)) then
+         vgrid_id = vgrid%get_id() ! allocate so "present" below
+      end if
       
       ! Note it is important that the next line ALLOCATEs has_geom we
       ! don't want to set it either way in info if geom is not
@@ -92,6 +98,7 @@ contains
       ! Some things are treated as field info:
       call ESMF_InfoGetFromHost(fieldBundle, bundle_info, _RC)
       call FieldBundleInfoSetInternal(bundle_info, &
+           vgrid_id=vgrid_id, &
            fieldBundleType=fieldBundleType, &
            typekind=typekind, interpolation_weights=interpolation_weights, &
            ungridded_dims=ungridded_dims, &


### PR DESCRIPTION
VerticalGrid now can be put and retrieved from the ESMF payload.

Should now be easy(TM) to complete remaining aspects in the same fasion.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

