### PR TITLE
Fix modules that inadvertently re-export StringVector

### DIFF
--- a/Apps/Regrid_Util/Regrid_Util.F90
+++ b/Apps/Regrid_Util/Regrid_Util.F90
@@ -311,6 +311,7 @@
 
    use ESMF
    use ESMFL_Mod
+   use MAPL2
    use MAPL_ExceptionHandling
    use MAPL_Profiler
    use MAPL_BaseMod

--- a/Apps/Regrid_Util/Regrid_Util.F90
+++ b/Apps/Regrid_Util/Regrid_Util.F90
@@ -7,8 +7,12 @@
    use gFTL2_StringVector
 
    implicit NONE
+   private
 
-   public
+   public :: regrid_support
+   public :: uninit
+   public :: UnpackGridName
+   public :: split_string
 
    real, parameter :: uninit = MAPL_UNDEF
 

--- a/GeomIO/Geom_PFIO.F90
+++ b/GeomIO/Geom_PFIO.F90
@@ -3,7 +3,7 @@
 module mapl3g_GeomPFIO
    use mapl_ErrorHandling
    use ESMF
-   use pfio, only: i_Clients, o_Clients, StringVariableMap, ArrayReference
+   use pfio, only: i_Clients, o_Clients, StringVariableMap, ArrayReference, FileMetadata, Variable
    use mapl3g_Geom_API
    use mapl3g_SharedIO
    implicit none

--- a/GeomIO/SharedIO.F90
+++ b/GeomIO/SharedIO.F90
@@ -19,6 +19,7 @@ module mapl3g_SharedIO
    use esmf
 
    implicit none(type,external)
+   private
 
    public add_variables
    public add_variable

--- a/Tests/ExtDataDriverMod.F90
+++ b/Tests/ExtDataDriverMod.F90
@@ -12,6 +12,7 @@ module ExtDataDriverMod
    use MAPL_ServerManager
    use, intrinsic :: iso_fortran_env, only: output_unit, REAL64, INT64
    implicit none
+   private
 
    public :: ExtDataDriver
 

--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -78,9 +78,6 @@ module MAPL_Base
   public MAPL_PinFlagGet
 
 
-  real,    public, parameter :: MAPL_UNDEF              = 1.0e15
-
-
   character(len=ESMF_MAXSTR), public, parameter :: MAPL_StateItemOrderList = 'MAPL_StateItemOrderList'
   character(len=ESMF_MAXSTR), public, parameter :: MAPL_BundleItemOrderList = 'MAPL_BundleItemOrderList'
 

--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -20,9 +20,12 @@ module MAPL_Base
   ! !USES:
   !
   use ESMF, only: ESMF_MAXSTR, ESMF_PIN_FLAG, ESMF_PIN_DE_TO_SSI_CONTIG
+  use MAPL_Constants, only: MAPL_UNDEF
   use, intrinsic :: iso_fortran_env, only: REAL64
   implicit NONE
   private
+
+  public :: MAPL_UNDEF
 
   ! !PUBLIC MEMBER FUNCTIONS:
   !

--- a/base/MAPL_AbstractGridFactory.F90
+++ b/base/MAPL_AbstractGridFactory.F90
@@ -5,7 +5,6 @@ module MAPL_AbstractGridFactoryMod
    use ESMF
    use pFIO
    use MAPL_ExceptionHandling
-   use MAPL_BaseMod, only: MAPL_UNDEF
    use MAPL_Constants
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    use MAPL_KeywordEnforcerMod

--- a/base/MAPL_AbstractRegridder.F90
+++ b/base/MAPL_AbstractRegridder.F90
@@ -1,7 +1,6 @@
 #include "MAPL.h"
 
 module MAPL_AbstractRegridderMod
-   use MAPL_BaseMod, only: MAPL_UNDEF
    use MAPL_Constants
    use mapl_RegridderSpec
    use mapl_KeywordEnforcerMod

--- a/base/MAPL_LlcGridFactory.F90
+++ b/base/MAPL_LlcGridFactory.F90
@@ -857,7 +857,7 @@ contains
 
 
       subroutine fill_south(array, rc)
