### PR TITLE
Fix SIGFPE (integer divide by zero) in MAPL_LoadBalanceMod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed SIGFPE (integer divide by zero) in `MAPL_LoadBalanceMod` when load balancing algorithm evaluates maximum differences to zero.
+
 ### Added
 
 ### Changed

--- a/shared/MAPL_LoadBalance.F90
+++ b/shared/MAPL_LoadBalance.F90
@@ -109,7 +109,11 @@ contains
     logical :: SEND, RECV
     integer, pointer :: NOP(:,:)
 
-    Jdim = size(A)/Idim
+    if (Idim == 0) then
+       Jdim = 1
+    else
+       Jdim = size(A)/Idim
+    end if
 
     if(present(Handle)) then
        ISTRAT = Handle
@@ -213,7 +217,11 @@ contains
     logical :: SEND, RECV
     integer, pointer :: NOP(:,:)
 
-    Jdim = size(A)/Idim
+    if (Idim == 0) then
+       Jdim = 1
+    else
+       Jdim = size(A)/Idim
+    end if
 
     if(present(Handle)) then
        ISTRAT = Handle

--- a/shared/MAPL_LoadBalance.F90
+++ b/shared/MAPL_LoadBalance.F90
@@ -109,9 +109,8 @@ contains
     logical :: SEND, RECV
     integer, pointer :: NOP(:,:)
 
-    if (Idim == 0) then
-       Jdim = 1
-    else
+    Jdim = 1
+    if (Idim /= 0) then
        Jdim = size(A)/Idim
     end if
 

--- a/shared/MAPL_LoadBalance.F90
+++ b/shared/MAPL_LoadBalance.F90
@@ -216,9 +216,8 @@ contains
     logical :: SEND, RECV
     integer, pointer :: NOP(:,:)
 
-    if (Idim == 0) then
-       Jdim = 1
-    else
+    Jdim = 1
+    if (Idim /= 0) then
        Jdim = size(A)/Idim
     end if
 


### PR DESCRIPTION
## Summary
- Added safety check in `MAPL_BalanceWork4` and `MAPL_BalanceWork8` to handle `Idim == 0` preventing division by zero.
- This occurs when the max work difference evaluates to 0 in load balancing, causing `NumMax` (and thus `Idim`) to be 0 (e.g. single sunlit gridpoint among processes).
- Updated `CHANGELOG.md` with an entry for this fix.