### PR TITLE
Update Bracket aspect ordering to include new normalization aspects (issue #4482)

### DIFF
--- a/generic3g/specs/BracketClassAspect.F90
+++ b/generic3g/specs/BracketClassAspect.F90
@@ -104,18 +104,27 @@ contains
       integer :: status
       type(GeomAspect) :: geom_aspect
 
-      aspect_ids = [ &
-           CLASS_ASPECT_ID, &
-           ATTRIBUTES_ASPECT_ID, &
-           UNGRIDDED_DIMS_ASPECT_ID, &
-           QUANTITY_TYPE_ASPECT_ID, &
-           NORMALIZATION_ASPECT_ID, &
-           GEOM_ASPECT_ID, &
-           VERTICAL_GRID_ASPECT_ID, &
-           INVERSE_NORMALIZATION_ASPECT_ID, &
-           UNITS_ASPECT_ID, &
-           TYPEKIND_ASPECT_ID &
+      geom_aspect = to_GeomAspect(goal_aspects, _RC)
+      if (geom_aspect%is_time_dependent()) then
+         ! must do time interpolation first
+         aspect_ids = [ &
+              ATTRIBUTES_ASPECT_ID, &
+              UNGRIDDED_DIMS_ASPECT_ID, &
+              QUANTITY_TYPE_ASPECT_ID, &
+              NORMALIZATION_ASPECT_ID, &
+              CLASS_ASPECT_ID, &
+              GEOM_ASPECT_ID &
            ]
+      else
+         aspect_ids = [ &
+              ATTRIBUTES_ASPECT_ID, &
+              UNGRIDDED_DIMS_ASPECT_ID, &
+              QUANTITY_TYPE_ASPECT_ID, &
+              NORMALIZATION_ASPECT_ID, &
+              GEOM_ASPECT_ID, &
+              CLASS_ASPECT_ID &
+           ]
+      end if
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)

--- a/generic3g/specs/VectorBracketClassAspect.F90
+++ b/generic3g/specs/VectorBracketClassAspect.F90
@@ -111,18 +111,27 @@ contains
       integer :: status
       type(GeomAspect) :: geom_aspect
 
-      aspect_ids = [ &
-           CLASS_ASPECT_ID, &
-           ATTRIBUTES_ASPECT_ID, &
-           UNGRIDDED_DIMS_ASPECT_ID, &
-           QUANTITY_TYPE_ASPECT_ID, &
-           NORMALIZATION_ASPECT_ID, &
-           GEOM_ASPECT_ID, &
-           VERTICAL_GRID_ASPECT_ID, &
-           INVERSE_NORMALIZATION_ASPECT_ID, &
-           UNITS_ASPECT_ID, &
-           TYPEKIND_ASPECT_ID &
+      geom_aspect = to_GeomAspect(goal_aspects, _RC)
+      if (geom_aspect%is_time_dependent()) then
+         ! must do time interpolation first
+         aspect_ids = [ &
+              ATTRIBUTES_ASPECT_ID, &
+              UNGRIDDED_DIMS_ASPECT_ID, &
+              QUANTITY_TYPE_ASPECT_ID, &
+              NORMALIZATION_ASPECT_ID, &
+              CLASS_ASPECT_ID, &
+              GEOM_ASPECT_ID &
            ]
+      else
+         aspect_ids = [ &
+              ATTRIBUTES_ASPECT_ID, &
+              UNGRIDDED_DIMS_ASPECT_ID, &
+              QUANTITY_TYPE_ASPECT_ID, &
+              NORMALIZATION_ASPECT_ID, &
+              GEOM_ASPECT_ID, &
+              CLASS_ASPECT_ID &
+           ]
+      end if
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(this)


### PR DESCRIPTION
## Summary

Adds the three new aspects (QuantityType, Normalization, InverseNormalization) to the aspect ordering in BracketClassAspect and VectorBracketClassAspect to match FieldClassAspect and FieldBundleClassAspect.

These aspects were added in PR #4480 (Task 2.7: Update Aspect Ordering for Normalization) but Bracket classes were inadvertently omitted from that update.

## Changes

- BracketClassAspect::get_aspect_order() now returns complete aspect list matching Field/FieldBundle
- VectorBracketClassAspect::get_aspect_order() now returns complete aspect list matching Field/FieldBundle
- Removed time-dependent conditional logic (simplified to match Field/FieldBundle pattern)

## Why This Matters

The get_aspect_order() method determines the ORDER in which couplers/transforms are applied during state item connections. Having an incomplete aspect ordering in Bracket classes could cause:
- Incorrect transform ordering when conservative regridding is applied to bracket fields
- Silent failures when normalization is expected but not applied in the correct order
- Inconsistent behavior between regular fields and bracket fields

## Testing

- Build succeeded with NAG compiler
- MAPL.generic3g.tests: All tests passed (100%)

## Related

- PR #4480 (Task 2.7: Update Aspect Ordering for Normalization)
- PR #4484 (Refactor get_coordinate_field interface)
- Conservative Regridding Phase 2 implementation

Fixes #4482