### PR TITLE
Phase 2 Task 2.2b: Refactor NormalizationTransform auxiliary field handling

### DIFF
--- a/generic3g/tests/Test_NormalizationTransform.pf
+++ b/generic3g/tests/Test_NormalizationTransform.pf
@@ -28,216 +28,235 @@ module Test_NormalizationTransform
    integer, parameter :: R4 = ESMF_KIND_R4
    integer, parameter :: R8 = ESMF_KIND_R8
 
-   character(len=*), parameter :: ESMF_NAMES(*) = &
-      & [character(len=ESMF_MAXSTR) :: COUPLER_IMPORT_NAME, COUPLER_EXPORT_NAME]
-   type(NormalizationTransform) :: transform
+    character(len=*), parameter :: ESMF_NAMES(*) = &
+       & [character(len=ESMF_MAXSTR) :: COUPLER_IMPORT_NAME, COUPLER_EXPORT_NAME]
 
 contains
 
-   @Test(type=ESMF_TestMethod, npes=[1])
-   subroutine test_normalize_field_R4(this)
-      class(ESMF_TestMethod), intent(inout) :: this
-      integer :: status
-      type(ESMF_Field) :: field_in, field_out, field_aux
-      real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
-      real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 1.0e-3_R4  ! kg/kg
-      real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 1000.0_R4   ! Pa
-      real(kind=ESMF_KIND_R4) :: expected_value
-      integer :: i
+    @Test(type=ESMF_TestMethod, npes=[1])
+    subroutine test_normalize_field_R4(this)
+       class(ESMF_TestMethod), intent(inout) :: this
+       integer :: status
+       type(ESMF_Field) :: field_in, field_out, field_aux
+       real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
+       real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 1.0e-3_R4  ! kg/kg
+       real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 1000.0_R4   ! Pa
+       real(kind=ESMF_KIND_R4) :: expected_value
+       integer :: i
+       type(NormalizationTransform) :: local_transform
 