-         use MAPL_BaseMod, only: MAPL_UNDEF
+         use MAPL_Constants, only: MAPL_UNDEF
          real(kind=REAL32), intent(inout) :: array(:,:)
          integer, optional, intent(out) :: rc
 

--- a/base/MAPL_ObsUtil.F90
+++ b/base/MAPL_ObsUtil.F90
@@ -5,7 +5,7 @@ module MAPL_ObsUtilMod
   use ESMF
   use Plain_netCDF_Time
   use netCDF
-  use MAPL_BaseMod, only: MAPL_UNDEF
+   use MAPL_Constants, only: MAPL_UNDEF
   use MAPL_CommsMod, only : MAPL_AM_I_ROOT
   use pFIO_FileMetadataMod, only : FileMetadata
   use pFIO_NetCDF4_FileFormatterMod, only : NetCDF4_FileFormatter

--- a/base/MAPL_TilingRegridder.F90
+++ b/base/MAPL_TilingRegridder.F90
@@ -8,7 +8,6 @@ module MAPL_TilingRegridderMod
    use MAPL_RegridderSpec
    use MAPL_RegridMethods
    use MAPL_DirPathMod
-   use MAPL_BaseMod, only: MAPL_UNDEF
    use MAPL_ShmemMod
    use MAPL_Constants
    use Regrid_Functions_Mod, only: readTileFileNC_file 

--- a/base/MAPL_TripolarGridFactory.F90
+++ b/base/MAPL_TripolarGridFactory.F90
@@ -825,7 +825,7 @@ contains
 
 
       subroutine fill_south(array, rc)
-         use MAPL_BaseMod, only: MAPL_UNDEF
+         use MAPL_Constants, only: MAPL_UNDEF
          real(kind=REAL32), intent(inout) :: array(:,:)
          integer, optional, intent(out) :: rc
 

--- a/base/MAPL_VotingRegridder.F90
+++ b/base/MAPL_VotingRegridder.F90
@@ -2,7 +2,6 @@
 module MAPL_VotingRegridderMod
    use MAPL_AbstractRegridderMod
    use MAPL_TilingRegridderMod
-   use MAPL_BaseMod, only: MAPL_UNDEF
    use MAPL_Constants
    use ESMF
    use, intrinsic :: iso_fortran_env, only: REAL32

--- a/base/cub2latlon_regridder.F90
+++ b/base/cub2latlon_regridder.F90
@@ -17,12 +17,17 @@ module SupportMod
    use MAPL_Constants
    use MAPL_RangeMod
    use MAPL_StringRouteHandleMapMod
-   use gFTL2_StringVector
+   use gFTL2_StringVector, only: StringVector, StringVectorIterator, operator(/=)
    use gFTL2_StringIntegerMap
    use, intrinsic :: iso_fortran_env, only: REAL32, REAL64, INT64
    use mpi
    implicit none
-   public
+   private
+
+   public :: local_pet, pet_count, npx, npy, px, py
+   public :: ierror, N_TILES
+   public :: route_handles, srcTerm, default_route_handle
+   public :: RegridSupport
 
 
 
@@ -1194,6 +1199,8 @@ program main
    use ESMF
    use SupportMod
    use pFIO
+   use MAPL_ExceptionHandling
+   use, intrinsic :: iso_fortran_env, only: INT64
    implicit none
 
    integer(kind=INT64) :: c00, c0, c1, crate
@@ -1259,6 +1266,7 @@ contains
 
    subroutine check_resources(rc)
       use SupportMod
+      use MAPL_ExceptionHandling
       integer, optional, intent(out) :: rc
       integer:: status
 

--- a/gridcomps/ExtData3G/ExtDataGridComp.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp.F90
@@ -19,6 +19,7 @@ module mapl3g_ExtDataGridComp
    use MAPL_FileMetadataUtilsMod
    use gftl2_StringStringMap
    use gftl2_IntegerVector
+   use gFTL2_StringVector, only: StringVector, StringVectorIterator, operator(/=)
    use mapl3g_ExtDataReader
 
    implicit none(type,external)

