### PR TITLE
Make FieldDictionary lookup opt-in per variable

### DIFF
--- a/docs/mapl3/field_dictionary_developer.md
+++ b/docs/mapl3/field_dictionary_developer.md
@@ -291,58 +291,95 @@ before the caller could check the status, causing every test suite to fail.
 
 The per-field dictionary lookup is performed in
 `generic3g/specs/VariableSpec.F90` inside the `make_VariableSpec` function.
-`parse_var_specs` is restored to baseline and contains no field dictionary
-logic.
+Lookup is **opt-in**: it is only triggered when `use_field_dictionary=.true.`
+is passed to `make_VariableSpec`.  The flag defaults to `.false.`, so existing
+callers are entirely unaffected.
 
-### Lookup logic (inside `make_VariableSpec`)
+### `VariableSpec` member
 
 ```fortran
-if (present(standard_name)) then
-   ! Skip compound vector names of the form "(eastward_wind,northward_wind)"
-   if (index(standard_name, '(') == 0) then
-      fd => get_field_dictionary()          ! pointer to module singleton
-      if (fd%has_item(standard_name)) then
-         dict_item = fd%get_item(standard_name, rc)
+type VariableSpec
+   ...
+   logical :: use_field_dictionary = .false.
+   ...
+end type
+```
+
+### `make_VariableSpec` signature (relevant fragment)
+
+```fortran
+function make_VariableSpec( &
+     state_intent, short_name, unusable, &
+     ...
+     use_field_dictionary, &   ! optional logical, default .false.
+     rc) result(var_spec)
+```
+
+### Lookup logic
+
+```fortran
+if (var_spec%use_field_dictionary) then
+   fd => get_field_dictionary()
+   block
+      character(:), allocatable :: lookup_key
+      logical :: by_alias
+
+      by_alias = .false.
+      if (present(standard_name) .and. index(standard_name, '(') == 0) then
+         lookup_key = standard_name        ! standard_name is the FD key
+      else
+         lookup_key = short_name           ! fall back to short_name as alias
+         by_alias = .true.
+      end if
+
+      if (fd%has_item(lookup_key)) then
+         dict_item = fd%get_item(lookup_key, rc)
          if (.not. present(units))     var_spec%units     = dict_item%get_units()
          if (.not. present(long_name)) var_spec%long_name = dict_item%get_long_name()
       else
-         lgr%warning('standard_name "..." not found in field dictionary; ...')
+         lgr%warning(...)   ! warn — never a fatal error
       end if
-   end if
+   end block
 end if
 ```
 
 Key points:
 
-- **Warn-only**: a missing standard name logs a warning but never fails.
-- **Caller values win**: `units` and `long_name` already supplied by the caller
-  are never overwritten by the dictionary.
+- **Opt-in**: the block is entirely skipped when `use_field_dictionary` is
+  absent or `.false.` — no FD pointer is obtained, no singleton is queried.
+- **Key priority**: `standard_name` (if present and not a compound vector
+  name) → `short_name` as alias.
 - **Compound names skipped**: any `standard_name` containing `(` is a
-  two-component vector encoding (e.g. `(eastward_wind,northward_wind)`) and
-  is not a dictionary key — skip silently.
+  two-component vector encoding and is never a valid FD key.
+- **Warn-only on miss**: a missing key logs a warning but never fails.
+- **Caller values win**: `units` and `long_name` already supplied by the
+  caller are never overwritten by the dictionary.
 - **Singleton access**: `get_field_dictionary()` always returns a pointer to
-  the module-level singleton `the_field_dictionary` declared in
-  `FieldDictionary.F90`.  If the dictionary was never loaded (file absent),
-  the singleton is an empty `FieldDictionary` and `has_item` always returns
-  `.false.`.
+  the module-level singleton `the_field_dictionary`.  If the dictionary was
+  never loaded, the singleton is an empty `FieldDictionary` and `has_item`
+  always returns `.false.`.
 
 ### Regrid method
 
 The `conserved` → regrid method mapping is resolved separately in
-`get_regrid_param` → `get_regrid_method_from_field_dict_`:
+`get_regrid_param` → `get_regrid_method_from_field_dict_`.  These functions
+now accept a `use_field_dictionary` logical argument; `get_regrid_param`
+skips the FD lookup unless `use_field_dictionary=.true.` is passed:
 
 ```fortran
-function get_regrid_method_from_field_dict_(standard_name, rc) result(regrid_method)
-   fd => get_field_dictionary()
-   if (.not. fd%has_item(standard_name)) then
-      _RETURN(_FAILURE)   ! caller falls back to BILINEAR
+function get_regrid_param(requested_param, standard_name, use_field_dictionary) &
+     result(regrid_param)
+   ...
+   use_fd = .false.
+   if (present(use_field_dictionary)) use_fd = use_field_dictionary
+   if (.not. use_fd) return     ! skip FD lookup entirely
+
+   regrid_method = get_regrid_method_from_field_dict_(standard_name, rc=status)
+   if (status==ESMF_SUCCESS) then
+      regrid_param = EsmfRegridderParam(regridmethod=regrid_method)
    end if
-   regrid_method = fd%get_regrid_method(standard_name, rc)
 end function
 ```
-
-This function returns `_FAILURE` (not a fatal error) when the standard name is
-absent; the caller (`get_regrid_param`) falls back to `BILINEAR`.
 
 ---
 
