### PR TITLE
Retrieve centers and corners of a grid via MAPL_GridGet

### DIFF
--- a/geom/API.F90
+++ b/geom/API.F90
@@ -7,7 +7,6 @@ module mapl3g_Geom_API
    use mapl3g_GeomUtilities, only: mapl_SameGeom, mapl_GeomGetId
    use mapl3g_GeomGet, only: mapl_GeomGet => GeomGet
    use mapl3g_GridGet, only: mapl_GridGet => GridGet, mapl_GridGetCoordinates => GridGetCoordinates
-   use mapl3g_VectorBasis, only: mapl_GridGetCorners => GridGetCorners
    use esmf, only: ESMF_Grid, ESMF_Geom, ESMF_KIND_R4
 
    implicit none(type,external)
@@ -18,7 +17,6 @@ module mapl3g_Geom_API
    public :: mapl_GeomGet
    public :: mapl_GridGet
    public :: mapl_GridGetCoordinates
-   public :: mapl_GridGetCorners
 
    ! Used internally by MAPL
    ! Users shouldn't need these

--- a/geom/CMakeLists.txt
+++ b/geom/CMakeLists.txt
@@ -16,6 +16,7 @@ set(srcs
 
   GeomGet.F90
   GridGet.F90
+  GridGetGlobal.F90
 
   # gFTL containers
   GeomFactoryVector.F90
@@ -23,14 +24,15 @@ set(srcs
   IntegerMaplGeomMap.F90
 
   VectorBasis.F90
-  )
+)
 
 esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL.pfio MAPL.shared MAPL.hconfig_utils MAPL.field GFTL::gftl-v2
   TYPE SHARED
-  )
+)
 
+add_subdirectory(GridGet)
 add_subdirectory(MaplGeom)
 add_subdirectory(CoordinateAxis)
 add_subdirectory(LatLon)

--- a/geom/GridGet.F90
+++ b/geom/GridGet.F90
@@ -5,9 +5,8 @@ module mapl3g_GridGet
    use esmf
    use mapl_KeywordEnforcer
    use mapl_ErrorHandling
-   use mapl3g_VectorBasis, only: GridGetCorners
 
-   implicit none
+   implicit none(type, external)
    private
 
    public :: GridGet
@@ -23,17 +22,32 @@ module mapl3g_GridGet
       procedure :: grid_get_coordinates_r8ptr
    end interface GridGetCoordinates
 
+   interface
+
+      module subroutine grid_get_centers(grid, centers, rc)
+         type(ESMF_Grid), intent(in) :: grid
+         real(kind=ESMF_KIND_R8), allocatable, intent(out) :: centers(:,:,:)
+         integer, optional, intent(out) :: rc
+      end subroutine grid_get_centers
+
+      module subroutine grid_get_corners(grid, corners, rc)
+         type(ESMF_Grid), intent(in) :: grid
+         real(kind=ESMF_KIND_R8), allocatable, intent(out) :: corners(:,:,:)
+         integer, optional, intent(out) :: rc
+      end subroutine grid_get_corners
+
+   end interface
+
 contains
 
-   subroutine grid_get(grid, unusable, name, dimCount, coordDimCount, &
-                       im, jm, globalCellCountPerDim, corners, rc)
+   subroutine grid_get(grid, unusable, name, dimCount, coordDimCount, im, jm, centers, corners, rc)
       type(esmf_Grid), intent(in) :: grid
       class(KeywordEnforcer), optional, intent(in) :: unusable
       character(:), optional, allocatable, intent(out) :: name
       integer, optional, intent(out) :: dimCount
       integer, optional, allocatable, intent(out) :: coordDimCount(:)
       integer, optional, intent(out) :: im, jm
-      integer, optional, allocatable, intent(out) :: globalCellCountPerDim(:)
+      real(kind=ESMF_KIND_R8), optional, allocatable, intent(out) :: centers(:,:,:)
       real(kind=ESMF_KIND_R8), optional, allocatable, intent(out) :: corners(:,:,:)
       integer, optional, intent(out) :: rc
 
@@ -41,11 +55,6 @@ contains
       character(ESMF_MAXSTR) :: name_
       integer :: status
       real(kind=ESMF_KIND_R8), pointer :: coords(:,:)
