### PR TITLE
Add simplified build system with meta-modules and wrapper scripts

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,127 @@
+# MAPL Build System
+
+This directory contains simplified build and test scripts for MAPL development.
+
+## Quick Start
+
+### Building MAPL
+
+```bash
+./build.sh [compiler] [build_type]
+```
+
+**Examples:**
+```bash
+# Build with NAG compiler (Debug mode, default)
+./build.sh nag
+
+# Build with GFortran compiler (Debug mode)
+./build.sh gfortran
+
+# Build with NAG compiler (Release mode)
+./build.sh nag Release
+```
+
+### Running Tests
+
+```bash
+./test.sh [compiler] [test_pattern]
+```
+
+**Examples:**
+```bash
+# Run all tests with NAG compiler
+./test.sh nag
+
+# Run all tests with GFortran compiler
+./test.sh gfortran
+
+# Run specific test(s) matching pattern
+./test.sh nag ConservationAspect
+```
+
+## How It Works
+
+The build system uses **meta-modules** (compiler stacks) and **wrapper scripts** to simplify the workflow:
+
+### Meta-Modules
+
+- `nag-stack` - Loads NAG compiler + OpenMPI + baselibs
+- `gfortran-stack` - Loads GFortran compiler + OpenMPI + baselibs
+- `ifort-stack` - Loads Intel Fortran compiler + OpenMPI + baselibs
+
+These meta-modules automatically handle:
+- `module purge` and `module load` sequences
+- Compiler dependencies (e.g., NAG requires clang)
+- MPI configuration
+- Baselibs setup
+
+### Wrapper Scripts
+
+**`build.sh`**:
+- Loads the appropriate compiler stack module
+- Creates build directory (`build-<compiler>`)
+- Configures CMake with appropriate settings
+- Builds the project
+
+**`test.sh`**:
+- Loads the appropriate compiler stack module
+- Uses `ctest` to run tests (automatically handles DYLD_LIBRARY_PATH on macOS)
+- Supports test filtering with regex patterns
+
+## Build Directories
+
+By convention, builds are organized by compiler:
+- `build-nag/` - NAG compiler builds
+- `build-gfortran/` - GFortran compiler builds
+- `build-ifort/` - Intel compiler builds
+
+## Manual Module Loading
+
+If you need more control, you can still use modules manually:
+
+```bash
+module purge
+module load nag-stack
+cmake -B build-nag -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-nag -j8
+```
+
+## Supported Compilers
+
+- **nag** - NAG Fortran compiler (default: 7.2.41)
+- **gfortran** - GNU Fortran compiler (default: 15.2.0)
+- **ifort** - Intel Fortran compiler
+
+## System Requirements
+
+- Lmod module system
+- CMake 3.12+
+- Appropriate compiler stack modules installed
+
+## Troubleshooting
+
+**"Module not found" errors:**
+- Ensure you have the meta-modules installed in `~/modulefiles/core/`
+- Check `module avail` to see available modules
+
+**Build failures:**
+- Check that all dependencies are loaded: `module list`
+- Verify the build directory is clean or rebuild from scratch
+
+**Test failures on macOS:**
+- The `test.sh` script uses `ctest` which automatically handles DYLD_LIBRARY_PATH
+- If running tests manually, ensure proper library paths are set
+
+## For AI Agents
+
+The simplified workflow is designed to reduce cognitive load:
+
+1. **To build**: `./build.sh <compiler>`
+2. **To test**: `./test.sh <compiler>`
+
+No need to remember:
+- Module loading sequences
+- DYLD_LIBRARY_PATH settings
+- CMake configuration options
+- Build directory naming conventions

--- a/BUILD.md
+++ b/BUILD.md
@@ -96,7 +96,7 @@ cmake --build build-nag -j8
 ## System Requirements
 
 - Lmod module system
-- CMake 3.12+
+- CMake 3.24+
 - Appropriate compiler stack modules installed
 
 ## Troubleshooting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add simplified build system with wrapper scripts (`build.sh` and `test.sh`) for easier compilation with different compilers
