### PR TITLE
Task 2.6: Enhance VerticalRegridTransform for Fused Normalization

### DIFF
--- a/generic3g/specs/QuantityTypeAspect.F90
+++ b/generic3g/specs/QuantityTypeAspect.F90
@@ -59,6 +59,9 @@ module mapl3g_QuantityTypeAspect
       procedure :: set_molecular_weight
       procedure :: set_from_metadata
 
+      ! Query methods
+      procedure :: needs_vertical_normalization
+
       procedure :: update_from_payload
       procedure :: update_payload
       procedure :: print_aspect
@@ -341,6 +344,21 @@ contains
 
       _RETURN(_SUCCESS)
    end subroutine set_molecular_weight
+
+   !> Query whether this quantity type requires vertical normalization for conservative regridding
+   !!
+   !! Wet mass mixing ratios (kg/kg) need normalization by layer pressure thickness (delp)
+   !! for conservative vertical regridding to preserve mass.
+   !!
+   !! @return .true. if quantity requires normalization (divide by dp, regrid, multiply by dp)
+   logical function needs_vertical_normalization(this)
+      class(QuantityTypeAspect), intent(in) :: this
+
+      ! Wet mass mixing ratios need normalization for conservative vertical regridding
+      needs_vertical_normalization = &
+         (this%quantity_type == QUANTITY_MIXING_RATIO .and. this%basis == BASIS_WET_MASS)
+
+   end function needs_vertical_normalization
 
    subroutine set_from_metadata(this, metadata, rc)
       class(QuantityTypeAspect), intent(inout) :: this

--- a/generic3g/specs/VerticalGridAspect.F90
+++ b/generic3g/specs/VerticalGridAspect.F90
@@ -15,6 +15,7 @@ module mapl3g_VerticalGridAspect
    use mapl3g_VerticalRegridTransform
    use mapl3g_GeomAspect
    use mapl3g_TypekindAspect
+   use mapl3g_QuantityTypeAspect
    use mapl3g_VerticalRegridMethod
    use mapl3g_VerticalStaggerLoc
    use mapl3g_VerticalRegridMethod
@@ -229,18 +230,20 @@ contains
       type(AspectMap), target, intent(in)  :: other_aspects
       integer, optional, intent(out) :: rc
 
-      class(ComponentDriver), pointer :: v_in_coupler
-      class(ComponentDriver), pointer :: v_out_coupler
-      type(ESMF_Field) :: v_in_field, v_out_field
-      type(VerticalGridAspect) :: dst_
-      type(GeomAspect) :: geom_aspect
-      type(TypekindAspect) :: typekind_aspect
-       character(:), allocatable :: units
-       character(:), allocatable :: physical_dimension
-       type(VerticalCoordinateDirection) :: src_alignment, dst_alignment
-       logical :: grids_match
-       type(VerticalRegridParam) :: regrid_param
-       integer :: status
+       class(ComponentDriver), pointer :: v_in_coupler
+       class(ComponentDriver), pointer :: v_out_coupler
+       type(ESMF_Field) :: v_in_field, v_out_field
+       type(VerticalGridAspect) :: dst_
+       type(GeomAspect) :: geom_aspect
+       type(TypekindAspect) :: typekind_aspect
+       type(QuantityTypeAspect) :: quantity_type_aspect
+        character(:), allocatable :: units
+        character(:), allocatable :: physical_dimension
+        type(VerticalCoordinateDirection) :: src_alignment, dst_alignment
+        logical :: grids_match
+        logical :: needs_normalization
+        type(VerticalRegridParam) :: regrid_param
+        integer :: status
 
       if (src%is_mirror()) then
          allocate(transform, source=ExtendTransform())
@@ -250,8 +253,19 @@ contains
       allocate(transform,source=NullTransform()) ! just in case
       dst_ = to_VerticalGridAspect(dst, _RC)
 
-      geom_aspect = to_GeomAspect(other_aspects, _RC)
-      typekind_aspect = to_TypekindAspect(other_aspects, _RC)
+       geom_aspect = to_GeomAspect(other_aspects, _RC)
+       typekind_aspect = to_TypekindAspect(other_aspects, _RC)
+
+       ! Query QuantityTypeAspect to determine if normalization is needed
+       ! for conservative vertical regridding. If QuantityTypeAspect is not present,
+       ! default to no normalization (status will be non-zero).
+       needs_normalization = .false.
+       if (dst_%regrid_method == VERTICAL_REGRID_CONSERVATIVE) then
+          quantity_type_aspect = to_QuantityTypeAspect(other_aspects, status)
+          if (status == _SUCCESS) then
+             needs_normalization = quantity_type_aspect%needs_vertical_normalization()
+          end if
+       end if
 
 
       physical_dimension = find_common_physical_dimension(src, dst_, _RC)