-      _UNUSED_DUMMY(this)
-      
-      ! Expected: input × (delp × scale) = 1.0e-3 × (1000.0 × 0.102) = 0.102 kg/m²
-      expected_value = INPUT_VALUE * DELP_VALUE * SCALE_FACTOR
-      
-      call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
-         & ESMF_NAMES, rc=status)
-      @assertEqual(0, status, "Unable to initialize ESMF_State's")
-      
-      ! Get fields and set input values
-      call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
-      call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
-      call assign_fptr(field_in, fptr_in, _RC)
-      call assign_fptr(field_out, fptr_out, _RC)
-      fptr_in = INPUT_VALUE
-      fptr_out = 0.0
-      
-      ! Create auxiliary field (DELP)
-      field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
-      call assign_fptr(field_aux, fptr_aux, _RC)
-      fptr_aux = DELP_VALUE
-      call ESMF_StateAdd(importState, fieldList=[field_aux], _RC)
-      
-      ! Apply normalization transform
-      call transform%update(importState, exportState, clock, rc=status)
-      @assertEqual(_SUCCESS, status, 'Failed to update transform')
-      
-      ! Verify output
-      do i=1, size(fptr_out)
-         @assertEqual(expected_value, fptr_out(i), tolerance=1.0e-6_R4)
-      end do
-      
-      call ESMF_FieldDestroy(field_aux, _RC)
+       _UNUSED_DUMMY(this)
+       
+       ! Expected: input × (delp × scale) = 1.0e-3 × (1000.0 × 0.102) = 0.102 kg/m²
+       expected_value = INPUT_VALUE * DELP_VALUE * SCALE_FACTOR
+       
+       call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
+          & ESMF_NAMES, rc=status)
+       @assertEqual(0, status, "Unable to initialize ESMF_State's")
+       
+       ! Get fields and set input values
+       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
+       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
+       call assign_fptr(field_in, fptr_in, _RC)
+       call assign_fptr(field_out, fptr_out, _RC)
+       fptr_in = INPUT_VALUE
+       fptr_out = 0.0
+       
+       ! Create auxiliary field (DELP)
+       field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
+       call assign_fptr(field_aux, fptr_aux, _RC)
+       fptr_aux = DELP_VALUE
+       
+       ! Create transform with auxiliary field
+       local_transform = NormalizationTransform(AUX_FIELD_NAME, SCALE_FACTOR, field_aux)
+       call local_transform%initialize(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to initialize transform')
+       
+       ! Apply normalization transform
+       call local_transform%update(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to update transform')
+       
+       ! Verify output
+       do i=1, size(fptr_out)
+          @assertEqual(expected_value, fptr_out(i), tolerance=1.0e-6_R4)
+       end do
+       
+       call ESMF_FieldDestroy(field_aux, _RC)
 
-   end subroutine test_normalize_field_R4
+    end subroutine test_normalize_field_R4
 
-   @Test(type=ESMF_TestMethod, npes=[1])
-   subroutine test_normalize_field_R8(this)
-      class(ESMF_TestMethod), intent(inout) :: this
-      integer :: status
-      type(ESMF_Field) :: field_in, field_out, field_aux
-      real(kind=ESMF_KIND_R8), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
-      real(kind=ESMF_KIND_R8), parameter :: INPUT_VALUE = 1.0e-3_R8  ! kg/kg
-      real(kind=ESMF_KIND_R8), parameter :: DELP_VALUE = 1000.0_R8   ! Pa
-      real(kind=ESMF_KIND_R8) :: expected_value, scale_R8
-      integer :: i
+    @Test(type=ESMF_TestMethod, npes=[1])
+    subroutine test_normalize_field_R8(this)
+       class(ESMF_TestMethod), intent(inout) :: this
+       integer :: status
+       type(ESMF_Field) :: field_in, field_out, field_aux
+       real(kind=ESMF_KIND_R8), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
+       real(kind=ESMF_KIND_R8), parameter :: INPUT_VALUE = 1.0e-3_R8  ! kg/kg
+       real(kind=ESMF_KIND_R8), parameter :: DELP_VALUE = 1000.0_R8   ! Pa
+       real(kind=ESMF_KIND_R8) :: expected_value, scale_R8
+       integer :: i
+       type(NormalizationTransform) :: local_transform
 
-      _UNUSED_DUMMY(this)
-      
-      scale_R8 = real(SCALE_FACTOR, kind=ESMF_KIND_R8)
-      expected_value = INPUT_VALUE * DELP_VALUE * scale_R8
-      
-      call initialize_states(states, grid, [ESMF_TYPEKIND_R8, ESMF_TYPEKIND_R8],&
-         & ESMF_NAMES, rc=status)
-      @assertEqual(0, status, "Unable to initialize ESMF_State's")
-      
-      ! Get fields and set input values
-      call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
-      call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
-      call assign_fptr(field_in, fptr_in, _RC)
-      call assign_fptr(field_out, fptr_out, _RC)
-      fptr_in = INPUT_VALUE
-      fptr_out = 0.0
-      
-      ! Create auxiliary field (DELP)
-      field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R8, _RC)
-      call assign_fptr(field_aux, fptr_aux, _RC)
-      fptr_aux = DELP_VALUE
-      call ESMF_StateAdd(importState, fieldList=[field_aux], _RC)
-      
-      ! Apply normalization transform
-      call transform%update(importState, exportState, clock, rc=status)
-      @assertEqual(_SUCCESS, status, 'Failed to update transform')
-      
-      ! Verify output
-      do i=1, size(fptr_out)
-         @assertEqual(expected_value, fptr_out(i), tolerance=1.0e-12_R8)
-      end do
-      
-      call ESMF_FieldDestroy(field_aux, _RC)
+       _UNUSED_DUMMY(this)
+       
+       scale_R8 = real(SCALE_FACTOR, kind=ESMF_KIND_R8)
+       expected_value = INPUT_VALUE * DELP_VALUE * scale_R8
+       
+       call initialize_states(states, grid, [ESMF_TYPEKIND_R8, ESMF_TYPEKIND_R8],&
+          & ESMF_NAMES, rc=status)
+       @assertEqual(0, status, "Unable to initialize ESMF_State's")
+       
+       ! Get fields and set input values
+       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
+       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
+       call assign_fptr(field_in, fptr_in, _RC)
+       call assign_fptr(field_out, fptr_out, _RC)
+       fptr_in = INPUT_VALUE
+       fptr_out = 0.0
+       
+       ! Create auxiliary field (DELP)
+       field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R8, _RC)
+       call assign_fptr(field_aux, fptr_aux, _RC)
+       fptr_aux = DELP_VALUE
+       
+       ! Create transform with auxiliary field
+       local_transform = NormalizationTransform(AUX_FIELD_NAME, SCALE_FACTOR, field_aux)
+       call local_transform%initialize(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to initialize transform')
+       
+       ! Apply normalization transform
+       call local_transform%update(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to update transform')
+       
+       ! Verify output
+       do i=1, size(fptr_out)
+          @assertEqual(expected_value, fptr_out(i), tolerance=1.0e-12_R8)
+       end do
+       
+       call ESMF_FieldDestroy(field_aux, _RC)
 
-   end subroutine test_normalize_field_R8
+    end subroutine test_normalize_field_R8
 
-   @Test(type=ESMF_TestMethod, npes=[1])
-   subroutine test_normalize_bundle_R4(this)
-      class(ESMF_TestMethod), intent(inout) :: this
-      integer :: status
-      type(ESMF_Field), allocatable :: fields_in(:), fields_out(:)
-      type(ESMF_Field) :: field_aux
-      real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
-      real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 2.0e-3_R4
-      real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 500.0_R4
-      real(kind=ESMF_KIND_R4) :: expected_value
-      integer :: i, j
+    @Test(type=ESMF_TestMethod, npes=[1])
+    subroutine test_normalize_bundle_R4(this)
+       class(ESMF_TestMethod), intent(inout) :: this
+       integer :: status
+       type(ESMF_Field), allocatable :: fields_in(:), fields_out(:)
+       type(ESMF_Field) :: field_aux
+       real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
+       real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 2.0e-3_R4
+       real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 500.0_R4
+       real(kind=ESMF_KIND_R4) :: expected_value
+       integer :: i, j
+       type(NormalizationTransform) :: local_transform
 
-      _UNUSED_DUMMY(this)
-      
-      expected_value = INPUT_VALUE * DELP_VALUE * SCALE_FACTOR
-      
-      call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
-         & ESMF_NAMES, [2, 2], rc=status)
-      @assertEqual(0, status, "Unable to initialize ESMF_State's")
-      
-      ! Get bundle fields and set input values
-      call get_bundle_fields(importState, COUPLER_IMPORT_NAME, fields_in, rc=status)
-      call get_bundle_fields(exportState, COUPLER_EXPORT_NAME, fields_out, rc=status)
-      do i=1, size(fields_in)
-         call assign_fptr(fields_in(i), fptr_in, _RC)
-         call assign_fptr(fields_out(i), fptr_out, _RC)
-         fptr_in = INPUT_VALUE
-         fptr_out = 0.0
-      end do
-      
-      ! Create auxiliary field (DELP)
-      field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
-      call assign_fptr(field_aux, fptr_aux, _RC)
-      fptr_aux = DELP_VALUE
-      call ESMF_StateAdd(importState, fieldList=[field_aux], _RC)
-      
-      ! Apply normalization transform
-      call transform%update(importState, exportState, clock, rc=status)
-      @assertEqual(_SUCCESS, status, 'Failed to update transform')
-      
-      ! Verify all fields in bundle are normalized
-      do i=1, size(fields_out)
-         call assign_fptr(fields_out(i), fptr_out, _RC)
-         do j=1, size(fptr_out)
-            @assertEqual(expected_value, fptr_out(j), tolerance=1.0e-6_R4)
-         end do
-      end do
-      
-      call ESMF_FieldDestroy(field_aux, _RC)
+       _UNUSED_DUMMY(this)
+       
+       expected_value = INPUT_VALUE * DELP_VALUE * SCALE_FACTOR
+       
+       call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
+          & ESMF_NAMES, [2, 2], rc=status)
+       @assertEqual(0, status, "Unable to initialize ESMF_State's")
+       
+       ! Get bundle fields and set input values
+       call get_bundle_fields(importState, COUPLER_IMPORT_NAME, fields_in, rc=status)
+       call get_bundle_fields(exportState, COUPLER_EXPORT_NAME, fields_out, rc=status)
+       do i=1, size(fields_in)
+          call assign_fptr(fields_in(i), fptr_in, _RC)
+          call assign_fptr(fields_out(i), fptr_out, _RC)
+          fptr_in = INPUT_VALUE
+          fptr_out = 0.0
+       end do
+       
+       ! Create auxiliary field (DELP)
+       field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
+       call assign_fptr(field_aux, fptr_aux, _RC)
+       fptr_aux = DELP_VALUE
+       
+       ! Create transform with auxiliary field
+       local_transform = NormalizationTransform(AUX_FIELD_NAME, SCALE_FACTOR, field_aux)
+       call local_transform%initialize(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to initialize transform')
+       
+       ! Apply normalization transform
+       call local_transform%update(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to update transform')
+       
+       ! Verify all fields in bundle are normalized
+       do i=1, size(fields_out)
+          call assign_fptr(fields_out(i), fptr_out, _RC)
+          do j=1, size(fptr_out)
+             @assertEqual(expected_value, fptr_out(j), tolerance=1.0e-6_R4)
+          end do
+       end do
+       
+       call ESMF_FieldDestroy(field_aux, _RC)
 
-   end subroutine test_normalize_bundle_R4
+    end subroutine test_normalize_bundle_R4
 
-   @Test(type=ESMF_TestMethod, npes=[1])
-   subroutine test_zero_normalization(this)
-      class(ESMF_TestMethod), intent(inout) :: this
-      integer :: status
-      type(ESMF_Field) :: field_in, field_out, field_aux
-      real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
-      real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 0.0_R4
-      real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 1000.0_R4
+    @Test(type=ESMF_TestMethod, npes=[1])
+    subroutine test_zero_normalization(this)
+       class(ESMF_TestMethod), intent(inout) :: this
+       integer :: status
+       type(ESMF_Field) :: field_in, field_out, field_aux
+       real(kind=ESMF_KIND_R4), pointer :: fptr_in(:), fptr_out(:), fptr_aux(:)
+       real(kind=ESMF_KIND_R4), parameter :: INPUT_VALUE = 0.0_R4
+       real(kind=ESMF_KIND_R4), parameter :: DELP_VALUE = 1000.0_R4
+       type(NormalizationTransform) :: local_transform
 
-      _UNUSED_DUMMY(this)
-      
-      call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
-         & ESMF_NAMES, rc=status)
-      
-      call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
-      call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
-      call assign_fptr(field_in, fptr_in, _RC)
-      call assign_fptr(field_out, fptr_out, _RC)
-      fptr_in = INPUT_VALUE
-      
-      field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
-      call assign_fptr(field_aux, fptr_aux, _RC)
-      fptr_aux = DELP_VALUE
-      call ESMF_StateAdd(importState, fieldList=[field_aux], _RC)
-      
-      call transform%update(importState, exportState, clock, rc=status)
-      @assertEqual(_SUCCESS, status, 'Failed to update transform')
-      
-      ! Output should be zero
-      @assertEqual(0.0_R4, fptr_out(1), tolerance=1.0e-10_R4)
-      
-      call ESMF_FieldDestroy(field_aux, _RC)
+       _UNUSED_DUMMY(this)
+       
+       call initialize_states(states, grid, [ESMF_TYPEKIND_R4, ESMF_TYPEKIND_R4],&
+          & ESMF_NAMES, rc=status)
+       
+       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=field_in, _RC)
+       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=field_out, _RC)
+       call assign_fptr(field_in, fptr_in, _RC)
+       call assign_fptr(field_out, fptr_out, _RC)
+       fptr_in = INPUT_VALUE
+       
+       field_aux = ESMF_FieldCreate(grid=grid, name=AUX_FIELD_NAME, typekind=ESMF_TYPEKIND_R4, _RC)
+       call assign_fptr(field_aux, fptr_aux, _RC)
+       fptr_aux = DELP_VALUE
+       
+       ! Create transform with auxiliary field
+       local_transform = NormalizationTransform(AUX_FIELD_NAME, SCALE_FACTOR, field_aux)
+       call local_transform%initialize(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to initialize transform')
+       
+       call local_transform%update(importState, exportState, clock, rc=status)
+       @assertEqual(_SUCCESS, status, 'Failed to update transform')
+       
+       ! Output should be zero
+       @assertEqual(0.0_R4, fptr_out(1), tolerance=1.0e-10_R4)
+       
+       call ESMF_FieldDestroy(field_aux, _RC)
 
-   end subroutine test_zero_normalization
+    end subroutine test_zero_normalization
 
-   @Before
-   subroutine set_up(this)
-      class(ESMF_TestMethod), intent(inout) :: this
-      integer :: status 
-      integer(kind=ESMF_KIND_I4), parameter :: DTS = 1, YEAR=2025, MONTH=1, DAY=1, HOUR=9, MINUTE=30
-      type(ESMF_Time) :: start_time
-      type(ESMF_TimeInterval) :: timestep
+    @Before
+    subroutine set_up(this)
+       class(ESMF_TestMethod), intent(inout) :: this
+       integer :: status 
+       integer(kind=ESMF_KIND_I4), parameter :: DTS = 1, YEAR=2025, MONTH=1, DAY=1, HOUR=9, MINUTE=30
+       type(ESMF_Time) :: start_time
+       type(ESMF_TimeInterval) :: timestep
 
-      _UNUSED_DUMMY(this)
-      call ESMF_TimeIntervalSet(TIMESTEP, s=DTS, rc=status)
-      @assertEqual(0, status, 'Unable to set timeStep')
-      call ESMF_TimeSet(START_TIME, yy=YEAR, mm=MONTH, dd=DAY, h=HOUR, m=MINUTE, _RC)
-      @assertEqual(0, status, 'Unable to set startTime')
-      clock = ESMF_ClockCreate(timeStep=TIMESTEP, startTime=START_TIME, _RC)
-      @assertEqual(0, status, 'Unable to create ESMF_Clock')
-      call create_grid(grid, _RC)
-      importState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_IMPORT, name='import', _RC)
-      exportState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_EXPORT, name='export', _RC)
-      if(allocated(states)) deallocate(states)
-      states = [importState, exportState]
-      transform = NormalizationTransform(AUX_FIELD_NAME, SCALE_FACTOR)
+       _UNUSED_DUMMY(this)
+       call ESMF_TimeIntervalSet(TIMESTEP, s=DTS, rc=status)
+       @assertEqual(0, status, 'Unable to set timeStep')
+       call ESMF_TimeSet(START_TIME, yy=YEAR, mm=MONTH, dd=DAY, h=HOUR, m=MINUTE, _RC)
+       @assertEqual(0, status, 'Unable to set startTime')
+       clock = ESMF_ClockCreate(timeStep=TIMESTEP, startTime=START_TIME, _RC)
+       @assertEqual(0, status, 'Unable to create ESMF_Clock')
+       call create_grid(grid, _RC)
+       importState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_IMPORT, name='import', _RC)
+       exportState = ESMF_StateCreate(stateIntent=ESMF_STATEINTENT_EXPORT, name='export', _RC)
+       if(allocated(states)) deallocate(states)
+       states = [importState, exportState]
+       ! Note: transform is now created in each test with the auxiliary field
 
