### PR TITLE
Add CDash nightly workflow

### DIFF
--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -1,0 +1,81 @@
+name: CDash Nightly
+
+on:
+  # Run nightly at 06:00 UTC
+  schedule:
+    - cron: '0 6 * * *'
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+    inputs:
+      model:
+        description: 'CTest dashboard model'
+        required: false
+        default: 'Nightly'
+        type: choice
+        options:
+          - Nightly
+          - Experimental
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cdash:
+    name: CDash / gfortran-15 / ${{ matrix.cmake-build-type }}
+    runs-on: ubuntu-latest
+    container:
+      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-build-type: [Release, Debug]
+    env:
+      OMPI_ALLOW_RUN_AS_ROOT: 1
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+      OMPI_MCA_btl_vader_single_copy_mechanism: none
+      # Tell the dashboard script which build type and model to use
+      CTEST_MODEL: ${{ inputs.model || 'Nightly' }}
+      CTEST_BUILD_TYPE: ${{ matrix.cmake-build-type }}
+      # Extra cmake args picked up by CTestDashboard.cmake
+      CTEST_EXTRA_CMAKE_ARGS: >-
+        -DCMAKE_Fortran_COMPILER=gfortran
+        -DUSE_F2PY=OFF
+        -DMPIEXEC_PREFLAGS=--oversubscribe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Set all directories as git safe
+        shell: bash
+        run: git config --global --add safe.directory '*'
+
+      - name: Install CMake 4.3
+        shell: bash
+        run: |
+          pip install --quiet cmake==4.3.1
+          cmake --version
+
+      - name: Mepo clone external repos
+        shell: bash
+        run: |
+          mepo clone --partial blobless
+          mepo status
+
+      - name: Run CDash dashboard
+        shell: bash
+        env:
+          CDASH_AUTH_TOKEN: ${{ secrets.CDASH_AUTH_TOKEN }}
+        run: |
+          ctest \
+            -D model=${CTEST_MODEL} \
+            -D build_type=${CTEST_BUILD_TYPE} \
+            -D generator="Unix Makefiles" \
+            -D jobs=4 \
+            -D build_name="GHA-ubuntu24-gfortran15-${CTEST_BUILD_TYPE}" \
+            -S CTestDashboard.cmake \
+            -V


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cdash-nightly.yml` to enable CDash nightly CI submissions

## Notes

- Scheduled runs (`cron`) only execute on `release/MAPL-v3`; `workflow_dispatch` can be triggered manually on any branch
- Requires a `CDASH_AUTH_TOKEN` repository secret to be set for CDash submission
- This file is added to `main` so that `workflow_dispatch` is available in the Actions UI; the full CDash infrastructure (`CTestConfig.cmake`, `CTestDashboard.cmake`, `CTestCustom.cmake`) is being added separately via PR #4586 targeting `release/MAPL-v3`

## Types of change(s)
- [x] New feature (non-breaking change which adds functionality)