+  - Uses modern CMake syntax (`-B`, `-S`, `--install-prefix`, `--test-dir`)
+  - Supports NAG, gfortran, and Intel compilers via meta-module stacks
+  - Compiler-specific build and install directories
+  - Full path handling for improved safety
+
 ### Changed
 
 - Update `components.yaml` to match GEOSgcm v12

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# MAPL build wrapper script
+# Simplifies building with different compilers by handling module loading
+
+set -e
+
+# Default values
+COMPILER="${1:-nag}"
+BUILD_TYPE="${2:-Debug}"
+BUILD_DIR="build-${COMPILER}"
+
+# Supported compilers
+SUPPORTED_COMPILERS="nag gfortran ifort"
+
+# Check if compiler is supported
+if [[ ! " $SUPPORTED_COMPILERS " =~ " $COMPILER " ]]; then
+    echo "Error: Unsupported compiler '$COMPILER'"
+    echo "Supported compilers: $SUPPORTED_COMPILERS"
+    exit 1
+fi
+
+echo "========================================="
+echo "MAPL Build Configuration"
+echo "========================================="
+echo "Compiler:    $COMPILER"
+echo "Build Type:  $BUILD_TYPE"
+echo "Build Dir:   $BUILD_DIR"
+echo "========================================="
+
+# Load the appropriate compiler stack
+echo "Loading ${COMPILER}-stack module..."
+module purge
+module load ${COMPILER}-stack
+
+echo ""
+echo "Loaded modules:"
+module list
+
+# Create build directory
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Configure with CMake
+echo ""
+echo "Configuring with CMake..."
+cmake .. \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DCMAKE_INSTALL_PREFIX=../install
+
+# Build
+echo ""
+echo "Building..."
+cmake --build . -j8
+
+echo ""
+echo "========================================="
+echo "Build completed successfully!"
+echo "========================================="
+echo "Build directory: $BUILD_DIR"
+echo "To run tests: ./test.sh $COMPILER"

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,16 @@ set -e
 # Default values
 COMPILER="${1:-nag}"
 BUILD_TYPE="${2:-Debug}"
-BUILD_DIR="build-${COMPILER}"
+INSTALL_PREFIX="${3:-}"
+
+# Use full paths for safety
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SOURCE_DIR}/build-${COMPILER}"
+if [[ -z "$INSTALL_PREFIX" ]]; then
+    INSTALL_DIR="${SOURCE_DIR}/install-${COMPILER}"
+else
+    INSTALL_DIR="$INSTALL_PREFIX"
+fi
 
 # Supported compilers
 SUPPORTED_COMPILERS="nag gfortran ifort"
@@ -25,6 +34,7 @@ echo "========================================="
 echo "Compiler:    $COMPILER"
 echo "Build Type:  $BUILD_TYPE"
 echo "Build Dir:   $BUILD_DIR"
+echo "Install Dir: $INSTALL_DIR"
 echo "========================================="
 
 # Load the appropriate compiler stack
@@ -36,25 +46,24 @@ echo ""
 echo "Loaded modules:"
 module list
 
-# Create build directory
-mkdir -p "$BUILD_DIR"
-cd "$BUILD_DIR"
-
-# Configure with CMake
+# Configure with CMake (modern syntax)
 echo ""
 echo "Configuring with CMake..."
-cmake .. \
-    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-    -DCMAKE_INSTALL_PREFIX=../install
+cmake -B "${BUILD_DIR}" \
+      -S "${SOURCE_DIR}" \
+      --install-prefix="${INSTALL_DIR}" \
+      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
 
 # Build
 echo ""
 echo "Building..."
-cmake --build . -j8
+cmake --build "${BUILD_DIR}" --parallel 8
 
 echo ""
 echo "========================================="
 echo "Build completed successfully!"
 echo "========================================="
 echo "Build directory: $BUILD_DIR"
+echo "Install directory: $INSTALL_DIR"
 echo "To run tests: ./test.sh $COMPILER"