@@ -298,13 +312,14 @@ contains
          _RETURN(_SUCCESS)
       end if
       
-      ! Build regrid parameters
-      regrid_param%stagger_in = src%vertical_stagger
-      regrid_param%stagger_out = dst_%vertical_stagger
-      regrid_param%method = dst_%regrid_method
-      regrid_param%src_alignment = src_alignment
-      regrid_param%dst_alignment = dst_alignment
-      regrid_param%is_degenerate_case = grids_match
+       ! Build regrid parameters
+       regrid_param%stagger_in = src%vertical_stagger
+       regrid_param%stagger_out = dst_%vertical_stagger
+       regrid_param%method = dst_%regrid_method
+       regrid_param%src_alignment = src_alignment
+       regrid_param%dst_alignment = dst_alignment
+       regrid_param%is_degenerate_case = grids_match
+       regrid_param%needs_normalization = needs_normalization
       
       deallocate(transform)
       transform = VerticalRegridTransform(v_in_field, v_in_coupler, v_out_field, v_out_coupler, regrid_param)

--- a/generic3g/transforms/VerticalRegridTransform.F90
+++ b/generic3g/transforms/VerticalRegridTransform.F90
@@ -39,10 +39,11 @@ module mapl3g_VerticalRegridTransform
    type :: VerticalRegridParam
       type(VerticalStaggerLoc) :: stagger_in                               !< Source vertical stagger location
       type(VerticalStaggerLoc) :: stagger_out                              !< Destination vertical stagger location
-      type(VerticalRegridMethod) :: method = VERTICAL_REGRID_UNKNOWN       !< Regridding method (currently only LINEAR)
+      type(VerticalRegridMethod) :: method = VERTICAL_REGRID_UNKNOWN       !< Regridding method (LINEAR or CONSERVATIVE)
       type(VerticalCoordinateDirection) :: src_alignment = VCOORD_DIRECTION_DOWN  !< Source data storage convention
       type(VerticalCoordinateDirection) :: dst_alignment = VCOORD_DIRECTION_DOWN  !< Destination data storage convention  
       logical :: is_degenerate_case = .false.                              !< True if grids match, only alignment differs
+      logical :: needs_normalization = .false.                             !< True if conservative regridding requires normalization
    end type VerticalRegridParam
 
    !> @brief Vertical regridding transform with support for data alignment
@@ -91,6 +92,7 @@ module mapl3g_VerticalRegridTransform
       type(VerticalCoordinateDirection) :: src_alignment
       type(VerticalCoordinateDirection) :: dst_alignment
       logical :: is_degenerate_case = .false.
+      logical :: needs_normalization = .false.
    contains
       procedure :: initialize
       procedure :: update
@@ -127,6 +129,7 @@ contains
       transform%src_alignment = regrid_param%src_alignment
       transform%dst_alignment = regrid_param%dst_alignment
       transform%is_degenerate_case = regrid_param%is_degenerate_case
+      transform%needs_normalization = regrid_param%needs_normalization
    end function new_VerticalRegridTransform
 
    !> Initialize the vertical regrid transform.
@@ -191,13 +194,14 @@ contains
        type(ESMF_FieldBundle) :: fb_in, fb_out
        integer :: status
 
-      ! if (associated(this%v_in_coupler)) then
-      !    call this%v_in_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
-      ! end if
+      ! Update vertical coordinates (time-varying)
+      if (associated(this%v_in_coupler)) then
+         call this%v_in_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
+      end if
 
-      ! if (associated(this%v_out_coupler)) then
-      !    call this%v_out_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
-      ! end if
+      if (associated(this%v_out_coupler)) then
+         call this%v_out_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
+      end if
 
       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, itemtype=itemtype_in, _RC)
       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, itemtype=itemtype_out, _RC)
@@ -237,7 +241,7 @@ contains
    !! @param[inout] fb_out   Output field bundle (modified in place)
    !! @param[out]   rc       Return code
    subroutine process_fieldbundle(this, fb_in, fb_out, rc)
