### PR TITLE
Formatted using codee. Also using 'use <>, only: <>' format in some …

### DIFF
--- a/Python/PythonBridge.F90
+++ b/Python/PythonBridge.F90
@@ -1,142 +1,154 @@
 #include "MAPL_Generic.h"
 
 module MAPL_PythonBridge
-    ! -----------------------------
-    ! Generic bridge mechanism to pull MAPL down to the python level
-    !
-    ! WARNING: All functional code should be #ifdef with PYTHONBRIDGE_INTEGRATION
-    !          in order to keep the functionality as a deliberate opt-in
-    !
-    ! -----------------------------
-    
-    use ESMF
-    use MAPL_BaseMod
-    use MAPL_GenericMod
-    use MaplShared
-#ifdef PYTHONBRIDGE_INTEGRATION
-    use mapl_fortran_python_bridge
-    use ieee_exceptions, only: ieee_get_halting_mode, ieee_set_halting_mode, ieee_overflow, ieee_support_halting
-    use iso_c_binding, only: c_loc, C_NULL_CHAR
-#endif
-    implicit none
-    private
 
-    public initialize_python_bridge
-    public MAPL_pybridge_gcrun
-    public MAPL_pybridge_gcrun_with_internal
-    public MAPL_pybridge_gcinit
-    public MAPL_pybridge_gcfinalize
+   ! -----------------------------
+   ! Generic bridge mechanism to pull MAPL down to the python level
+   !
+   ! WARNING: All functional code should be #ifdef with PYTHONBRIDGE_INTEGRATION
+   !          in order to keep the functionality as a deliberate opt-in
+   !
+   ! -----------------------------
+   use ESMF
+   use MAPL_BaseMod
+   use MAPL_GenericMod
+   use MaplShared
+#ifdef PYTHONBRIDGE_INTEGRATION
+   use mapl_fortran_python_bridge, only: mapl_fortran_python_bridge_global_initialize
+   use mapl_fortran_python_bridge, only: mapl_fortran_python_bridge_user_init
+   use mapl_fortran_python_bridge, only: mapl_fortran_python_bridge_user_run
+   use mapl_fortran_python_bridge, only: mapl_fortran_python_bridge_user_run_with_internal
+   use mapl_fortran_python_bridge, only: mapl_fortran_python_bridge_user_finalize
+   use mapl_fortran_python_bridge, only: pygeosbridge_name_buffer
+   use ieee_exceptions, only: ieee_get_halting_mode, ieee_set_halting_mode
+   use ieee_exceptions, only: ieee_overflow, ieee_support_halting
+   use iso_c_binding, only: c_loc, C_NULL_CHAR
+#endif
+
+   implicit none
+   private
+
+   public initialize_python_bridge
+   public MAPL_pybridge_gcrun
+   public MAPL_pybridge_gcrun_with_internal
+   public MAPL_pybridge_gcinit
+   public MAPL_pybridge_gcfinalize
 
 contains
 
-    subroutine initialize_python_bridge ( IM, JM, LM )
-        ! -----------------------------
-        ! Initialize the underlying python tools with a grid size.
-        ! It will spin a central CFFI-handled python interpreter
-        ! It also gives us a hook to do pre-load of common packages (numpy, tf, etc.)
-        !
-        ! TODO | Dev Note : this works for a single GRID. A much powerful system
-        !                   would not get the dimensions upfront but have them part
-        !                   of the backward fetch from python to MAPL
-        ! -----------------------------
+   subroutine initialize_python_bridge(im, jm, lm)
+      ! -----------------------------
+      ! Initialize the underlying python tools with a grid size.
+      ! It will spin a central CFFI-handled python interpreter
+      ! It also gives us a hook to do pre-load of common packages (numpy, tf, etc.)
+      !
+      ! TODO | Dev Note : this works for a single GRID. A much powerful system
+      !                   would not get the dimensions upfront but have them part
+      !                   of the backward fetch from python to MAPL
+      ! -----------------------------
+      integer, intent(in), value :: im, jm, lm
 
-        integer, intent(in), value :: IM, JM, LM
-        character(len=ESMF_MAXSTR) :: IAm
-        integer                    :: STATUS
-        integer                    :: RC
+      character(len=ESMF_MAXSTR) :: IAm
+      integer :: STATUS
+      integer :: RC
 
 #ifdef PYTHONBRIDGE_INTEGRATION
-        logical                    :: halting_mode(5)
-        logical                    :: set_halting_allowed
+      logical :: halting_mode(5)
+      logical :: set_halting_allowed
 
-        ! Spin the interface - we have to deactivate the ieee error
-        ! to be able to load numpy, scipy and other numpy packages
-        ! that generate an overflow during init
+      ! Spin the interface - we have to deactivate the ieee error
+      ! to be able to load numpy, scipy and other numpy packages
+      ! that generate an overflow during init
 
-        set_halting_allowed = ieee_support_halting(ieee_overflow)
+      set_halting_allowed = ieee_support_halting(ieee_overflow)
 
