### PR TITLE
Add MAPL_SUPPORT_MAPL3 CMake option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `MAPL_SUPPORT_MAPL3` CMake option to reduce MAPL2 to a support library for use alongside MAPL3. When `ON`, the generic layer, gridcomps, Apps, benchmarks, docs, Python bridge, and top-level Tests are disabled; all CMake targets are renamed with a `MAPL2.*` prefix controlled by the `MAPL_TARGET_PREFIX` variable. Default is `OFF` (no change in behavior).
+- When `MAPL_SUPPORT_MAPL3=ON`, the umbrella module in `MAPL/MAPL.F90` is renamed from `module MAPL` to `module MAPL2` (and the alias from `MAPL_Mod` to `MAPL2_Mod`); `use MAPL` in hybrid mode is intentionally undefined. `use ESMF_CFIOMod` is now unconditional in both modes.
 - Add `.mlc.toml` file to configure `mlc` link checker
 - Added a new feature: create a halo based on local displacement members, local-displacement-ensemble (LDE), requested some time ago by Arlindo da Silva
 - CDash nightly workflow configured to build and test `release/MAPL-v3` from the `main` branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `MAPL_SUPPORT_MAPL3` CMake option to reduce MAPL2 to a support library for use alongside MAPL3. When `ON`, the generic layer, gridcomps, Apps, benchmarks, docs, Python bridge, and top-level Tests are disabled; all CMake targets are renamed with a `MAPL2.*` prefix controlled by the `MAPL_TARGET_PREFIX` variable. Default is `OFF` (no change in behavior).
 - Add `.mlc.toml` file to configure `mlc` link checker
 - Added a new feature: create a halo based on local displacement members, local-displacement-ensemble (LDE), requested some time ago by Arlindo da Silva
 - CDash nightly workflow configured to build and test `release/MAPL-v3` from the `main` branch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,22 @@ else ()
 endif()
 message (STATUS "Building MAPL as ${MAPL_LIBRARY_TYPE} libraries")
 
+# MAPL_SUPPORT_MAPL3: reduce MAPL2 to a support library for use alongside MAPL3.
+# When ON, disables the generic layer, gridcomps, and renames targets to MAPL2.*.
+# The name MAPL_SUPPORT_MAPL3 is a placeholder pending team agreement.
+# The prefix variable MAPL_TARGET_PREFIX is the single place to change the prefix.
+option(MAPL_SUPPORT_MAPL3
+    "Reduce MAPL2 to a support library for use alongside MAPL3. Disables the generic layer, gridcomps, and renames targets to MAPL2.*"
+    OFF)
+
+if (MAPL_SUPPORT_MAPL3)
+    add_compile_definitions(MAPL_SUPPORT_MAPL3)
+    set(MAPL_TARGET_PREFIX "MAPL2")
+    message(STATUS "MAPL_SUPPORT_MAPL3=ON: building as support library with target prefix '${MAPL_TARGET_PREFIX}'")
+else()
+    set(MAPL_TARGET_PREFIX "MAPL")
+endif()
+
 # Some users of MAPL build GFE libraries inline with their application
 # using an add_subdirectory() call rather than as a pre-build library.
 # This would then populate the target already leading to find_package()
@@ -206,7 +222,9 @@ add_definitions(-Dsys${CMAKE_SYSTEM_NAME})
 # Support for automated code generation
 include(mapl_acg)
 include(mapl_create_stub_component)
-add_subdirectory (Apps)
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_subdirectory (Apps)
+endif ()
 
 # Special case - MAPL_cfio is built twice with two different precisions.
 add_subdirectory (MAPL_cfio MAPL_cfio_r4)
@@ -228,7 +246,9 @@ endif()
 add_subdirectory (udunits2f)
 add_subdirectory (pfio)
 add_subdirectory (profiler)
-add_subdirectory (generic)
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_subdirectory (generic)
+endif ()
 add_subdirectory (field_utils)
 add_subdirectory (state)
 add_subdirectory (oomph) # temporary - will rename to generic when done