-   end subroutine set_up
+    end subroutine set_up
 
    subroutine initialize_states(states, grid, typekinds, names, num_fields, rc)
       type(ESMF_State), intent(inout) :: states(:)

--- a/generic3g/transforms/NormalizationTransform.F90
+++ b/generic3g/transforms/NormalizationTransform.F90
@@ -1,6 +1,25 @@
 #include "MAPL.h"
 #include "unused_dummy.H"
 
+!> @brief Transform that multiplies fields by auxiliary normalization fields
+!!
+!! This transform normalizes fields for conservative regridding by multiplying
+!! with an auxiliary field (e.g., DELP, DZ) and a scale factor (e.g., 1/g).
+!! For example, mixing ratios [kg/kg] are converted to column masses [kg/m²]
+!! by multiplying with DELP/g.
+!!
+!! @par Limitation (Phase 2, Task 2.2):
+!! This is a simplified implementation for testing the core normalization logic.
+!! The auxiliary field must be provided at construction time and kept valid
+!! externally. The framework CANNOT use this in production form.
+!!
+!! @par Future Work (Task 2.2c or later):
+!! Full coupler infrastructure needed:
+!! - Auxiliary field obtained via coupler (similar to VerticalRegridTransform)
+!! - Coupler run during update() to ensure latest values
+!! - Handles case where auxiliary field is itself an extension (e.g., regridded)
+!! - See VerticalGridAspect::make_transform and VerticalRegridTransform pattern
+!!
 module mapl3g_NormalizationTransform
    use mapl3g_TransformId
    use mapl3g_StateItem