-      class(VerticalRegridTransform), intent(in) :: this
+      class(VerticalRegridTransform), intent(inout) :: this
       type(ESMF_FieldBundle), intent(in) :: fb_in
       type(ESMF_FieldBundle), intent(inout) :: fb_out
       integer, optional, intent(out) :: rc
@@ -270,12 +274,12 @@ contains
    !!   - Uses regrid_field_ with pre-computed interpolation matrix
    !!   - Regridding handles both interpolation and alignment adjustment
    !!
-    !! @param[in]    this   The transform object
+    !! @param[inout] this   The transform object (need inout to access mutable ESMF fields)
     !! @param[inout] f_in   Input field (ESMF requires inout for pointer access)
     !! @param[inout] f_out  Output field (modified in place)
    !! @param[out]   rc     Return code
     subroutine process_field(this, f_in, f_out, rc)
-       class(VerticalRegridTransform), intent(in) :: this
+       class(VerticalRegridTransform), intent(inout) :: this
        type(ESMF_Field), intent(inout) :: f_in
        type(ESMF_Field), intent(inout) :: f_out
        integer, optional, intent(out) :: rc
@@ -288,7 +292,9 @@ contains
          call copy_field_flipped_(f_in, f_out, _RC)
       else
          ! Different grids → regrid with alignment support
-         call regrid_field_(this%matrix, f_in, this%src_alignment, f_out, this%dst_alignment, _RC)
+         call regrid_field_(this%matrix, this%needs_normalization, &
+              this%v_in_coord, this%v_out_coord, &
+              f_in, this%src_alignment, f_out, this%dst_alignment, _RC)
       end if
 
       _RETURN(_SUCCESS)
@@ -477,59 +483,120 @@ contains
     !! - Final output:       [Ta, Tb, Tc] aligned with DOWN coords
     !!
     !! @param[in]    matrix        Pre-computed interpolation matrix
-    !! @param[inout] f_in          Source field
-    !! @param[in]    src_alignment Source coordinate direction
-    !! @param[inout] f_out         Destination field (modified in place)
-    !! @param[in]    dst_alignment Destination coordinate direction
-    !! @param[out]   rc            Return code
-    subroutine regrid_field_(matrix, f_in, src_alignment, f_out, dst_alignment, rc)
-       type(SparseMatrix_sp), allocatable, intent(in) :: matrix(:)
-       type(ESMF_Field), intent(inout) :: f_in, f_out
-       type(VerticalCoordinateDirection), intent(in) :: src_alignment
-       type(VerticalCoordinateDirection), intent(in) :: dst_alignment
-       integer, optional, intent(out) :: rc
+   !! @param[in]    matrix          Sparse interpolation matrix
+   !! @param[in]    needs_normalization  True if conservative regridding requires normalization
+   !! @param[inout] v_in_coord     Source vertical coordinate field (for layer thickness if normalizing)
+   !! @param[inout] v_out_coord    Destination vertical coordinate field (for layer thickness if normalizing)
+   !! @param[inout] f_in           Source field
+   !! @param[in]    src_alignment  Source coordinate direction
+   !! @param[inout] f_out          Destination field (modified in place)
+   !! @param[in]    dst_alignment  Destination coordinate direction
+   !! @param[out]   rc             Return code
+   subroutine regrid_field_(matrix, needs_normalization, v_in_coord, v_out_coord, &
+                             f_in, src_alignment, f_out, dst_alignment, rc)
+      type(SparseMatrix_sp), allocatable, intent(in) :: matrix(:)
+      logical, intent(in) :: needs_normalization
+      type(ESMF_Field), intent(inout) :: v_in_coord, v_out_coord
+      type(ESMF_Field), intent(inout) :: f_in, f_out
+      type(VerticalCoordinateDirection), intent(in) :: src_alignment
+      type(VerticalCoordinateDirection), intent(in) :: dst_alignment
+      integer, optional, intent(out) :: rc
 
-       real(ESMF_KIND_R4), pointer :: x_in(:,:,:), x_out(:,:,:)
-       real(ESMF_KIND_R4), allocatable :: x_in_working(:,:,:), x_out_working(:,:,:)
-       integer :: shape_in(3), shape_out(3), n_horz, n_ungridded
-       integer :: horz, ungrd, status
+      real(ESMF_KIND_R4), pointer :: x_in(:,:,:), x_out(:,:,:)
+      real(ESMF_KIND_R4), pointer :: v_in(:,:,:), v_out(:,:,:)
+      real(ESMF_KIND_R4), allocatable :: x_in_working(:,:,:), x_out_working(:,:,:)
+      real(ESMF_KIND_R4), allocatable :: dp_in(:,:,:), dp_out(:,:,:)
+      integer :: shape_in(3), shape_out(3), n_horz, n_ungridded, nlev_in, nlev_out
+      integer :: horz, ungrd, k, status
 
