### PR TITLE
Port CDash nightly workflow to main branch

### DIFF
--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           # Replace slashes with dashes to ensure the CDash build name is safe/clean
           SAFE_BRANCH=$(echo "${TESTED_BRANCH}" | tr '/' '-')
-          
+
           ctest \
             -D model=${CTEST_MODEL} \
             -D build_type=${CTEST_BUILD_TYPE} \

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -125,6 +125,6 @@ jobs:
             -D build_type=${CTEST_BUILD_TYPE} \
             -D generator="Unix Makefiles" \
             -D jobs=4 \
-            -D build_name="${SAFE_BRANCH}-GHA-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
+            -D build_name="GHA-${SAFE_BRANCH}-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
             -S CTestDashboard.cmake \
             -V

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -115,12 +115,16 @@ jobs:
         shell: bash
         env:
           CDASH_AUTH_TOKEN: ${{ secrets.CDASH_AUTH_TOKEN }}
+          TESTED_BRANCH: ${{ inputs.branch || 'release/MAPL-v3' }}
         run: |
+          # Replace slashes with dashes to ensure the CDash build name is safe/clean
+          SAFE_BRANCH=$(echo "${TESTED_BRANCH}" | tr '/' '-')
+          
           ctest \
             -D model=${CTEST_MODEL} \
             -D build_type=${CTEST_BUILD_TYPE} \
             -D generator="Unix Makefiles" \
             -D jobs=4 \
-            -D build_name="GHA-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
+            -D build_name="${SAFE_BRANCH}-GHA-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
             -S CTestDashboard.cmake \
             -V

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -24,8 +24,7 @@ jobs:
   cdash:
     name: CDash / gfortran-15 / ${{ matrix.cmake-build-type }}
     runs-on: ubuntu-latest
-    # Scheduled runs only on release/MAPL-v3; workflow_dispatch runs on any branch
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/release/MAPL-v3'
+
     container:
       image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
     strategy:
@@ -46,9 +45,10 @@ jobs:
         -DMPIEXEC_PREFLAGS=--oversubscribe
 
     steps:
-      - name: Checkout
+      - name: Checkout release/MAPL-v3
         uses: actions/checkout@v4
         with:
+          ref: release/MAPL-v3
           fetch-depth: 0
           filter: blob:none
 

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -7,6 +7,29 @@ on:
   # Allow manual runs from the Actions tab
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch to test'
+        required: false
+        default: 'release/MAPL-v3'
+        type: string
+      build_type:
+        description: 'CMake build type (workflow_dispatch only)'
+        required: false
+        default: 'Debug'
+        type: choice
+        options:
+          - Debug
+          - Release
+      compiler:
+        description: 'Compiler to test'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - gfortran-15
+          - ifort
+          - ifx
       model:
         description: 'CTest dashboard model'
         required: false
@@ -22,15 +45,32 @@ concurrency:
 
 jobs:
   cdash:
-    name: CDash / gfortran-15 / ${{ matrix.cmake-build-type }}
+    name: CDash / ${{ matrix.compiler }} / ${{ matrix.cmake-build-type }}
     runs-on: ubuntu-latest
 
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+      image: ${{ matrix.image }}
     strategy:
       fail-fast: false
       matrix:
-        cmake-build-type: [Release, Debug]
+        compiler: ${{ fromJSON(github.event_name == 'schedule' && '["gfortran-15", "ifort", "ifx"]' || inputs.compiler == 'all' && '["gfortran-15", "ifort", "ifx"]' || format('["{0}"]', inputs.compiler || 'gfortran-15')) }}
+        cmake-build-type:
+          - ${{ inputs.build_type || 'Debug' }}
+        include:
+          - compiler: gfortran-15
+            image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+            fc: gfortran
+            extra-cmake-args: >-
+              -DUSE_F2PY=OFF
+              -DMPIEXEC_PREFLAGS=--oversubscribe
+          - compiler: ifort
+            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+            fc: ifort
+            extra-cmake-args: -DUSE_F2PY=OFF
+          - compiler: ifx
+            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
+            fc: ifx
+            extra-cmake-args: -DUSE_F2PY=OFF
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
@@ -40,15 +80,14 @@ jobs:
       CTEST_BUILD_TYPE: ${{ matrix.cmake-build-type }}
       # Extra cmake args picked up by CTestDashboard.cmake
       CTEST_EXTRA_CMAKE_ARGS: >-