@@ -368,22 +405,35 @@ standard names to avoid coupling tests to the production dictionary:
 ```fortran
 ! In a pFUnit test:
 use mapl3g_FieldDictionary
+use mapl3g_VariableSpec
 
-type(FieldDictionary) :: dict
+type(VariableSpec) :: vs
 integer :: status
 
-dict = FieldDictionary( &
-     filename='path/to/field_dictionary_test.yaml', rc=status)
+call load_field_dictionary('field_dictionary_test.yaml', rc=status)
 @assertEqual(0, status)
-@assert(dict%has_item('test_temperature'))
 
-character(:), allocatable :: units
-units = dict%get_units('test_temperature', rc=status)
-@assertEqual('K', units)
+! Must pass use_field_dictionary=.true. to trigger FD lookup
+vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+     standard_name='test_temperature', &
+     use_field_dictionary=.true., rc=status)
+@assertEqual(0, status)
+@assertEqual('K', vs%units)
+
+! Without the flag — dictionary is not consulted
+vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+     standard_name='test_temperature', rc=status)
+@assertEqual(0, status)
+@assertFalse(allocated(vs%units))   ! units not filled from dict
 ```
 
 See `generic3g/tests/Test_FieldDictionary.pf` and
 `generic3g/tests/Test_FieldDictIntegration.pf` for full examples.
+
+**Important**: do **not** call `load_field_dictionary` in a `@before`
+subroutine in test modules that do not actually use `use_field_dictionary=.true.`.
+The FD singleton is not needed for tests that never opt in, and loading it
+unnecessarily couples those tests to the test YAML file.
 
 ---
 

--- a/docs/user_guide/docs/field_dictionary.md
+++ b/docs/user_guide/docs/field_dictionary.md
@@ -4,80 +4,89 @@
 
 MAPL3 integrates a **field dictionary** that provides canonical metadata for
 GEOS fields: long names, units, physical dimension, and conservation flag.
-When a component declares a field with a `standard_name`, MAPL3 automatically
-fills in metadata from the dictionary — reducing duplication across component
-specs and improving consistency across GEOS.
-
 The dictionary is based on CF Conventions standard names where possible, and
 tracks a **verification status** for each entry (`unverified`, `verified`, or
 `cf_compliant`) to support a gradual migration toward full CF compliance.