@@ -15,15 +34,29 @@ module mapl3g_NormalizationTransform
 
    public :: NormalizationTransform
 
-   type, extends(ExtensionTransform) :: NormalizationTransform
-      private
-      character(:), allocatable :: aux_field_name
-      real :: scale_factor
-   contains
-      procedure :: initialize
-      procedure :: update
-      procedure :: get_transformId
-   end type NormalizationTransform
+    !> Transform that multiplies a field by an auxiliary normalization field
+    !!
+    !! This transform normalizes fields by multiplying with an auxiliary field
+    !! (e.g., DELP, DZ) scaled by a constant factor (e.g., 1/g).
+    !!
+    !! LIMITATION (Phase 2, Task 2.2):
+    !! - Auxiliary field is stored directly in the transform
+    !! - No coupler support yet - auxiliary field must be passed at construction
+    !! - Framework cannot use this in production form
+    !! - Future work: Add coupler infrastructure to update auxiliary field values
+    !!   (see VerticalRegridTransform pattern with v_in_coupler/v_out_coupler)
+     type, extends(ExtensionTransform) :: NormalizationTransform
+        private
+        character(:), allocatable :: aux_field_name     ! Name of auxiliary field (for debugging/logging)
+        real :: scale_factor = 0.0                      ! Scaling factor (e.g., 1/g for DELP)
+        type(ESMF_Field) :: aux_field                   ! Auxiliary field (DELP or DZ)
+        ! TODO (future): Add coupler support
+        ! class(ComponentDriver), pointer :: aux_coupler => null()
+     contains
+        procedure :: initialize
+        procedure :: update
+        procedure :: get_transformId
+     end type NormalizationTransform
 
 
    interface NormalizationTransform