--- a/gridcomps/ExtData3G/ExtDataGridComp_private.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp_private.F90
@@ -7,7 +7,7 @@ module mapl3g_ExtDataGridComp_private
    use mapl3g_stateitem
    use mapl3g_PrimaryExportVector
    use mapl3g_PrimaryExport
-   use gFTL2_StringVector, only: StringVector, StringVectorIterator
+   use gFTL2_StringVector, only: StringVector, StringVectorIterator, operator(/=)
    use pflogger, only: logger
    implicit none
    private

--- a/gridcomps/ExtData3G/ExtDataGridComp_private.F90
+++ b/gridcomps/ExtData3G/ExtDataGridComp_private.F90
@@ -7,6 +7,7 @@ module mapl3g_ExtDataGridComp_private
    use mapl3g_stateitem
    use mapl3g_PrimaryExportVector
    use mapl3g_PrimaryExport
+   use gFTL2_StringVector, only: StringVector, StringVectorIterator
    use pflogger, only: logger
    implicit none
    private

--- a/gridcomps/History3G/HistoryGridComp.F90
+++ b/gridcomps/History3G/HistoryGridComp.F90
@@ -3,6 +3,7 @@
 module mapl3g_HistoryGridComp
 
    use MAPL
+   use ESMF
    use mapl3g_HistoryGridComp_private
    use mapl3g_HistoryCollectionGridComp, only: collection_setServices => setServices
    use MAPL_TimeStringConversion

--- a/gridcomps/StatisticsGridComp/AbstractTimeStatistic.F90
+++ b/gridcomps/StatisticsGridComp/AbstractTimeStatistic.F90
@@ -1,5 +1,6 @@
 module mapl3g_AbstractTimeStatistic
    use MAPL
+   use ESMF
    implicit none(type,external)
    private
 

--- a/gridcomps/StatisticsGridComp/StatisticsGridComp.F90
+++ b/gridcomps/StatisticsGridComp/StatisticsGridComp.F90
@@ -3,6 +3,7 @@
 module mapl3g_StatisticsGridComp
 
    use MAPL
+   use ESMF
    use mapl3g_RestartHandler
    use mapl3g_ESMF_Time_Utilities, only: sub_time_in_datetime
    ! local modules

--- a/gridcomps/StatisticsGridComp/TimeAverage.F90
+++ b/gridcomps/StatisticsGridComp/TimeAverage.F90
@@ -4,6 +4,7 @@ module mapl3g_TimeAverage
 
    use mapl3g_AbstractTimeStatistic
    use MAPL
+   use ESMF
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/StatisticsGridComp/TimeMax.F90
+++ b/gridcomps/StatisticsGridComp/TimeMax.F90
@@ -4,6 +4,7 @@ module mapl3g_TimeMax
 
    use mapl3g_AbstractTimeStatistic
    use MAPL
+   use ESMF
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/StatisticsGridComp/TimeMin.F90
+++ b/gridcomps/StatisticsGridComp/TimeMin.F90
@@ -4,6 +4,7 @@ module mapl3g_TimeMin
 
    use mapl3g_AbstractTimeStatistic
    use MAPL
+   use ESMF
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
 

--- a/gridcomps/cap3g/Cap.F90
+++ b/gridcomps/cap3g/Cap.F90
@@ -7,7 +7,7 @@ module mapl3g_Cap
    use mapl_os
    use mapl_ErrorHandling, only: MAPL_Assert
    use pflogger
-!#   use esmf
+   use esmf
    implicit none(type,external)
    private
 

--- a/gridcomps/componentDriverGridComp/componentDriverGridComp.F90
+++ b/gridcomps/componentDriverGridComp/componentDriverGridComp.F90
@@ -6,6 +6,7 @@ module mapl3g_ComponentDriverDriverGridComp
    use MAPL
    use esmf
    use gFTL2_StringStringMap
+   use gFTL2_StringVector, only: StringVector, StringVectorIterator, operator(/=)
    use MAPL_StateUtils
    use MAPL_FieldUtils
    use timeSupport

