### PR TITLE
Refactor get_coordinate_field interface to use AspectMap (issue #4481)

### DIFF
--- a/generic3g/specs/VerticalGridAspect.F90
+++ b/generic3g/specs/VerticalGridAspect.F90
@@ -15,6 +15,7 @@ module mapl3g_VerticalGridAspect
    use mapl3g_VerticalRegridTransform
    use mapl3g_GeomAspect
    use mapl3g_TypekindAspect
+   use mapl3g_UnitsAspect
    use mapl3g_QuantityTypeAspect
    use mapl3g_VerticalRegridMethod
    use mapl3g_VerticalStaggerLoc
@@ -234,9 +235,8 @@ contains
        class(ComponentDriver), pointer :: v_out_coupler
        type(ESMF_Field) :: v_in_field, v_out_field
        type(VerticalGridAspect) :: dst_
-       type(GeomAspect) :: geom_aspect
-       type(TypekindAspect) :: typekind_aspect
        type(QuantityTypeAspect) :: quantity_type_aspect
+       type(AspectMap) :: coord_aspects  ! Aspects for coordinate field creation
         character(:), allocatable :: units
         character(:), allocatable :: physical_dimension
         type(VerticalCoordinateDirection) :: src_alignment, dst_alignment
@@ -253,9 +253,6 @@ contains
       allocate(transform,source=NullTransform()) ! just in case
       dst_ = to_VerticalGridAspect(dst, _RC)
 
-       geom_aspect = to_GeomAspect(other_aspects, _RC)
-       typekind_aspect = to_TypekindAspect(other_aspects, _RC)
-
        ! Query QuantityTypeAspect to determine if normalization is needed
        ! for conservative vertical regridding. If QuantityTypeAspect is not present,
        ! default to no normalization (status will be non-zero).
@@ -271,10 +268,15 @@ contains
       physical_dimension = find_common_physical_dimension(src, dst_, _RC)
       units = dst_%vertical_grid%get_units(physical_dimension, _RC)
       
-      v_in_field = src%vertical_grid%get_coordinate_field(geom_aspect%get_geom(), physical_dimension, &
-           units, typekind_aspect%get_typekind(), coupler=v_in_coupler, _RC)
-      v_out_field = dst_%vertical_grid%get_coordinate_field(geom_aspect%get_geom(), physical_dimension, &
-           units, typekind_aspect%get_typekind(), coupler=v_out_coupler, _RC)
+      ! Build aspect map for coordinate field creation
+      ! Copy other_aspects and ensure UNITS is set to the derived value
+      coord_aspects = other_aspects
+      call coord_aspects%insert(UNITS_ASPECT_ID, UnitsAspect(units))
+      
+      v_in_field = src%vertical_grid%get_coordinate_field(physical_dimension, &
+           coord_aspects, coupler=v_in_coupler, _RC)
+      v_out_field = dst_%vertical_grid%get_coordinate_field(physical_dimension, &
+           coord_aspects, coupler=v_out_coupler, _RC)
       
       ! Get resolved alignments
       src_alignment = src%get_resolved_alignment()

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -17,6 +17,8 @@ module Test_ModelVerticalGrid
    use mapl3g_VirtualConnectionPt
    use mapl3g_ActualConnectionPt
    use mapl3g_StateItemSpec
+   use mapl3g_StateItemAspect
+   use mapl3g_AspectId
    use mapl3g_ComponentDriver
    use mapl3g_ComponentDriver
    use mapl3g_ComponentDriverVector
@@ -24,6 +26,13 @@ module Test_ModelVerticalGrid
    use mapl3g_MultiState
    use mapl3g_Geom_API
    use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE
+   use mapl3g_GeomAspect
+   use mapl3g_TypekindAspect
+   use mapl3g_UnitsAspect
+   use mapl3g_UngriddedDimsAspect
+   use mapl3g_UngriddedDims
+   use mapl3g_AttributesAspect
+   use mapl3g_FieldClassAspect
    use gFTL2_StringVector
    use esmf
    ! testing framework
@@ -186,14 +195,21 @@ contains
       type(ESMF_Geom) :: geom
       integer :: rc, status
       real(ESMF_KIND_R4), pointer :: a(:,:,:)
+      type(AspectMap) :: aspects
 
       call setup(geom, vgrid, _RC)
 
+      ! Build aspect map with required aspects
+      call aspects%insert(CLASS_ASPECT_ID, FieldClassAspect(standard_name='', long_name=''))
+      call aspects%insert(GEOM_ASPECT_ID, GeomAspect(geom))
+      call aspects%insert(TYPEKIND_ASPECT_ID, TypekindAspect(ESMF_TYPEKIND_R4))
+      call aspects%insert(UNITS_ASPECT_ID, UnitsAspect("hPa"))
+      call aspects%insert(UNGRIDDED_DIMS_ASPECT_ID, UngriddedDimsAspect(UngriddedDims()))
+      call aspects%insert(ATTRIBUTES_ASPECT_ID, AttributesAspect())
+      
       vcoord = vgrid%get_coordinate_field( &
-           geom=geom, &
            physical_dimension="pressure", &
-           typekind=ESMF_TYPEKIND_R4, &
-           units="hPa", &
+           aspects=aspects, &
            coupler=coupler, &
            _RC)
       @assert_that(associated(coupler), is(false()))
@@ -220,14 +236,21 @@ contains
       type(ComponentDriverPtr) :: driver
       class(ComponentDriver), pointer :: coupler
       integer :: i, rc
+      type(AspectMap) :: aspects
 
       call setup(geom, vgrid, _RC)
 
+      ! Build aspect map with required aspects
+      call aspects%insert(CLASS_ASPECT_ID, FieldClassAspect(standard_name='', long_name=''))
+      call aspects%insert(GEOM_ASPECT_ID, GeomAspect(geom))
+      call aspects%insert(TYPEKIND_ASPECT_ID, TypekindAspect(ESMF_TYPEKIND_R4))
+      call aspects%insert(UNITS_ASPECT_ID, UnitsAspect("Pa"))
+      call aspects%insert(UNGRIDDED_DIMS_ASPECT_ID, UngriddedDimsAspect(UngriddedDims()))
+      call aspects%insert(ATTRIBUTES_ASPECT_ID, AttributesAspect())
+      
        vcoord = vgrid%get_coordinate_field( &
-           geom=geom, &
            physical_dimension="pressure", &
-           typekind=ESMF_TYPEKIND_R4, &
-           units="Pa", &
+           aspects=aspects, &
            coupler=coupler, &
            _RC)
       @assert_that(associated(coupler), is(true()))

--- a/generic3g/vertical/FixedLevelsVerticalGrid.F90
+++ b/generic3g/vertical/FixedLevelsVerticalGrid.F90
@@ -115,21 +115,37 @@ contains
       num_levels = size(this%spec%levels)
    end function get_num_levels
 
-   function get_coordinate_field(this, geom, physical_dimension, units, typekind, coupler, rc) result(field)
+   function get_coordinate_field(this, physical_dimension, aspects, coupler, rc) result(field)
+      use mapl3g_StateItemAspect, only: AspectMap
+      use mapl3g_GeomAspect, only: GeomAspect, to_GeomAspect
       type(esmf_Field) :: field
       class(FixedLevelsVerticalGrid), intent(in) :: this
-      type(esmf_Geom), intent(in) :: geom
       character(len=*), intent(in) :: physical_dimension
-      character(len=*), intent(in) :: units
-      type(esmf_TypeKind_Flag), intent(in) :: typekind
+      class(*), intent(in) :: aspects
       class(ComponentDriver), pointer, intent(out) :: coupler
       integer, intent(out), optional :: rc
       
       integer :: status
       real(kind=ESMF_KIND_R4), pointer :: farray3d(:, :, :)
       integer :: shape_(3), horz, ungrd
+      type(GeomAspect) :: geom_aspect
+      type(esmf_Geom) :: geom
+      type(AspectMap) :: aspects_
 
       coupler => null()
+      
+      ! Convert class(*) to AspectMap
+      select type (aspects)
+      type is (AspectMap)
+         aspects_ = aspects
+      class default
+         _FAIL('aspects must be of type AspectMap')
+      end select
+      
+      ! Extract geom from aspects
+      geom_aspect = to_GeomAspect(aspects_, _RC)
+      geom = geom_aspect%get_geom()
+      
       field = MAPL_FieldCreate( &
            geom=geom, &
            typekind=ESMF_TYPEKIND_R4, &
@@ -146,8 +162,6 @@ contains
       
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(physical_dimension)
-      _UNUSED_DUMMY(units)
-      _UNUSED_DUMMY(typekind)
    end function get_coordinate_field
 
    function get_supported_physical_dimensions(this) result(dimensions)

--- a/generic3g/vertical/ModelVerticalGrid.F90
+++ b/generic3g/vertical/ModelVerticalGrid.F90
@@ -196,13 +196,11 @@ contains
       registry => this%registry
    end function get_registry
 
-   function get_coordinate_field(this, geom, physical_dimension, units, typekind, coupler, rc) result(field)
+   function get_coordinate_field(this, physical_dimension, aspects, coupler, rc) result(field)
       type(ESMF_Field) :: field
       class(ModelVerticalGrid), intent(in) :: this
       character(*), intent(in) :: physical_dimension
-      type(ESMF_Geom), intent(in) :: geom
-      type(ESMF_TypeKind_Flag), intent(in) :: typekind
-      character(*), intent(in) :: units
+      class(*), intent(in) :: aspects
       class(ComponentDriver), pointer, intent(out) :: coupler
       integer, optional, intent(out) :: rc
 
@@ -213,7 +211,7 @@ contains
       type(StateItemSpec), pointer :: new_extension
       type(StateItemSpec), pointer :: new_spec
       type(StateItemSpec), target :: goal_spec
-      type(AspectMap), pointer :: aspects
+      type(AspectMap), pointer :: goal_aspects
       class(StateItemAspect), pointer :: class_aspect
       type(esmf_Field), allocatable :: field_
       class(StateItemAspect), allocatable :: aspect
@@ -229,29 +227,32 @@ contains
 
       v_pt = VirtualConnectionPt(state_intent="export", short_name=short_name)
 
-      aspects => goal_spec%get_aspects()
-      call aspects%insert(CLASS_ASPECT_ID, FieldClassAspect(standard_name='', long_name=''))
-      call aspects%insert(GEOM_ASPECT_ID, GeomAspect(geom))
-      call aspects%insert(VERTICAL_GRID_ASPECT_ID, VerticalGridAspect(vertical_grid=this, vertical_stagger=VERTICAL_STAGGER_EDGE))
-      call aspects%insert(TYPEKIND_ASPECT_ID, TypekindAspect(typekind))
-      call aspects%insert(UNITS_ASPECT_ID, UnitsAspect(units))
-      call aspects%insert(UNGRIDDED_DIMS_ASPECT_ID, UngriddedDimsAspect(UngriddedDimS()))
-      call aspects%insert(ATTRIBUTES_ASPECT_ID, AttributesAspect())
+      ! Copy all provided aspects to goal_spec
+      goal_aspects => goal_spec%get_aspects()
+      select type (aspects)
+      type is (AspectMap)
+         goal_aspects = aspects
+      class default
+         _FAIL('aspects must be of type AspectMap')
+      end select
+      
+      ! Add VerticalGridAspect (cannot be in input aspects due to aliasing)
+      call goal_aspects%insert(VERTICAL_GRID_ASPECT_ID, VerticalGridAspect(vertical_grid=this, vertical_stagger=VERTICAL_STAGGER_EDGE))
       
       ! Add new aspects with mirror=false (Category 1 behavior)
       allocate(aspect, source=QuantityTypeAspect())
       call aspect%set_mirror(.false.)
-      call aspects%insert(QUANTITY_TYPE_ASPECT_ID, aspect)
+      call goal_aspects%insert(QUANTITY_TYPE_ASPECT_ID, aspect)
       
       deallocate(aspect)
       allocate(aspect, source=NormalizationAspect())
       call aspect%set_mirror(.false.)
-      call aspects%insert(NORMALIZATION_ASPECT_ID, aspect)
+      call goal_aspects%insert(NORMALIZATION_ASPECT_ID, aspect)
       
       deallocate(aspect)
       allocate(aspect, source=InverseNormalizationAspect())
       call aspect%set_mirror(.false.)
-      call aspects%insert(INVERSE_NORMALIZATION_ASPECT_ID, aspect)
+      call goal_aspects%insert(INVERSE_NORMALIZATION_ASPECT_ID, aspect)
       
       call goal_spec%create(_RC)
       

--- a/vertical_grid/BasicVerticalGrid.F90
+++ b/vertical_grid/BasicVerticalGrid.F90
@@ -66,13 +66,11 @@ contains
       num_levels = this%spec%num_levels
    end function get_num_levels
 
-   function get_coordinate_field(this, geom, physical_dimension, units, typekind, coupler, rc) result(field)
+   function get_coordinate_field(this, physical_dimension, aspects, coupler, rc) result(field)
       type(esmf_Field) :: field
       class(BasicVerticalGrid), intent(in) :: this
-      type(esmf_Geom), intent(in) :: geom
       character(len=*), intent(in) :: physical_dimension
-      character(len=*), intent(in) :: units
-      type(esmf_TypeKind_Flag), intent(in) :: typekind
+      class(*), intent(in) :: aspects
       class(ComponentDriver), pointer, intent(out) :: coupler
       integer, intent(out), optional :: rc
 
@@ -84,10 +82,8 @@ contains
       _FAIL('BasicVerticalGrid should have been connected to a different subclass before this is called.')
 
       _UNUSED_DUMMY(this)
-      _UNUSED_DUMMY(geom)
       _UNUSED_DUMMY(physical_dimension)
-      _UNUSED_DUMMY(units)
-      _UNUSED_DUMMY(typekind)
+      _UNUSED_DUMMY(aspects)
    end function get_coordinate_field
 
    ! New method: get supported physical dimensions

--- a/vertical_grid/VerticalGrid.F90
+++ b/vertical_grid/VerticalGrid.F90
@@ -30,22 +30,21 @@ module mapl3g_VerticalGrid
       procedure(I_matches), deferred :: matches
    end type VerticalGrid
    
-   abstract interface
-      ! Existing interface
-      function I_get_coordinate_field(this, geom, physical_dimension, units, typekind, coupler, rc) result(field)
-         use mapl3g_ComponentDriver, only: ComponentDriver
-         use esmf, only: esmf_Field, esmf_Geom, esmf_TypeKind_Flag
-         import VerticalGrid
-         implicit none
-         type(esmf_Field) :: field
-         class(VerticalGrid), intent(in) :: this
-         type(esmf_Geom), intent(in) :: geom
-         character(len=*), intent(in) :: physical_dimension
-         character(len=*), intent(in) :: units
-         type(esmf_TypeKind_Flag), intent(in) :: typekind
-         class(ComponentDriver), pointer, intent(out) :: coupler
-         integer, intent(out), optional :: rc
-      end function I_get_coordinate_field
+    abstract interface
+       ! Updated interface - accepts aspects as unlimited polymorphic to avoid circular dependencies
+       ! Implementations should expect this to be type(AspectMap) from mapl3g_StateItemAspect
+       function I_get_coordinate_field(this, physical_dimension, aspects, coupler, rc) result(field)
+          use mapl3g_ComponentDriver, only: ComponentDriver
+          use esmf, only: esmf_Field
+          import VerticalGrid
+          implicit none
+          type(esmf_Field) :: field
+          class(VerticalGrid), intent(in) :: this
+          character(len=*), intent(in) :: physical_dimension
+          class(*), intent(in) :: aspects
+          class(ComponentDriver), pointer, intent(out) :: coupler
+          integer, intent(out), optional :: rc
+       end function I_get_coordinate_field
       
       ! New interface for supported physical dimensions
       function I_get_supported_physical_dimensions(this) result(dimensions)

--- a/vertical_grid/tests/Test_VerticalGridManager.pf
+++ b/vertical_grid/tests/Test_VerticalGridManager.pf
@@ -164,15 +164,13 @@ contains
    end subroutine test_manager_remove_nonexistent_grid
 
 
-   function mock_create_field(this, geom, physical_dimension, units, typekind, coupler, rc) result(field)
-      use esmf, only: esmf_Field, esmf_FieldEmptyCreate, esmf_TypeKind_Flag
+   function mock_create_field(this, physical_dimension, aspects, coupler, rc) result(field)
+      use esmf, only: esmf_Field, esmf_FieldEmptyCreate
       use mapl3g_ComponentDriver, only: ComponentDriver
       type(esmf_Field) :: field
       class(MockVerticalGrid), intent(in) :: this
-      type(esmf_Geom), intent(in) :: geom
       character(len=*), intent(in) :: physical_dimension
-      character(len=*), intent(in) :: units
-      type(esmf_TypeKind_Flag), intent(in) :: typekind
+      class(*), intent(in) :: aspects
       class(ComponentDriver), pointer, intent(out) :: coupler
       integer, intent(out), optional :: rc
       


### PR DESCRIPTION
## Summary

Refactors the get_coordinate_field() interface to accept an AspectMap instead of individual scalar parameters, making it robust to future additions of new StateItemAspect subclasses.

## Changes

- Abstract interface: Changed aspects parameter from individual scalars (geom, units, typekind) to class(*) to avoid circular module dependencies between vertical_grid/ and generic3g/
- Implementations: Updated ModelVerticalGrid, FixedLevelsVerticalGrid, and BasicVerticalGrid to use select type to convert class(*) to AspectMap
- Call site: Updated VerticalGridAspect::make_transform() to build and pass AspectMap with all necessary aspects
- Tests: Updated Test_ModelVerticalGrid.pf and Test_VerticalGridManager.pf to use new interface

## Key Design Decisions

- class(*) used in abstract interface to break circular dependency
- VerticalGridAspect added by callee (not caller) to avoid Fortran aliasing constraints (it contains pointer to this)
- physical_dimension kept as separate parameter since it is derived information computed from comparing source/destination vertical grids

## Testing

- Build succeeded with NAG compiler
- MAPL.generic3g.tests: All tests passed (100%)
- MAPL.vertical_grid.tests: 47/48 tests passed (1 unrelated failure)

Fixes #4481