-      logical :: has_de
-      logical :: isCubedSphere, isRegular
-      integer, allocatable :: globalIndexBounds(:,:)
-      integer, allocatable :: maxIndexPTile(:,:)
-      integer :: tileCount
 
       call esmf_GridGet(grid, dimCount=dimCount_, _RC)
       if (present(dimCount)) then
@@ -64,90 +73,21 @@ contains
 
       if (present(im) .or. present(jm)) then
          call esmf_GridGetCoord(grid, coordDim=1, farrayPtr=coords, _RC)
-         if (present(im)) im = size(coords,1)
-         if (present(jm)) jm = size(coords,2)
+         if (present(im)) im = size(coords, 1)
+         if (present(jm)) jm = size(coords, 2)
       end if
 
-      ! Getting global cell counts
-      if (present(globalCellCountPerDim)) then
-         call get_globalCellCountPerDim(grid, globalCellCountPerDim, _RC)
+      if (present(centers)) then
+         call grid_get_centers(grid, centers, _RC)
       end if
-      
+
       if (present(corners)) then
-         call GridGetCorners(grid, corners, _RC)
+         call grid_get_corners(grid, corners, _RC)
       end if
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine grid_get
-   
-   !subroutine check_grid_type(grid, unusable, globalCoordDimCount)
-   subroutine get_globalCellCountPerDim(grid, globalCellCountPerDim, rc)
-      type(ESMF_Grid), intent(in) :: grid
-      !class(KeywordEnforcer), optional, intent(in) :: unusable
-      !integer, allocatable, optional, intent(inout) :: globalCoordDimCount(:)
-      integer, allocatable, intent(inout) :: globalCellCountPerDim(:)
-      integer, optional, intent(out) :: rc
-      
-      integer :: tileCount, dimCount
-      integer, allocatable :: minIndexPTile(:,:), maxIndexPTile(:,:)
-      integer, allocatable :: minCounts(:), maxCounts(:)
-      integer, allocatable :: globalIndexBounds(:,:)
-      character(len=ESMF_MAXSTR) :: error_message
-      integer :: status, iTile
-      
-      ! Get grid information
-      !if (present(globalCoordDimCount)) then
-      call ESMF_GridGet(grid, tileCount=tileCount, dimCount=dimCount, _RC)
-      allocate(globalCellCountPerDim(dimCount))
-      
-      ! Check grid type based on tile count
-      if (tileCount == 6) then
-         ! Likely cubed-sphere
-         ! Additional verification: check if all tiles are square and equal
-         allocate(minIndexPTile(dimCount, tileCount), maxIndexPTile(dimCount, tileCount))
-         do iTile = 1,6
-            call ESMF_GridGet(grid, tile=iTile, &
-                 staggerloc=ESMF_STAGGERLOC_CENTER_VCENTER, &
-                 minIndex=minIndexPTile(:,iTile),  &
-                 maxIndex=maxIndexPTile(:,iTile), _RC)
-         end do
-         ! Verify all tiles have same dimensions and are square
-         if (all(maxIndexPTile(1,:) == maxIndexPTile(1,1)) .and. &
-             all(maxIndexPTile(2,:) == maxIndexPTile(2,1)) .and. &
-             maxIndexPTile(1,1) == maxIndexPTile(2,1)     .and. &
-             all(minIndexPTile(1,:) == minIndexPTile(1,1))  .and. &
-             all(minIndexPTile(2,:) == minIndexPTile(2,1))  .and. &
-             minIndexPTile(1,1) == minIndexPTile(2,1)) then
-             globalCellCountPerDim(1) = maxIndexPTile(1,1) - minIndexPtile(1,1) 
-             globalCellCountPerDim(2) = globalCellCountPerDim(1)*6
-             deallocate(minIndexPTile, maxIndexPTile)
-             print *, "Confirmed cubed-sphere: C", maxIndexPTile(1,1)
-         else
-             error stop "6-tile grid but not standard cubed-sphere"
-         end if
-         deallocate(minIndexPTile)
-         deallocate(maxIndexPTile)
-      else if (tileCount == 1) then
-         ! Regular lat-lon or regional grid
-         allocate(minCounts(dimCount), maxCounts(dimCount))
-         call ESMF_GridGet(grid, tile=1, staggerloc=ESMF_STAGGERLOC_CENTER_VCENTER, &
-                 minIndex=minCounts,  &
-                 maxIndex=maxCounts, _RC)
-         globalCellCountPerDim =  maxCounts - minCounts
-         deallocate(minCounts, maxCounts)
-         print *, "Regular (single-tile) grid"
-      else
-         write(error_message, '(A,i0,A)') "Non-standard grid with ", tileCount, " tiles"
-         error stop trim(error_message)
-      end if
-       
-      !end if
-       
-      _RETURN(_SUCCESS)
-      !_UNUSED_DUMMY(unusable)
-       
-   end subroutine get_globalCellCountPerDim
 
    logical function grid_has_DE(grid,rc) result(has_DE)
       type(ESMF_Grid), intent(in) :: grid