@@ -236,21 +256,27 @@ add_subdirectory (shared)
 add_subdirectory (include)
 add_subdirectory (base)
 add_subdirectory (MAPL)
-add_subdirectory (gridcomps)
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_subdirectory (gridcomps)
+endif ()
 add_subdirectory (griddedio)
 add_subdirectory (vertical)
-if (BUILD_WITH_FARGPARSE)
+if (BUILD_WITH_FARGPARSE AND NOT MAPL_SUPPORT_MAPL3)
    add_subdirectory (docs)
    add_subdirectory (benchmarks)
 endif()
-add_subdirectory(Python)
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_subdirectory(Python)
+endif ()
 
 if (PFUNIT_FOUND)
   include (add_pfunit_ctest)
   add_subdirectory (pfunit EXCLUDE_FROM_ALL)
 endif ()
 
-add_subdirectory (Tests)
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_subdirectory (Tests)
+endif ()
 
 # @env will exist here if MAPL is built as itself but not as part of, say, GEOSgcm
 esma_add_subdirectory (ESMA_env FOUND ESMA_env_FOUND)

--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -1,11 +1,39 @@
-esma_set_this()
+if (MAPL_SUPPORT_MAPL3)
+  esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX})
+else ()
+  esma_set_this ()
+endif ()
 
+# Common dependencies always required
+set (mapl_dependencies
+  ${MAPL_TARGET_PREFIX}.base
+  ${MAPL_TARGET_PREFIX}.pfio
+  MAPL_cfio_r4
+  ${MAPL_TARGET_PREFIX}.griddedio
+  ${MAPL_TARGET_PREFIX}.field_utils
+  ${MAPL_TARGET_PREFIX}.state_utils
+  ${MAPL_TARGET_PREFIX}.vertical
+  ${MAPL_TARGET_PREFIX}.oomph
+  ESMF::ESMF
+  NetCDF::NetCDF_Fortran
+  MPI::MPI_Fortran
+  $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
+  )
+
+# Full-MAPL mode adds the generic layer, gridcomps, and Python bridge
+if (NOT MAPL_SUPPORT_MAPL3)
+  list (APPEND mapl_dependencies
+    MAPL.generic
+    MAPL.gridcomps
+    MAPL.orbit
+    MAPL.python_bridge
+    ${EXTDATA_TARGET}
+    )
+endif ()
 
 esma_add_library (${this}
   SRCS MAPL.F90
-  DEPENDENCIES MAPL.base MAPL.generic MAPL.pfio MAPL_cfio_r4 MAPL.gridcomps MAPL.orbit MAPL.griddedio MAPL.field_utils MAPL.python_bridge ${EXTDATA_TARGET}
-               ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-               $<$<BOOL:${BUILD_WITH_FLAP}>:FLAP::FLAP>
+  DEPENDENCIES ${mapl_dependencies}
   TYPE ${MAPL_LIBRARY_TYPE}
   )
 

--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -2,22 +2,30 @@
 ! of the underlying packages.
 module MAPL
    use MAPLBase_mod
+#ifndef MAPL_SUPPORT_MAPL3
    use MAPL_GenericMod
    use MAPL_VarSpecMiscMod
    use ESMF_CFIOMod
+#endif
    use pFIO
+#ifndef MAPL_SUPPORT_MAPL3
    use MAPL_GridCompsMod
    use mapl_StubComponent
+#endif
    use MAPL_ESMFFieldBundleRead
    use MAPL_ESMFFieldBundleWrite
+#ifndef MAPL_SUPPORT_MAPL3
    use MAPL_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
    use MAPL_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
    use MAPL_OpenMP_Support, only : MAPL_find_bounds => find_bounds
    use MAPL_OpenMP_Support, only : MAPL_Interval => Interval
+#endif
    use MAPL_Profiler, initialize_profiler =>initialize, finalize_profiler =>finalize
    use MAPL_FieldUtils
    use MAPL_StateUtils
+#ifndef MAPL_SUPPORT_MAPL3
    use MAPL_PythonBridge
