### PR TITLE
v3: Fix precision changes in constants per Gemini

### DIFF
--- a/shared/Constants/EarthConstants.F90
+++ b/shared/Constants/EarthConstants.F90
@@ -13,11 +13,11 @@ module MAPL_EarthConstants
    real(kind=REAL64), parameter :: MAPL_MEAN_DRY_SURFACE_PRESSURE = 98305.0_REAL64  ! Pa
    real,              parameter :: MAPL_SECONDS_PER_SIDEREAL_DAY  = 86164.0          ! s
    real,              parameter :: MAPL_GRAVITY                   = 9.80665          ! mean surface gravitational acceleration  m/s^2
-   real(kind=REAL64), parameter :: MAPL_RADIUS                    = 6371.0E3_REAL64  ! mean radius  m
+   real,              parameter :: MAPL_RADIUS                    = 6371.0E3         ! mean radius  m
    real(kind=REAL64), parameter :: MAPL_ROTATION_RATE_R8          = &
         2.0_REAL64 * MAPL_PI_R8 / MAPL_SECONDS_PER_SIDEREAL_DAY                     ! rotation rate (REAL64)  1/s
    real(kind=REAL32), parameter :: MAPL_ROTATION_RATE             = &
-        real(MAPL_ROTATION_RATE_R8, REAL32)                                          ! rotation rate (REAL32)  1/s
+        2.0*MAPL_PI/MAPL_SECONDS_PER_SIDEREAL_DAY                                    ! rotation rate (REAL32)  1/s
    real(kind=REAL64), parameter :: MAPL_ECCENTRICITY              = &
         8.181919084262200d-2                                                          ! WGS84 first eccentricity  --
    real(kind=REAL64), parameter :: MAPL_SEMIMAJOR_AXIS            = 6378137.0_REAL64 ! WGS84 semi-major axis  m


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is a fix from Gemini looking at the constants code to solve @pchakraborty 's issue with MAPL3 being non-zero-diff. He figured out it was the update to the constants that caused it.

Here is its text:

1. MAPL_OMEGA has a bitwise difference
Previously, MAPL_OMEGA was calculated purely in REAL32 precision:
real(kind=REAL32), parameter :: MAPL_OMEGA = 2.0*MAPL_PI/MAPL_SECONDS_PER_SIDEREAL_DAY 
In the new implementation, it computes the rotation rate in REAL64 first and then downcasts it to REAL32:
real(kind=REAL64), parameter :: MAPL_ROTATION_RATE_R8 = 2.0_REAL64 * MAPL_PI_R8 / MAPL_SECONDS_PER_SIDEREAL_DAY
real(kind=REAL32), parameter :: MAPL_ROTATION_RATE    = real(MAPL_ROTATION_RATE_R8, REAL32)
Because floating-point arithmetic is not associative across different precisions, the new REAL32 downcasted value is exactly 1 bit different from the purely REAL32 calculation.
    - Old value: 7.29212406E-05
    - New value: 7.29212334E-05
2. MAPL_RADIUS changed precision kind
Previously, MAPL_RADIUS was a standard real (typically 4-byte / REAL32):
real, parameter :: MAPL_RADIUS = 6371.0E3
In the new EarthConstants.F90, it is explicitly cast as an 8-byte REAL64:
real(kind=REAL64), parameter :: MAPL_RADIUS = 6371.0E3_REAL64
While the numerical value (6371000.0) is exact in both precisions, changing the kind to REAL64 alters how expressions are evaluated. If a calculation multiplies MAPL_RADIUS by a REAL32 variable, Fortran will now promote the whole expression to REAL64 prior to computation instead of staying in REAL32. This often results in different roundoffs downstream.
---
Both of these changes are "more accurate" mathematically, but they represent a break in bitwise reproducibility for users. You could test reverting just MAPL_OMEGA's derivation and MAPL_RADIUS's kind back to their old forms to verify if this resolves the user's differences.

## Related Issue