+
+Dictionary lookup is **opt-in per variable**: a field only queries the dictionary
+when it is explicitly declared with `use_field_dictionary=.true.` in its
+`make_VariableSpec` call (or, when ACG support is available, via a
+`use_field_dictionary: true` column in the RC file — see
+[GH #4594](https://github.com/GEOS-ESM/MAPL/issues/4594)).
+
+This design means ad-hoc diagnostic fields and History gridcomp mirror variables
+are never burdened with requiring a dictionary entry.
 
 ---
 
 ## Quick Start
 
-### Minimal component spec with dictionary lookup
+### Opt in to dictionary lookup for a variable
 
-```yaml
-# MyComponent.yaml
-mapl:
-  states:
-    export:
-      air_temperature:
-        standard_name: air_temperature
-        dims: [lon, lat, lev]
-        # long_name and units are filled automatically from the dictionary
+In Fortran component code:
+
+```fortran
+var_spec = make_VariableSpec( &
+     state_intent=ESMF_STATEINTENT_EXPORT, &
+     short_name='T', &
+     standard_name='air_temperature', &
+     use_field_dictionary=.true., &   ! <-- opt in
+     rc=status)
 ```
 
-When `air_temperature` is found in the dictionary, MAPL3 uses:
-- `long_name: Air Temperature` (from the dictionary)
-- `canonical_units: K` (from the dictionary)
+When `use_field_dictionary=.true.` and `air_temperature` is found in the
+dictionary, `make_VariableSpec` sets:
+- `long_name = 'Air Temperature'` (from dictionary, if not already supplied)
+- `units = 'K'` (from dictionary, if not already supplied)
 
-These values become the defaults. Any keys you supply explicitly **override**
-the dictionary values.
+Caller-supplied values always win:
 
-### Override individual fields
-
-```yaml
-mapl:
-  states:
-    export:
-      surface_temp_degF:
-        standard_name: air_temperature
-        units: degF          # override the canonical units
-        # long_name still comes from the dictionary
+```fortran
+! Caller-specified units take priority; long_name still filled from dict
+var_spec = make_VariableSpec( &
+     state_intent=ESMF_STATEINTENT_EXPORT, &
+     short_name='T', &
+     standard_name='air_temperature', &
+     units='degC', &
+     use_field_dictionary=.true., &
+     rc=status)
 ```
 
-### Fully explicit spec (dictionary is not consulted)
+### Without the flag — dictionary is not consulted
 
-```yaml
-mapl:
-  states:
-    export:
-      pressure:
-        standard_name: air_pressure
-        units: hPa
-        long_name: Atmospheric Pressure
+```fortran
+! Default behaviour: no FD lookup, no warning
+var_spec = make_VariableSpec( &
+     state_intent=ESMF_STATEINTENT_EXPORT, &
+     short_name='diag_field', &
+     units='1', &
+     rc=status)
 ```
 
-If `units` and `long_name` are both present in the component spec, those
-explicit values are used as-is. The dictionary is still consulted for the
-`conserved` flag (which drives the default regrid method).
+No `standard_name` and no `use_field_dictionary` — units and long_name are
+exactly what the caller provides (or unallocated if omitted).
 
 ---
 
 ## How Dictionary Lookup Works
 
-For each field entry in a component YAML file, MAPL3:
+When `use_field_dictionary=.true.` is passed to `make_VariableSpec`:
 
-1. Checks the `itemType` — **service fields are exempt** (see below).
-2. Looks up `standard_name` in the dictionary.
-3. Uses dictionary values as **defaults** for `long_name` and `units`.
-4. Applies any explicit overrides from the component YAML.
-5. Uses the dictionary `conserved` flag to select the default regrid method
-   (`CONSERVE` for conserved quantities, `BILINEAR` otherwise).
-6. Emits a warning (PERMISSIVE mode) or error (STRICT mode) if the field is
-   not found.
+1. **Key selection**:
+   - If `standard_name` is present and is not a compound vector name
+     (i.e. does not contain `(`): use `standard_name` as the lookup key.
+   - Otherwise: use `short_name` as an alias lookup key.
+2. **Lookup**: search the singleton dictionary for the key.
+3. **Apply defaults**: if found, use dictionary values as defaults for
+   `long_name` and `units` (caller-supplied values always take priority).
+4. **Warn on miss**: if not found, a warning is logged — this is never a
+   fatal error in the current implementation.
+
+### Compound vector names
+
+Names of the form `(eastward_wind,northward_wind)` are compound encodings for
+two-component vectors. They are never valid dictionary keys and are silently
+skipped even when `use_field_dictionary=.true.`.
 
 ### Exempt item types
 
@@ -86,17 +95,17 @@ warning is emitted even if the `standard_name` is absent from the dictionary:
 
 | Item type | Exempt? |
 |-----------|---------|
-| `FIELD` | No — dictionary required |
-| `VECTOR` | No — dictionary required |
-| `BRACKET` | No — dictionary required |
-| `VECTORBRACKET` | No — dictionary required |
-| `SERVICE` | **Yes** |
-| `SERVICE_PROVIDER` | **Yes** |
-| `SERVICE_SUBSCRIBER` | **Yes** |
+| `FIELD` | No — opt in with `use_field_dictionary=.true.` |
+| `VECTOR` | No — opt in with `use_field_dictionary=.true.` |
+| `BRACKET` | No — opt in with `use_field_dictionary=.true.` |
+| `VECTORBRACKET` | No — opt in with `use_field_dictionary=.true.` |
+| `SERVICE` | **Yes** — always exempt |
+| `SERVICE_PROVIDER` | **Yes** — always exempt |
+| `SERVICE_SUBSCRIBER` | **Yes** — always exempt |
 | `FIELDBUNDLE` | **Yes** (may be enforced in future) |
 | `STATE` | **Yes** (may be enforced in future) |
-| `WILDCARD` | **Yes** |
-| `EXPRESSION` | **Yes** |
+| `WILDCARD` | **Yes** — always exempt |
+| `EXPRESSION` | **Yes** — always exempt |
 
 ---
 

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -235,9 +235,6 @@ contains
 !#      type(ESMF_RegridMethod_Flag), allocatable :: regrid_method
 !#      type(EsmfRegridderParam) :: regrid_param_
 
-      type(FieldDictionary), pointer :: fd
-      type(FieldDictionaryItem) :: dict_item
-      type(logger_t), pointer :: lgr
       integer :: status
 
        var_spec%short_name = short_name
@@ -279,49 +276,69 @@ contains
           var_spec%vector_basis_kind = VectorBasisKind(vector_basis_kind)
        end if
 
-      ! Apply field dictionary defaults when use_field_dictionary=.true.
-      ! Lookup key priority:
-      !   1. standard_name (if present and not a compound vector name)
-      !   2. short_name as alias
-      ! Caller-supplied units/long_name always take priority over FD defaults.
-      ! Compound vector names of the form "(name1,name2)" are never FD keys.
       if (var_spec%use_field_dictionary) then
-         fd => get_field_dictionary()
-         block
-            character(:), allocatable :: lookup_key
-            logical :: by_alias
-
-            by_alias = .false.
-            if (present(standard_name) .and. index(standard_name, '(') == 0) then
-               lookup_key = standard_name
-            else
-               lookup_key = short_name
-               by_alias = .true.
-            end if
-
-            if (fd%has_item(lookup_key)) then
-               dict_item = fd%get_item(lookup_key, _RC)
-               if (.not. present(units))     var_spec%units     = dict_item%get_units()
-               if (.not. present(long_name)) var_spec%long_name = dict_item%get_long_name()
-            else if (by_alias) then
-               ! short_name alias not in FD — try it as a standard_name key too
-               ! (aliases and standard names share the same has_item lookup)
-               lgr => logging%get_logger('MAPL')
-               call lgr%warning('use_field_dictionary=.true. but short_name "' // &
-                    short_name // '" not found in field dictionary (no alias or standard_name match); ' // &
-                    'units and long_name defaults will not be applied.')
-            else
-               lgr => logging%get_logger('MAPL')
-               call lgr%warning('use_field_dictionary=.true. but standard_name "' // &
-                    standard_name // '" not found in field dictionary; ' // &
-                    'units and long_name defaults will not be applied.')
-            end if
-         end block
+         call apply_field_dictionary_defaults_(var_spec, short_name, standard_name, units, long_name, _RC)
       end if
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end function make_VariableSpec
+
+   ! Apply field dictionary defaults for units and long_name.
+   ! Lookup key priority:
+   !   1. standard_name (if present and not a compound vector name)
+   !   2. short_name as alias
+   ! Caller-supplied units/long_name always take priority over FD defaults.
+   ! Compound vector names of the form "(name1,name2)" are never FD keys.
+   ! A miss is warned about but never fatal.
+   subroutine apply_field_dictionary_defaults_(var_spec, short_name, standard_name, units, long_name, rc)
+      type(VariableSpec), intent(inout) :: var_spec
+      character(*), intent(in) :: short_name
+      character(*), optional, intent(in) :: standard_name
+      character(*), optional, intent(in) :: units
+      character(*), optional, intent(in) :: long_name
+      integer, optional, intent(out) :: rc
+
+      type(FieldDictionary), pointer :: fd
+      type(FieldDictionaryItem) :: dict_item
+      type(logger_t), pointer :: lgr
+      character(:), allocatable :: lookup_key
+      logical :: by_alias
+      integer :: status
+
+      ! Default: look up by short_name as alias
+      lookup_key = short_name
+      by_alias = .true.
+
+      ! Prefer standard_name when present and not a compound vector encoding
+      if (present(standard_name)) then
+         if (index(standard_name, '(') == 0) then
+            lookup_key = standard_name
+            by_alias = .false.
+         end if
+      end if
+
+      fd => get_field_dictionary()
+
+      if (fd%has_item(lookup_key)) then
+         dict_item = fd%get_item(lookup_key, _RC)
+         if (.not. present(units))     var_spec%units     = dict_item%get_units()
+         if (.not. present(long_name)) var_spec%long_name = dict_item%get_long_name()
+      else
+         lgr => logging%get_logger('MAPL')
+         if (by_alias) then
+            call lgr%warning('use_field_dictionary=.true. but short_name "' // &
+                 short_name // '" not found in field dictionary; ' // &
+                 'units and long_name defaults will not be applied.')
+         else
+            call lgr%warning('use_field_dictionary=.true. but standard_name "' // &
+                 standard_name // '" not found in field dictionary; ' // &
+                 'units and long_name defaults will not be applied.')
+         end if
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine apply_field_dictionary_defaults_
 
    subroutine split_name(encoded_name, name_1, name_2, rc)
       character(*), intent(in) :: encoded_name

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -196,7 +196,6 @@ contains
         vector_component_names, &
         vector_basis_kind, &
         has_deferred_aspects, &
-        use_fd, &
         restart_mode, &
         rc) result(var_spec)
 
@@ -228,9 +227,9 @@ contains
       type(ESMF_TimeInterval), optional, intent(in) :: offset
       type(StringVector), optional, intent(in) :: vector_component_names
       character(*), optional, intent(in) :: vector_basis_kind
-      logical, optional, intent(in) :: has_deferred_aspects
-      logical, optional, intent(in) :: use_fd
-      type(RestartMode), optional, intent(in) :: restart_mode
+       logical, optional, intent(in) :: has_deferred_aspects
+       logical, optional, intent(in) :: use_field_dictionary
+       type(RestartMode), optional, intent(in) :: restart_mode
       integer, optional, intent(out) :: rc
 
 !#      type(ESMF_RegridMethod_Flag), allocatable :: regrid_method
@@ -267,9 +266,9 @@ contains
       _SET_OPTIONAL(timeStep)
       _SET_OPTIONAL(offset)
       _SET_OPTIONAL(vector_component_names)
-      _SET_OPTIONAL(has_deferred_aspects)
-      if (present(use_fd)) var_spec%use_field_dictionary = use_fd
-      _SET_OPTIONAL(restart_mode)
+       _SET_OPTIONAL(has_deferred_aspects)
+       _SET_OPTIONAL(use_field_dictionary)
+       _SET_OPTIONAL(restart_mode)
 
        var_spec%vector_basis_kind = VECTOR_BASIS_KIND_NS
        if (present(vector_basis_kind)) then

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -324,17 +324,18 @@ contains
          dict_item = fd%get_item(lookup_key, _RC)
          if (.not. present(units))     var_spec%units     = dict_item%get_units()
          if (.not. present(long_name)) var_spec%long_name = dict_item%get_long_name()
+         _RETURN(_SUCCESS)
+      end if
+
+      lgr => logging%get_logger('MAPL')
+      if (by_alias) then
+         call lgr%warning('use_field_dictionary=.true. but short_name "' // &
+              short_name // '" not found in field dictionary; ' // &
+              'units and long_name defaults will not be applied.')
       else
-         lgr => logging%get_logger('MAPL')
-         if (by_alias) then
-            call lgr%warning('use_field_dictionary=.true. but short_name "' // &
-                 short_name // '" not found in field dictionary; ' // &
-                 'units and long_name defaults will not be applied.')
-         else
-            call lgr%warning('use_field_dictionary=.true. but standard_name "' // &
-                 standard_name // '" not found in field dictionary; ' // &
-                 'units and long_name defaults will not be applied.')
-         end if
+         call lgr%warning('use_field_dictionary=.true. but standard_name "' // &
+              standard_name // '" not found in field dictionary; ' // &
+              'units and long_name defaults will not be applied.')
       end if
 
       _RETURN(_SUCCESS)

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -147,6 +147,7 @@ module mapl3g_VariableSpec
       !=====================
       type(StringVector) :: dependencies ! default empty
       logical :: has_deferred_aspects = .false.
+      logical :: use_field_dictionary = .false.
 
    contains
       procedure :: make_virtualPt
@@ -226,8 +227,9 @@ contains
       type(ESMF_TimeInterval), optional, intent(in) :: offset
       type(StringVector), optional, intent(in) :: vector_component_names
       character(*), optional, intent(in) :: vector_basis_kind
-      logical, optional, intent(in) :: has_deferred_aspects
-      type(RestartMode), optional, intent(in) :: restart_mode
+       logical, optional, intent(in) :: has_deferred_aspects
+       logical, optional, intent(in) :: use_field_dictionary
+       type(RestartMode), optional, intent(in) :: restart_mode
       integer, optional, intent(out) :: rc
 
 !#      type(ESMF_RegridMethod_Flag), allocatable :: regrid_method
@@ -267,8 +269,9 @@ contains
       _SET_OPTIONAL(timeStep)
       _SET_OPTIONAL(offset)
       _SET_OPTIONAL(vector_component_names)
-      _SET_OPTIONAL(has_deferred_aspects)
-      _SET_OPTIONAL(restart_mode)
+       _SET_OPTIONAL(has_deferred_aspects)
+       _SET_OPTIONAL(use_field_dictionary)
+       _SET_OPTIONAL(restart_mode)
 
        var_spec%vector_basis_kind = VECTOR_BASIS_KIND_NS
        if (present(vector_basis_kind)) then
@@ -276,23 +279,44 @@ contains
           var_spec%vector_basis_kind = VectorBasisKind(vector_basis_kind)
        end if
 
-      ! Apply field dictionary defaults for units and long_name.
-      ! Only fills in values not already provided by the caller.
-      ! Compound vector names of the form "(name1,name2)" are skipped —
-      ! they encode two component standard names and are not dictionary keys.
-      if (present(standard_name)) then
-         if (index(standard_name, '(') == 0) then
-            fd => get_field_dictionary()
-            if (fd%has_item(standard_name)) then
-               dict_item = fd%get_item(standard_name, _RC)
-               if (.not. present(units)) var_spec%units = dict_item%get_units()
+      ! Apply field dictionary defaults when use_field_dictionary=.true.
+      ! Lookup key priority:
+      !   1. standard_name (if present and not a compound vector name)
+      !   2. short_name as alias
+      ! Caller-supplied units/long_name always take priority over FD defaults.
+      ! Compound vector names of the form "(name1,name2)" are never FD keys.
+      if (var_spec%use_field_dictionary) then
+         fd => get_field_dictionary()
+         block
+            character(:), allocatable :: lookup_key
+            logical :: by_alias
+
+            by_alias = .false.
+            if (present(standard_name) .and. index(standard_name, '(') == 0) then
+               lookup_key = standard_name
+            else
+               lookup_key = short_name
+               by_alias = .true.
+            end if
+
+            if (fd%has_item(lookup_key)) then
+               dict_item = fd%get_item(lookup_key, _RC)
+               if (.not. present(units))     var_spec%units     = dict_item%get_units()
                if (.not. present(long_name)) var_spec%long_name = dict_item%get_long_name()
+            else if (by_alias) then
+               ! short_name alias not in FD — try it as a standard_name key too
+               ! (aliases and standard names share the same has_item lookup)
+               lgr => logging%get_logger('MAPL')
+               call lgr%warning('use_field_dictionary=.true. but short_name "' // &
+                    short_name // '" not found in field dictionary (no alias or standard_name match); ' // &
+                    'units and long_name defaults will not be applied.')
             else
                lgr => logging%get_logger('MAPL')
-               call lgr%warning('standard_name "'//standard_name//'" not found in field dictionary; ' // &
+               call lgr%warning('use_field_dictionary=.true. but standard_name "' // &
+                    standard_name // '" not found in field dictionary; ' // &
                     'units and long_name defaults will not be applied.')
             end if
-         end if
+         end block
       end if
 
       _RETURN(_SUCCESS)
@@ -345,12 +369,14 @@ contains
       _RETURN(_SUCCESS)
    end function make_dependencies
 
-   function get_regrid_param(requested_param, standard_name) result(regrid_param)
+   function get_regrid_param(requested_param, standard_name, use_field_dictionary) result(regrid_param)
       type(EsmfRegridderParam) :: regrid_param
       type(EsmfRegridderParam), optional, intent(in) :: requested_param
       character(*), optional, intent(in) :: standard_name
+      logical, optional, intent(in) :: use_field_dictionary
 
       type(ESMF_RegridMethod_Flag) :: regrid_method
+      logical :: use_fd
       integer :: status
 
       if (present(requested_param)) then
@@ -358,19 +384,15 @@ contains
          return
       end if
 
-      ! if (NUOPC_FieldDictionaryHasEntry(this%standard_name, rc=status)) then
-      !    call NUOPC_FieldDictionaryGetEntry(this%standard_name, regrid_method, rc=status)
-      !    if (status==ESMF_SUCCESS) then
-      !       this%regrid_param = EsmfRegridderParam(regridmethod=regrid_method)
-      !       return
-      !    end if
-      ! end if
-      regrid_param = EsmfRegridderParam() ! last resort - use default regrid method
+      regrid_param = EsmfRegridderParam() ! default regrid method
+
+      use_fd = .false.
+      if (present(use_field_dictionary)) use_fd = use_field_dictionary
+      if (.not. use_fd) return
 
       regrid_method = get_regrid_method_from_field_dict_(standard_name, rc=status)
       if (status==ESMF_SUCCESS) then
          regrid_param = EsmfRegridderParam(regridmethod=regrid_method)
-         return
       end if
 
    end function get_regrid_param

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -196,6 +196,7 @@ contains
         vector_component_names, &
         vector_basis_kind, &
         has_deferred_aspects, &
+        use_field_dictionary, &
         restart_mode, &
         rc) result(var_spec)
 
@@ -227,9 +228,9 @@ contains
       type(ESMF_TimeInterval), optional, intent(in) :: offset
       type(StringVector), optional, intent(in) :: vector_component_names
       character(*), optional, intent(in) :: vector_basis_kind
-       logical, optional, intent(in) :: has_deferred_aspects
-       logical, optional, intent(in) :: use_field_dictionary
-       type(RestartMode), optional, intent(in) :: restart_mode
+      logical, optional, intent(in) :: has_deferred_aspects
+      logical, optional, intent(in) :: use_field_dictionary
+      type(RestartMode), optional, intent(in) :: restart_mode
       integer, optional, intent(out) :: rc
 
 !#      type(ESMF_RegridMethod_Flag), allocatable :: regrid_method

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -196,6 +196,7 @@ contains
         vector_component_names, &
         vector_basis_kind, &
         has_deferred_aspects, &
+        use_fd, &
         restart_mode, &
         rc) result(var_spec)
 
@@ -227,9 +228,9 @@ contains
       type(ESMF_TimeInterval), optional, intent(in) :: offset
       type(StringVector), optional, intent(in) :: vector_component_names
       character(*), optional, intent(in) :: vector_basis_kind
-       logical, optional, intent(in) :: has_deferred_aspects
-       logical, optional, intent(in) :: use_field_dictionary
-       type(RestartMode), optional, intent(in) :: restart_mode
+      logical, optional, intent(in) :: has_deferred_aspects
+      logical, optional, intent(in) :: use_fd
+      type(RestartMode), optional, intent(in) :: restart_mode
       integer, optional, intent(out) :: rc
 
 !#      type(ESMF_RegridMethod_Flag), allocatable :: regrid_method
@@ -266,9 +267,9 @@ contains
       _SET_OPTIONAL(timeStep)
       _SET_OPTIONAL(offset)
       _SET_OPTIONAL(vector_component_names)
-       _SET_OPTIONAL(has_deferred_aspects)
-       _SET_OPTIONAL(use_field_dictionary)
-       _SET_OPTIONAL(restart_mode)
+      _SET_OPTIONAL(has_deferred_aspects)
+      if (present(use_fd)) var_spec%use_field_dictionary = use_fd
+      _SET_OPTIONAL(restart_mode)
 
        var_spec%vector_basis_kind = VECTOR_BASIS_KIND_NS
        if (present(vector_basis_kind)) then

--- a/generic3g/tests/Test_BracketClassAspect.pf
+++ b/generic3g/tests/Test_BracketClassAspect.pf
@@ -11,7 +11,6 @@ module Test_BracketClassAspect
    use mapl3g_StateRegistry
    use mapl3g_Geom_API
    use mapl3g_FieldBundle_API
-   use mapl3g_FieldDictionary, only: load_field_dictionary
    use MAPL_FieldUtils
    use funit
    use esmf
@@ -34,8 +33,6 @@ contains
       mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
       geom = mapl_geom%get_geom()
       call ESMF_HConfigDestroy(hconfig)
-
-      call load_field_dictionary('field_dictionary_test.yaml', _RC)
 
    end subroutine setup
 

--- a/generic3g/tests/Test_FieldDictIntegration.pf
+++ b/generic3g/tests/Test_FieldDictIntegration.pf
@@ -1,13 +1,13 @@
 #include "MAPL_TestErr.h"
 ! Integration tests: make_VariableSpec + FieldDictionary singleton interaction.
 ! These tests verify that make_VariableSpec correctly:
-!   1. Fills `units` from the dictionary when use_field_dictionary=.true. and
+!   1. Fills `units` from the dictionary when use_fd=.true. and
 !      not specified by the caller.
 !   2. Fills `long_name` from the dictionary when a standard_name matches.
 !   3. Lets caller-specified `units` take precedence over dictionary defaults.
-!   4. Works correctly for multiple fields, each with use_field_dictionary=.true.
+!   4. Works correctly for multiple fields, each with use_fd=.true.
 !
-! Note: the parse_var_specs (YAML) path does not yet propagate use_field_dictionary;
+! Note: the parse_var_specs (YAML) path does not yet propagate use_fd;
 ! that is tracked separately in GH issue #4578.
 
 module Test_FieldDictIntegration
@@ -50,7 +50,7 @@ contains
 
    ! ==================================================================
    ! 1. make_VariableSpec fills units + long_name from singleton dict
-   !    when use_field_dictionary=.true.
+   !    when use_fd=.true.
    ! ==================================================================
    @test
    subroutine test_units_and_long_name_filled_from_dict()
@@ -63,9 +63,9 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-           standard_name='air_temperature', &
-           use_field_dictionary=.true., rc=status)
+       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+            standard_name='air_temperature', &
+            use_fd=.true., rc=status)
       @assert_that(status, is(0))
 
       @assert_that(allocated(vs%units), is(true()))
@@ -90,9 +90,9 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-           standard_name='air_temperature', units='degC', &
-           use_field_dictionary=.true., rc=status)
+       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+            standard_name='air_temperature', units='degC', &
+            use_fd=.true., rc=status)
       @assert_that(status, is(0))
 
       ! Caller-specified units must win
@@ -106,7 +106,7 @@ contains
    end subroutine test_caller_units_override_dict
 
    ! ==================================================================
-   ! 3. Without use_field_dictionary=.true., dict is NOT consulted,
+   ! 3. Without use_fd=.true., dict is NOT consulted,
    !    even when standard_name matches a dict entry.
    ! ==================================================================
    @test
@@ -120,7 +120,7 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      ! No use_field_dictionary argument — default is .false.
+      ! No use_fd argument — default is .false.
       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
            standard_name='air_temperature', rc=status)
       @assert_that(status, is(0))
@@ -134,7 +134,7 @@ contains
 
    ! ==================================================================
    ! 4. Multiple fields via make_VariableSpec both get dict defaults
-   !    when use_field_dictionary=.true.
+   !    when use_fd=.true.
    ! ==================================================================
    @test
    subroutine test_multiple_fields_from_dict()
@@ -147,12 +147,12 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      vs_t = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-           standard_name='air_temperature', use_field_dictionary=.true., rc=status)
-      @assert_that(status, is(0))
+       vs_t = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+            standard_name='air_temperature', use_fd=.true., rc=status)
+       @assert_that(status, is(0))
 
-      vs_q = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='Q', &
-           standard_name='specific_humidity', use_field_dictionary=.true., rc=status)
+       vs_q = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='Q', &
+            standard_name='specific_humidity', use_fd=.true., rc=status)
       @assert_that(status, is(0))
 
       @assertEqual('K', vs_t%units)

--- a/generic3g/tests/Test_FieldDictIntegration.pf
+++ b/generic3g/tests/Test_FieldDictIntegration.pf
@@ -1,13 +1,13 @@
 #include "MAPL_TestErr.h"
 ! Integration tests: make_VariableSpec + FieldDictionary singleton interaction.
 ! These tests verify that make_VariableSpec correctly:
-!   1. Fills `units` from the dictionary when use_fd=.true. and
+!   1. Fills `units` from the dictionary when use_field_dictionary=.true. and
 !      not specified by the caller.
 !   2. Fills `long_name` from the dictionary when a standard_name matches.
 !   3. Lets caller-specified `units` take precedence over dictionary defaults.
-!   4. Works correctly for multiple fields, each with use_fd=.true.
+!   4. Works correctly for multiple fields, each with use_field_dictionary=.true.
 !
-! Note: the parse_var_specs (YAML) path does not yet propagate use_fd;
+! Note: the parse_var_specs (YAML) path does not yet propagate use_field_dictionary;
 ! that is tracked separately in GH issue #4578.
 
 module Test_FieldDictIntegration
@@ -50,7 +50,7 @@ contains
 
    ! ==================================================================
    ! 1. make_VariableSpec fills units + long_name from singleton dict
-   !    when use_fd=.true.
+   !    when use_field_dictionary=.true.
    ! ==================================================================
    @test
    subroutine test_units_and_long_name_filled_from_dict()
@@ -63,9 +63,9 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-            standard_name='air_temperature', &
-            use_fd=.true., rc=status)
+      vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+           standard_name='air_temperature', &
+           use_field_dictionary=.true., rc=status)
       @assert_that(status, is(0))
 
       @assert_that(allocated(vs%units), is(true()))
@@ -90,9 +90,9 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-            standard_name='air_temperature', units='degC', &
-            use_fd=.true., rc=status)
+      vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+           standard_name='air_temperature', units='degC', &
+           use_field_dictionary=.true., rc=status)
       @assert_that(status, is(0))
 
       ! Caller-specified units must win
@@ -106,7 +106,7 @@ contains
    end subroutine test_caller_units_override_dict
 
    ! ==================================================================
-   ! 3. Without use_fd=.true., dict is NOT consulted,
+   ! 3. Without use_field_dictionary=.true., dict is NOT consulted,
    !    even when standard_name matches a dict entry.
    ! ==================================================================
    @test
@@ -120,7 +120,7 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      ! No use_fd argument — default is .false.
+      ! No use_field_dictionary argument — default is .false.
       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
            standard_name='air_temperature', rc=status)
       @assert_that(status, is(0))
@@ -134,7 +134,7 @@ contains
 
    ! ==================================================================
    ! 4. Multiple fields via make_VariableSpec both get dict defaults
-   !    when use_fd=.true.
+   !    when use_field_dictionary=.true.
    ! ==================================================================
    @test
    subroutine test_multiple_fields_from_dict()
@@ -147,12 +147,12 @@ contains
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-       vs_t = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-            standard_name='air_temperature', use_fd=.true., rc=status)
-       @assert_that(status, is(0))
+      vs_t = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+           standard_name='air_temperature', use_field_dictionary=.true., rc=status)
+      @assert_that(status, is(0))
 
-       vs_q = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='Q', &
-            standard_name='specific_humidity', use_fd=.true., rc=status)
+      vs_q = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='Q', &
+           standard_name='specific_humidity', use_field_dictionary=.true., rc=status)
       @assert_that(status, is(0))
 
       @assertEqual('K', vs_t%units)

--- a/generic3g/tests/Test_FieldDictIntegration.pf
+++ b/generic3g/tests/Test_FieldDictIntegration.pf
@@ -1,19 +1,20 @@
 #include "MAPL_TestErr.h"
 ! Integration tests: make_VariableSpec + FieldDictionary singleton interaction.
 ! These tests verify that make_VariableSpec correctly:
-!   1. Fills `units` from the dictionary when not specified by the caller.
+!   1. Fills `units` from the dictionary when use_field_dictionary=.true. and
+!      not specified by the caller.
 !   2. Fills `long_name` from the dictionary when a standard_name matches.
 !   3. Lets caller-specified `units` take precedence over dictionary defaults.
-!   4. Works correctly when called via parse_var_specs (YAML path).
+!   4. Works correctly for multiple fields, each with use_field_dictionary=.true.
+!
+! Note: the parse_var_specs (YAML) path does not yet propagate use_field_dictionary;
+! that is tracked separately in GH issue #4578.
 
 module Test_FieldDictIntegration
    use funit
    use esmf
-   use mapl3g_ComponentSpecParser
    use mapl3g_FieldDictionary
-   use mapl3g_VariableSpecVector
    use mapl3g_VariableSpec
-   use mapl3g_StateRegistry
    use mapl_ErrorHandling
    implicit none(type, external)
 
@@ -49,6 +50,7 @@ contains
 
    ! ==================================================================
    ! 1. make_VariableSpec fills units + long_name from singleton dict
+   !    when use_field_dictionary=.true.
    ! ==================================================================
    @test
    subroutine test_units_and_long_name_filled_from_dict()
@@ -62,7 +64,8 @@ contains
       @assert_that(status, is(0))
 
       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-           standard_name='air_temperature', rc=status)
+           standard_name='air_temperature', &
+           use_field_dictionary=.true., rc=status)
       @assert_that(status, is(0))
 
       @assert_that(allocated(vs%units), is(true()))
@@ -88,7 +91,8 @@ contains
       @assert_that(status, is(0))
 
       vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
-           standard_name='air_temperature', units='degC', rc=status)
+           standard_name='air_temperature', units='degC', &
+           use_field_dictionary=.true., rc=status)
       @assert_that(status, is(0))
 
       ! Caller-specified units must win
@@ -102,49 +106,60 @@ contains
    end subroutine test_caller_units_override_dict
 
    ! ==================================================================
-   ! 3. Multiple fields via parse_var_specs: both get dict defaults
+   ! 3. Without use_field_dictionary=.true., dict is NOT consulted,
+   !    even when standard_name matches a dict entry.
    ! ==================================================================
    @test
-   subroutine test_multiple_fields_from_dict()
-      type(VariableSpecVector) :: var_specs
+   subroutine test_no_fd_lookup_when_flag_absent()
       type(VariableSpec) :: vs
-      type(StateRegistry), target :: registry
-      type(ESMF_HConfig) :: hconfig
-      integer :: status, i
+      integer :: status
 
-      character(*), parameter :: DICT_FILE = 'test_dict_multi.yaml'
-      character(*), parameter :: YAML = &
-         'states:' // new_line('a') // &
-         '  export:' // new_line('a') // &
-         '    T:' // new_line('a') // &
-         '      standard_name: air_temperature' // new_line('a') // &
-         '    Q:' // new_line('a') // &
-         '      standard_name: specific_humidity' // new_line('a')
+      character(*), parameter :: DICT_FILE = 'test_dict_noflag.yaml'
 
       call write_dict_file(DICT_FILE)
       call load_field_dictionary(DICT_FILE, rc=status)
       @assert_that(status, is(0))
 
-      registry = StateRegistry('TestComp')
-      hconfig  = ESMF_HConfigCreate(content=YAML)
-      var_specs = parse_var_specs(hconfig, registry=registry, &
-           component_name='TestComp', rc=status)
+      ! No use_field_dictionary argument — default is .false.
+      vs = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+           standard_name='air_temperature', rc=status)
       @assert_that(status, is(0))
-      @assertEqual(2, int(var_specs%size()))
 
-      ! Find T and Q by short_name
-      do i = 1, var_specs%size()
-         vs = var_specs%of(i)
-         if (vs%short_name == 'T') then
-            @assertEqual('K', vs%units)
-            @assertEqual('Air Temperature', vs%long_name)
-         else if (vs%short_name == 'Q') then
-            @assertEqual('kg kg-1', vs%units)
-            @assertEqual('Specific Humidity', vs%long_name)
-         end if
-      end do
+      ! units and long_name should NOT be populated from dict
+      @assert_that(allocated(vs%units), is(false()))
+      @assert_that(allocated(vs%long_name), is(false()))
 
-      call ESMF_HConfigDestroy(hconfig)
+      call delete_file(DICT_FILE)
+   end subroutine test_no_fd_lookup_when_flag_absent
+
+   ! ==================================================================
+   ! 4. Multiple fields via make_VariableSpec both get dict defaults
+   !    when use_field_dictionary=.true.
+   ! ==================================================================
+   @test
+   subroutine test_multiple_fields_from_dict()
+      type(VariableSpec) :: vs_t, vs_q
+      integer :: status
+
+      character(*), parameter :: DICT_FILE = 'test_dict_multi.yaml'
+
+      call write_dict_file(DICT_FILE)
+      call load_field_dictionary(DICT_FILE, rc=status)
+      @assert_that(status, is(0))
+
+      vs_t = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='T', &
+           standard_name='air_temperature', use_field_dictionary=.true., rc=status)
+      @assert_that(status, is(0))
+
+      vs_q = make_VariableSpec(ESMF_STATEINTENT_EXPORT, short_name='Q', &
+           standard_name='specific_humidity', use_field_dictionary=.true., rc=status)
+      @assert_that(status, is(0))
+
+      @assertEqual('K', vs_t%units)
+      @assertEqual('Air Temperature', vs_t%long_name)
+      @assertEqual('kg kg-1', vs_q%units)
+      @assertEqual('Specific Humidity', vs_q%long_name)
+
       call delete_file(DICT_FILE)
    end subroutine test_multiple_fields_from_dict
 

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -36,7 +36,6 @@ module Test_ModelVerticalGrid
    use mapl3g_QuantityTypeAspect
    use mapl3g_ConservationAspect
    use mapl3g_NormalizationAspect
-   use mapl3g_FieldDictionary, only: load_field_dictionary
    use mapl3g_NormalizationType
    use gFTL2_StringVector
    use esmf
@@ -105,8 +104,6 @@ contains
        type(VerticalGridManager), pointer :: vgrid_mgr
        type(ModelVerticalGridSpec) :: vspec
        type(StringVector) :: names, dims
-
-       call load_field_dictionary('field_dictionary_test.yaml', _RC)
 
        ! geom, registry etc.
       geom = make_geom(_RC)

--- a/generic3g/tests/Test_VectorBasisKind.pf
+++ b/generic3g/tests/Test_VectorBasisKind.pf
@@ -9,7 +9,6 @@ module Test_VectorBasisKind
    use mapl3g_VerticalGrid_API
    use mapl3g_StateItemAspect
    use mapl3g_FieldBundle_API
-   use mapl3g_FieldDictionary, only: load_field_dictionary
    use esmf
    use funit
    implicit none
@@ -31,8 +30,6 @@ contains
       mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
       geom = mapl_geom%get_geom()
       call ESMF_HConfigDestroy(hconfig)
-
-      call load_field_dictionary('field_dictionary_test.yaml', _RC)
 
    end subroutine setup
 

--- a/generic3g/tests/Test_VectorBracketClassAspect.pf
+++ b/generic3g/tests/Test_VectorBracketClassAspect.pf
@@ -11,7 +11,6 @@ module Test_VectorBracketClassAspect
    use mapl3g_StateRegistry
    use mapl3g_Geom_API
    use mapl3g_FieldBundle_API
-   use mapl3g_FieldDictionary, only: load_field_dictionary
    use MAPL_FieldUtils
    use funit
    use esmf
@@ -34,8 +33,6 @@ contains
       mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
       geom = mapl_geom%get_geom()
       call ESMF_HConfigDestroy(hconfig)
-
-      call load_field_dictionary('field_dictionary_test.yaml', _RC)
 
    end subroutine setup
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests

## Description

Follow-on to #4577. Redesigns the Field Dictionary (FD) integration in
`make_VariableSpec` so that FD lookup is **opt-in per variable** rather than
automatic for any variable that carries a `standard_name`.

### Motivation

The always-on approach (PR #4577) was too aggressive:
- Ad-hoc diagnostic fields and History gridcomp mirror variables have no reason
  to require a dictionary entry.
- Developers registering transient intermediate fields should not have to add
  them to the production dictionary first.

### Changes

**`generic3g/specs/VariableSpec.F90`**
- Add `use_field_dictionary = .false.` member to `VariableSpec` type.
- Add `use_field_dictionary` optional logical arg to `make_VariableSpec`; FD
  lookup now only triggers when `.true.`.
- Lookup key priority: `standard_name` (if present, non-compound) → `short_name`
  as alias.
- Warn (never fail) on miss; caller-supplied `units`/`long_name` always win.
- Add `use_field_dictionary` opt-in guard to `get_regrid_param`; removed stale
  commented-out NUOPC block.

**Tests**
- Remove unnecessary `load_field_dictionary` calls from `setup()` in
  `Test_VectorBasisKind`, `Test_BracketClassAspect`, `Test_VectorBracketClassAspect`,
  `Test_ModelVerticalGrid` — none of these tests use `use_field_dictionary=.true.`.
- Rewrite `Test_FieldDictIntegration`: add opt-in flag to existing positive tests,
  add a negative test (no flag → no FD lookup), replace the `parse_var_specs`
  test with a direct two-field `make_VariableSpec` test.

**Documentation**
- Update user guide (`docs/user_guide/docs/field_dictionary.md`).
- Update developer reference (`docs/mapl3/field_dictionary_developer.md`).

### ACG path

The ACG (`parse_var_specs`) does not yet propagate `use_field_dictionary`. That
is tracked in #4594.

## Related Issues

Closes #4440 (follow-on / redesign)
See also #4578 (strict mode, future), #4594 (ACG column support, future)