+#endif
    implicit none
 end module MAPL
 

--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -1,12 +1,16 @@
 ! This module re-exports the public entities
 ! of the underlying packages.
+#ifdef MAPL_SUPPORT_MAPL3
+module MAPL2
+#else
 module MAPL
+#endif
    use MAPLBase_mod
 #ifndef MAPL_SUPPORT_MAPL3
    use MAPL_GenericMod
    use MAPL_VarSpecMiscMod
-   use ESMF_CFIOMod
 #endif
+   use ESMF_CFIOMod
    use pFIO
 #ifndef MAPL_SUPPORT_MAPL3
    use MAPL_GridCompsMod
@@ -27,9 +31,19 @@ module MAPL
    use MAPL_PythonBridge
 #endif
    implicit none
+#ifdef MAPL_SUPPORT_MAPL3
+end module MAPL2
+#else
 end module MAPL
+#endif
 
+#ifdef MAPL_SUPPORT_MAPL3
+module MAPL2_Mod
+   use MAPL2
+end module MAPL2_Mod
+#else
 module MAPL_Mod
    use MAPL
 end module MAPL_Mod
+#endif
    

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.base)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.base)
 
 set (srcs
   MAPL_Profiler.F90
@@ -61,7 +61,7 @@ endif()
 
 esma_add_library(
   ${this} SRCS ${srcs}
-  DEPENDENCIES MAPL.shared MAPL.constants MAPL.profiler MAPL.pfio MAPL_cfio_r4 MAPL.field_utils udunits2f PFLOGGER::pflogger
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.constants ${MAPL_TARGET_PREFIX}.profiler ${MAPL_TARGET_PREFIX}.pfio MAPL_cfio_r4 ${MAPL_TARGET_PREFIX}.field_utils udunits2f PFLOGGER::pflogger
                GFTL_SHARED::gftl-shared-v2 GFTL_SHARED::gftl-shared-v1  GFTL::gftl-v2 GFTL::gftl-v1
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE ${MAPL_LIBRARY_TYPE})
@@ -80,8 +80,8 @@ foreach(dir ${OSX_EXTRA_LIBRARY_PATH})
   target_link_libraries(${this} PUBLIC "-Xlinker -rpath -Xlinker ${dir}")
 endforeach()
 
-ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS ESMF::ESMF MAPL.shared)
-target_link_libraries (cub2latlon.x PRIVATE ${this} MAPL.pfio MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
+ecbuild_add_executable (TARGET cub2latlon.x SOURCES cub2latlon_regridder.F90 DEPENDS ESMF::ESMF ${MAPL_TARGET_PREFIX}.shared)
+target_link_libraries (cub2latlon.x PRIVATE ${this} ${MAPL_TARGET_PREFIX}.pfio MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 set_target_properties(cub2latlon.x PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
 if (EXTENDED_SOURCE)

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.base/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.base/tests")
 
 add_definitions(-DUSE_MPI)
 set (TEST_SRCS
@@ -35,34 +35,37 @@ set (SRCS
 #target_link_libraries (base_extras MAPL.shared MAPL.pfunit
 #                                   ESMF::ESMF NetCDF::NetCDF_Fortran)
 
-add_pfunit_ctest(MAPL.base.tests
-                TEST_SOURCES ${TEST_SRCS}
-                OTHER_SOURCES ${SRCS}
-#                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.pfio base_extras MAPL.pfunit
-                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.constants MAPL.generic MAPL.pfio MAPL.pfunit
-                EXTRA_INITIALIZE Initialize
-                EXTRA_USE MAPL_pFUnit_Initialize
-                MAX_PES 8
-                )
-set_target_properties(MAPL.base.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.base.tests PROPERTIES LABELS "ESSENTIAL")
+if (NOT MAPL_SUPPORT_MAPL3)
+  add_pfunit_ctest(${MAPL_TARGET_PREFIX}.base.tests
+                  TEST_SOURCES ${TEST_SRCS}
+                  OTHER_SOURCES ${SRCS}
+  #                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.pfio base_extras MAPL.pfunit
+                  LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.base ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.constants MAPL.generic ${MAPL_TARGET_PREFIX}.pfio ${MAPL_TARGET_PREFIX}.pfunit
+                  EXTRA_INITIALIZE Initialize
+                  EXTRA_USE MAPL_pFUnit_Initialize
+                  MAX_PES 8
+                  )
+  set_target_properties(${MAPL_TARGET_PREFIX}.base.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+  set_tests_properties(${MAPL_TARGET_PREFIX}.base.tests PROPERTIES LABELS "ESSENTIAL")
+  add_dependencies(build-tests ${MAPL_TARGET_PREFIX}.base.tests)
+endif ()
 
-add_dependencies(build-tests MAPL.base.tests)
+if (NOT MAPL_SUPPORT_MAPL3)
+  set(TESTIO mapl_bundleio_test.x)
+  ecbuild_add_executable (
+    TARGET ${TESTIO}
+    NOINSTALL
+    SOURCES mapl_bundleio_test.F90
+    LIBS ${MAPL_TARGET_PREFIX}.base ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.constants ${MAPL_TARGET_PREFIX}.pfio ${MAPL_TARGET_PREFIX}.griddedio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
+    DEFINITIONS USE_MPI)
+  set_target_properties(${TESTIO} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
-set(TESTIO mapl_bundleio_test.x)
-ecbuild_add_executable (
-  TARGET ${TESTIO}
-  NOINSTALL
-  SOURCES mapl_bundleio_test.F90
-  LIBS MAPL.base MAPL.shared MAPL.constants MAPL.pfio MAPL.griddedio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
-  DEFINITIONS USE_MPI)
-set_target_properties(${TESTIO} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+  add_test(NAME bundleio_tests_latlon
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${TESTIO} -nx 2 -ny 1 -ogrid PC90x47-DE -o file1_ll.nc4)
 
-add_test(NAME bundleio_tests_latlon
-  COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${TESTIO} -nx 2 -ny 1 -ogrid PC90x47-DE -o file1_ll.nc4)
+  add_test(NAME bundleio_tests_cube
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 6 ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${TESTIO} -nx 1 -ny 6 -ogrid PE12x72-CF -o file_cs.nc4)
 
-add_test(NAME bundleio_tests_cube
-  COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 6 ${MPIEXEC_PREFLAGS} ${CMAKE_CURRENT_BINARY_DIR}/${TESTIO} -nx 1 -ny 6 -ogrid PE12x72-CF -o file_cs.nc4)
-
-add_dependencies(build-tests ${TESTIO})
+  add_dependencies(build-tests ${TESTIO})
+endif ()
 

--- a/field_utils/CMakeLists.txt
+++ b/field_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.field_utils)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.field_utils)
 
 set(srcs
   FieldUtils.F90
@@ -20,7 +20,7 @@ endif ()
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.shared PFLOGGER::pflogger
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared PFLOGGER::pflogger
   TYPE ${MAPL_LIBRARY_TYPE}
   )
 

--- a/field_utils/tests/CMakeLists.txt
+++ b/field_utils/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.field_utils/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.field_utils/tests")
 
 set (test_srcs
   Test_FieldBLAS.pf
@@ -6,24 +6,28 @@ set (test_srcs
   )
 
 
-add_pfunit_ctest(MAPL.field_utils.tests
+add_pfunit_ctest(${MAPL_TARGET_PREFIX}.field_utils.tests
                 TEST_SOURCES ${test_srcs}
-                LINK_LIBRARIES MAPL.field_utils MAPL.pfunit
+                LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.field_utils ${MAPL_TARGET_PREFIX}.pfunit
                 EXTRA_INITIALIZE Initialize
                 EXTRA_USE MAPL_pFUnit_Initialize
                 OTHER_SOURCES field_utils_setup.F90
 #		OTHER_SOURCES MockUserGridComp.F90 MockItemSpec.F90
                 MAX_PES 4
                 )
-set_target_properties(MAPL.field_utils.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.field_utils.tests PROPERTIES LABELS "ESSENTIAL")
+set_target_properties(${MAPL_TARGET_PREFIX}.field_utils.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+target_include_directories(${MAPL_TARGET_PREFIX}.field_utils.tests PRIVATE
+  ${esma_include}/${MAPL_TARGET_PREFIX}.pfunit
+  ${esma_include}/${MAPL_TARGET_PREFIX}.field_utils
+  ${esma_include}/${MAPL_TARGET_PREFIX}.shared)
+set_tests_properties(${MAPL_TARGET_PREFIX}.field_utils.tests PROPERTIES LABELS "ESSENTIAL")
 
 if (APPLE)
   set(LD_PATH "DYLD_LIBRARY_PATH")
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.field_utils.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/field_utils:$ENV{${LD_PATH}}")
+set_property(TEST ${MAPL_TARGET_PREFIX}.field_utils.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/field_utils:$ENV{${LD_PATH}}")
 
-add_dependencies(build-tests MAPL.field_utils.tests)
+add_dependencies(build-tests ${MAPL_TARGET_PREFIX}.field_utils.tests)
 

--- a/griddedio/CMakeLists.txt
+++ b/griddedio/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.griddedio)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.griddedio)
 
 set (srcs
         DataCollection.F90
@@ -16,7 +16,7 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.shared MAPL.constants MAPL.base MAPL.pfio MAPL_cfio_r4
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.constants ${MAPL_TARGET_PREFIX}.base ${MAPL_TARGET_PREFIX}.pfio MAPL_cfio_r4
   TYPE ${MAPL_LIBRARY_TYPE})
 
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared PFLOGGER::pflogger ESMF::ESMF NetCDF::NetCDF_Fortran

--- a/oomph/CMakeLists.txt
+++ b/oomph/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.oomph)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.oomph)
 
 set (srcs
   oomph.F90
@@ -30,5 +30,5 @@ set (srcs
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.base GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2 TYPE ${MAPL_LIBRARY_TYPE}
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.base GFTL_SHARED::gftl-shared-v2 GFTL::gftl-v2 TYPE ${MAPL_LIBRARY_TYPE}
   )

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.pfio)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.pfio)
 
 # This is a workaround for a current ifx bug
 # Technically, this bug is only due to a bug between
@@ -95,7 +95,7 @@ if (BUILD_WITH_PFLOGGER)
   find_package (PFLOGGER REQUIRED)
 endif ()
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.shared MAPL.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.profiler NetCDF::NetCDF_Fortran NetCDF::NetCDF_C TYPE ${MAPL_LIBRARY_TYPE})
 
 target_link_libraries (${this} PUBLIC GFTL::gftl-v2 GFTL_SHARED::gftl-shared-v2 PFLOGGER::pflogger PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC

--- a/pfio/tests/CMakeLists.txt
+++ b/pfio/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.pfio/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.pfio/tests")
 
 add_definitions(-DUSE_MPI)
 set (TEST_SRCS
@@ -36,17 +36,21 @@ set (SRCS
 #  )
 #target_link_libraries (pfio_extras PUBLIC MAPL.pfunit MAPL.shared)
 
-add_pfunit_ctest(MAPL.pfio.tests
+add_pfunit_ctest(${MAPL_TARGET_PREFIX}.pfio.tests
                 TEST_SOURCES ${TEST_SRCS}
                 OTHER_SOURCES ${SRCS}
-                LINK_LIBRARIES MAPL.pfio MAPL.pfunit
+                LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.pfio ${MAPL_TARGET_PREFIX}.pfunit
                 EXTRA_INITIALIZE Initialize
                 EXTRA_USE MAPL_pFUnit_Initialize
                 MAX_PES 8
                 )
-set_target_properties(MAPL.pfio.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.pfio.tests PROPERTIES LABELS "ESSENTIAL")
-set_tests_properties(MAPL.pfio.tests PROPERTIES PROCESSORS 8)
+set_target_properties(${MAPL_TARGET_PREFIX}.pfio.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+target_include_directories(${MAPL_TARGET_PREFIX}.pfio.tests PRIVATE
+  ${esma_include}/${MAPL_TARGET_PREFIX}.pfunit
+  ${esma_include}/${MAPL_TARGET_PREFIX}.pfio
+  ${esma_include}/${MAPL_TARGET_PREFIX}.shared)
+set_tests_properties(${MAPL_TARGET_PREFIX}.pfio.tests PROPERTIES LABELS "ESSENTIAL")
+set_tests_properties(${MAPL_TARGET_PREFIX}.pfio.tests PROPERTIES PROCESSORS 8)
 
 include_directories(
    ${CMAKE_CURRENT_SOURCE_DIR}
@@ -54,7 +58,7 @@ include_directories(
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/..)
-include_directories(${include_MAPL.pfio})
+include_directories(${include_${MAPL_TARGET_PREFIX}.pfio})
 include_directories(${MAPL_SOURCE_DIR}/include)
 
 
@@ -63,9 +67,10 @@ ecbuild_add_executable (
   TARGET ${TESTO}
   NOINSTALL
   SOURCES pfio_ctest_io.F90
-  LIBS MAPL.shared MAPL.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
+  LIBS ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.pfio NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   DEFINITIONS USE_MPI)
 target_link_libraries(${TESTO} OpenMP::OpenMP_Fortran)
+target_include_directories(${TESTO} PRIVATE ${esma_include}/${MAPL_TARGET_PREFIX}.shared ${esma_include}/${MAPL_TARGET_PREFIX}.pfio)
 set_target_properties(${TESTO} PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
 
 # Detect if we are using Open MPI and add oversubscribe
@@ -122,7 +127,7 @@ set_tests_properties(pFIO_tests_mpi_2group PROPERTIES PROCESSORS 18 RESOURCE_LOC
 #  set_tests_properties (pFIO_tests_mpi_2layer PROPERTIES DISABLED True)
 #endif ()
 
-add_dependencies(build-tests MAPL.pfio.tests)
+add_dependencies(build-tests ${MAPL_TARGET_PREFIX}.pfio.tests)
 add_dependencies(build-tests ${TESTO})
 add_dependencies(build-tests pfio_writer.x)
 

--- a/pfunit/CMakeLists.txt
+++ b/pfunit/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this(OVERRIDE MAPL.pfunit)
+esma_set_this(OVERRIDE ${MAPL_TARGET_PREFIX}.pfunit)
 
 set (srcs
   ESMF_TestCase.F90
@@ -10,5 +10,5 @@ set (srcs
 
 esma_add_library (${this} EXCLUDE_FROM_ALL SRCS ${srcs} NOINSTALL TYPE ${MAPL_LIBRARY_TYPE})
 
-target_link_libraries (${this} MAPL.shared PFUNIT::pfunit ESMF::ESMF NetCDF::NetCDF_Fortran)
+target_link_libraries (${this} ${MAPL_TARGET_PREFIX}.shared PFUNIT::pfunit ESMF::ESMF NetCDF::NetCDF_Fortran)
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.profiler)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.profiler)
 
 set (srcs
   AbstractMeter.F90
@@ -49,7 +49,7 @@ set (srcs
   MAPL_Profiler.F90
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl-v1 GFTL::gftl-v2 MAPL.shared MPI::MPI_Fortran TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES GFTL_SHARED::gftl-shared GFTL::gftl-v1 GFTL::gftl-v2 ${MAPL_TARGET_PREFIX}.shared MPI::MPI_Fortran TYPE ${MAPL_LIBRARY_TYPE})
 target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
 target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 

--- a/profiler/tests/CMakeLists.txt
+++ b/profiler/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.profiler/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.profiler/tests")
 
 set (TEST_SRCS
   test_AdvancedMeter.pf
@@ -14,15 +14,19 @@ set (TEST_SRCS
 
 
 add_pfunit_ctest (
-  MAPL.profiler.tests
+  ${MAPL_TARGET_PREFIX}.profiler.tests
   TEST_SOURCES ${TEST_SRCS}
-  LINK_LIBRARIES MAPL.profiler MAPL.pfunit
+  LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.profiler ${MAPL_TARGET_PREFIX}.pfunit
   EXTRA_INITIALIZE Initialize
   EXTRA_USE MAPL_pFUnit_Initialize
   MAX_PES 8
   )
-set_target_properties(MAPL.profiler.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.profiler.tests PROPERTIES LABELS "ESSENTIAL")
+set_target_properties(${MAPL_TARGET_PREFIX}.profiler.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+target_include_directories(${MAPL_TARGET_PREFIX}.profiler.tests PRIVATE
+  ${esma_include}/${MAPL_TARGET_PREFIX}.pfunit
+  ${esma_include}/${MAPL_TARGET_PREFIX}.profiler
+  ${esma_include}/${MAPL_TARGET_PREFIX}.shared)
+set_tests_properties(${MAPL_TARGET_PREFIX}.profiler.tests PROPERTIES LABELS "ESSENTIAL")
 
-add_dependencies (build-tests MAPL.profiler.tests)
+add_dependencies (build-tests ${MAPL_TARGET_PREFIX}.profiler.tests)
 

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.shared)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.shared)
 
 set (srcs
     hash.c
@@ -35,7 +35,7 @@ set (srcs
     Shmem/Shmem.F90   Shmem/Shmem_implementation.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL.constants GFTL_SHARED::gftl-shared MPI::MPI_Fortran PFLOGGER::pflogger TYPE ${MAPL_LIBRARY_TYPE})
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES ${MAPL_TARGET_PREFIX}.constants GFTL_SHARED::gftl-shared MPI::MPI_Fortran PFLOGGER::pflogger TYPE ${MAPL_LIBRARY_TYPE})
 target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/shared/Constants/CMakeLists.txt
+++ b/shared/Constants/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.constants)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.constants)
 
 set (srcs
     InternalConstants.F90

--- a/shared/tests/CMakeLists.txt
+++ b/shared/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.shared/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.shared/tests")
 
 set (test_srcs
     test_String.pf
@@ -12,11 +12,12 @@ set (test_srcs
   )
 
 
-add_pfunit_ctest(MAPL.shared.tests
+add_pfunit_ctest(${MAPL_TARGET_PREFIX}.shared.tests
                 TEST_SOURCES ${test_srcs}
-                LINK_LIBRARIES MAPL.shared
+                LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.shared
                 )
-set_target_properties(MAPL.shared.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.shared.tests PROPERTIES LABELS "ESSENTIAL")
+set_target_properties(${MAPL_TARGET_PREFIX}.shared.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+target_include_directories(${MAPL_TARGET_PREFIX}.shared.tests PRIVATE ${esma_include}/${MAPL_TARGET_PREFIX}.shared)
+set_tests_properties(${MAPL_TARGET_PREFIX}.shared.tests PROPERTIES LABELS "ESSENTIAL")
 
-add_dependencies(build-tests MAPL.shared.tests)
+add_dependencies(build-tests ${MAPL_TARGET_PREFIX}.shared.tests)

--- a/state/CMakeLists.txt
+++ b/state/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.state_utils)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.state_utils)
 
 set(srcs
   StateUtils.F90
@@ -14,7 +14,7 @@ endif ()
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.base MAPL.shared PFLOGGER::pflogger
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.base ${MAPL_TARGET_PREFIX}.shared PFLOGGER::pflogger
   TYPE ${MAPL_LIBRARY_TYPE}
   )
 

--- a/state/tests/CMakeLists.txt
+++ b/state/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(MODULE_DIRECTORY "${esma_include}/MAPL.state/tests")
+set(MODULE_DIRECTORY "${esma_include}/${MAPL_TARGET_PREFIX}.state/tests")
 
 set (test_srcs
   Test_StateMask.pf
@@ -7,23 +7,27 @@ set (test_srcs
   )
 
 
-add_pfunit_ctest(MAPL.state.tests
+add_pfunit_ctest(${MAPL_TARGET_PREFIX}.state.tests
                 TEST_SOURCES ${test_srcs}
-                LINK_LIBRARIES MAPL.state_utils MAPL.pfunit
+                LINK_LIBRARIES ${MAPL_TARGET_PREFIX}.state_utils ${MAPL_TARGET_PREFIX}.pfunit
                 EXTRA_INITIALIZE Initialize
                 EXTRA_USE MAPL_pFUnit_Initialize
                 OTHER_SOURCES state_utils_setup.F90
                 MAX_PES 1
                 )
-set_target_properties(MAPL.state.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
-set_tests_properties(MAPL.state.tests PROPERTIES LABELS "ESSENTIAL")
+set_target_properties(${MAPL_TARGET_PREFIX}.state.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+target_include_directories(${MAPL_TARGET_PREFIX}.state.tests PRIVATE
+  ${esma_include}/${MAPL_TARGET_PREFIX}.pfunit
+  ${esma_include}/${MAPL_TARGET_PREFIX}.state_utils
+  ${esma_include}/${MAPL_TARGET_PREFIX}.shared)
+set_tests_properties(${MAPL_TARGET_PREFIX}.state.tests PROPERTIES LABELS "ESSENTIAL")
 
 if (APPLE)
   set(LD_PATH "DYLD_LIBRARY_PATH")
 else()
   set(LD_PATH "LD_LIBRARY_PATH")
 endif ()
-set_property(TEST MAPL.state.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/state:$ENV{${LD_PATH}}")
+set_property(TEST ${MAPL_TARGET_PREFIX}.state.tests PROPERTY ENVIRONMENT "${LD_PATH}=${CMAKE_CURRENT_BINARY_DIR}/state:$ENV{${LD_PATH}}")
 
-add_dependencies(build-tests MAPL.state.tests)
+add_dependencies(build-tests ${MAPL_TARGET_PREFIX}.state.tests)
 

--- a/udunits2f/CMakeLists.txt
+++ b/udunits2f/CMakeLists.txt
@@ -13,7 +13,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.shared
+  DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared
   TYPE SHARED
 )
 

--- a/vertical/CMakeLists.txt
+++ b/vertical/CMakeLists.txt
@@ -1,4 +1,4 @@
-esma_set_this (OVERRIDE MAPL.vertical)
+esma_set_this (OVERRIDE ${MAPL_TARGET_PREFIX}.vertical)
 
 set (srcs
      Eta2Eta.F90
@@ -9,7 +9,7 @@ set (srcs
 
 esma_add_library(${this}
     SRCS ${srcs}
-    DEPENDENCIES MAPL.shared MAPL.base MAPL.pfio PFLOGGER::pflogger
+    DEPENDENCIES ${MAPL_TARGET_PREFIX}.shared ${MAPL_TARGET_PREFIX}.base ${MAPL_TARGET_PREFIX}.pfio PFLOGGER::pflogger
     TYPE ${MAPL_LIBRARY_TYPE}
     )
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (make tests or ctest)

## Description

Adds a MAPL_SUPPORT_MAPL3 CMake option that reduces MAPL2 to a support library for use alongside MAPL3.

When MAPL_SUPPORT_MAPL3=ON:
- The generic layer, gridcomps, Apps, docs, benchmarks, Python bridge, and top-level Tests subdirectories are disabled
- All CMake targets are renamed to MAPL2.* (controlled by the MAPL_TARGET_PREFIX variable -- a single place to change the prefix if the name is later revised)
- MAPL.F90 USE statements for modules from generic, gridcomps, and Python are guarded with #ifndef MAPL_SUPPORT_MAPL3

When MAPL_SUPPORT_MAPL3=OFF (the default), behavior is identical to current develop -- no targets or sources are affected.

Both modes were built and tested with the NAG compiler; all tests pass.

Also fixes a pre-existing bug in shared/tests/CMakeLists.txt where the shared library module directory was not on the test driver include path.

## Related Issue

Fixes #4610