-        if (set_halting_allowed) then
-            call ieee_get_halting_mode(ieee_overflow, halting_mode)
-            call ieee_set_halting_mode(ieee_overflow, .false.)
-        endif
-        call mapl_fortran_python_bridge_global_initialize(IM, JM, LM)
-        if (set_halting_allowed) then
-            call ieee_set_halting_mode(ieee_overflow, halting_mode)
-        endif
+      if (set_halting_allowed) then
+         call ieee_get_halting_mode(ieee_overflow, halting_mode)
+         call ieee_set_halting_mode(ieee_overflow, .false.)
+      end if
+      call mapl_fortran_python_bridge_global_initialize(im, jm, lm)
+      if (set_halting_allowed) then
+         call ieee_set_halting_mode(ieee_overflow, halting_mode)
+      end if
 #endif
 
-    end subroutine initialize_python_bridge
+   end subroutine initialize_python_bridge
 
-    subroutine MAPL_pybridge_gcinit(PYPKG_NAME, MAPL, IMPORT, EXPORT)
-        ! -----------------------------
-        ! Call the python integration by marhshalling Fortran object/memory
-        ! into C compatible memory
-        ! Will trigger the `GEOSInterfaceCode.init` python function on the user code
-        ! -----------------------------
-        type(MAPL_MetaComp), intent(inout), TARGET :: MAPL   ! MAPL state
-        type(ESMF_State),    intent(inout), TARGET :: IMPORT ! Import state
-        type(ESMF_State),    intent(inout), TARGET :: EXPORT ! Export state
+   subroutine MAPL_pybridge_gcinit(pypkg_name, mapl, import, export)
+      ! -----------------------------
+      ! Call the python integration by marhshalling Fortran object/memory
+      ! into C compatible memory
+      ! Will trigger the `GEOSInterfaceCode.init` python function on the user code
+      ! -----------------------------
+      character(len=*), intent(in) :: pypkg_name
+      type(MAPL_MetaComp), intent(inout), target :: mapl ! MAPL state
+      type(ESMF_State), intent(inout), target :: import ! Import state
+      type(ESMF_State), intent(inout), target :: export ! Export state
 
-        character(len=*),    intent(in)            :: PYPKG_NAME
-    
 #ifdef PYTHONBRIDGE_INTEGRATION
-        PYGEOSBRIDGE_NAME_BUFFER = PYPKG_NAME // C_NULL_CHAR
-        call mapl_fortran_python_bridge_user_init( c_loc(PYGEOSBRIDGE_NAME_BUFFER), c_loc(MAPL), c_loc(IMPORT), c_loc(EXPORT) )
+      pygeosbridge_name_buffer = pypkg_name // C_NULL_CHAR
+      call mapl_fortran_python_bridge_user_init( &
+           c_loc(pygeosbridge_name_buffer), &
+           c_loc(mapl), c_loc(import), c_loc(export))
 #endif
-    end subroutine
+   end subroutine MAPL_pybridge_gcinit
 
-    subroutine MAPL_pybridge_gcrun(PYPKG_NAME, MAPL, IMPORT, EXPORT)
-        ! -----------------------------
-        ! Call the python integration by marhshalling Fortran object/memory
-        ! into C compatible memory
-        ! Will trigger the `GEOSInterfaceCode.run` python function on the user code
-        ! -----------------------------
-        type(MAPL_MetaComp), intent(inout), TARGET  :: MAPL   ! MAPL state
-        type(ESMF_State),    intent(inout), TARGET :: IMPORT ! Import state
-        type(ESMF_State),    intent(inout), TARGET :: EXPORT ! Export state
+   subroutine MAPL_pybridge_gcrun(pypkg_name, mapl, import, export)
+      ! -----------------------------
+      ! Call the python integration by marhshalling Fortran object/memory
+      ! into C compatible memory
+      ! Will trigger the `GEOSInterfaceCode.run` python function on the user code
+      ! -----------------------------
+      character(len=*), intent(in) :: pypkg_name
+      type(MAPL_MetaComp), intent(inout), target :: mapl ! MAPL state
+      type(ESMF_State), intent(inout), target :: import ! Import state
+      type(ESMF_State), intent(inout), target :: export ! Export state
 
-        character(len=*),    intent(in)            :: PYPKG_NAME
-    
 #ifdef PYTHONBRIDGE_INTEGRATION
-        PYGEOSBRIDGE_NAME_BUFFER = PYPKG_NAME // C_NULL_CHAR
-        call mapl_fortran_python_bridge_user_run( c_loc(PYGEOSBRIDGE_NAME_BUFFER), c_loc(MAPL), c_loc(IMPORT), c_loc(EXPORT) )
+      pygeosbridge_name_buffer = pypkg_name // C_NULL_CHAR
+      call mapl_fortran_python_bridge_user_run( &
+           c_loc(pygeosbridge_name_buffer), &
+           c_loc(mapl), c_loc(import), c_loc(export))
 #endif
-    end subroutine
+   end subroutine MAPL_pybridge_gcrun
 
