### PR TITLE
v2: Updates for ctest in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v4.35.0
     - Multiple fixes for f2py with spack and on macOS
   - ecbuild geos/v3.13.1
+- Add CTest scheduling metadata for pFIO tests so parallel `ctest` runs do not overlap the pFIO performance cases in the same working directory.
 
 ### Removed
 

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_pfunit_ctest(MAPL.pfio.tests
                 )
 set_target_properties(MAPL.pfio.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 set_tests_properties(MAPL.pfio.tests PROPERTIES LABELS "ESSENTIAL")
+set_tests_properties(MAPL.pfio.tests PROPERTIES PROCESSORS 8)
 
 include_directories(
    ${CMAKE_CURRENT_SOURCE_DIR}
@@ -110,6 +111,12 @@ set (pfio_tests
 foreach (test ${pfio_tests})
   set_tests_properties (${test} PROPERTIES LABELS "PERFORMANCE")
 endforeach ()
+
+set_tests_properties(pFIO_tests_mpi PROPERTIES PROCESSORS 18 RESOURCE_LOCK pfio_ctest_io)
+set_tests_properties(pFIO_tests_simple PROPERTIES PROCESSORS 24 RESOURCE_LOCK pfio_ctest_io)
+set_tests_properties(pFIO_tests_hybrid PROPERTIES PROCESSORS 12 RESOURCE_LOCK pfio_ctest_io)
+set_tests_properties(pFIO_tests_mpi_2comm PROPERTIES PROCESSORS 18 RESOURCE_LOCK pfio_ctest_io)
+set_tests_properties(pFIO_tests_mpi_2group PROPERTIES PROCESSORS 18 RESOURCE_LOCK pfio_ctest_io)
 
 #if (APPLE)
 #  set_tests_properties (pFIO_tests_mpi_2layer PROPERTIES DISABLED True)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

I talked with ChatGPT about why `ctest -jN` can be slower in parallel. In the end, it's main thought was to add some ctest metadata so that ctest knows some of the pfio tests are big. This way, it knows not to schedule them at the same time to not have resource contention.

## Related Issue

