### PR TITLE
Rename MAPL/mapl3 modules: legacy->MAPL2, new->MAPL

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -28,11 +28,11 @@ install(
   DESTINATION bin/forcing_converter)
 
 ecbuild_add_executable (TARGET Regrid_Util.x SOURCES Regrid_Util/Regrid_Util.F90)
-target_link_libraries (Regrid_Util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
+target_link_libraries (Regrid_Util.x PRIVATE MAPL2 MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (Regrid_Util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 ecbuild_add_executable (TARGET time_ave_util.x SOURCES time_ave_util.F90)
-target_link_libraries (time_ave_util.x PRIVATE MAPL MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
+target_link_libraries (time_ave_util.x PRIVATE MAPL2 MPI::MPI_Fortran ESMF::ESMF OpenMP::OpenMP_Fortran)
 target_include_directories (time_ave_util.x PRIVATE $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
 if (PFUNIT_FOUND)

--- a/Apps/Regrid_Util/Regrid_Util.F90
+++ b/Apps/Regrid_Util/Regrid_Util.F90
@@ -3,7 +3,7 @@
    module regrid_util_support_mod
 
    use ESMF
-   use MAPL
+   use MAPL2
    use gFTL2_StringVector
 
    implicit NONE

--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -4,7 +4,7 @@
 program  time_ave
 
    use ESMF
-   use MAPL
+   use MAPL2
    use MAPL_FileMetadataUtilsMod
    use gFTL_StringVector
    use gFTL2_StringVector

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -1,9 +1,9 @@
-esma_set_this()
+esma_set_this(OVERRIDE MAPL2)
 
 
 esma_add_library (${this}
   SRCS MAPL.F90
-  DEPENDENCIES mapl3g MAPL.base MAPL.generic MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps MAPL.orbit MAPL.griddedio MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
+  DEPENDENCIES MAPL MAPL.base MAPL.generic MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps MAPL.orbit MAPL.griddedio MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE SHARED
   )

--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -1,6 +1,6 @@
 ! This module re-exports the public entities
-! of the underlying packages.
-module MAPL
+! of the legacy (MAPL2) underlying packages.
+module MAPL2
    use MAPLBase_mod
    use MAPL_GenericMod
    use MAPL_VarSpecMiscMod
@@ -18,9 +18,5 @@ module MAPL
    use MAPL_StateUtils
    use MAPL_PythonBridge
    implicit none
-end module MAPL
-
-module MAPL_Mod
-   use MAPL
-end module MAPL_Mod
+end module MAPL2
 

--- a/Tests/CapDriver.F90
+++ b/Tests/CapDriver.F90
@@ -4,7 +4,7 @@
 
 program CapDriver_Main
    use MPI
-   use MAPL
+   use MAPL2
    use ExtDataUtRoot_GridCompMod, only:  ROOT_SetServices => SetServices
    implicit none
 

--- a/Tests/ExtDataDriver.F90
+++ b/Tests/ExtDataDriver.F90
@@ -8,7 +8,7 @@ program ExtData_Driver
   use ExtData_DriverGridCompMod, only: ExtData_DriverGridComp, new_ExtData_DriverGridComp
   use ExtDataUtRoot_GridCompMod, only:  ROOT_SetServices => SetServices
   use ExtDataDriverMod
-  use MAPL
+  use MAPL2
 
   implicit none
 

--- a/Tests/ExtDataDriverGridComp.F90
+++ b/Tests/ExtDataDriverGridComp.F90
@@ -3,7 +3,7 @@
 
 module ExtData_DriverGridCompMod
   use ESMF
-  use MAPL
+  use MAPL2
   use MAPL_ExtDataGridComp2G, only : ExtData2G_SetServices => SetServices
   use MAPL_HistoryGridCompMod, only : Hist_SetServices => SetServices
   use MAPL_Profiler, only : get_global_time_profiler, BaseProfiler

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -4,7 +4,7 @@ module ExtDataDriverMod
 
    use MPI  
    use ESMF
-   use MAPL
+   use MAPL2
    use ExtData_DriverGridCompMod, only: ExtData_DriverGridComp, new_ExtData_DriverGridComp
    use ExtDataUtRoot_GridCompMod, only:  ROOT_SetServices => SetServices
    use gFTL_StringVector

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -7,7 +7,7 @@
 
 MODULE ExtDataUtRoot_GridCompMod
       use ESMF
-      use MAPL
+      use MAPL2
       use MAPLShared
       use VarspecDescriptionMod
       use VarspecDescriptionVectorMod

--- a/Tests/GetHorzIJIndex/GridComp.F90
+++ b/Tests/GetHorzIJIndex/GridComp.F90
@@ -5,7 +5,7 @@
 module GridComp
 
   use ESMF
-  use MAPL
+  use MAPL2
 
   implicit none
   private

--- a/Tests/GetHorzIJIndex/driver.F90
+++ b/Tests/GetHorzIJIndex/driver.F90
@@ -3,7 +3,7 @@
 #include "MAPL.h"
 
 program driver_GetHorzIJIndex
-   use MAPL
+   use MAPL2
    use GridComp, only: SetServices
    implicit none
 

--- a/Tests/MAPL_demo_fargparse.F90
+++ b/Tests/MAPL_demo_fargparse.F90
@@ -8,7 +8,7 @@
 #include "MAPL_ErrLog.h"
 module main_mod
 
-   use MAPL
+   use MAPL2
    use mpi
    use fargparse
 

--- a/Tests/VarspecDescription.F90
+++ b/Tests/VarspecDescription.F90
@@ -5,7 +5,7 @@
 #define _RETURN(A)   if(present(rc)) rc=A; return
 
 module VarspecDescriptionMod
-   use MAPL
+   use MAPL2
    use ESMF
    use gFTL_StringVector
    implicit none

--- a/Tests/pfio_MAPL_demo.F90
+++ b/Tests/pfio_MAPL_demo.F90
@@ -19,7 +19,7 @@
 program main
       use, intrinsic :: iso_fortran_env, only: REAL32
       use mpi
-      use MAPL
+      use MAPL2
       use ESMF
       use pFIO_UnlimitedEntityMod
       use pFIO_ClientManagerMod, only: o_Clients

--- a/gridcomps/ExtData3G/CMakeLists.txt
+++ b/gridcomps/ExtData3G/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package (MPI REQUIRED)
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES mapl3g MAPL.pfio MAPL.base MAPL.vertical MAPL.regridder_mgr PFLOGGER::pflogger TYPE SHARED)
+  DEPENDENCIES MAPL MAPL.pfio MAPL.base MAPL.vertical MAPL.regridder_mgr PFLOGGER::pflogger TYPE SHARED)
 
 if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
   target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)

--- a/gridcomps/ExtData3G/ExtDataGridComp_private.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp_private.F90
@@ -3,7 +3,7 @@ module mapl3g_ExtDataGridComp_private
    use mapl_ErrorHandlingMod
    use mapl_keywordenforcermod
    use esmf
-   use mapl3
+   use MAPL
    use mapl3g_stateitem
    use mapl3g_PrimaryExportVector
    use mapl3g_PrimaryExport

--- a/gridcomps/History3G/CMakeLists.txt
+++ b/gridcomps/History3G/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package (MPI REQUIRED)
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES mapl3g MAPL_StatisticsGridComp PFLOGGER::pflogger TYPE SHARED)
+  DEPENDENCIES MAPL MAPL_StatisticsGridComp PFLOGGER::pflogger TYPE SHARED)
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/gridcomps/History3G/HistoryCollectionGridComp.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp.F90
@@ -2,7 +2,7 @@
 
 module mapl3g_HistoryCollectionGridComp
 
