### PR TITLE
Fixes #4645

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug so that an informative error message will be emitted when extrapolation is attempted to be used without a valid range in ExtData2G
+
 ### Added
 
 ### Changed

--- a/gridcomps/ExtData2G/ExtDataClimFileHandler.F90
+++ b/gridcomps/ExtData2G/ExtDataClimFileHandler.F90
@@ -53,7 +53,7 @@ contains
       end if
 
       target_time=input_time
-      _ASSERT(size(this%valid_range) == 2, 'Valid time is not defined so can not do any extrapolation or climatology')
+      _ASSERT(size(this%valid_range) == 2, 'Valid time is not defined for template '//trim(this%file_template)//' so can not do any extrapolation or climatology')
       call ESMF_TimeGet(this%valid_range(1),yy=valid_years(1),_RC)
       call ESMF_TimeGet(this%valid_range(2),yy=valid_years(2),_RC)
       if (size(source_time)==2) then

--- a/gridcomps/ExtData2G/ExtDataFileStream.F90
+++ b/gridcomps/ExtData2G/ExtDataFileStream.F90
@@ -177,7 +177,7 @@ contains
 
       collection => DataCollections%at(this%collection_id)
       if (get_range_ .and. (.not.allocated(this%valid_range))) then
-         if (index('%',this%file_template) == 0) then
+         if (index(this%file_template, '%') == 0) then
             metadata => collection%find(this%file_template)
             call metadata%get_time_info(timeVector=time_series,_RC)
             allocate(this%valid_range(2))


### PR DESCRIPTION
This fixes issue #4645 which prevented a useful error from being emitted when one attempted to use the extrapolation option on a collection that had tokens in the template but was not provided a valid range which is not allowed.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