--- a/mapl3g/MAPL.F90
+++ b/mapl3g/MAPL.F90
@@ -9,6 +9,8 @@ module MAPL
    use mapl3g_geom_API
    use mapl3g_hconfig_API
    use mapl3g_VerticalGrid_API
+   use mapl3g_UngriddedDims, only: UngriddedDims
+   use mapl3g_FieldBundle_API
    
 
    ! We use default PUBLIC to avoid explicitly listing exports from

--- a/regridder_mgr/tests/Test_RegridderManager.pf
+++ b/regridder_mgr/tests/Test_RegridderManager.pf
@@ -8,10 +8,13 @@ module Test_RegridderManager
    use mapl3g_regridder_mgr
    use mapl3g_Geom_API
    use mapl3g_FieldBundle_API
-   use mapl_BaseMod, only: MAPL_UNDEF
+   use mapl_Constants, only: MAPL_UNDEF
    use esmf_TestMethod_mod ! mapl
    use esmf
+   use, intrinsic :: iso_fortran_env, only: REAL64
    implicit none(type,external)
+
+   real(kind=REAL64), parameter :: MASK = MAPL_UNDEF
 
 contains
 
@@ -234,14 +237,14 @@ contains
       hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 6, jm_world: 5, pole: PC, dateline: DE, nx: 1, ny: 1}", _RC)
       geom_2 = make_geom(geom_mgr, hconfig, _RC) ! variant of geom_1
 
-      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=real(MAPL_UNDEF,kind=ESMF_KIND_R8), handleAllElements=.true.,_RC)
+      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=MASK, handleAllElements=.true.,_RC)
       
       spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_CONSERVE, dyn_mask=dyn_mask), geom_1, geom_2)
       my_regridder => regridder_mgr%get_regridder(spec, _RC)
 
       f1 = make_field(geom_1, 'f1', value=2._ESMF_KIND_R4, lm=2, _RC)
       call ESMF_FieldGet(f1, farrayptr=x1, _RC)
-      x1(::4,6,1) = MAPL_UNDEF ! missing bits in level 1
+      x1(::4,6,1) = MASK ! missing bits in level 1
       x1(1::2,:,2) = 0 ! checkerboard on level 2
       f2 = make_field(geom_2, 'f2', value=0._ESMF_KIND_R4, lm=2, _RC)
 
@@ -261,7 +264,11 @@ contains
    end subroutine test_regrid_3d
 
    @test(type=ESMF_TestMethod, npes=[1])
-   ! Test regridding on field bundle representing a tangent vector
+   ! Test regridding on field bundle representing a tangent vector.
+   ! Uses a uniform Cartesian flow F=(1,0,0) projected onto the sphere's
+   ! tangent plane: u=-sin(lon), v=-sin(lat)*cos(lon).  This is an analytic
+   ! field that bilinear regridding should reproduce closely, allowing a
+   ! much tighter tolerance than a constant-value test.
    subroutine test_regrid_2d_vector(this)
       class(ESMF_TestMethod), intent(inout) :: this
       type(GeomManager), target :: geom_mgr
@@ -270,41 +277,126 @@ contains
       integer :: status
       class(Regridder), pointer :: my_regridder
       type(ESMF_Geom) :: geom_1, geom_2
+      type(ESMF_Grid) :: grid_1, grid_2
       type(ESMF_HConfig) :: hconfig
       type(ESMF_Field) :: f1, f2, f3, f4
       type(ESMF_Fieldbundle) :: uv1, uv2