-   use mapl3
+   use MAPL
    use mapl3g_HistoryCollectionGridComp_private
    use mapl3g_HistoryConstants
    use esmf

--- a/gridcomps/History3G/HistoryCollectionGridComp_private.F90
+++ b/gridcomps/History3G/HistoryCollectionGridComp_private.F90
@@ -2,7 +2,7 @@
 
 module mapl3g_HistoryCollectionGridComp_private
 
-   use mapl3
+   use MAPL
    use esmf
    use gFTL2_StringVector
    use gFTL2_StringSet

--- a/gridcomps/History3G/HistoryGridComp.F90
+++ b/gridcomps/History3G/HistoryGridComp.F90
@@ -2,7 +2,7 @@
 
 module mapl3g_HistoryGridComp
 
-   use mapl3
+   use MAPL
    use mapl3g_HistoryGridComp_private
    use mapl3g_HistoryCollectionGridComp, only: collection_setServices => setServices
    use MAPL_TimeStringConversion

--- a/gridcomps/History3G/HistoryGridComp_private.F90
+++ b/gridcomps/History3G/HistoryGridComp_private.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 module mapl3g_HistoryGridComp_private
-   use mapl3
+   use MAPL
    use mapl_ErrorHandlingMod
    use mapl_keywordenforcermod
    use mapl3g_HistoryConstants

--- a/gridcomps/History3G/HistoryUtilities.F90
+++ b/gridcomps/History3G/HistoryUtilities.F90
@@ -1,6 +1,6 @@
 #include "MAPL.h"
 module mapl3g_HistoryUtilities
-   use mapl3
+   use MAPL
    use esmf
    use mapl3g_HistoryConstants
    !use gFTL2_StringVector

