### PR TITLE
FakeParent: add ability to configure the execution of two run phases of its children

### DIFF
--- a/gridcomps/FakeParent/FakeParentGridComp.F90
+++ b/gridcomps/FakeParent/FakeParentGridComp.F90
@@ -71,10 +71,10 @@ contains
       has_run_phases = ESMF_HConfigIsDefined(mapl_hconfig, keyString='run_phases', _RC)
       if (has_run_phases) then
          run_phases_hconfig = ESMF_HConfigCreateAt(mapl_hconfig, keyString='run_phases', _RC)
-         has_run1 = ESMF_HConfigIsDefined(run_phases_hconfig, keyString='run1', _RC)
-         if (has_run1) run1 = ESMF_HConfigAsLogical(run_phases_hconfig, keyString='run1', _RC)
-         has_run2 = ESMF_HConfigIsDefined(run_phases_hconfig, keyString='run2', _RC)
-         if (has_run2) run2 = ESMF_HConfigAsLogical(run_phases_hconfig, keyString='run2', _RC)
+         has_run1 = ESMF_HConfigIsDefined(run_phases_hconfig, keyString='Run1', _RC)
+         if (has_run1) run1 = ESMF_HConfigAsLogical(run_phases_hconfig, keyString='Run1', _RC)
+         has_run2 = ESMF_HConfigIsDefined(run_phases_hconfig, keyString='Run2', _RC)
+         if (has_run2) run2 = ESMF_HConfigAsLogical(run_phases_hconfig, keyString='Run2', _RC)
          call ESMF_HConfigDestroy(run_phases_hconfig, _RC)
       end if
       call ESMF_HConfigDestroy(mapl_hconfig, _RC)

--- a/gridcomps/FakeParent/fake-parent-example.yaml
+++ b/gridcomps/FakeParent/fake-parent-example.yaml
@@ -2,8 +2,8 @@
 mapl:
 
   run_phases:
-    run1: false
-    run2: true
+    Run1: false
+    Run2: true
 
   geometry:
     esmf_geom:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Summary
FakeParent behavior was hard-coded for two run phases of its children. This change allows phase selection via configuration, improving flexibility and keeping behavior explicit in YAML.

## Changes

- Updated `gridcomps/FakeParent/FakeParentGridComp.F90`
  - Reads `mapl.run_phases.Run1` and `mapl.run_phases.Run2` from HConfig. Defaults 
    - `Run1: false`
    - `Run2: true`
  - Executes `Run1` and `Run2` conditionally
- Added `gridcomps/FakeParent/fake-parent-example.yaml`
  - Example YAML showing expected `mapl.run_phases` layout

## Related Issue