+echo "To install: cmake --build ${BUILD_DIR} --target install"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# MAPL test wrapper script
+# Simplifies running tests with different compilers
+
+set -e
+
+# Default values
+COMPILER="${1:-nag}"
+TEST_PATTERN="${2:-}"
+BUILD_DIR="build-${COMPILER}"
+
+# Supported compilers
+SUPPORTED_COMPILERS="nag gfortran ifort"
+
+# Check if compiler is supported
+if [[ ! " $SUPPORTED_COMPILERS " =~ " $COMPILER " ]]; then
+    echo "Error: Unsupported compiler '$COMPILER'"
+    echo "Supported compilers: $SUPPORTED_COMPILERS"
+    exit 1
+fi
+
+# Check if build directory exists
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "Error: Build directory '$BUILD_DIR' does not exist"
+    echo "Please run './build.sh $COMPILER' first"
+    exit 1
+fi
+
+echo "========================================="
+echo "MAPL Test Configuration"
+echo "========================================="
+echo "Compiler:      $COMPILER"
+echo "Build Dir:     $BUILD_DIR"
+if [[ -n "$TEST_PATTERN" ]]; then
+    echo "Test Pattern:  $TEST_PATTERN"
+fi
+echo "========================================="
+
+# Load the appropriate compiler stack
+echo "Loading ${COMPILER}-stack module..."
+module purge
+module load ${COMPILER}-stack
+
+echo ""
+echo "Loaded modules:"
+module list
+
+# Change to build directory
+cd "$BUILD_DIR"
+
+# Run tests using ctest
+echo ""
+echo "Running tests..."
+if [[ -n "$TEST_PATTERN" ]]; then
+    ctest --output-on-failure -R "$TEST_PATTERN"
+else
+    ctest --output-on-failure
+fi
+
+echo ""
+echo "========================================="
+echo "Tests completed!"
+echo "========================================="

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,10 @@ set -e
 # Default values
 COMPILER="${1:-nag}"
 TEST_PATTERN="${2:-}"
-BUILD_DIR="build-${COMPILER}"
+
+# Use full paths for safety
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SOURCE_DIR}/build-${COMPILER}"
 
 # Supported compilers
 SUPPORTED_COMPILERS="nag gfortran ifort"
@@ -45,16 +48,13 @@ echo ""
 echo "Loaded modules:"
 module list
 
-# Change to build directory
-cd "$BUILD_DIR"
-
-# Run tests using ctest
+# Run tests using ctest (modern syntax with --test-dir)
 echo ""
 echo "Running tests..."
 if [[ -n "$TEST_PATTERN" ]]; then
-    ctest --output-on-failure -R "$TEST_PATTERN"
+    ctest --test-dir "${BUILD_DIR}" --output-on-failure -R "$TEST_PATTERN"
 else
-    ctest --output-on-failure
+    ctest --test-dir "${BUILD_DIR}" --output-on-failure
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

This PR introduces a simplified build system for MAPL that reduces cognitive load for both developers and AI agents by providing meta-modules and wrapper scripts.

## Changes

### Wrapper Scripts
- **`build.sh`** - Simple build wrapper: `./build.sh [compiler] [build_type]`
- **`test.sh`** - Simple test wrapper: `./test.sh [compiler] [test_pattern]`
- **`BUILD.md`** - Comprehensive documentation

### Meta-Modules (Created in `~/modulefiles/core/`)
- **`nag-stack`** - Loads NAG + OpenMPI + baselibs
- **`gfortran-stack`** - Loads GFortran + OpenMPI + baselibs

## Benefits

**Before:**
```bash
module purge
module load nag/7.2.41
module load openmpi/5.0.5
module load baselibs/9.7.0
mkdir -p build-nag
cd build-nag
cmake .. -DCMAKE_BUILD_TYPE=Debug
cmake --build . -j8
# For tests: remember to set DYLD_LIBRARY_PATH...
```

**After:**
```bash
./build.sh nag
./test.sh nag
```

## Key Features

- Automatic module loading (no need to remember sequences)
- Automatic DYLD_LIBRARY_PATH handling via ctest
- Consistent build directory naming
- Support for test filtering
- Clear error messages

## Related Issues

- Partially addresses #4511 (wrapper scripts and meta-modules complete)
- Skill documentation update tracked separately in #4511

## Testing

Meta-modules tested and confirmed working:
```bash
module load nag-stack      # ✓ Loads all dependencies
module load gfortran-stack # ✓ Loads all dependencies
```

Scripts tested for proper module loading and error handling.