--- a/gridcomps/Orbit/CMakeLists.txt
+++ b/gridcomps/Orbit/CMakeLists.txt
@@ -4,7 +4,7 @@ set (srcs
         MAPL_OrbGridCompMod.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES mapl3g MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/gridcomps/StatisticsGridComp/AbstractTimeStatistic.F90
+++ b/gridcomps/StatisticsGridComp/AbstractTimeStatistic.F90
@@ -1,5 +1,5 @@
 module mapl3g_AbstractTimeStatistic
-   use mapl3
+   use MAPL
    implicit none(type,external)
    private
 

--- a/gridcomps/StatisticsGridComp/CMakeLists.txt
+++ b/gridcomps/StatisticsGridComp/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package (MPI REQUIRED)
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES mapl3g TYPE SHARED)
+  DEPENDENCIES MAPL TYPE SHARED)
 
 #add_subdirectory(tests EXCLUDE_FROM_ALL)
 

--- a/gridcomps/StatisticsGridComp/StatisticsGridComp.F90
+++ b/gridcomps/StatisticsGridComp/StatisticsGridComp.F90
@@ -2,7 +2,7 @@
 
 module mapl3g_StatisticsGridComp
 
-   use mapl3
+   use MAPL
    use mapl3g_RestartHandler
    use mapl3g_ESMF_Time_Utilities, only: sub_time_in_datetime
    ! local modules
@@ -459,7 +459,7 @@ contains
 end module mapl3g_StatisticsGridComp
 
 subroutine setServices(gridComp, rc)
-   use mapl3
+   use MAPL
    use mapl3g_StatisticsGridComp, only: StatisticsSetServices => setServices
    implicit none(type,external)
    type(esmf_GridComp), intent(inout) :: gridcomp

--- a/gridcomps/StatisticsGridComp/TimeAverage.F90
+++ b/gridcomps/StatisticsGridComp/TimeAverage.F90
@@ -3,7 +3,7 @@
 module mapl3g_TimeAverage
 
    use mapl3g_AbstractTimeStatistic
-   use mapl3
+   use MAPL
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/StatisticsGridComp/TimeMax.F90
+++ b/gridcomps/StatisticsGridComp/TimeMax.F90
@@ -3,7 +3,7 @@
 module mapl3g_TimeMax
 
    use mapl3g_AbstractTimeStatistic
-   use mapl3
+   use MAPL
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/StatisticsGridComp/TimeMin.F90
+++ b/gridcomps/StatisticsGridComp/TimeMin.F90
@@ -3,7 +3,7 @@
 module mapl3g_TimeMin
 
    use mapl3g_AbstractTimeStatistic
-   use mapl3
+   use MAPL
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/cap3g/CMakeLists.txt
+++ b/gridcomps/cap3g/CMakeLists.txt
@@ -9,11 +9,11 @@ find_package (MPI REQUIRED)
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES mapl3g TYPE SHARED)
+  DEPENDENCIES MAPL TYPE SHARED)
 
 add_subdirectory(tests EXCLUDE_FROM_ALL)
 
-ecbuild_add_executable(TARGET GEOS.x SOURCES GEOS.F90 DEPENDS mapl3g MAPL.cap3g ESMF::ESMF)
+ecbuild_add_executable(TARGET GEOS.x SOURCES GEOS.F90 DEPENDS MAPL MAPL.cap3g ESMF::ESMF)
 target_link_libraries(GEOS.x PRIVATE ${this})
 
 # GEOS.x is needed for 'make tests'

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 module mapl3g_Cap
-   use mapl3
+   use MAPL
    use mapl3g_CapGridComp, only: cap_setservices => setServices
    use mapl_TimeStringConversion, only: string_to_esmf_time
    use mapl_os

--- a/gridcomps/cap3g/GEOS.F90
+++ b/gridcomps/cap3g/GEOS.F90
@@ -2,7 +2,7 @@
 #include "MAPL.h"
 
 program geos
-   use mapl3
+   use MAPL
    use mapl3g_Cap
    use esmf
    implicit none

--- a/gridcomps/componentDriverGridComp/componentDriverGridComp.F90
+++ b/gridcomps/componentDriverGridComp/componentDriverGridComp.F90
@@ -3,8 +3,7 @@
 module mapl3g_ComponentDriverDriverGridComp
 
    use mapl_ErrorHandling
-   use mapl3
-   use mapl, only: MAPL_GetPointer
+   use MAPL
    use esmf
    use gFTL2_StringStringMap
    use MAPL_StateUtils

--- a/gridcomps/componentDriverGridComp/time_support.F90
+++ b/gridcomps/componentDriverGridComp/time_support.F90
@@ -1,6 +1,6 @@
 #include "MAPL.h"
 module timeSupport
-   use mapl3
+   use MAPL
    use esmf
    implicit none
 

