### PR TITLE
v2: specify fixed site name for CDash runs in GitHub Actions

### DIFF
--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -125,6 +125,7 @@ jobs:
             -D build_type=${CTEST_BUILD_TYPE} \
             -D generator="Unix Makefiles" \
             -D jobs=4 \
+            -D site="GitHub-Actions" \
             -D build_name="GHA-${SAFE_BRANCH}-ubuntu24-${{ matrix.compiler }}-${CTEST_BUILD_TYPE}" \
             -S CTestDashboard.cmake \
             -V

--- a/CTestDashboard.cmake
+++ b/CTestDashboard.cmake
@@ -10,6 +10,10 @@
 ##   -D generator=Ninja        # default: Ninja
 ##   -D jobs=8                 # default: 6
 ##   -D site=myhost            # default: auto-detected hostname
+##                             # NOTE: Set this explicitly on CI runners (GitHub Actions),
+##                             # SLURM compute nodes, or laptops on VPNs. Otherwise, CDash
+##                             # sees a different random hostname each time and cannot
+##                             # connect the builds into a contiguous history timeline.
 ##   -D build_name=my-label    # default: auto-generated
 ##
 ## Environment variables (optional):


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

GitHub Actions uses random hostnames for each job runner, causing CDash to register each nightly build under a different site. This breaks the contiguous build history timeline. By explicitly passing `-D site="GitHub-Actions"` in the nightly workflow, CDash can properly group and connect the build history. 

Additionally, added a comment in `CTestDashboard.cmake` to remind me to explicitly set the site on ephemeral nodes like SLURM, CI, etc.

## Related Issue

