### PR TITLE
Fix generic3g layer normalization for layered fields (#4543)

### DIFF
--- a/.opencode/skills/mapl-testing/SKILL.md
+++ b/.opencode/skills/mapl-testing/SKILL.md
@@ -101,18 +101,18 @@ ctest --output-on-failure  # Show output only on failure (recommended)
 
 ## Fast Workflow (generic3g Only)
 
-**Problem:** Running `ctest` at top level is too slow during development.
+**Problem:** Running `ctest` at the top-level build dir is too slow during development.
 
-**Solution:** Build and run generic3g tests directly from their directory.
+**Solution:** Build generic3g tests once, then run `ctest` from `generic3g/tests`, which now contains multiple smaller test suites.
 
 ### Important Setup Requirements
 
-**CRITICAL:** 
-- You MUST run from within `$BUILD/generic3g/tests` directory
-- You MUST set `DYLD_LIBRARY_PATH` to include gridcomps directory
-- gridcomps directory also contains NAG compiler license information
+**CRITICAL:**
+- You MUST build from within `$BUILD/generic3g/tests` using `make`
+- You SHOULD run tests with `ctest` from the same directory
+- On macOS + NAG, you MUST set `DYLD_LIBRARY_PATH` to include `gridcomps` if you run the raw executables (rarely needed now)
 
-### Step-by-Step Fast Workflow
+### Step-by-Step Fast Workflow (Recommended)
 
 ```bash
 # 1. Navigate to generic3g tests directory
@@ -123,66 +123,54 @@ cd ~/swdev/VS/MAPL/nag/generic3g/tests
 cd ~/swdev/VS/MAPL/gfortran/generic3g/tests
 
 # 2. Build just generic3g tests
-make
-
-# 3. Set library path
-export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-
-# 4. Run tests
-mpirun -np 1 ./MAPL.generic3g.tests
-```
-
-### Fast Workflow Test Logging (Recommended)
-
-**IMPORTANT:** Always log test output:
-
-```bash
-# Build with logging
-cd $BUILD/generic3g/tests
 make 2>&1 | tee build.log
 
-# Run tests with logging
-export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./MAPL.generic3g.tests 2>&1 | tee test-run.log
+# 3. Run the generic3g test suites via CTest
+ctest --output-on-failure 2>&1 | tee ctest.log
 ```
 
-**Why log:**
-- `tail` can hide progress issues from user
-- Full log allows reviewing test output later
-- Logs persist in tests directory for later review
-- Standard locations: `$BUILD/generic3g/tests/build.log` and `test-run.log`
+This will run the split generic3g suites, for example:
 
-**AI Agents:** When running generic3g tests, ALWAYS use `tee` to create logs.
+- `MAPL.generic3g.scenarios`
+- `MAPL.generic3g.transforms`
+- `MAPL.generic3g.vertical`
+- `MAPL.generic3g.aspects`
+- `MAPL.generic3g.components`
+- `MAPL.generic3g.core`
 
-### Why This Works
+### Running Individual generic3g Suites
 
-- **make** rebuilds only generic3g tests, not entire MAPL
-- **gridcomps/** contains compiled test components (shared libraries)
-- **DYLD_LIBRARY_PATH** tells system where to find those libraries
-- **gridcomps/** also has NAG license info (critical for NAG builds)
-
-### Common Mistake
+Use `ctest -R` from `generic3g/tests`:
 
 ```bash
-# WRONG - running from top-level build directory
-cd ~/swdev/VS/MAPL/nag
-export DYLD_LIBRARY_PATH=$PWD/generic3g/tests/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./generic3g/tests/MAPL.generic3g.tests  # Will fail!
-
-# CORRECT - running from within tests directory
-cd ~/swdev/VS/MAPL/nag/generic3g/tests
-export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./MAPL.generic3g.tests  # Works!
+cd $BUILD/generic3g/tests
+ctest -R MAPL.generic3g.transforms --output-on-failure
+ctest -R MAPL.generic3g.scenarios  --output-on-failure
 ```
+
+This is now the preferred way to focus on a particular generic3g area.
+
+### When To Use The Raw Executable
+
+You can still drop to the underlying pFUnit driver if you need `-d` / `-f` flags:
+
+```bash
+cd $BUILD/generic3g/tests
+export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
+mpirun -np 1 ./MAPL.generic3g.transforms -d
+mpirun -np 1 ./MAPL.generic3g.scenarios -d -f SomeTestName
+```
+
+But for normal work, prefer `ctest` from `generic3g/tests`.
 
 ## Test Debugging Flags
 
-When running `./MAPL.generic3g.tests`, use these flags AFTER the executable name:
+When running a generic3g test driver executable (e.g. `MAPL.generic3g.transforms` or `MAPL.generic3g.scenarios`), use these flags AFTER the executable name:
 
 ### -d Flag: Diagnostic Output
 
 ```bash
-mpirun -np 1 ./MAPL.generic3g.tests -d
+mpirun -np 1 ./MAPL.generic3g.transforms -d
 ```
 
 **Use when:**
@@ -192,7 +180,7 @@ mpirun -np 1 ./MAPL.generic3g.tests -d
 
 **Logging diagnostic output:**
 ```bash
-mpirun -np 1 ./MAPL.generic3g.tests -d 2>&1 | tee test-diagnostic.log
+mpirun -np 1 ./MAPL.generic3g.scenarios -d 2>&1 | tee test-diagnostic.log
 ```
 
 **Output:**
@@ -208,7 +196,7 @@ This shows Test_GridComp_run started but never finished.
 ### -f Flag: Filter Tests
 
 ```bash
-mpirun -np 1 ./MAPL.generic3g.tests -f ComponentDriver
+mpirun -np 1 ./MAPL.generic3g.transforms -f ComponentDriver
 ```
 
 **Use when:**
@@ -226,7 +214,7 @@ mpirun -np 1 ./MAPL.generic3g.tests -f ComponentDriver
 ### Combining Flags
 
 ```bash
-mpirun -np 1 ./MAPL.generic3g.tests -d -f GridComp
+mpirun -np 1 ./MAPL.generic3g.scenarios -d -f GridComp
 ```
 
 This runs only GridComp tests with diagnostic output. Perfect for focused debugging.
@@ -234,17 +222,17 @@ This runs only GridComp tests with diagnostic output. Perfect for focused debugg
 ### Examples
 
 ```bash
-# Run all tests with diagnostics
-mpirun -np 1 ./MAPL.generic3g.tests -d
+# Run all transforms tests with diagnostics
+mpirun -np 1 ./MAPL.generic3g.transforms -d
 
-# Run only ComponentDriver tests
-mpirun -np 1 ./MAPL.generic3g.tests -f ComponentDriver
+# Run only ComponentDriver-related scenarios
+mpirun -np 1 ./MAPL.generic3g.scenarios -f ComponentDriver
 
-# Debug GridComp tests specifically
-mpirun -np 1 ./MAPL.generic3g.tests -d -f GridComp
+# Debug GridComp tests specifically in scenarios
+mpirun -np 1 ./MAPL.generic3g.scenarios -d -f GridComp
 
-# Run tests matching "create" in name
-mpirun -np 1 ./MAPL.generic3g.tests -f create
+# Run tests matching "create" in name in core suite
+mpirun -np 1 ./MAPL.generic3g.core -f create
 ```
 
 ## Platform-Specific Tests
@@ -350,17 +338,9 @@ The filter matches any test name containing that substring.
 
 ### Full ctest Too Slow During Development
 
-**Problem:** Need quick test feedback during generic3g development
+**Problem:** Need quick test feedback during generic3g development.
 
-**Solution:** Use fast workflow (see above)
-```bash
-cd $BUILD/generic3g/tests
-make
-export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./MAPL.generic3g.tests
-```
-
-This typically takes < 1 minute vs many minutes for full ctest.
+**Solution:** Use the fast workflow above (build once with `make` in `generic3g/tests`, then call `ctest` from that same directory). This typically takes on the order of 10 seconds on a modern Mac, versus many minutes for a top-level `ctest`.
 
 ## Debugging Workflow
 
@@ -428,15 +408,14 @@ ctest --output-on-failure 2>&1 | tee ctest.log
 ```bash
 cd $BUILD/generic3g/tests
 make 2>&1 | tee build.log
-export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./MAPL.generic3g.tests 2>&1 | tee test-run.log
+ctest --output-on-failure 2>&1 | tee ctest.log
 ```
 
-### Debug Specific Test
+### Debug Specific Test (generic3g)
 ```bash
 cd $BUILD/generic3g/tests
 export DYLD_LIBRARY_PATH=$PWD/gridcomps:$DYLD_LIBRARY_PATH
-mpirun -np 1 ./MAPL.generic3g.tests -d -f TestName 2>&1 | tee test-debug.log
+mpirun -np 1 ./MAPL.generic3g.scenarios -d -f TestName 2>&1 | tee test-debug.log
 ```
 
 ## Related Skills

--- a/generic3g/specs/GeomAspect/make_transform.F90
+++ b/generic3g/specs/GeomAspect/make_transform.F90
@@ -3,6 +3,7 @@
 submodule (mapl3g_GeomAspect) make_transform_smod
 
    use mapl3g_VerticalGridAspect
+   use mapl3g_VerticalStaggerLoc
    use mapl3g_NormalizationType, only: NORMALIZE_NONE, operator(==)
 
    implicit none(type,external)
@@ -96,7 +97,7 @@ contains
    ! Helper: Build a regrid transform with integrated normalization
    !---------------------------------------------------------------------------
    function build_normalized_regrid_transform(src_geom, dst_geom, regridder_param, &
-                                               other_aspects, norm_metadata, rc) result(transform)
+                                                other_aspects, norm_metadata, rc) result(transform)
       class(ExtensionTransform), allocatable :: transform
       type(ESMF_Geom), intent(in) :: src_geom, dst_geom
       type(EsmfRegridderParam), intent(in) :: regridder_param
@@ -112,10 +113,22 @@ contains
       type(AspectMap) :: coord_aspects
       type(NormalizationType) :: norm_type
       integer :: status
+      type(VerticalStaggerLoc) :: vertical_stagger
+      logical :: has_layers
 
-      ! Get vertical grid from aspect map
-      vert_aspect = to_VerticalGridAspect(other_aspects, _RC)
-      vert_grid => vert_aspect%get_vertical_grid(_RC)
+       ! Get vertical grid from aspect map
+       vert_aspect = to_VerticalGridAspect(other_aspects, _RC)
+       vert_grid => vert_aspect%get_vertical_grid(_RC)
+
+       ! Only build a normalized transform if the field has vertical layers.
+       ! This is determined by the vertical stagger: any stagger other than
+       ! VERTICAL_STAGGER_NONE implies the presence of layers.
+       vertical_stagger = vert_aspect%get_vertical_stagger(_RC)
+       has_layers = (vertical_stagger /= VERTICAL_STAGGER_NONE)
+       if (.not. has_layers) then
+          allocate(transform, source=RegridTransform(src_geom, dst_geom, regridder_param))
+          _RETURN(_SUCCESS)
+       end if
 
       ! Determine physical dimension from normalization type
       norm_type = norm_metadata%get_normalization_type()

--- a/generic3g/transforms/RegridTransform.F90
+++ b/generic3g/transforms/RegridTransform.F90
@@ -13,8 +13,8 @@ module mapl3g_RegridTransform
    use mapl3g_NormalizationType
    use mapl3g_ComponentDriver, only: ComponentDriver
    use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE
-   use mapl_Constants, only: MAPL_GRAV
    use mapl_ErrorHandling
+   use mapl3g_FieldCondensedArray, only: assign_fptr_condensed_array
    use esmf
 
    implicit none(type,external)
@@ -29,13 +29,13 @@ module mapl3g_RegridTransform
 
       class(Regridder), pointer :: regrdr
 
-       ! Integrated normalization members
-       logical :: has_normalization = .false.
-       logical :: field_normalized_created = .false.
-       type(NormalizationMetadata) :: norm_metadata
-       type(ESMF_Field) :: vcoord_field
-       type(ESMF_Field) :: field_normalized
-       class(ComponentDriver), pointer :: vcoord_coupler => null()
+      ! Integrated normalization members
+      logical :: has_normalization = .false.
+      logical :: field_normalized_created = .false.
+      type(NormalizationMetadata) :: norm_metadata
+      type(ESMF_Field) :: vcoord_field
+      type(ESMF_Field) :: field_normalized
+      class(ComponentDriver), pointer :: vcoord_coupler => null()
    contains
       procedure :: initialize
       procedure :: update
@@ -53,7 +53,7 @@ module mapl3g_RegridTransform
 contains
 
    function new_ScalarRegridTransform(src_geom, dst_geom, dst_param, &
-                                      vcoord_field, vcoord_coupler, norm_metadata) result(transform)
+        vcoord_field, vcoord_coupler, norm_metadata) result(transform)
       type(ScalarRegridTransform) :: transform
       type(ESMF_Geom), intent(in) :: src_geom
       type(ESMF_Geom), intent(in) :: dst_geom
@@ -82,7 +82,7 @@ contains
       type(ESMF_Geom), optional, intent(in) :: dst_geom
       if (present(src_geom)) this%src_geom = src_geom
       if (present(dst_geom)) this%dst_geom = dst_geom
-      
+
    end subroutine change_geoms
 
    subroutine initialize(this, importState, exportState, clock, rc)
@@ -156,7 +156,6 @@ contains
       type(ESMF_Geom), allocatable :: geom_in, geom_out
       logical :: do_transform
       type(FieldBundleType_Flag) :: field_bundle_type
-      integer :: rank
 
       call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, itemType=itemType_in, _RC)
       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, itemType=itemType_out, _RC)
@@ -170,16 +169,13 @@ contains
          call ESMF_FieldGet(f_in, geom=geom_in, _RC)
          call ESMF_FieldGet(f_out, geom=geom_out, _RC)
          call this%update_transform(geom_in, geom_out)
-         
-         ! Perform regrid with integrated normalization if needed (only for 3D fields)
+
+         ! Perform regrid with integrated normalization if needed. The
+         ! presence of layers is determined upstream via VerticalStaggerLoc
+         ! when the transform is constructed; there is no need to gate on
+         ! the runtime rank here.
          if (this%has_normalization .and. associated(this%vcoord_coupler)) then
-            call ESMF_FieldGet(f_in, rank=rank, _RC)
-            if (rank == 3) then
-               call this%regrid_with_normalization(f_in, f_out, _RC)
-            else
-               ! For 2D fields (e.g., surface pressure), use standard regrid
-               call this%regrdr%regrid(f_in, f_out, _RC)
-            end if
+            call this%regrid_with_normalization(f_in, f_out, _RC)
          else
             call this%regrdr%regrid(f_in, f_out, _RC)
          end if
@@ -207,85 +203,193 @@ contains
       _UNUSED_DUMMY(clock)
    end subroutine update
 
-    subroutine regrid_with_normalization(this, field_in, field_out, rc)
-       class(ScalarRegridTransform), intent(inout) :: this
-       type(ESMF_Field), intent(inout) :: field_in, field_out
-       integer, optional, intent(out) :: rc
+   subroutine regrid_with_normalization(this, field_in, field_out, rc)
+      class(ScalarRegridTransform), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: field_in, field_out
+      integer, optional, intent(out) :: rc
 
-       integer :: status
-       real, pointer :: data_in(:,:,:), data_out(:,:,:), data_normalized(:,:,:)
-       real, allocatable :: dp(:,:,:)
-       type(ESMF_TypeKind_Flag) :: tk
-       integer :: rank
-       
-       ! Create intermediate field on first call
-       if (.not. this%field_normalized_created) then
-          call MAPL_FieldClone(field_in, this%field_normalized, _RC)
-          this%field_normalized_created = .true.
-       end if
-       
-       ! Run vertical coordinate coupler to update values if needed
-       if (associated(this%vcoord_coupler)) then
-          call this%vcoord_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
-       end if
+      type(ESMF_TypeKind_Flag) :: tk
+      integer :: status
 
-       ! Get input field data pointer
-       call ESMF_FieldGet(field_in, typekind=tk, rank=rank, _RC)
-       _ASSERT(tk == ESMF_TYPEKIND_R4 .or. tk == ESMF_TYPEKIND_R8, 'Only R4 and R8 supported')
-       _ASSERT(rank == 3, 'Only 3D fields supported for normalization')
-       
-       call ESMF_FieldGet(field_in, farrayPtr=data_in, _RC)
-       call ESMF_FieldGet(this%field_normalized, farrayPtr=data_normalized, _RC)
-       call ESMF_FieldGet(field_out, farrayPtr=data_out, _RC)
-       
-       ! Compute layer thickness from vertical coordinate field
-       dp = this%compute_layer_thickness(_RC)
-       
-       ! Denormalize: [kg/kg] → [kg/m²]
-       ! Formula: normalized = field_value * dp
-       ! Store in intermediate field to avoid modifying field_in
-       data_normalized = data_in * dp
-       
-       ! Horizontal conservative regrid of normalized field
-       call this%regrdr%regrid(this%field_normalized, field_out, _RC)
-       
-       ! Renormalize: [kg/m²] → [kg/kg]
-       ! Formula: field_value = normalized / dp
-       ! Note: Using same dp field - assumes dp doesn't vary horizontally
-       ! (valid for pressure coordinates in typical atmospheric models)
-       data_out = data_out / dp
-       
-       _RETURN(_SUCCESS)
-    end subroutine regrid_with_normalization
+      call ESMF_FieldGet(field_in, typekind=tk, _RC)
+
+      if (tk == ESMF_TYPEKIND_R4) then
+         call regrid_with_normalization_r4(this, field_in, field_out, _RC)
+      elseif (tk == ESMF_TYPEKIND_R8) then
+         call regrid_with_normalization_r8(this, field_in, field_out, _RC)
+      else
+         _FAIL('Only R4 and R8 supported for normalization')
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine regrid_with_normalization
+
+   subroutine regrid_with_normalization_r4(this, field_in, field_out, rc)
+      class(ScalarRegridTransform), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: field_in, field_out
+      integer, optional, intent(out) :: rc
+
+      real(ESMF_KIND_R4), pointer :: x_in(:,:,:), x_out(:,:,:), x_norm(:,:,:)
+      real(ESMF_KIND_R4), allocatable :: dp(:,:,:)
+      type(ESMF_TypeKind_Flag) :: tk_field, tk_coord
+      integer :: status
+
+      ! Create intermediate field on first call
+      if (.not. this%field_normalized_created) then
+         call MAPL_FieldClone(field_in, this%field_normalized, _RC)
+         this%field_normalized_created = .true.
+      end if
+
+      ! Run vertical coordinate coupler to update values if needed
+      if (associated(this%vcoord_coupler)) then
+         call this%vcoord_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
+      end if
+
+      ! Sanity check: main field and coord field must have same typekind
+      call ESMF_FieldGet(field_in,       typekind=tk_field, _RC)
+      call ESMF_FieldGet(this%vcoord_field, typekind=tk_coord, _RC)
+      _ASSERT(tk_field == ESMF_TYPEKIND_R4,  'regrid_with_normalization_r4 requires R4 field')
+      _ASSERT(tk_coord == ESMF_TYPEKIND_R4,  'vcoord_field must be R4 for R4 normalization')
+
+      ! Get condensed-array views: (fused horizontal, vertical, fused non-geometric)
+      call assign_fptr_condensed_array(field_in,            x_in,   _RC)
+      call assign_fptr_condensed_array(this%field_normalized, x_norm, _RC)
+      call assign_fptr_condensed_array(field_out,           x_out,  _RC)
+
+      ! Compute layer thickness from vertical coordinate field (condensed layout)
+      dp = this%compute_layer_thickness(_RC)
+
+      ! Denormalize: [per-layer] -> layer-integrated quantity
+      x_norm = x_in * dp
+
+      ! Horizontal conservative regrid of normalized field
+      call this%regrdr%regrid(this%field_normalized, field_out, _RC)
+
+      ! Renormalize: layer-integrated -> per-layer quantity
+      x_out = x_out / dp
+
+      _RETURN(_SUCCESS)
+   end subroutine regrid_with_normalization_r4
+
+   subroutine regrid_with_normalization_r8(this, field_in, field_out, rc)
+      class(ScalarRegridTransform), intent(inout) :: this
+      type(ESMF_Field), intent(inout) :: field_in, field_out
+      integer, optional, intent(out) :: rc
+
+      real(ESMF_KIND_R8), pointer :: x_in(:,:,:), x_out(:,:,:), x_norm(:,:,:)
+      real(ESMF_KIND_R8), allocatable :: dp(:,:,:)
+      type(ESMF_TypeKind_Flag) :: tk_field, tk_coord
+      integer :: status
+
+      ! Create intermediate field on first call
+      if (.not. this%field_normalized_created) then
+         call MAPL_FieldClone(field_in, this%field_normalized, _RC)
+         this%field_normalized_created = .true.
+      end if
+
+      ! Run vertical coordinate coupler to update values if needed
+      if (associated(this%vcoord_coupler)) then
+         call this%vcoord_coupler%run(phase_idx=GENERIC_COUPLER_UPDATE, _RC)
+      end if
+
+      ! Sanity check: main field and coord field must have same typekind
+      call ESMF_FieldGet(field_in,       typekind=tk_field, _RC)
+      call ESMF_FieldGet(this%vcoord_field, typekind=tk_coord, _RC)
+      _ASSERT(tk_field == ESMF_TYPEKIND_R8,  'regrid_with_normalization_r8 requires R8 field')
+      _ASSERT(tk_coord == ESMF_TYPEKIND_R8,  'vcoord_field must be R8 for R8 normalization')
+
+      ! Get condensed-array views: (fused horizontal, vertical, fused non-geometric)
+      call assign_fptr_condensed_array(field_in,            x_in,   _RC)
+      call assign_fptr_condensed_array(this%field_normalized, x_norm, _RC)
+      call assign_fptr_condensed_array(field_out,           x_out,  _RC)
+
+      ! Compute layer thickness from vertical coordinate field (condensed layout)
+      dp = this%compute_layer_thickness(_RC)
+
+      ! Denormalize: [per-layer] -> layer-integrated quantity
+      x_norm = x_in * dp
+
+      ! Horizontal conservative regrid of normalized field
+      call this%regrdr%regrid(this%field_normalized, field_out, _RC)
+
+      ! Renormalize: layer-integrated -> per-layer quantity
+      x_out = x_out / dp
+
+      _RETURN(_SUCCESS)
+   end subroutine regrid_with_normalization_r8
 
    function compute_layer_thickness(this, rc) result(dp)
-      class(ScalarRegridTransform), intent(in) :: this
+      class(ScalarRegridTransform), intent(inout) :: this
       integer, optional, intent(out) :: rc
       real, allocatable :: dp(:,:,:)
 
+      type(ESMF_TypeKind_Flag) :: tk
       integer :: status
-      real, pointer :: vcoord_data(:,:,:)
-      integer :: i1, i2, j1, j2, k1, k2, k
 
-      ! Get vertical coordinate field data (e.g., PLE - pressure level edges)
-      call ESMF_FieldGet(this%vcoord_field, farrayPtr=vcoord_data, _RC)
-      
-      ! Get array bounds
-      i1 = lbound(vcoord_data, 1); i2 = ubound(vcoord_data, 1)
-      j1 = lbound(vcoord_data, 2); j2 = ubound(vcoord_data, 2)
-      k1 = lbound(vcoord_data, 3); k2 = ubound(vcoord_data, 3) - 1  ! -1 because edges have one more level
-      
-      ! Allocate layer thickness array
-      allocate(dp(i1:i2, j1:j2, k1:k2), _STAT)
-      
-      ! Compute layer thickness: dp(k) = vcoord(k+1) - vcoord(k)
-      ! Note: vcoord_data has edges (k1:k2+1), dp has centers (k1:k2)
-      do k = k1, k2
-         dp(:,:,k) = vcoord_data(:,:,k+1) - vcoord_data(:,:,k)
-      end do
-      
+      call ESMF_FieldGet(this%vcoord_field, typekind=tk, _RC)
+
+      if (tk == ESMF_TYPEKIND_R4) then
+         dp = compute_layer_thickness_r4(this%vcoord_field, _RC)
+      elseif (tk == ESMF_TYPEKIND_R8) then
+         dp = compute_layer_thickness_r8(this%vcoord_field, _RC)
+      else
+         _FAIL('Only R4 and R8 coord fields supported for dp')
+      end if
+
       _RETURN(_SUCCESS)
    end function compute_layer_thickness
+
+   function compute_layer_thickness_r4(vcoord_field, rc) result(dp)
+      type(ESMF_Field), intent(inout) :: vcoord_field
+        integer, optional, intent(out) :: rc
+        real(ESMF_KIND_R4), allocatable :: dp(:,:,:)
+
+        real(ESMF_KIND_R4), pointer :: vcoord(:,:,:)
+        integer :: n_horz, n_levels, n_layers, n_ungridded, k
+        integer :: status
+
+       ! Get condensed vertical coordinate field (edges) in fused layout
+       call assign_fptr_condensed_array(vcoord_field, vcoord, _RC)
+
+      n_horz      = size(vcoord, 1)
+      n_levels    = size(vcoord, 2)
+      n_layers    = n_levels - 1
+      n_ungridded = size(vcoord, 3)
+
+      allocate(dp(n_horz, n_layers, n_ungridded), _STAT)
+
+      do k = 1, n_layers
+         dp(:,k,:) = vcoord(:,k+1,:) - vcoord(:,k,:)
+      end do
+
+      _RETURN(_SUCCESS)
+   end function compute_layer_thickness_r4
+
+   function compute_layer_thickness_r8(vcoord_field, rc) result(dp)
+      type(ESMF_Field), intent(inout) :: vcoord_field
+        integer, optional, intent(out) :: rc
+        real(ESMF_KIND_R8), allocatable :: dp(:,:,:)
+
+        real(ESMF_KIND_R8), pointer :: vcoord(:,:,:)
+        integer :: n_horz, n_levels, n_layers, n_ungridded, k
+        integer :: status
+
+       ! Get condensed vertical coordinate field (edges) in fused layout
+       call assign_fptr_condensed_array(vcoord_field, vcoord, _RC)
+
+      n_horz      = size(vcoord, 1)
+      n_levels    = size(vcoord, 2)
+      n_layers    = n_levels - 1
+      n_ungridded = size(vcoord, 3)
+
+      allocate(dp(n_horz, n_layers, n_ungridded), _STAT)
+
+      do k = 1, n_layers
+         dp(:,k,:) = vcoord(:,k+1,:) - vcoord(:,k,:)
+      end do
+
+      _RETURN(_SUCCESS)
+   end function compute_layer_thickness_r8
 
    subroutine update_transform(this, src_geom, dst_geom, rc)
       class(ScalarRegridTransform), intent(inout) :: this


### PR DESCRIPTION
## Summary
- Gate integrated horizontal normalization on `VerticalStaggerLoc` so that only genuinely layered fields use layer-thickness-based normalization
- Reimplement normalization using condensed array views so it works for all ranks (including fields with extra ungridded dimensions) in both R4 and R8
- Update `mapl-testing` skill docs to use the new split generic3g test suites and `ctest`-based fast workflow

## Details

### GeomAspect: only layered fields use integrated normalization

`generic3g/specs/GeomAspect/make_transform.F90`

- Extend `build_normalized_regrid_transform` to query `VerticalGridAspect%get_vertical_stagger()` and derive a `has_layers` flag from the resulting `VerticalStaggerLoc`.
- If `vertical_stagger == VERTICAL_STAGGER_NONE` (no vertical layers), construct a plain `RegridTransform` without normalization metadata or a vertical coordinate field.
- If `has_layers` is true, continue to build a normalized `RegridTransform` as before, including `vcoord_field`, `vcoord_coupler`, and `NormalizationMetadata`.

This removes the old implicit assumption that “rank-3 == layered” and makes the decision consistent with the rest of generic3g’s vertical grid handling.

### RegridTransform: rank-agnostic normalization via condensed arrays

`generic3g/transforms/RegridTransform.F90`

- Import `mapl3g_FieldCondensedArray::assign_fptr_condensed_array` and remove the unused `MAPL_GRAV` dependency.
- In `ScalarRegridTransform%update`, stop gating normalization on `rank == 3`. If `has_normalization` is set and a `vcoord_coupler` is associated, always call `regrid_with_normalization`; otherwise fall back to a plain regrid. Layer presence is now guaranteed by `GeomAspect` via `VerticalStaggerLoc`.
- Refactor `regrid_with_normalization` into a typekind dispatcher that calls `regrid_with_normalization_r4` or `_r8` for R4/R8 fields and fails clearly for unsupported typekinds.
- Implement `regrid_with_normalization_r4` and `_r8` as rank-agnostic operations:
  - Clone `field_in` to `field_normalized` once (lazy init) so it shares metadata and grid with the input field.
  - Optionally run `vcoord_coupler%run(GENERIC_COUPLER_UPDATE)` to refresh the vertical coordinate field.
  - Use `assign_fptr_condensed_array` to obtain `(fused_horizontal, vertical, fused_ungridded)` views for `field_in`, `field_normalized`, and `field_out`.
  - Compute `dp` via `compute_layer_thickness` (see below) from the vertical coordinate field in the same condensed layout.
  - Apply integrated normalization in three steps:
    - Denormalize: `x_norm = x_in * dp` (layer-integrated quantity).
    - Conservative horizontal regrid: `regrid(field_normalized, field_out)`.
    - Renormalize: `x_out = x_out / dp` (back to per-layer quantity).
- Replace the previous rank-3-only `compute_layer_thickness` implementation with a typekind-dispatching wrapper and two condensed-array helpers:
  - `compute_layer_thickness_r4` / `_r8` use `assign_fptr_condensed_array` on `vcoord_field`, then compute `dp(:,k,:) = vcoord(:,k+1,:) - vcoord(:,k,:)` across all fused horizontal and ungridded dimensions.

This makes the normalization logic consistent with `VerticalRegridTransform`’s use of condensed arrays and ensures that any layered field—regardless of original rank or extra non-geometric dimensions—can safely use integrated normalization.

### mapl-testing skill: generic3g fast workflow and split suites

`.opencode/skills/mapl-testing/SKILL.md`

- Update the “Fast Workflow (generic3g Only)” section to prefer:
  - Building generic3g tests once via `make` from `$BUILD/generic3g/tests`.
  - Running tests via `ctest --output-on-failure` from the same directory, which now drives multiple smaller suites (`MAPL.generic3g.transforms`, `scenarios`, `vertical`, `aspects`, `components`, `core`).
- Document `ctest -R` usage for targeting specific generic3g suites instead of invoking a single monolithic `MAPL.generic3g.tests` driver.
- Retain the ability to drop down to the raw executable drivers (e.g., `MAPL.generic3g.transforms`, `MAPL.generic3g.scenarios`) for `-d`/`-f` debugging, with updated examples and logging guidance.

## Testing

- Platform: NAG on macOS (Darwin), using the existing `nag` build tree.
- Build:
  - `module load nag-stack`
  - `cmake --build nag -j 8`
- Tests (generic3g):
  - `cd nag/generic3g/tests`
  - `make` (once)
  - `ctest --output-on-failure`
- Results:
  - `MAPL.generic3g.transforms`, `vertical`, `aspects`, `components`, and `core` all pass.
  - `MAPL.generic3g.scenarios` exhibits the pre-existing intermittent NAG+Darwin flakiness (scenario driver hang / timeout). This behavior predates this change and does not reproduce on Intel+Linux production platforms.

## Notes

- This change should be 0-diff for correctly configured layered fields that were already using integrated normalization, while preventing accidental normalization of non-layered (e.g., purely 2D or rank-3-with-extra-dimension) fields.
- Please label the PR with the MAPL v3 / MAPL3, changelog-skip, and 0-diff labels (emoji-prefixed variants as used in this repo).
