### PR TITLE
Fix logger calls which use argument that is sometimes not defined

### DIFF
--- a/generic3g/OuterMetaComponent/run_child_by_name.F90
+++ b/generic3g/OuterMetaComponent/run_child_by_name.F90
@@ -34,9 +34,9 @@ contains
 
       lgr => this%get_logger()
       this_name = this%get_name() ! workaround for gfortran
-      call lgr%debug('%a run child <%a~> (phase=%a~)', this_name, child_name, phase_name, _RC)
+      call lgr%debug('%a run child <%a~> (phase=%i1~)', this_name, child_name, phase_idx, _RC)
       call child%run(phase_idx=phase_idx, _RC)
-      call lgr%debug('  ... %a completed run child <%a~> (phase=%a~)', this_name, child_name, phase_name, _RC)
+      call lgr%debug('  ... %a completed run child <%a~> (phase=%i1~)', this_name, child_name, phase_idx, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)
- [X] Tested this change with a run of GCHP (one gridcomp version)

## Description

This update fixes a problem encountered testing GCHP using MAPL3 in a simplified version of one gridded component. The two logging commands I changed were causing the model to hang without an error when using gfortran 12.2, and to crash with a pFlogger error when using Intel 2024. The problem is when the root child run is called from `run` in `CapGridComp.F90` there is no `phase_name` passed:

```
      if (cap%run_extdata) then
         call MAPL_GridCompRunChild(gridcomp, cap%extdata_name, _RC)
      end if
      call MAPL_GridCompRunChild(gridcomp, cap%root_name, _RC)
      if (cap%run_history) then
         call MAPL_GridCompRunChild(gridcomp, cap%history_name, phase_name='run', _RC)
      end if
```

`phase_name` is then used in the logging commands in `run_child_by_name` even though it is an optional input. This ultimately causes issues in pFlogger within file `FormatString.F90`.

```
FormatString.F90         158
format_vector() - not enough position arguments for format string.
```

I am not sure why the error only shows up with Intel compiler and the model hangs with GNU. I created a separate issue about pFlogger error handling.

Applying the fix included in this PR makes the single gridcomp version of GCHP run to completion for both GNU 12.2 and Intel 2024 compilers.

## Related Issue

https://github.com/Goddard-Fortran-Ecosystem/pFlogger/issues/150