-    subroutine MAPL_pybridge_gcrun_with_internal(PYPKG_NAME, MAPL, IMPORT, EXPORT, INTERNAL)
-        ! -----------------------------
-        ! Call the python integration by marhshalling Fortran object/memory
-        ! into C compatible memory. Variation of `gcrun` with an INTERNAL state
-        ! Will trigger the `GEOSInterfaceCode.run_with_internal` python function on the user code
-        ! -----------------------------
-        type(MAPL_MetaComp), intent(inout), TARGET  :: MAPL   ! MAPL state
-        type(ESMF_State),    intent(inout), TARGET :: IMPORT ! Import state
-        type(ESMF_State),    intent(inout), TARGET :: EXPORT ! Export state
-        type(ESMF_State),    intent(inout), TARGET :: INTERNAL ! Internal state
+   subroutine MAPL_pybridge_gcrun_with_internal(pypkg_name, mapl, import, export, internal)
+      ! -----------------------------
+      ! Call the python integration by marhshalling Fortran object/memory
+      ! into C compatible memory. Variation of `gcrun` with an INTERNAL state
+      ! Will trigger the `GEOSInterfaceCode.run_with_internal` python function on the user code
+      ! -----------------------------
+      character(len=*), intent(in) :: pypkg_name
+      type(MAPL_MetaComp), intent(inout), target :: mapl ! MAPL state
+      type(ESMF_State), intent(inout), target :: import ! Import state
+      type(ESMF_State), intent(inout), target :: export ! Export state
+      type(ESMF_State), intent(inout), target :: internal ! Internal state
 
-        character(len=*),    intent(in)            :: PYPKG_NAME
-    
 #ifdef PYTHONBRIDGE_INTEGRATION
-        PYGEOSBRIDGE_NAME_BUFFER = PYPKG_NAME // C_NULL_CHAR
-        call mapl_fortran_python_bridge_user_run_with_internal( c_loc(PYGEOSBRIDGE_NAME_BUFFER), c_loc(MAPL), c_loc(IMPORT), c_loc(EXPORT), c_loc(INTERNAL) )
+      pygeosbridge_name_buffer = pypkg_name // C_NULL_CHAR
+      call mapl_fortran_python_bridge_user_run_with_internal( &
+           c_loc(pygeosbridge_name_buffer), &
+           c_loc(mapl), c_loc(import), c_loc(export), c_loc(internal))
 #endif
-    end subroutine
+   end subroutine MAPL_pybridge_gcrun_with_internal
 
-    subroutine MAPL_pybridge_gcfinalize(PYPKG_NAME, MAPL, IMPORT, EXPORT)
-        ! -----------------------------
-        ! Call the python integration by marhshalling Fortran object/memory
-        ! into C compatible memory.
-        ! Will trigger the `GEOSInterfaceCode.finalize` python function on the user code
-        ! -----------------------------
-        type(MAPL_MetaComp), intent(inout), TARGET  :: MAPL   ! MAPL state
-        type(ESMF_State),    intent(inout), TARGET :: IMPORT ! Import state
-        type(ESMF_State),    intent(inout), TARGET :: EXPORT ! Export state
+   subroutine MAPL_pybridge_gcfinalize(pypkg_name, mapl, import, export)
+      ! -----------------------------
+      ! Call the python integration by marhshalling Fortran object/memory
+      ! into C compatible memory.
+      ! Will trigger the `GEOSInterfaceCode.finalize` python function on the user code
+      ! -----------------------------
+      character(len=*), intent(in) :: pypkg_name
+      type(MAPL_MetaComp), intent(inout), target :: mapl ! MAPL state
+      type(ESMF_State), intent(inout), target :: import ! Import state
+      type(ESMF_State), intent(inout), target :: export ! Export state
 
-        character(len=*),    intent(in)            :: PYPKG_NAME
-    
 #ifdef PYTHONBRIDGE_INTEGRATION
-        PYGEOSBRIDGE_NAME_BUFFER = PYPKG_NAME // C_NULL_CHAR
-        call mapl_fortran_python_bridge_user_finalize( c_loc(PYGEOSBRIDGE_NAME_BUFFER), c_loc(MAPL), c_loc(IMPORT), c_loc(EXPORT) )
+      pygeosbridge_name_buffer = pypkg_name // C_NULL_CHAR
+      call mapl_fortran_python_bridge_user_finalize( &
+           c_loc(pygeosbridge_name_buffer), &
+           c_loc(mapl), c_loc(import), c_loc(export))
 #endif
-    end subroutine
-end MODULE MAPL_PythonBridge
+   end subroutine MAPL_pybridge_gcfinalize
+
+end module MAPL_PythonBridge


### PR DESCRIPTION
…cases

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Formatted the top level Fortran code using our new formatting tool “codee”. Also used the paradigm

`use ModuleName, only: routine_name`

for some of the `use` statements. It will be good to have the remaining `use` statements follow this pattern.

> [!NOTE]  
> The code changes have not been tested (not built, not run)


## Related Issue