--- a/geom/GridGet/CMakeLists.txt
+++ b/geom/GridGet/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(MAPL.geom PRIVATE
+  grid_get_centers.F90
+  grid_get_corners.F90
+)

--- a/geom/GridGet/grid_get_centers.F90
+++ b/geom/GridGet/grid_get_centers.F90
@@ -1,6 +1,11 @@
-#include "MAPL_ErrLog.h"
+#include "MAPL.h"
 
-submodule (mapl3g_VectorBasis) grid_get_centers_smod
+submodule (mapl3g_GridGet) grid_get_centers_smod
+
+   use mapl3g_VectorBasis, only: GridGetCoords
+
+   implicit none(type, external)
+
 contains
 
    module subroutine grid_get_centers(grid, centers, rc)

--- a/geom/GridGet/grid_get_corners.F90
+++ b/geom/GridGet/grid_get_corners.F90
@@ -1,11 +1,11 @@
 #include "MAPL_ErrLog.h"
 
-submodule (mapl3g_VectorBasis) grid_get_corners_smod
+submodule (mapl3g_GridGet) grid_get_corners_smod
 
    use mapl_Constants
    use esmf
 
-   implicit none(type,external)
+   implicit none(type, external)
 
 contains
 

--- a/geom/GridGetGlobal.F90
+++ b/geom/GridGetGlobal.F90
@@ -1,0 +1,79 @@
+#include "MAPL.h"
+
+module mapl3g_GridGetGlobal
+
+   use esmf
+   use mapl_ErrorHandling
+
+   implicit none(type, external)
+   private
+
+   public :: GridGetGlobalCellCountPerDim
+
+   interface GridGetGlobalCellCountPerDim
+      procedure :: grid_get_global_cell_count_per_dim
+   end interface GridGetGlobalCellCountPerDim
+
+contains
+
+   subroutine grid_get_global_cell_count_per_dim(grid, globalCellCountPerDim, rc)
+      type(ESMF_Grid), intent(in) :: grid
+      integer, allocatable, intent(inout) :: globalCellCountPerDim(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: tileCount, dimCount
+      integer, allocatable :: minIndexPTile(:,:), maxIndexPTile(:,:)
+      integer, allocatable :: minCounts(:), maxCounts(:)
+      integer, allocatable :: globalIndexBounds(:,:)
+      character(len=ESMF_MAXSTR) :: error_message
+      integer :: status, iTile
+
+      ! Get grid information
+      call ESMF_GridGet(grid, tileCount=tileCount, dimCount=dimCount, _RC)
+      allocate(globalCellCountPerDim(dimCount))
+
+      ! Check grid type based on tile count
+      if (tileCount == 6) then
+         ! Likely cubed-sphere
+         ! Additional verification: check if all tiles are square and equal
+         allocate(minIndexPTile(dimCount, tileCount), maxIndexPTile(dimCount, tileCount))
+         do iTile = 1,6
+            call ESMF_GridGet(grid, tile=iTile, &
+                 staggerloc=ESMF_STAGGERLOC_CENTER_VCENTER, &
+                 minIndex=minIndexPTile(:,iTile),  &
+                 maxIndex=maxIndexPTile(:,iTile), _RC)
+         end do
+         ! Verify all tiles have same dimensions and are square
+         if (all(maxIndexPTile(1,:) == maxIndexPTile(1,1)) .and. &
+             all(maxIndexPTile(2,:) == maxIndexPTile(2,1)) .and. &
+             maxIndexPTile(1,1) == maxIndexPTile(2,1)     .and. &
+             all(minIndexPTile(1,:) == minIndexPTile(1,1))  .and. &
+             all(minIndexPTile(2,:) == minIndexPTile(2,1))  .and. &
+             minIndexPTile(1,1) == minIndexPTile(2,1)) then
+             globalCellCountPerDim(1) = maxIndexPTile(1,1) - minIndexPtile(1,1)
+             globalCellCountPerDim(2) = globalCellCountPerDim(1)*6
+             deallocate(minIndexPTile, maxIndexPTile)
+             print *, "Confirmed cubed-sphere: C", maxIndexPTile(1,1)
+         else
+             error stop "6-tile grid but not standard cubed-sphere"
+         end if
+         deallocate(minIndexPTile)
+         deallocate(maxIndexPTile)
+      else if (tileCount == 1) then
+         ! Regular lat-lon or regional grid
+         allocate(minCounts(dimCount), maxCounts(dimCount))
+         call ESMF_GridGet(grid, tile=1, staggerloc=ESMF_STAGGERLOC_CENTER_VCENTER, &
+                 minIndex=minCounts,  &
+                 maxIndex=maxCounts, _RC)
+         globalCellCountPerDim =  maxCounts - minCounts
+         deallocate(minCounts, maxCounts)
+         print *, "Regular (single-tile) grid"
+      else
+         write(error_message, '(A,i0,A)') "Non-standard grid with ", tileCount, " tiles"
+         error stop trim(error_message)
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine grid_get_global_cell_count_per_dim
+
+end module mapl3g_GridGetGlobal

--- a/geom/VectorBasis.F90
+++ b/geom/VectorBasis.F90
@@ -6,12 +6,11 @@ module mapl3g_VectorBasis
    use mapl_FieldPointerUtilities
    use mapl_ErrorHandlingMod
 
-   implicit none(type,external)
+   implicit none(type, external)
    private
 
    public :: VectorBasis
    public :: GridGetCoords
-   public :: GridGetCorners
    ! Factory functions
    public :: NS_VectorBasis
    public :: GridVectorBasis
@@ -44,12 +43,7 @@ module mapl3g_VectorBasis
    interface GridGetCoords
       module procedure grid_get_coords_1d
       module procedure grid_get_coords_2d
-      module procedure grid_get_centers
    end interface GridGetCoords
-
-   interface GridGetCorners
-      module procedure grid_get_corners
-   end interface GridGetCorners
 
    interface
 
@@ -68,19 +62,16 @@ module mapl3g_VectorBasis
       end function new_GridVectorBasis
 
       ! Utility functions
-      !------------------
       pure module function get_unit_vector( p1, p2, p3 ) result(uvect)
-         real(kind=ESMF_KIND_R8), intent(in):: p1(2), p2(2), p3(2) 
-         real(kind=ESMF_KIND_R8) :: uvect(3) 
+         real(kind=ESMF_KIND_R8), intent(in):: p1(2), p2(2), p3(2)
+         real(kind=ESMF_KIND_R8) :: uvect(3)
       end function get_unit_vector
-
 
       module subroutine create_fields(elements, geom, rc)
          type(ESMF_Field), intent(inout) :: elements(NI,NJ)
          type(ESMF_Geom), intent(in) :: geom
          integer, optional, intent(out) :: rc
       end subroutine create_fields
-
 
       ! Geometry utilities
 
@@ -126,18 +117,8 @@ module mapl3g_VectorBasis
          integer, optional, intent(out) :: rc
       end subroutine grid_get_coords_2d
 
-      module subroutine grid_get_centers(grid, centers, rc)
-         type(ESMF_Grid), intent(in) :: grid
-         real(kind=ESMF_KIND_R8), allocatable, intent(out) :: centers(:,:,:)
-         integer, optional, intent(out) :: rc
-      end subroutine grid_get_centers
-
-      module subroutine grid_get_corners(grid, corners, rc)
-         type(ESMF_Grid), intent(in) :: grid
-         real(kind=ESMF_KIND_R8), allocatable, intent(out) :: corners(:,:,:)
-         integer, optional, intent(out) :: rc
-      end subroutine grid_get_corners
    end interface
+
 end module mapl3g_VectorBasis
 
 

--- a/geom/VectorBasis/CMakeLists.txt
+++ b/geom/VectorBasis/CMakeLists.txt
@@ -1,12 +1,9 @@
 target_sources(MAPL.geom PRIVATE
-
   create_fields.F90
   destroy_fields.F90
   get_unit_vector.F90
-  grid_get_centers.F90
   grid_get_coords_1d.F90
   grid_get_coords_2d.F90
-  grid_get_corners.F90
   latlon2xyz.F90
   MAPL_GeomGetCoords.F90
   mid_pt_sphere.F90

--- a/geom/VectorBasis/grid_get_coords_1d.F90
+++ b/geom/VectorBasis/grid_get_coords_1d.F90
@@ -1,8 +1,8 @@
 #include "MAPL_ErrLog.h"
 
 submodule (mapl3g_VectorBasis) grid_get_coords_1d_smod
-contains
 
+contains
 
    ! GridGetCoords - specific procedures
    module subroutine grid_get_coords_1d(grid, longitudes, latitudes, rc)

--- a/geom/VectorBasis/new_GridVectorBasis.F90
+++ b/geom/VectorBasis/new_GridVectorBasis.F90
@@ -1,11 +1,16 @@
-#include "MAPL_ErrLog.h"
+#include "MAPL.h"
 
 submodule (mapl3g_VectorBasis) new_GridVectorBasis_smod
-   implicit none(type,external)
+
+   use mapl3g_GridGet, only: GridGet
+
+   implicit none(type, external)
+
 contains
 
    ! Valid only for grids.
    module function new_GridVectorBasis(geom, inverse, rc) result(basis)
+
       type(VectorBasis) :: basis
       type(ESMF_Geom), intent(inout) :: geom
       logical, optional, intent(in) :: inverse
@@ -29,12 +34,11 @@ contains
        allocate(basis%elements(NI,NJ))
        call create_fields(basis%elements, geom, _RC)
 
-      call GridGetCoords(grid, centers, _RC)
-      call GridGetCorners(grid, corners, _RC)
-
+      call GridGet(grid, centers=centers, corners=corners, _RC)
       call fill_fields(basis, centers, corners, inverse_, _RC)
 
       _RETURN(ESMF_SUCCESS)
+
    contains
 
       subroutine fill_fields(basis, centers, corners, inverse, rc)
@@ -58,9 +62,8 @@ contains
             end do
          end do
 
-      do concurrent (i=1:im, j=1:jm)
-         associate (local_basis => fill_element(centers(i,j,:), corners(i:i+1,j:j+1,:), inverse) )
-              
+         do concurrent (i=1:im, j=1:jm)
+            associate (local_basis => fill_element(centers(i,j,:), corners(i:i+1,j:j+1,:), inverse) )
               do k2 = 1, NJ
                  do k1 = 1, NI
                     x(k1,k2)%ptr(i,j) = local_basis(k1,k2)
@@ -68,9 +71,10 @@ contains
               end do
             end associate
          end do
-       
+
          _RETURN(ESMF_SUCCESS)
       end subroutine fill_fields
+
       !--------------------------------------
       !
       !   ^ lat
@@ -117,7 +121,6 @@ contains
 
            end associate
          end associate
-
       end function fill_element
 
    end function new_GridVectorBasis

--- a/gridcomps/Orbit/MAPL_OrbGridCompMod.F90
+++ b/gridcomps/Orbit/MAPL_OrbGridCompMod.F90
@@ -40,6 +40,7 @@
    use mapl3g_generic, only: MAPL_STATEITEM_FIELDBUNDLE
    use mapl3g_generic, only: MAPL_GridCompSetEntryPoint
    use mapl3g_Geom_API, only: MAPL_GridGet, MAPL_GridGetCoordinates
+   use mapl3g_GridGetGlobal, only: GridGetGlobalCellCountPerDim
    use mapl3g_State_API, only: MAPL_StateGetPointer
    use mapl3g_FieldBundle_API, only: MAPL_FieldBundleGetPointer
    use mapl3g_generic, only: MAPL_GridCompGetResource
@@ -351,7 +352,7 @@ CONTAINS
 
 !  set swath to zero for now
    swath=0.
-   call MAPL_GridGet(GRID, globalCellCountPerDim=COUNTS, _RC)
+   call GridGetGlobalCellCountPerDim(GRID, globalCellCountPerDim=COUNTS, _RC)
    IM_world = counts(1)
    JM_world = counts(2)
    if (JM_world == 6*IM_world) then


### PR DESCRIPTION


## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

- Retrieve centers and corners of a grid via MAPL_GridGet
- Moved the routine to retrieve global im_world etc. to a separate routine, with no corresponding entry in API
## Related Issue