@@ -32,35 +65,45 @@ module mapl3g_NormalizationTransform
 
 contains
 
-   function new_NormalizationTransform(aux_field_name, scale_factor) result(transform)
-      type(NormalizationTransform) :: transform
-      character(*), intent(in) :: aux_field_name
-      real, intent(in) :: scale_factor
+    !> Constructor for NormalizationTransform
+    !!
+    !! @param aux_field_name Name of auxiliary field (for debugging/logging)
+    !! @param scale_factor   Scaling factor to apply (e.g., 1/g for DELP)
+    !! @param aux_field      Auxiliary field to multiply with
+    !!
+    !! LIMITATION: aux_field must be provided and kept valid externally.
+    !! Future work will add coupler support to update aux_field automatically.
+    function new_NormalizationTransform(aux_field_name, scale_factor, aux_field) result(transform)
+       type(NormalizationTransform) :: transform
+       character(*), intent(in) :: aux_field_name
+       real, intent(in) :: scale_factor
+       type(ESMF_Field), intent(in) :: aux_field
 
-      transform%aux_field_name = aux_field_name
-      transform%scale_factor = scale_factor
+       transform%aux_field_name = aux_field_name
+       transform%scale_factor = scale_factor
+       transform%aux_field = aux_field
 
-   end function new_NormalizationTransform
+    end function new_NormalizationTransform
 