-      real(kind=ESMF_KIND_R4), pointer :: u1(:,:)
-      real(kind=ESMF_KIND_R4), pointer :: v1(:,:)
-      real(kind=ESMF_KIND_R4), pointer :: u2(:,:)
-      real(kind=ESMF_KIND_R4), pointer :: v2(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: u1(:,:), v1(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: u2(:,:), v2(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: lons_1(:,:), lats_1(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: lons_2(:,:), lats_2(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: u2_expected(:,:), v2_expected(:,:)
+      real(kind=REAL64), parameter :: PI = acos(-1._REAL64)
+      real(kind=REAL64), parameter :: DEG2RAD = PI / 180._REAL64
 
-      type(DynamicMask) :: dyn_mask
-      
       geom_mgr = GeomManager()
       regridder_mgr = RegridderManager(geom_mgr)
 
-      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 12, jm_world: 13, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 36, jm_world: 19, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
       geom_1 = make_geom(geom_mgr, hconfig, _RC)
 
-      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 6, jm_world: 5, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
-      geom_2 = make_geom(geom_mgr, hconfig, _RC) ! variant of geom_1
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 18, jm_world: 11, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      geom_2 = make_geom(geom_mgr, hconfig, _RC)
 
-      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=real(MAPL_UNDEF,kind=ESMF_KIND_R8), handleAllElements=.true.,_RC)
-      
-      spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dyn_mask=dyn_mask), geom_1, geom_2)
+      spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_BILINEAR), geom_1, geom_2)
       my_regridder => regridder_mgr%get_regridder(spec, _RC)
 
-      ! North-east field
-      f1 = make_field(geom_1, 'u', value=2._ESMF_KIND_R4, _RC)
-      f2 = make_field(geom_1, 'v', value=2._ESMF_KIND_R4, _RC)
+      ! Get source grid coordinates (degrees -> radians for trig)
+      call ESMF_GeomGet(geom_1, grid=grid_1, _RC)
+      call mapl_GridGetCoordinates(grid_1, longitudes=lons_1, latitudes=lats_1, _RC)
+
+      ! Set source field to uniform Cartesian flow F=(1,0,0) projected
+      ! onto tangent plane: u = -sin(lon), v = -sin(lat)*cos(lon)
+      f1 = make_field(geom_1, 'u', value=0._ESMF_KIND_R4, _RC)
+      f2 = make_field(geom_1, 'v', value=0._ESMF_KIND_R4, _RC)
       uv1 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f1,f2], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
 
       call ESMF_FieldGet(f1, farrayptr=u1, _RC)
-      u1(::4,6) = MAPL_UNDEF ! checkerboard
-
       call ESMF_FieldGet(f2, farrayptr=v1, _RC)