-       call assign_fptr_condensed_array(f_in, x_in, _RC)
-       shape_in = shape(x_in)
-       call assign_fptr_condensed_array(f_out, x_out, _RC)
-       shape_out = shape(x_out)
-       _ASSERT((shape_in(1) == shape_out(1)), "horz dims are expected to be equal")
-       _ASSERT((shape_in(3) == shape_out(3)), "ungridded dims are expected to be equal")
+      call assign_fptr_condensed_array(f_in, x_in, _RC)
+      shape_in = shape(x_in)
+      call assign_fptr_condensed_array(f_out, x_out, _RC)
+      shape_out = shape(x_out)
+      _ASSERT((shape_in(1) == shape_out(1)), "horz dims are expected to be equal")
+      _ASSERT((shape_in(3) == shape_out(3)), "ungridded dims are expected to be equal")
 
-       n_horz = shape_in(1)
-       n_ungridded = shape_in(3)
-       
-       ! Canonicalize input data to match coordinate transformation
-       ! DOWN alignment = default (no flip)
-       ! UP alignment = reversed (flip to DOWN for interpolation)
-       if (src_alignment == VCOORD_DIRECTION_UP) then
-          x_in_working = flip_vertical_data(x_in)
-       else
-          x_in_working = x_in
-       end if
-       
-       ! Apply interpolation matrix
-       allocate(x_out_working(shape_out(1), shape_out(2), shape_out(3)))
-       do concurrent (horz=1:n_horz, ungrd=1:n_ungridded)
-          x_out_working(horz, :, ungrd) = matmul(matrix(horz), x_in_working(horz, :, ungrd))
-       end do
-       
-       ! Transform output to destination alignment
-       ! Matrix output is in DOWN alignment
-       ! If destination is UP, flip the result
-       if (dst_alignment == VCOORD_DIRECTION_UP) then
-          x_out = flip_vertical_data(x_out_working)
-       else
-          x_out = x_out_working
-       end if
+      n_horz = shape_in(1)
+      nlev_in = shape_in(2)
+      nlev_out = shape_out(2)
+      n_ungridded = shape_in(3)
+      
+      ! Canonicalize input data to match coordinate transformation
+      ! DOWN alignment = default (no flip)
+      ! UP alignment = reversed (flip to DOWN for interpolation)
+      if (src_alignment == VCOORD_DIRECTION_UP) then
+         x_in_working = flip_vertical_data(x_in)
+      else
+         x_in_working = x_in
+      end if
+      
+      ! Apply fused normalization for conservative regridding if needed
+      if (needs_normalization) then
+         ! Get vertical coordinate fields (layer interfaces)
+         call assign_fptr_condensed_array(v_in_coord, v_in, _RC)
+         call assign_fptr_condensed_array(v_out_coord, v_out, _RC)
+         
+         ! Compute layer thickness (dp) from interfaces
+         ! dp(k) = |coord(k+1) - coord(k)|
+         allocate(dp_in(n_horz, nlev_in, n_ungridded))
+         allocate(dp_out(n_horz, nlev_out, n_ungridded))
+         
+         do horz = 1, n_horz
+            do ungrd = 1, n_ungridded
+               do k = 1, nlev_in
+                  dp_in(horz, k, ungrd) = abs(v_in(horz, k+1, ungrd) - v_in(horz, k, ungrd))
+               end do
+               do k = 1, nlev_out
+                  dp_out(horz, k, ungrd) = abs(v_out(horz, k+1, ungrd) - v_out(horz, k, ungrd))
+               end do
+            end do
+         end do
+         
+         ! Step 1: Normalize by dividing by source layer thickness
+         ! Converts kg/m2 → kg/(m2·Pa) for mixing ratios
+         do horz = 1, n_horz
+            do ungrd = 1, n_ungridded
+               do k = 1, nlev_in
+                  x_in_working(horz, k, ungrd) = x_in_working(horz, k, ungrd) / dp_in(horz, k, ungrd)
+               end do
+            end do
+         end do
+         
+         ! Step 2: Apply conservative interpolation matrix
+         allocate(x_out_working(shape_out(1), shape_out(2), shape_out(3)))
+         do concurrent (horz=1:n_horz, ungrd=1:n_ungridded)
+            x_out_working(horz, :, ungrd) = matmul(matrix(horz), x_in_working(horz, :, ungrd))
+         end do
+         
+         ! Step 3: Denormalize by multiplying by destination layer thickness
+         ! Converts kg/(m2·Pa) → kg/m2
+         do horz = 1, n_horz
+            do ungrd = 1, n_ungridded
+               do k = 1, nlev_out
+                  x_out_working(horz, k, ungrd) = x_out_working(horz, k, ungrd) * dp_out(horz, k, ungrd)
+               end do
+            end do
+         end do
+         
+      else
+         ! Standard regridding without normalization
+         allocate(x_out_working(shape_out(1), shape_out(2), shape_out(3)))
+         do concurrent (horz=1:n_horz, ungrd=1:n_ungridded)
+            x_out_working(horz, :, ungrd) = matmul(matrix(horz), x_in_working(horz, :, ungrd))
+         end do
+      end if
+      
+      ! Transform output to destination alignment
+      ! Matrix output is in DOWN alignment
+      ! If destination is UP, flip the result
+      if (dst_alignment == VCOORD_DIRECTION_UP) then
+         x_out = flip_vertical_data(x_out_working)
+      else
+         x_out = x_out_working
+      end if
 