-   subroutine initialize(this, importState, exportState, clock, rc)
-      use esmf
-      class(NormalizationTransform), intent(inout) :: this
-      type(ESMF_State)      :: importState
-      type(ESMF_State)      :: exportState
-      type(ESMF_Clock)      :: clock      
-      integer, optional, intent(out) :: rc
+    subroutine initialize(this, importState, exportState, clock, rc)
+       use esmf
+       class(NormalizationTransform), intent(inout) :: this
+       type(ESMF_State)      :: importState
+       type(ESMF_State)      :: exportState
+       type(ESMF_Clock)      :: clock      
+       integer, optional, intent(out) :: rc
 
-      integer :: status
+       integer :: status
 
-       ! No initialization needed - just validate aux field exists
-       ! This is checked during update()
+        ! Validate that auxiliary field is initialized
+        ! TODO (future): When coupler support is added, run coupler here
+        _ASSERT(ESMF_FieldIsCreated(this%aux_field), "Auxiliary field not initialized")
 
-       _UNUSED_DUMMY(this)
-       _UNUSED_DUMMY(exportState)
-       _UNUSED_DUMMY(importState)
-       _UNUSED_DUMMY(clock)
-       _RETURN(_SUCCESS)
-   end subroutine initialize
+        _UNUSED_DUMMY(exportState)
+        _UNUSED_DUMMY(importState)
+        _UNUSED_DUMMY(clock)
+        _RETURN(_SUCCESS)
+    end subroutine initialize
 
    subroutine update_field(f_in, f_out, f_aux, scale_factor, rc)
       type(ESMF_Field), intent(inout) :: f_in, f_out, f_aux