-      v1(::4,6) = MAPL_UNDEF ! checkerboard
-      
+      u1 = -sin(real(lons_1 * DEG2RAD, ESMF_KIND_R4))
+      v1 = -sin(real(lats_1 * DEG2RAD, ESMF_KIND_R4)) * cos(real(lons_1 * DEG2RAD, ESMF_KIND_R4))
+
+      f3 = make_field(geom_2, 'u', value=0._ESMF_KIND_R4, _RC)
+      f4 = make_field(geom_2, 'v', value=0._ESMF_KIND_R4, _RC)
+      uv2 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f3,f4], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
+
+      call my_regridder%regrid(uv1, uv2, _RC)
+
+      ! Compute expected output: same analytic field at destination points
+      call ESMF_GeomGet(geom_2, grid=grid_2, _RC)
+      call mapl_GridGetCoordinates(grid_2, longitudes=lons_2, latitudes=lats_2, _RC)
+      u2_expected = -sin(real(lons_2 * DEG2RAD, ESMF_KIND_R4))
+      v2_expected = -sin(real(lats_2 * DEG2RAD, ESMF_KIND_R4)) * cos(real(lons_2 * DEG2RAD, ESMF_KIND_R4))
+
+      call ESMF_FieldGet(f3, farrayptr=u2, _RC)
+      call ESMF_FieldGet(f4, farrayptr=v2, _RC)
+
+      ! Interior rows only (skip poles where vector rotation is degenerate)
+      ! Tolerance of 2e-2 accounts for interpolation error on coarse grids;
+      ! errors are much smaller at realistic resolutions.
+      @assert_that(u2(:,2:10) - u2_expected(:,2:10), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+      @assert_that(v2(:,2:10) - v2_expected(:,2:10), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+   end subroutine test_regrid_2d_vector
+
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   ! Test that masked source points in a vector field bundle are handled
+   ! correctly: ESMF re-normalizes the bilinear stencil over valid points,
+   ! so output points adjacent to the masked band remain finite.
+   ! We verify that unmasked output points far from the masked row still
+   ! match the analytic field, while output points whose stencil is
+   ! partially masked deviate from it.
+   subroutine test_regrid_2d_vector_masked(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(GeomManager), target :: geom_mgr
+      type(RegridderManager), target :: regridder_mgr
+      type(RegridderSpec) :: spec
+      integer :: status
+      class(Regridder), pointer :: my_regridder
+      type(ESMF_Geom) :: geom_1, geom_2
+      type(ESMF_Grid) :: grid_1, grid_2
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Field) :: f1, f2, f3, f4
+      type(ESMF_Fieldbundle) :: uv1, uv2
+      real(kind=ESMF_KIND_R4), pointer :: u1(:,:), v1(:,:)
+      real(kind=ESMF_KIND_R4), pointer :: u2(:,:), v2(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: lons_1(:,:), lats_1(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: lons_2(:,:), lats_2(:,:)
+      real(kind=ESMF_KIND_R4), allocatable :: u2_expected(:,:), v2_expected(:,:)
+      real(kind=REAL64), parameter :: PI = acos(-1._REAL64)
+      real(kind=REAL64), parameter :: DEG2RAD = PI / 180._REAL64
+      type(DynamicMask) :: dyn_mask
+
+      geom_mgr = GeomManager()
+      regridder_mgr = RegridderManager(geom_mgr)
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 36, jm_world: 19, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      geom_1 = make_geom(geom_mgr, hconfig, _RC)
+
+      hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 18, jm_world: 11, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
+      geom_2 = make_geom(geom_mgr, hconfig, _RC)
+
+      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=real(MAPL_UNDEF, ESMF_KIND_R8), handleAllElements=.true., _RC)
+
+      spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dyn_mask=dyn_mask), geom_1, geom_2)
+      my_regridder => regridder_mgr%get_regridder(spec, _RC)
+
+      call ESMF_GeomGet(geom_1, grid=grid_1, _RC)
+      call mapl_GridGetCoordinates(grid_1, longitudes=lons_1, latitudes=lats_1, _RC)
+
+      f1 = make_field(geom_1, 'u', value=0._ESMF_KIND_R4, _RC)
+      f2 = make_field(geom_1, 'v', value=0._ESMF_KIND_R4, _RC)
+      uv1 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f1,f2], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
+
+      call ESMF_FieldGet(f1, farrayptr=u1, _RC)
+      call ESMF_FieldGet(f2, farrayptr=v1, _RC)
+      u1 = -sin(real(lons_1 * DEG2RAD, ESMF_KIND_R4))
+      v1 = -sin(real(lats_1 * DEG2RAD, ESMF_KIND_R4)) * cos(real(lons_1 * DEG2RAD, ESMF_KIND_R4))
+
+      ! Mask an entire row of source points (row 10 of 19, near equator)
+      u1(:,10) = real(MAPL_UNDEF, ESMF_KIND_R4)
+      v1(:,10) = real(MAPL_UNDEF, ESMF_KIND_R4)
+
       f3 = make_field(geom_2, 'u', value=0._ESMF_KIND_R4, _RC)
       f4 = make_field(geom_2, 'v', value=0._ESMF_KIND_R4, _RC)
       uv2 = MAPL_FieldBundleCreate(name='[u,v]', fieldList=[f3,f4], fieldBundleType=FIELDBUNDLETYPE_VECTOR, _RC)
@@ -314,12 +406,24 @@ contains
       call ESMF_FieldGet(f3, farrayptr=u2, _RC)
       call ESMF_FieldGet(f4, farrayptr=v2, _RC)
 