-       _RETURN(_SUCCESS)
-    end subroutine regrid_field_
+      _RETURN(_SUCCESS)
+   end subroutine regrid_field_
 
     function get_transformId(this) result(id)
        type(TransformId) :: id


### PR DESCRIPTION
## Summary

Completes **Task 2.6: Enhance VerticalRegridTransform for Fused Normalization** by integrating metadata-driven normalization with conservative vertical regridding. This enables automatic normalization/denormalization for fields that require mass conservation (wet mass mixing ratios).

## Changes

### 1. QuantityTypeAspect Enhancement
- Added `needs_vertical_normalization()` query method
- Returns `.true.` for wet mass mixing ratios (`QUANTITY_MIXING_RATIO` + `BASIS_WET_MASS`)
- Provides metadata-driven decision point for normalization

### 2. VerticalGridAspect Integration  
- Modified `make_transform()` to query `QuantityTypeAspect` when creating transforms
- Sets `needs_normalization` flag in `VerticalRegridParam` based on field metadata
- Gracefully handles absence of `QuantityTypeAspect` (defaults to no normalization)

### 3. VerticalRegridTransform Implementation
- Enhanced `regrid_field_()` to support fused normalization algorithm:
  - **With normalization**: Normalize by dp, apply conservative matrix, denormalize
  - **Without normalization**: Standard conservative matrix multiplication
- Enabled vertical coordinate couplers in `update()` for time-varying coordinates
- Updated method signatures to `intent(inout)` for mutable ESMF fields

## Fused Normalization Algorithm

For conservative vertical regridding with normalization:
1. Compute layer thickness: `dp(k) = |v(k+1) - v(k)|`
2. Normalize: `data_normalized = data_in / dp_src`
3. Apply conservative matrix: `data_regridded = matmul(matrix, data_normalized)`
4. Denormalize: `data_out = data_regridded * dp_dst`

This ensures mass conservation for wet mass mixing ratios during vertical regridding.

## Implementation Notes

- Follows **Option B** (full metadata integration) from Task 2.6 specification
- Backward compatible: normalization only activates when explicitly configured via metadata
- Builds successfully with NAG compiler
- Existing tests pass (pre-existing test failures confirmed on base branch)

## Dependencies

- **Requires**: Task 2.6b (Conservative Matrix Construction) - merged in commit 530b49f7
- **Builds on**: Task 2.6a (Fused Normalization in VerticalRegridTransform)
- **Enables**: Task 2.7 (End-to-end testing with realistic mixing ratio data)

## Related Issues

Closes #4478

## Testing

- ✅ Builds successfully with NAG compiler
- ✅ Verified backward compatibility (no normalization without metadata)
- ✅ Pre-existing test failures confirmed unrelated to changes
- ⏭️ End-to-end testing with realistic mixing ratios planned for Task 2.7

## Files Modified

- `generic3g/specs/QuantityTypeAspect.F90` - Added normalization query method
- `generic3g/specs/VerticalGridAspect.F90` - Integrated metadata query in transform creation
- `generic3g/transforms/VerticalRegridTransform.F90` - Implemented fused normalization algorithm

---

Ready for review @tclune