@@ -119,44 +162,46 @@ contains
 
    end subroutine update_field_bundle
 
-   subroutine update(this, importState, exportState, clock, rc)
-      use esmf
-      class(NormalizationTransform), intent(inout) :: this
-      type(ESMF_State)      :: importState
-      type(ESMF_State)      :: exportState
-      type(ESMF_Clock)      :: clock      
-      integer, optional, intent(out) :: rc
+    subroutine update(this, importState, exportState, clock, rc)
+       use esmf
+       class(NormalizationTransform), intent(inout) :: this
+       type(ESMF_State)      :: importState
+       type(ESMF_State)      :: exportState
+       type(ESMF_Clock)      :: clock      
+       integer, optional, intent(out) :: rc
 
-      integer :: status
-      type(ESMF_Field) :: f_in, f_out, f_aux
-      type(ESMF_FieldBundle) :: fb_in, fb_out
-      type(ESMF_StateItem_Flag) :: itemtype_in, itemtype_out
+       integer :: status
+       type(ESMF_Field) :: f_in, f_out
+       type(ESMF_FieldBundle) :: fb_in, fb_out
+       type(ESMF_StateItem_Flag) :: itemtype_in, itemtype_out
 
-      ! Get the field or bundle to normalize
-      call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, itemtype=itemtype_in, _RC)
-      call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, itemtype=itemtype_out, _RC)
-      _ASSERT(itemtype_in == itemtype_out, "Mismatched item types.")
+       ! TODO (future): When coupler support is added, run coupler to update aux field
+       ! if (associated(this%aux_coupler)) then
+       !    call this%aux_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
+       ! end if
 
-      ! Get the auxiliary field (e.g., DELP or DZ)
-      call ESMF_StateGet(importState, itemName=this%aux_field_name, field=f_aux, _RC)
+       ! Get the field or bundle to normalize
+       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, itemtype=itemtype_in, _RC)
+       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, itemtype=itemtype_out, _RC)
+       _ASSERT(itemtype_in == itemtype_out, "Mismatched item types.")
 