-        -DCMAKE_Fortran_COMPILER=gfortran
-        -DUSE_F2PY=OFF
-        -DMPIEXEC_PREFLAGS=--oversubscribe
+        -DCMAKE_Fortran_COMPILER=${{ matrix.fc }}
+        ${{ matrix.extra-cmake-args }}
 
     steps:
-      - name: Checkout release/MAPL-v3
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: release/MAPL-v3
+          ref: ${{ inputs.branch || 'release/MAPL-v3' }}
           fetch-depth: 0
           filter: blob:none
 
@@ -82,6 +121,6 @@ jobs:
             -D build_type=${CTEST_BUILD_TYPE} \
             -D generator="Unix Makefiles" \
             -D jobs=4 \
-            -D build_name="GHA-ubuntu24-gfortran15-${CTEST_BUILD_TYPE}" \
+            -D build_name="GHA-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
             -S CTestDashboard.cmake \
             -V

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.24.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
     name: gfortran-15 / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.24.0-openmpi_5.0.5-gcc_15.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -96,7 +96,7 @@ jobs:
     name: ifort / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.24.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +120,7 @@ jobs:
     name: ifx / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.24.0-intelmpi_2021.17-ifx_2025.3
+      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CDash nightly GitHub Actions workflow now allows manual selection of branch, CMake build type, and compiler via `workflow_dispatch`
 - CDash nightly GitHub Actions workflow now triggers scheduled builds from `main` while testing the `release/MAPL-v3` branch
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CDash nightly workflow configured to build and test `release/MAPL-v3` from the `main` branch
+- CTest dashboard configuration files (`CTestDashboard.cmake`, `CTestConfig.cmake`, `CTestCustom.cmake`) ported from `release/MAPL-v3` to support nightly CI/CD testing
+
 ### Changed
+
+- CDash nightly GitHub Actions workflow now triggers scheduled builds from `main` while testing the `release/MAPL-v3` branch
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CDash nightly GitHub Actions workflow now allows manual selection of branch, CMake build type, and compiler via `workflow_dispatch`
+- CDash nightly GitHub Actions workflow now includes the branch name in the CDash `build_name` for easier identification
+- `CTestDashboard.cmake` now combines `install` and `build-tests` targets into a single build step to accurately capture total build time in CDash
 - CDash nightly GitHub Actions workflow now triggers scheduled builds from `main` while testing the `release/MAPL-v3` branch
 
 ### Removed

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,18 @@
+## ---------------------------------------------------------------------------
+## CTestConfig.cmake -- CDash submission configuration for MAPL
+##
+## This file is read by:
+##   - CTest when run as a dashboard client (ctest -D Experimental, etc.)
+##   - ctest -S dashboard scripts
+##   - CMake's CTest module (include(CTest)) at configure time
+##
+## CDash project: https://my.cdash.org/index.php?project=MAPL
+## ---------------------------------------------------------------------------
+
+set(CTEST_PROJECT_NAME       "MAPL")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 UTC")
+
+set(CTEST_DROP_METHOD        "https")
+set(CTEST_DROP_SITE          "my.cdash.org")
+set(CTEST_DROP_LOCATION      "/submit.php?project=MAPL")
+set(CTEST_DROP_SITE_CDASH    TRUE)