--- a/gridcomps/configurable/ConfigurableGridComp.F90
+++ b/gridcomps/configurable/ConfigurableGridComp.F90
@@ -5,7 +5,7 @@ module mapl3g_ConfigurableGridComp
    use mapl_ErrorHandling
    use mapl3g_Generic, only: MAPL_GridCompSetEntryPoint, MAPL_GridCompRunChildren
    use mapl3g_Generic, only: MAPL_GridCompGet
-   use mapl, only: MAPL_GetPointer
+   use mapl3g_State_API, only: MAPL_StateGetPointer
    use MAPL_FieldPointerUtilities
    use esmf
 
@@ -68,7 +68,7 @@ contains
          has_default_vert_profile = ESMF_HConfigIsDefined(field_cfg, keyString=KEY_DEFAULT_VERT_PROFILE, _RC)
          if (has_default_vert_profile) then
             default_vert_profile = ESMF_HConfigAsR4Seq(field_cfg, keyString=KEY_DEFAULT_VERT_PROFILE, _RC)
-            call MAPL_GetPointer(exportState, ptr3d, trim(field_name), _RC)
+            call MAPL_StateGetPointer(exportState, ptr3d, trim(field_name), _RC)
             shape_ = shape(ptr3d)
             _ASSERT(shape_(3) == size(default_vert_profile), "incorrect size of vertical profile")
             do concurrent(ii = 1:shape_(1), jj=1:shape_(2))

--- a/mapl3g/CMakeLists.txt
+++ b/mapl3g/CMakeLists.txt
@@ -1,7 +1,7 @@
-esma_set_this()
+esma_set_this(OVERRIDE MAPL)
 
 set (srcs
-  mapl3g.F90
+  MAPL.F90
   MaplFramework.F90
   )
 

--- a/mapl3g/MAPL.F90
+++ b/mapl3g/MAPL.F90
@@ -1,5 +1,5 @@
-! Public interface (package) to MAPL3
-module mapl3
+! Public interface (package) to MAPL
+module MAPL
    use mapl3g_VM_API
    use mapl3g_MaplFramework
    use generic3g
@@ -15,4 +15,4 @@ module mapl3
    ! the other layers.  When the dust settles and such micro
    ! management become feasible, this can be reconsidered.
    
-end module mapl3
+end module MAPL

--- a/pfunit/CMakeLists.txt
+++ b/pfunit/CMakeLists.txt
@@ -11,7 +11,7 @@ set (srcs
 esma_add_library (${this} EXCLUDE_FROM_ALL SRCS ${srcs} NOINSTALL TYPE SHARED)
 
 target_link_libraries (${this}
-  mapl3g MAPL.shared
+  MAPL MAPL.shared
   PFUNIT::pfunit
   ESMF::ESMF
   NetCDF::NetCDF_Fortran

--- a/pfunit/MAPL_Initialize.F90
+++ b/pfunit/MAPL_Initialize.F90
@@ -4,7 +4,7 @@ module MAPL_pFUnit_Initialize
 
 contains
    subroutine Initialize()
-      use mapl3
+      use MAPL
       use fArgParse
       use MAPL_ThrowMod, only: MAPL_set_throw_method
       use MAPL_pFUnit_ThrowMod


### PR DESCRIPTION
## Types of change(s)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Tested this change with a local build
- [ ] Tested this change with a run of GEOSgcm (in progress)
- [ ] Ran the Unit Tests (`make tests` or `ctest`)

## Description

The repository previously exposed two top-level Fortran module aggregators:

- `module MAPL` — the legacy/2G interface (`MAPL/MAPL.F90`)
- `module mapl3` — the new/3G interface (`mapl3g/mapl3g.F90`)

This PR swaps the names so that `MAPL` now refers to the new 3G interface and `MAPL2` to the legacy one (which will eventually shrink and be deleted).

### Fortran modules
- `module MAPL` → `module MAPL2` (`MAPL/MAPL.F90`); unused `MAPL_Mod` alias dropped
- `module mapl3` → `module MAPL` (`mapl3g/mapl3g.F90`, renamed to `mapl3g/MAPL.F90`)

### CMake targets
- `mapl3g` library target → `MAPL` (via `esma_set_this(OVERRIDE MAPL)`)
- `MAPL` library target → `MAPL2` (via `esma_set_this(OVERRIDE MAPL2)`)

### Consumer updates
- 14 files using `use MAPL` updated to `use MAPL2` (legacy Apps/Tests)
- 16 files using `use mapl3` updated to `use MAPL` (3G gridcomps)
- All downstream `CMakeLists.txt` dependency references updated
- `MAPL_GetPointer` (from MAPL2) replaced with `MAPL_StateGetPointer` in
  `ConfigurableGridComp`; dead import removed from `componentDriverGridComp`

## Follow-up

A subsequent PR will audit how many remaining `MAPL2` references can be safely
converted to the new `MAPL` (given overlap between the two module sets).

## Related Issue

Closes #4600