-      if(itemtype_in == MAPL_STATEITEM_FIELD) then
-         call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=f_in, _RC)
-         call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=f_out, _RC)
-         call update_field(f_in, f_out, f_aux, this%scale_factor, _RC)
-      elseif(itemType_in == MAPL_STATEITEM_FIELDBUNDLE) then
-         call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, fieldBundle=fb_in, _RC)
-         call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, fieldBundle=fb_out, _RC)
-         call bundle_types_valid(fb_in, fb_out, _RC)
-         call update_field_bundle(fb_in, fb_out, f_aux, this%scale_factor, _RC)
-       else
-          _FAIL("Unsupported state item type")
-       end if
+       if(itemtype_in == MAPL_STATEITEM_FIELD) then
+          call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=f_in, _RC)
+          call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=f_out, _RC)
+          call update_field(f_in, f_out, this%aux_field, this%scale_factor, _RC)
+       elseif(itemType_in == MAPL_STATEITEM_FIELDBUNDLE) then
+          call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, fieldBundle=fb_in, _RC)
+          call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, fieldBundle=fb_out, _RC)
+          call bundle_types_valid(fb_in, fb_out, _RC)
+          call update_field_bundle(fb_in, fb_out, this%aux_field, this%scale_factor, _RC)
+        else
+           _FAIL("Unsupported state item type")
+        end if
 
-       _UNUSED_DUMMY(clock)
-       _RETURN(_SUCCESS)
+        _UNUSED_DUMMY(clock)
+        _RETURN(_SUCCESS)
 
-    end subroutine update
+     end subroutine update
 
     function get_transformId(this) result(id)
        type(TransformId) :: id


### PR DESCRIPTION
## Summary

Refactors `NormalizationTransform` to properly handle auxiliary fields without violating the coupler design constraint that each coupler has exactly ONE item in import and ONE in export.

**Previous approach (Task 2.2 - flawed):** Tried to get auxiliary field directly from `importState` using `ESMF_StateGet()`, which violated the one-item-per-state constraint.

**Current approach (Task 2.2b - simplified):** Pass auxiliary field directly to constructor and store it in the transform. This is a simplified implementation for testing the core normalization logic.

**Future work (deferred):** Full coupler infrastructure to automatically update auxiliary field values, following the `VerticalRegridTransform` pattern with couplers.

## Changes

### Core Implementation
- **`NormalizationTransform.F90`**:
  - Modified constructor to accept `aux_field` as third parameter
  - Added `aux_field` member to store the field
  - Initialize `scale_factor = 0.0` in type declaration
  - Updated `initialize()` to validate auxiliary field is created
  - Updated `update()` to use stored `this%aux_field` instead of getting from state
  - Added comprehensive module-level and inline documentation about limitations

### Tests
- **`Test_NormalizationTransform.pf`**:
  - Removed global `transform` variable
  - Each test creates local `local_transform` with auxiliary field
  - Tests create `field_aux`, initialize it, then pass to constructor
  - Updated `set_up()` to not create transform (done per-test now)

## Testing

All 4 tests pass:
- ✅ `test_normalize_field_R4` - R4 field normalization
- ✅ `test_normalize_field_R8` - R8 field normalization  
- ✅ `test_normalize_bundle_R4` - R4 bundle normalization
- ✅ `test_zero_normalization` - Zero input handling

```bash
mpiexec -n 1 ./MAPL.generic3g.tests -d -f Test_NormalizationTransform
# Result: OK (4 tests)
```

## Documentation

Added clear documentation that this is a simplified implementation with limitations:
- Auxiliary field must be provided at construction and kept valid externally
- Framework CANNOT use this in production form
- Future work needed for coupler infrastructure (see `VerticalRegridTransform` pattern)

## Related Issues

- Addresses #4448 Phase 2 Task 2.2b
- Builds on PRs #4449 (Task 2.1) and #4452 (Task 2.2)
- Target branch: `integration/conservative-regridding`