--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -1,0 +1,27 @@
+## ---------------------------------------------------------------------------
+## CTestCustom.cmake -- CTest warning/error suppression rules for MAPL
+##
+## This file is read by CTest from the BUILD directory at the start of each
+## dashboard run.  It is copied there by CMake during configure (because it
+## lives in the source root, CMake copies it automatically).
+##
+## See: https://cmake.org/cmake/help/latest/manual/ctest.1.html#customizing-testing
+## ---------------------------------------------------------------------------
+
+## ---------------------------------------------------------------------------
+## Suppress known-noisy linker warnings on macOS (clang + gfortran toolchain)
+##
+## These all originate from ESMF and Baselibs CMake config files injecting
+## raw -Wl,-rpath and -l flags multiple times into the transitive link
+## closure.  They are upstream issues, not MAPL bugs.
+## ---------------------------------------------------------------------------
+list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
+  # Apple ld: duplicate -rpath entries (same Baselibs lib dir added multiple times)
+  "ld: warning: duplicate -rpath"
+
+  # Apple ld: duplicate libraries (same -l flag appears more than once)
+  "ld: warning: ignoring duplicate libraries"
+
+  # Apple ld: gfortran Cellar path mismatch (15.2.0 vs 15.2.0_1 Homebrew suffix)
+  "ld: warning: search path.*not found"
+)

--- a/CTestDashboard.cmake
+++ b/CTestDashboard.cmake
@@ -157,13 +157,11 @@ string(APPEND CTEST_CONFIGURE_COMMAND " \"${CTEST_SOURCE_DIRECTORY}\"")
 ## 4. Build commands  (all must be single strings)
 ##    Step 1: install (the main build)
 ##    Step 2: build-tests (MAPL test executables are a separate target)
+##    Note: We combine both into a single build command to ensure the
+##          total build time is correctly captured in a single CDash step.
 ## ---------------------------------------------------------------------------
 set(CTEST_BUILD_COMMAND
-    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target install"
-)
-# Second build step for tests -- called explicitly after ctest_build()
-set(_build_tests_command
-    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target build-tests"
+    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target install --target build-tests"
 )
 
 ## ---------------------------------------------------------------------------
@@ -247,7 +245,7 @@ if(_configure_result)
   return()
 endif()
 
