### PR TITLE
v2: Prepare for 2.66.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- guarded against 32-bit integer overflow in QSswap
+
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.66.0] - 2026-02-13
+
+### Fixed
+
+- Guarded against 32-bit integer overflow in QSswap
 
 ### Added
 
@@ -44,10 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Updates for f2py and f2py3 for running on macOS with Spack
     - Add Athena frontend nodes for NAS detection
     - Remove `ctest` pre-test build
-
-### Removed
-
-### Deprecated
 
 ## [2.65.0] - 2026-01-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.65.0
+  VERSION 2.66.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
This is a preparation PR for MAPL to work to a 2.66 release.

The main reason is to get the QSswap fix from @atrayano into a release for use in BCs work by @biljanaorescanin 