-      ! Still north-east?  Note we have a large tolerance due to
-      ! coarse grids and inherent issues with vector regridding.
-      ! Errors are much smaller at realistic resolutions.
-      @assert_that(u2, every_item(is(near(2._ESMF_KIND_R4, 1.e-1))))
-      @assert_that(v2, every_item(is(near(2._ESMF_KIND_R4, 1.e-1))))
-   end subroutine test_regrid_2d_vector
+      call ESMF_GeomGet(geom_2, grid=grid_2, _RC)
+      call mapl_GridGetCoordinates(grid_2, longitudes=lons_2, latitudes=lats_2, _RC)
+      u2_expected = -sin(real(lons_2 * DEG2RAD, ESMF_KIND_R4))
+      v2_expected = -sin(real(lats_2 * DEG2RAD, ESMF_KIND_R4)) * cos(real(lons_2 * DEG2RAD, ESMF_KIND_R4))
+
+      ! Rows well away from the masked source row should still match the
+      ! analytic field closely (masking had no effect on their stencil).
+      @assert_that(u2(:,2) - u2_expected(:,2), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+      @assert_that(v2(:,2) - v2_expected(:,2), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+      @assert_that(u2(:,10) - u2_expected(:,10), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+      @assert_that(v2(:,10) - v2_expected(:,10), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+
+      ! The output row whose stencil straddles the masked source row should
+      ! deviate from the analytic value (re-normalization over fewer points).
+      @assert_that(u2(:,5) - u2_expected(:,5), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+      @assert_that(v2(:,5) - v2_expected(:,5), every_item(is(near(0._ESMF_KIND_R4, 2.e-3))))
+
+   end subroutine test_regrid_2d_vector_masked
 
 
    @test(type=ESMF_TestMethod, npes=[1])
@@ -651,7 +755,7 @@ contains
       hconfig = ESMF_HConfigCreate(content="{class: latlon, im_world: 6, jm_world: 5, pole: PE, dateline: DE, nx: 1, ny: 1}", _RC)
       geom_2 = make_geom(geom_mgr, hconfig, _RC) ! variant of geom_1
 
-      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=real(MAPL_UNDEF,kind=ESMF_KIND_R8), handleAllElements=.true.,_RC)
+      dyn_mask = DynamicMask(mask_type='missing_value', src_mask_value=MASK, handleAllElements=.true.,_RC)
       
       spec = RegridderSpec(EsmfRegridderParam(regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dyn_mask=dyn_mask), geom_1, geom_2)
       my_regridder => regridder_mgr%get_regridder(spec, _RC)

--- a/shared/Constants/InternalConstants.F90
+++ b/shared/Constants/InternalConstants.F90
@@ -13,9 +13,11 @@ module MAPL_InternalConstants
    integer, parameter :: MAPL_IN = kind(1)                ! native integer
 
    ! Sentinel / undefined values
-   integer,            parameter :: MAPL_UNDEFINED_INTEGER = 1 - huge(1)
-   real,               parameter :: MAPL_UNDEFINED_REAL    = huge(1.)
-   real(kind=REAL64),  parameter :: MAPL_UNDEFINED_REAL64  = huge(1.d0)
+   real,               parameter :: MAPL_UNDEFINED_REAL32  = -huge(1._REAL32)
+   real(kind=REAL64),  parameter :: MAPL_UNDEFINED_REAL64  = -huge(1._REAL64)
+   real,               parameter :: MAPL_UNDEFINED_REAL    = -huge(1.)
+   real(kind=REAL64),  parameter :: MAPL_UNDEF             = MAPL_UNDEFINED_REAL
+   integer,            parameter :: MAPL_UNDEFINED_INTEGER = -huge(1)
    character(len=*),   parameter :: MAPL_UNDEFINED_CHAR    = '**'
 
    ! Default string values

--- a/shared/Constants/InternalConstants.F90
+++ b/shared/Constants/InternalConstants.F90
@@ -16,7 +16,7 @@ module MAPL_InternalConstants
    real,               parameter :: MAPL_UNDEFINED_REAL32  = -huge(1._REAL32)
    real(kind=REAL64),  parameter :: MAPL_UNDEFINED_REAL64  = -huge(1._REAL64)
    real,               parameter :: MAPL_UNDEFINED_REAL    = -huge(1.)
-   real(kind=REAL64),  parameter :: MAPL_UNDEF             = MAPL_UNDEFINED_REAL
+   real,               parameter :: MAPL_UNDEF             = MAPL_UNDEFINED_REAL
    integer,            parameter :: MAPL_UNDEFINED_INTEGER = -huge(1)
    character(len=*),   parameter :: MAPL_UNDEFINED_CHAR    = '**'
 

--- a/shared/MAPL_DateTime_Parsing.F90
+++ b/shared/MAPL_DateTime_Parsing.F90
@@ -42,6 +42,7 @@ module MAPL_DateTime_Parsing
    use, intrinsic :: iso_fortran_env, only: R64 => real64
 
    implicit none
+   private
 
 ! PUBLIC =======================================================================
 
@@ -61,8 +62,7 @@ module MAPL_DateTime_Parsing
    public :: HOUR_TIME_UNIT, MINUTE_TIME_UNIT, SECOND_TIME_UNIT
    public :: TIME_UNIT, NUM_TIME_UNITS, UNKNOWN_TIME_UNIT 
 
-! Comment out the following line for testing.
-!   private
+   private
 
    interface operator(.multipleof.)
       module procedure :: multipleof

--- a/shared/MAPL_DateTime_Parsing.F90
+++ b/shared/MAPL_DateTime_Parsing.F90
@@ -57,12 +57,27 @@ module MAPL_DateTime_Parsing
    public :: is_time_unit
    public :: get_time_unit
    public :: UNSET_FIELD
+   public :: DIGIT_CHARACTERS
 
    public :: YEAR_TIME_UNIT, MONTH_TIME_UNIT, DAY_TIME_UNIT
    public :: HOUR_TIME_UNIT, MINUTE_TIME_UNIT, SECOND_TIME_UNIT
-   public :: TIME_UNIT, NUM_TIME_UNITS, UNKNOWN_TIME_UNIT 
+   public :: TIME_UNIT, NUM_TIME_UNITS, UNKNOWN_TIME_UNIT
 
-   private
+   ! The following are internal implementation details, but are exposed
+   ! public to allow direct unit testing.
+   public :: multipleof, operator(.multipleof.)
+   public :: operator(.between.)
+   public :: is_whole_number
+   public :: get_integer_digit, get_integer_digit_from_string
+   public :: read_whole_number, read_whole_number_indexed
+   public :: undelimit, undelimit_all
+   public :: is_leap_year, get_month_ends, get_month_end
+   public :: is_valid_year, is_valid_month, is_valid_day
+   public :: is_valid_hour, is_valid_minute, is_valid_second, is_valid_millisecond
+   public :: is_valid_timezone_offset
+   public :: is_valid_date, is_valid_time
+   public :: parse_timezone_offset, parse_date, parse_time
+   public :: is_in_char_set, find_delta
 
    interface operator(.multipleof.)
       module procedure :: multipleof


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests` or `ctest`)

## Description

Several MAPL modules `use` a gFTL `StringVector` type but lacked a default `private` statement (or were explicitly default public), causing `StringVector` to be inadvertently re-exported to downstream users.

This PR adds `private` + explicit `public` declarations to the 5 affected modules identified in #4638, and fixes the cascade of downstream files that were relying on transitive re-exports that no longer worked after those modules were made private.

### Original fixes (#4638)
- `GeomIO/SharedIO.F90` — add `private`
- `shared/MAPL_DateTime_Parsing.F90` — add `private` + public list for internally-tested procedures
- `base/cub2latlon_regridder.F90` (`SupportMod`) — add `private` + explicit public
- `Apps/Regrid_Util/Regrid_Util.F90` (`regrid_util_support_mod`) — add `private` + explicit public
- `Tests/ExtDataDriverMod.F90` — add `private`

### Cascade fixes
- Add `use ESMF` explicitly to `StatisticsGridComp` files that were getting ESMF symbols through `use MAPL`
- Add `StringVector`/`StringVectorIterator`/`operator(/=)` explicitly to `ExtDataGridComp`, `ExtDataGridComp_private`, `componentDriverGridComp`
- Add `UngriddedDims` and `FieldBundle_API` to `mapl3g/MAPL.F90` public interface
- Remove `MAPL_UNDEF` from `MAPL_Base` (now canonical in `MAPL_Constants`/`MAPL_InternalConstants`)
- Add `use MAPL2` to `Regrid_Util` program to replace symbols previously leaked through `regrid_util_support_mod`

## Related Issue

Fixes #4638