-# Build (install target)
+# Build (install & build-tests targets)
 ctest_build(
   NUMBER_ERRORS   _build_errors
   NUMBER_WARNINGS _build_warnings
@@ -255,10 +253,9 @@ ctest_build(
 )
 message(STATUS "Build: ${_build_errors} error(s), ${_build_warnings} warning(s)")
 
-# Stop early if the main build failed -- don't overwrite its log with the
-# build-tests step, and don't attempt to run tests against broken binaries.
+# Stop early if the build failed -- don't attempt to run tests against broken binaries.
 if(_build_errors GREATER 0)
-  message(WARNING "Main build had ${_build_errors} error(s) -- skipping test step")
+  message(WARNING "Build had ${_build_errors} error(s) -- skipping test step")
   if(_cdash_auth_header)
     ctest_submit(PARTS Configure Build HTTPHEADER "${_cdash_auth_header}"
                  RETURN_VALUE _submit_result)
@@ -272,18 +269,6 @@ if(_build_errors GREATER 0)
   endif()
   return()
 endif()
-
-# Build test executables (separate target in MAPL)
-message(STATUS "Building test executables (build-tests target)...")
-set(CTEST_BUILD_COMMAND "${_build_tests_command}")
-ctest_build(
-  TARGET          build-tests
-  NUMBER_ERRORS   _build_tests_errors
-  NUMBER_WARNINGS _build_tests_warnings
-  RETURN_VALUE    _build_tests_result
-  APPEND
-)
-message(STATUS "Build-tests: ${_build_tests_errors} error(s), ${_build_tests_warnings} warning(s)")
 
 # Run ESSENTIAL tests only (matching CI behaviour).
 # Run serially (parallel 1) as in CI to avoid MPI oversubscription issues.

--- a/CTestDashboard.cmake
+++ b/CTestDashboard.cmake
@@ -1,0 +1,313 @@
+## ---------------------------------------------------------------------------
+## CTestDashboard.cmake -- CTest dashboard driver script for MAPL
+##
+## Usage:
+##   ctest -S CTestDashboard.cmake [options] -V
+##
+## Optional command-line overrides (pass with -D before -S):
+##   -D model=Nightly          # default: Experimental
+##   -D build_type=Debug       # default: Release
+##   -D generator=Ninja        # default: Ninja
+##   -D jobs=8                 # default: 6
+##   -D site=myhost            # default: auto-detected hostname
+##   -D build_name=my-label    # default: auto-generated
+##
+## Environment variables (optional):
+##   CTEST_EXTRA_CMAKE_ARGS   Space-separated extra args passed to cmake
+##                            configure.  Example:
+##                              export CTEST_EXTRA_CMAKE_ARGS="-DCMAKE_Fortran_COMPILER=gfortran -DMPIEXEC_PREFLAGS=--oversubscribe"
+##   CDASH_AUTH_TOKEN         CDash authentication token for submissions.
+##                            Generate one at my.cdash.org → Project Settings
+##                            → Authentication tokens.  Keep this out of git!
+##
+## Example - quick experimental submit:
+##   ctest -S CTestDashboard.cmake -V
+##
+## Example - nightly with 8 jobs:
+##   ctest -D model=Nightly -D jobs=8 -S CTestDashboard.cmake -V
+##
+## CDash project: https://my.cdash.org/index.php?project=MAPL
+## ---------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.27)
+
+## ---------------------------------------------------------------------------
+## 0. Defaults (can be overridden via -D on the ctest command line)
+## ---------------------------------------------------------------------------
+if(NOT DEFINED model)
+  set(model "Experimental")
+endif()
+
+if(NOT DEFINED build_type)
+  set(build_type "Release")
+endif()
+
+if(NOT DEFINED generator)
+  set(generator "Ninja")
+endif()
+
+if(NOT DEFINED jobs)
+  set(jobs 6)
+endif()
+
+## ---------------------------------------------------------------------------
+## 1. Source and binary directories
+## ---------------------------------------------------------------------------
+# Source directory is the directory containing this script
+get_filename_component(CTEST_SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+
+# Build directory mirrors the preset naming convention: build-<preset>
+# For Release+Ninja -> build-Release-Ninja
+# For Release+Unix Makefiles -> build-Release
+if(generator STREQUAL "Ninja")
+  set(_preset_suffix "${build_type}-Ninja")
+else()
+  set(_preset_suffix "${build_type}")
+endif()
+set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build-${_preset_suffix}")
+
+## ---------------------------------------------------------------------------
+## 2. Site and build name
+## ---------------------------------------------------------------------------
+cmake_host_system_information(RESULT _hostname QUERY HOSTNAME)
+cmake_host_system_information(RESULT _os_name  QUERY OS_NAME)
+cmake_host_system_information(RESULT _os_rel   QUERY OS_RELEASE)
+
+if(NOT DEFINED site)
+  set(site "${_hostname}")
+endif()
+set(CTEST_SITE "${site}")
+
+# Auto-detect compiler from environment if possible
+if(NOT DEFINED build_name)
+  # Try to identify the Fortran compiler for a descriptive name
+  if(DEFINED ENV{FC})
+    get_filename_component(_fc_name "$ENV{FC}" NAME)
+  elseif(EXISTS "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt")
+    # Read from an existing cache
+    file(STRINGS "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" _cache_fc
+         REGEX "^CMAKE_Fortran_COMPILER:FILEPATH=")
+    if(_cache_fc)
+      string(REGEX REPLACE ".*=(.*)" "\\1" _fc_path "${_cache_fc}")
+      get_filename_component(_fc_name "${_fc_path}" NAME)
+    endif()
+  endif()
+  if(NOT _fc_name)
+    set(_fc_name "unknown-FC")
+  endif()
+  set(build_name "${_os_name}-${_os_rel}-${_fc_name}-${build_type}-${generator}")
+endif()
+set(CTEST_BUILD_NAME "${build_name}")
+
+## ---------------------------------------------------------------------------
+## 3. CMake configure command (equivalent to cmake --preset <name>)
+##    We call cmake directly so the script controls the preset selection.
+## ---------------------------------------------------------------------------
+# Use the same cmake that is running this script -- avoids picking up
+# CMake.app or other GUI wrappers via find_program() on macOS.
+set(CTEST_CMAKE_COMMAND "${CMAKE_COMMAND}")
+find_program(CTEST_GIT_COMMAND NAMES git)
+
+# Map generator name to cmake -G argument
+if(generator STREQUAL "Ninja")
+  set(_cmake_generator "Ninja")
+else()
+  set(_cmake_generator "Unix Makefiles")
+endif()
+
+# We pick up the preset's installDir convention too
+set(_install_dir "${CTEST_SOURCE_DIRECTORY}/install-${_preset_suffix}")
+
+# Pick up any extra cmake args from the environment
+# (e.g. -DCMAKE_Fortran_COMPILER=gfortran set by CI)
+set(_extra_cmake_args "$ENV{CTEST_EXTRA_CMAKE_ARGS}")
+
+# CTEST_CONFIGURE_COMMAND must be a single string (not a CMake list) --
+# CTest passes it directly to the shell via 'sh -c'.
+# Rules:
+#   - Quote the cmake binary path (may contain spaces on some systems).
+#   - Quote the generator name (may contain spaces, e.g. "Unix Makefiles").
+#   - Do NOT add extra shell-level quotes around -D values; cmake receives
+#     them after shell word-splitting and the literal " chars corrupt the value.
+#   - Quote the source directory path at the end.
+set(CTEST_CONFIGURE_COMMAND "\"${CTEST_CMAKE_COMMAND}\"")
+string(APPEND CTEST_CONFIGURE_COMMAND " -G \"${_cmake_generator}\"")
+string(APPEND CTEST_CONFIGURE_COMMAND " -DCMAKE_BUILD_TYPE=${build_type}")
+string(APPEND CTEST_CONFIGURE_COMMAND " -DCMAKE_INSTALL_PREFIX=${_install_dir}")
+if(_extra_cmake_args)
+  string(APPEND CTEST_CONFIGURE_COMMAND " ${_extra_cmake_args}")
+endif()
+string(APPEND CTEST_CONFIGURE_COMMAND " \"${CTEST_SOURCE_DIRECTORY}\"")
+
+## ---------------------------------------------------------------------------
+## 4. Build commands  (all must be single strings)
+##    Step 1: install (the main build)
+##    Step 2: build-tests (MAPL test executables are a separate target)
+## ---------------------------------------------------------------------------
+set(CTEST_BUILD_COMMAND
+    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target install"
+)
+# Second build step for tests -- called explicitly after ctest_build()
+set(_build_tests_command
+    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target build-tests"
+)
+
+## ---------------------------------------------------------------------------
+## 5. CMake 4.3 instrumentation: add cdashSubmit + dynamicSystemInformation
+##    for this dashboard run.  CMakeLists.txt already enables trace +
+##    staticSystemInformation for all builds; we add the CDash-specific
+##    options here so they only apply when running via this script.
+## ---------------------------------------------------------------------------
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.3")
+  set(_query_dir
+      "${CTEST_BINARY_DIRECTORY}/.cmake/instrumentation/v1/query")
+  file(MAKE_DIRECTORY "${_query_dir}")
+  file(WRITE "${_query_dir}/dashboard-cdash.json"
+[=[{
+  "version": 1,
+  "options": [
+    "dynamicSystemInformation",
+    "cdashSubmit"
+  ]
+}
+]=])
+  message(STATUS "CDash instrumentation query written to ${_query_dir}/dashboard-cdash.json")
+endif()
+
+## ---------------------------------------------------------------------------
+## 6. CTest Use Launchers
+##    Enables per-compile-line error/warning capture in Build.xml on CDash.
+## ---------------------------------------------------------------------------
+set(CTEST_USE_LAUNCHERS ON)
+set(ENV{CTEST_USE_LAUNCHERS_DEFAULT} 1)
+
+## ---------------------------------------------------------------------------
+## 7. CDash authentication token
+##    Set CDASH_AUTH_TOKEN in your environment (never commit the value).
+##    On GitHub Actions this comes from a repository secret.
+##    CDash requires an HTTP Authorization Bearer header -- CTEST_AUTH_TOKEN
+##    is not a real CMake variable; the token must be passed via HTTPHEADER
+##    in every ctest_submit() call.
+## ---------------------------------------------------------------------------
+if(DEFINED ENV{CDASH_AUTH_TOKEN})
+  set(_cdash_auth_header "Authorization: Bearer $ENV{CDASH_AUTH_TOKEN}")
+  message(STATUS "CDash auth token loaded from CDASH_AUTH_TOKEN env var")
+else()
+  set(_cdash_auth_header "")
+  message(WARNING
+    "CDASH_AUTH_TOKEN is not set -- submission will likely be rejected.\n"
+    "Generate a token at https://my.cdash.org then:\n"
+    "  export CDASH_AUTH_TOKEN=<your-token>")
+endif()
+
+## ---------------------------------------------------------------------------
+## 8. Dashboard pipeline
+## ---------------------------------------------------------------------------
+message(STATUS "=== MAPL CDash Dashboard ===")
+message(STATUS "  Model:      ${model}")
+message(STATUS "  Site:       ${CTEST_SITE}")
+message(STATUS "  Build name: ${CTEST_BUILD_NAME}")
+message(STATUS "  Source:     ${CTEST_SOURCE_DIRECTORY}")
+message(STATUS "  Binary:     ${CTEST_BINARY_DIRECTORY}")
+message(STATUS "  Generator:  ${_cmake_generator}")
+message(STATUS "  Build type: ${build_type}")
+message(STATUS "  Jobs:       ${jobs}")
+message(STATUS "============================")
+
+# Start the dashboard submission
+ctest_start(${model})
+
+# Update step (records git revision info; non-fatal if no remote)
+ctest_update(RETURN_VALUE _update_result)
+message(STATUS "Update result: ${_update_result}")
+
+# Configure (runs cmake to generate build system)
+ctest_configure(RETURN_VALUE _configure_result)
+if(_configure_result)
+  message(WARNING "Configure step returned ${_configure_result} -- submitting configure errors")
+  if(_cdash_auth_header)
+    ctest_submit(PARTS Configure HTTPHEADER "${_cdash_auth_header}")
+  else()
+    ctest_submit(PARTS Configure)
+  endif()
+  return()
+endif()
+
+# Build (install target)
+ctest_build(
+  NUMBER_ERRORS   _build_errors
+  NUMBER_WARNINGS _build_warnings
+  RETURN_VALUE    _build_result
+)
+message(STATUS "Build: ${_build_errors} error(s), ${_build_warnings} warning(s)")
+
+# Stop early if the main build failed -- don't overwrite its log with the
+# build-tests step, and don't attempt to run tests against broken binaries.
+if(_build_errors GREATER 0)
+  message(WARNING "Main build had ${_build_errors} error(s) -- skipping test step")
+  if(_cdash_auth_header)
+    ctest_submit(PARTS Configure Build HTTPHEADER "${_cdash_auth_header}"
+                 RETURN_VALUE _submit_result)
+  else()
+    ctest_submit(PARTS Configure Build RETURN_VALUE _submit_result)
+  endif()
+  if(_submit_result)
+    message(WARNING "CDash submission returned ${_submit_result}")
+  else()
+    message(STATUS "Build errors submitted to https://my.cdash.org/index.php?project=MAPL")
+  endif()
+  return()
+endif()
+
+# Build test executables (separate target in MAPL)
+message(STATUS "Building test executables (build-tests target)...")
+set(CTEST_BUILD_COMMAND "${_build_tests_command}")
+ctest_build(
+  TARGET          build-tests
+  NUMBER_ERRORS   _build_tests_errors
+  NUMBER_WARNINGS _build_tests_warnings
+  RETURN_VALUE    _build_tests_result
+  APPEND
+)
+message(STATUS "Build-tests: ${_build_tests_errors} error(s), ${_build_tests_warnings} warning(s)")
+
+# Run ESSENTIAL tests only (matching CI behaviour).
+# Run serially (parallel 1) as in CI to avoid MPI oversubscription issues.
+ctest_test(
+  INCLUDE_LABEL   "ESSENTIAL"
+  PARALLEL_LEVEL  1
+  RETURN_VALUE    _test_result
+)
+message(STATUS "Test result: ${_test_result}")
+
+# If any tests failed, rerun only the failing ones once (matching CI behaviour)
+if(_test_result)
+  message(STATUS "Re-running only failing tests...")
+  ctest_test(
+    INCLUDE_LABEL  "ESSENTIAL"
+    PARALLEL_LEVEL 1
+    RERUN_FAILED
+    RETURN_VALUE   _test_result
+    APPEND
+  )
+  message(STATUS "Rerun result: ${_test_result}")
+endif()
+
+# Submit everything to CDash
+if(_cdash_auth_header)
+  ctest_submit(
+    PARTS Configure Build Test
+    HTTPHEADER "${_cdash_auth_header}"
+    RETURN_VALUE _submit_result
+  )
+else()
+  ctest_submit(
+    PARTS Configure Build Test
+    RETURN_VALUE _submit_result
+  )
+endif()
+if(_submit_result)
+  message(WARNING "CDash submission returned ${_submit_result}")
+else()
+  message(STATUS "Results submitted to https://my.cdash.org/index.php?project=MAPL")
+endif()

--- a/CTestDashboard.cmake
+++ b/CTestDashboard.cmake
@@ -95,7 +95,21 @@ if(NOT DEFINED build_name)
   if(NOT _fc_name)
     set(_fc_name "unknown-FC")
   endif()
-  set(build_name "${_os_name}-${_os_rel}-${_fc_name}-${build_type}-${generator}")
+
+  # Try to grab the current git branch name
+  execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY "${CTEST_SOURCE_DIRECTORY}"
+    RESULT_VARIABLE _git_res
+    OUTPUT_VARIABLE _git_branch
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(_git_res EQUAL 0 AND NOT _git_branch STREQUAL "HEAD" AND NOT _git_branch STREQUAL "")
+    string(REPLACE "/" "-" _safe_branch "${_git_branch}")
+    set(build_name "${_safe_branch}-${_os_name}-${_os_rel}-${_fc_name}-${build_type}-${generator}")
+  else()
+    set(build_name "${_os_name}-${_os_rel}-${_fc_name}-${build_type}-${generator}")
+  endif()
 endif()
 set(CTEST_BUILD_NAME "${build_name}")
 

--- a/CTestDashboard.cmake
+++ b/CTestDashboard.cmake
@@ -161,7 +161,7 @@ string(APPEND CTEST_CONFIGURE_COMMAND " \"${CTEST_SOURCE_DIRECTORY}\"")
 ##          total build time is correctly captured in a single CDash step.
 ## ---------------------------------------------------------------------------
 set(CTEST_BUILD_COMMAND
-    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target install --target build-tests"
+    "\"${CTEST_CMAKE_COMMAND}\" --build \"${CTEST_BINARY_DIRECTORY}\" --parallel ${jobs} --target install build-tests"
 )
 
 ## ---------------------------------------------------------------------------


### PR DESCRIPTION
So, turns out scheduled workflows only run on the *main* branch. 

Configures the CDash nightly CI/CD workflow to:
- Trigger scheduled builds from the `main` branch
- Checkout and test the `release/MAPL-v3` branch
- Includes ported CTest dashboard configuration files

This allows nightly testing of `release/MAPL-v3` without needing the workflow to live on that branch.

---

### Additional Enhancements
- **Enhanced `workflow_dispatch`:** Added manual selection of `branch`, `build_type` (Debug/Release), and `compiler` (`all`, `gfortran-15`, `ifort`, `ifx`).
- **Updated Docker Images:** Updated tags from `v8.24.0` to `v8.27.0` across workflows.
- **Improved CDash Naming:** The evaluated branch name is now dynamically injected into the CDash `build_name` (e.g. `GHA-release-MAPL-v3-ubuntu24-gfortran15-Debug`) for easier identification.
- **Accurate CDash Build Time:** Combined the `install` and `build-tests` targets in `CTestDashboard.cmake` into a single CMake multi-target build command so CDash correctly captures the *total* combined build time in one step.
- **Changelog:** Updated `CHANGELOG.md` with these enhancements.