### PR TITLE
v2: Update ESMA_env and ESMA_cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added to `workflow.yml`, `changelog-enforcer.yml`, `enforce-labels.yml`, `markup-link-checker.yml`, `validate_yaml_files.yml`
   - Fixed `spack-ci.yml` to scope concurrency per PR number rather than per ref
 - Update `components.yaml` to match GEOSgcm v12
-  - ESMA_cmake v4.35.0
+  - ESMA_env v5.21.0
+    - Update to Baselibs 8.27.0
+      - ESMF v9.0.0b10
+      - GFE v1.23.0
+        - gFTL v1.17.0
+        - gFTL-shared v1.12.0
+        - fArgParse v1.11.0
+        - pFUnit v4.16.0
+      - Better support for LLVM Flang
+    - Fixes for Athena at NAS
+    - Updates for DSL work
+  - ESMA_cmake v4.36.0
     - Multiple fixes for f2py with spack and on macOS
+    - CMake updates mainly for MAPL3 work
   - ecbuild geos/v3.13.1
 - Add CTest scheduling metadata for pFIO tests so parallel `ctest` runs do not overlap the pFIO performance cases in the same working directory.
 - Update CI to use Baselibs 8.27.0

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v5.17.0
+  tag: v5.21.0
   develop: main
 
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v4.35.0
+  tag: v4.36.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This PR updates ESMA_env and ESMA_cmake to mainly match (or exceed) GEOSgcm v12. 

The ESMA_cmake update is mainly for MAPL3 (and already there) but we pull it here now.

## Related Issue

