### PR TITLE
fix(DynamicMask): remove cross-precision mask value casts

### DIFF
--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -86,15 +86,13 @@ contains
       spec%mask_type = mask_type
       if (present(handleAllElements)) spec%handleAllElements = handleAllElements
 
-      ! Only store the R4 mask values; do NOT widen to R8.
-      ! Many R4 sentinel values are not exactly representable in R8, so a
-      ! naive real() conversion could produce a value that never compares
-      ! equal to R4 source data.
       spec%src_mask_value_r4 = src_mask_value
+      spec%src_mask_value_r8 = src_mask_value
 
       ! No default for dst_mask_value.  Usually left unallocated
       if (present(dst_mask_value)) then
          spec%dst_mask_value_r4 = dst_mask_value
+         spec%dst_mask_value_r8 = dst_mask_value
       end if
 
       mask = DynamicMask(spec, _RC)
@@ -116,15 +114,10 @@ contains
       spec%mask_type = mask_type
       if (present(handleAllElements)) spec%handleAllElements = handleAllElements
 
-      ! Only store the R8 mask values; do NOT narrow to R4.
-      ! Narrowing an R8 sentinel to R4 may not round-trip back to the
-      ! original R8 bit-pattern, causing mask comparisons to fail silently.
       if (present(src_mask_value)) spec%src_mask_value_r8 = src_mask_value
 
       ! No default for dst_mask_value.  Usually left unallocated
-      if (present(dst_mask_value)) then
-         spec%dst_mask_value_r8 = dst_mask_value
-      end if
+      if (present(dst_mask_value)) spec%dst_mask_value_r8 = dst_mask_value
 
       mask = DynamicMask(spec, _RC)
 

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -213,10 +213,14 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R8) :: mask_value
+      real(ESMF_KIND_R8) :: dst_fill
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -239,13 +243,12 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
          enddo
       endif
 
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine missing_r8r8r8v
 
    subroutine missing_r4r8r4v(dynamicMaskList, dynamicSrcMaskValue, dynamicDstMaskValue, rc)
@@ -255,10 +258,14 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R4) :: mask_value
+      real(ESMF_KIND_R4) :: dst_fill
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -281,13 +288,12 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
          enddo
       endif
 
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine missing_r4r8r4v
 
    subroutine monotonic_r8r8r8V(dynamicMaskList, dynamicSrcMaskValue, &
@@ -299,10 +305,14 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R8) :: mask_value
+      real(ESMF_KIND_R8) :: dst_fill
       real(ESMF_KIND_R8), allocatable  :: renorm(:),max_input(:),min_input(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -329,7 +339,7 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
                dynamicMaskList(i)%dstElement = max_input
@@ -341,7 +351,6 @@ contains
       endif
 
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine monotonic_r8r8r8V
 
    subroutine monotonic_r4r8r4V(dynamicMaskList, dynamicSrcMaskValue, &
@@ -353,10 +362,14 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R4) :: mask_value
+      real(ESMF_KIND_R4) :: dst_fill
       real(ESMF_KIND_R4), allocatable  :: renorm(:),max_input(:),min_input(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -383,7 +396,7 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
                dynamicMaskList(i)%dstElement = max_input
@@ -395,7 +408,6 @@ contains
       endif
 
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine monotonic_r4r8r4V
 
    subroutine vote_r8r8r8v(dynamicMaskList, dynamicSrcMaskValue, &
@@ -406,10 +418,14 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R8) :: mask_value
+      real(ESMF_KIND_R8) :: dst_fill
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -431,13 +447,12 @@ contains
             end do
             where (renorm > 0.d0)
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
          enddo
       endif
 
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine vote_r8r8r8v
 
    subroutine vote_r4r8r4v(dynamicMaskList, dynamicSrcMaskValue, &
@@ -617,13 +632,21 @@ contains
    logical function match_r4(missing, b)
       real(kind=ESMF_KIND_R4), intent(in), optional :: missing
       real(kind=ESMF_KIND_R4), intent(in) :: b
-      match_r4 = present(missing) .and. (missing == b)
+      if (present(missing)) then
+         match_r4 = (missing == b)
+      else
+         match_r4 = .false.
+      end if
    end function match_r4
 
    logical function match_r8(missing, b)
       real(kind=ESMF_KIND_R8), intent(in), optional :: missing
       real(kind=ESMF_KIND_R8), intent(in) :: b
-      match_r8 = present(missing) .and. (missing == b)
+      if (present(missing)) then
+         match_r8 = (missing == b)
+      else
+         match_r8 = .false.
+      end if
    end function match_r8
 
 end module mapl3g_DynamicMask

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -75,7 +75,7 @@ contains
    function new_DynamicMask_r4(mask_type, src_mask_value, dst_mask_value, handleAllElements, rc) result(mask)
       type(DynamicMask) :: mask
       character(*), intent(in) :: mask_type
-      real(kind=ESMF_KIND_R4) :: src_mask_value
+      real(kind=ESMF_KIND_R4), intent(in) :: src_mask_value
       real(kind=ESMF_KIND_R4), optional, intent(in) :: dst_mask_value
       logical, optional :: handleAllElements
       integer, optional, intent(out) :: rc
@@ -86,13 +86,15 @@ contains
       spec%mask_type = mask_type
       if (present(handleAllElements)) spec%handleAllElements = handleAllElements
 
+      ! Only store the R4 mask values; do NOT widen to R8.
+      ! Many R4 sentinel values are not exactly representable in R8, so a
+      ! naive real() conversion could produce a value that never compares
+      ! equal to R4 source data.
       spec%src_mask_value_r4 = src_mask_value
-      spec%src_mask_value_r8 = spec%src_mask_value_r4
 
       ! No default for dst_mask_value.  Usually left unallocated
       if (present(dst_mask_value)) then
          spec%dst_mask_value_r4 = dst_mask_value
-         spec%dst_mask_value_r8 = dst_mask_value
       end if
 
       mask = DynamicMask(spec, _RC)
@@ -114,13 +116,14 @@ contains
       spec%mask_type = mask_type
       if (present(handleAllElements)) spec%handleAllElements = handleAllElements
 
-      spec%src_mask_value_r8 = src_mask_value
-      spec%src_mask_value_r4 = spec%src_mask_value_r8
+      ! Only store the R8 mask values; do NOT narrow to R4.
+      ! Narrowing an R8 sentinel to R4 may not round-trip back to the
+      ! original R8 bit-pattern, causing mask comparisons to fail silently.
+      if (present(src_mask_value)) spec%src_mask_value_r8 = src_mask_value
 
       ! No default for dst_mask_value.  Usually left unallocated
       if (present(dst_mask_value)) then
          spec%dst_mask_value_r8 = dst_mask_value
-         spec%dst_mask_value_r4 = dst_mask_value
       end if
 
       mask = DynamicMask(spec, _RC)
@@ -284,7 +287,8 @@ contains
    end subroutine missing_r4r8r4v
 
    subroutine monotonic_r8r8r8V(dynamicMaskList, dynamicSrcMaskValue, &
-        dynamicDstMaskValue, rc)
+         dynamicDstMaskValue, rc)
+      use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_positive_inf, ieee_negative_inf
       type(ESMF_DynamicMaskElementR8R8R8V), pointer              :: dynamicMaskList(:)
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
@@ -300,42 +304,43 @@ contains
          do i=1, size(dynamicMaskList)
             dynamicMaskList(i)%dstElement = 0.0 ! set to zero
 
-            renorm = 0.d0 ! reset
-            max_input = -huge(0.0)
-            min_input = huge(0.0)
-            do j=1, size(dynamicMaskList(i)%factor)
-               do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
-                     dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
-                          + dynamicMaskList(i)%factor(j) &
-                          * dynamicMaskList(i)%srcElement(j)%ptr(k)
-                     renorm(k) = renorm(k) + dynamicMaskList(i)%factor(j)
-                     if (dynamicMaskList(i)%srcElement(j)%ptr(k) > max_input(k)) max_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
-                     if (dynamicMaskList(i)%srcElement(j)%ptr(k) < min_input(k)) min_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
-                  endif
-               end do
-            end do
-            where (renorm > 0.d0)
-               dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
-            elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
-            end where
-            where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
-               dynamicMaskList(i)%dstElement = max_input
-            end where
-            where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement < min_input)
-               dynamicMaskList(i)%dstElement = min_input
-            end where
-         enddo
-      endif
-      ! return successfully
-      rc = ESMF_SUCCESS
+             renorm = 0.d0 ! reset
+             max_input = ieee_value(max_input, ieee_negative_inf)
+             min_input = ieee_value(min_input, ieee_positive_inf)
+             do j=1, size(dynamicMaskList(i)%factor)
+                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
+                   if (.not. &
+                        match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
+                           + dynamicMaskList(i)%factor(j) &
+                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
+                      renorm(k) = renorm(k) + dynamicMaskList(i)%factor(j)
+                      if (dynamicMaskList(i)%srcElement(j)%ptr(k) > max_input(k)) max_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
+                      if (dynamicMaskList(i)%srcElement(j)%ptr(k) < min_input(k)) min_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
+                   endif
+                end do
+             end do
+             where (renorm > 0.d0)
+                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
+             elsewhere
+                dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+             end where
+             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
+                dynamicMaskList(i)%dstElement = max_input
+             end where
+             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement < min_input)
+                dynamicMaskList(i)%dstElement = min_input
+             end where
+          enddo
+       endif
+
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine monotonic_r8r8r8V
 
    subroutine monotonic_r4r8r4V(dynamicMaskList, dynamicSrcMaskValue, &
-        dynamicDstMaskValue, rc)
+         dynamicDstMaskValue, rc)
+      use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_positive_inf, ieee_negative_inf
       type(ESMF_DynamicMaskElementR4R8R4V), pointer              :: dynamicMaskList(:)
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
@@ -351,8 +356,8 @@ contains
             dynamicMaskList(i)%dstElement = 0.0 ! set to zero
 
             renorm = 0.d0 ! reset
-            max_input = -huge(0.0)
-            min_input = huge(0.0)
+            max_input = ieee_value(max_input, ieee_negative_inf)
+            min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
                   if (.not. &
@@ -378,10 +383,9 @@ contains
                dynamicMaskList(i)%dstElement = min_input
             end where
          enddo
-      endif
+       endif
 
-      ! return successfully
-      rc = ESMF_SUCCESS
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine monotonic_r4r8r4V
 
@@ -418,10 +422,9 @@ contains
                dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
             end where
          enddo
-      endif
+       endif
 
-      ! return successfully
-      rc = ESMF_SUCCESS
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine vote_r8r8r8v
 
@@ -458,23 +461,21 @@ contains
                dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
             end where
          enddo
-      endif
+       endif
 
-      ! return successfully
-      rc = ESMF_SUCCESS
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine vote_r4r8r4v
 
    subroutine fraction_r8r8r8v(dynamicMaskList, dynamicSrcMaskValue, &
-        dynamicDstMaskValue, rc)
+         dynamicDstMaskValue, rc)
       type(ESMF_DynamicMaskElementR8R8R8V), pointer              :: dynamicMaskList(:)
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
-      integer :: i, j, k, n
+      integer :: i, j, k
 
       if (associated(dynamicMaskList)) then
-         n = size(dynamicMaskList(1)%srcElement(1)%ptr)
 
          do i=1, size(dynamicMaskList)
             dynamicMaskList(i)%dstElement = 0.0 ! set to zero
@@ -491,23 +492,21 @@ contains
                end do
             end do
          enddo
-      endif
+       endif
 
-      ! return successfully
-      rc = ESMF_SUCCESS
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine fraction_r8r8r8v
 
    subroutine fraction_r4r8r4v(dynamicMaskList, dynamicSrcMaskValue, &
-        dynamicDstMaskValue, rc)
+         dynamicDstMaskValue, rc)
       type(ESMF_DynamicMaskElementR4R8R4V), pointer              :: dynamicMaskList(:)
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
-      integer :: i, j, k, n
+      integer :: i, j, k
 
       if (associated(dynamicMaskList)) then
-         n = size(dynamicMaskList(1)%srcElement(1)%ptr)
 
          do i=1, size(dynamicMaskList)
             dynamicMaskList(i)%dstElement = 0.0 ! set to zero
@@ -524,10 +523,9 @@ contains
                end do
             end do
          enddo
-      endif
+       endif
 
-      ! return successfully
-      rc = ESMF_SUCCESS
+      _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
    end subroutine fraction_r4r8r4v
 
@@ -561,8 +559,15 @@ contains
       equal_to = a%mask_type == b%mask_type
       if (.not. equal_to) return
 
-      equal_to = a%src_mask_value_r4 == b%src_mask_value_r4
+      ! src_mask_value_r4/r8 are allocatable and may be unset when only one
+      ! precision was supplied to the constructor.  Check allocation status
+      ! before dereferencing.
+      equal_to = allocated(a%src_mask_value_r4) .eqv. allocated(b%src_mask_value_r4)
       if (.not. equal_to) return
+      if (allocated(a%src_mask_value_r4)) then
+         equal_to = a%src_mask_value_r4 == b%src_mask_value_r4
+         if (.not. equal_to) return
+      end if
 
       equal_to = allocated(a%dst_mask_value_r4) .eqv. allocated(b%dst_mask_value_r4)
       if (.not. equal_to) return
@@ -572,8 +577,12 @@ contains
       end if
       if (.not. equal_to) return
 
-      equal_to = a%src_mask_value_r8 == b%src_mask_value_r8
+      equal_to = allocated(a%src_mask_value_r8) .eqv. allocated(b%src_mask_value_r8)
       if (.not. equal_to) return
+      if (allocated(a%src_mask_value_r8)) then
+         equal_to = a%src_mask_value_r8 == b%src_mask_value_r8
+         if (.not. equal_to) return
+      end if
 
       equal_to = allocated(a%dst_mask_value_r8) .eqv. allocated(b%dst_mask_value_r8)
       if (.not. equal_to) return

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -600,13 +600,21 @@ contains
    end function not_equal_to_spec
 
    logical function match_r4(missing,b)
-      real(kind=ESMF_KIND_R4), intent(in) :: missing, b
-      match_r4 = (missing==b)
+      real(kind=ESMF_KIND_R4), intent(in), optional :: missing, b
+      if (present(missing)) then
+         match_r4 = (missing==b)
+      else
+         match_r4 = .false.
+      end if
    end function match_r4
 
    logical function match_r8(missing,b)
-      real(kind=ESMF_KIND_R8), intent(in) :: missing, b
-      match_r8 = (missing==b)
+      real(kind=ESMF_KIND_R8), intent(in), optional :: missing, b
+      if (present(missing)) then
+         match_r8 = (missing==b)
+      else
+         match_r8 = .false.
+      end if
    end function match_r8
 
 end module mapl3g_DynamicMask

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -213,7 +213,12 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -225,8 +230,8 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -237,7 +242,7 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+               dynamicMaskList(i)%dstElement = mask_value
             end where
          enddo
       endif
@@ -253,7 +258,12 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R4) :: mask_value
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -265,8 +275,8 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -277,7 +287,7 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+               dynamicMaskList(i)%dstElement = mask_value
             end where
          enddo
       endif
@@ -293,60 +303,14 @@ contains
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
+
       integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:),max_input(:),min_input(:)
 
-
-      if (associated(dynamicMaskList)) then
-         n = size(dynamicMaskList(1)%srcElement(1)%ptr)
-         allocate(renorm(n),max_input(n),min_input(n))
-
-         do i=1, size(dynamicMaskList)
-            dynamicMaskList(i)%dstElement = 0.0 ! set to zero
-
-             renorm = 0.d0 ! reset
-             max_input = ieee_value(max_input, ieee_negative_inf)
-             min_input = ieee_value(min_input, ieee_positive_inf)
-             do j=1, size(dynamicMaskList(i)%factor)
-                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                   if (.not. &
-                        match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
-                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
-                           + dynamicMaskList(i)%factor(j) &
-                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
-                      renorm(k) = renorm(k) + dynamicMaskList(i)%factor(j)
-                      if (dynamicMaskList(i)%srcElement(j)%ptr(k) > max_input(k)) max_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
-                      if (dynamicMaskList(i)%srcElement(j)%ptr(k) < min_input(k)) min_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
-                   endif
-                end do
-             end do
-             where (renorm > 0.d0)
-                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
-             elsewhere
-                dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
-             end where
-             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
-                dynamicMaskList(i)%dstElement = max_input
-             end where
-             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement < min_input)
-                dynamicMaskList(i)%dstElement = min_input
-             end where
-          enddo
-       endif
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(dynamicDstMaskValue)
-   end subroutine monotonic_r8r8r8V
-
-   subroutine monotonic_r4r8r4V(dynamicMaskList, dynamicSrcMaskValue, &
-         dynamicDstMaskValue, rc)
-      use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_positive_inf, ieee_negative_inf
-      type(ESMF_DynamicMaskElementR4R8R4V), pointer              :: dynamicMaskList(:)
-      real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
-      real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
-      integer,                       intent(out)          :: rc
-      integer :: i, j, k, n
-      real(ESMF_KIND_R4), allocatable  :: renorm(:),max_input(:),min_input(:)
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -360,8 +324,8 @@ contains
             min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -374,7 +338,7 @@ contains
             where (renorm > 0.d0)
                dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
             elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+               dynamicMaskList(i)%dstElement = mask_value
             end where
             where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
                dynamicMaskList(i)%dstElement = max_input
@@ -383,7 +347,64 @@ contains
                dynamicMaskList(i)%dstElement = min_input
             end where
          enddo
-       endif
+      endif
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(dynamicDstMaskValue)
+   end subroutine monotonic_r8r8r8V
+
+   subroutine monotonic_r4r8r4V(dynamicMaskList, dynamicSrcMaskValue, &
+         dynamicDstMaskValue, rc)
+      use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_positive_inf, ieee_negative_inf
+      type(ESMF_DynamicMaskElementR4R8R4V), pointer              :: dynamicMaskList(:)
+      real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
+      real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
+      integer,                       intent(out)          :: rc
+
+      integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R4) :: mask_value
+      real(ESMF_KIND_R4), allocatable  :: renorm(:),max_input(:),min_input(:)
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
+
+      if (associated(dynamicMaskList)) then
+         n = size(dynamicMaskList(1)%srcElement(1)%ptr)
+         allocate(renorm(n),max_input(n),min_input(n))
+
+         do i=1, size(dynamicMaskList)
+            dynamicMaskList(i)%dstElement = 0.0 ! set to zero
+
+            renorm = 0.d0 ! reset
+            max_input = ieee_value(max_input, ieee_negative_inf)
+            min_input = ieee_value(min_input, ieee_positive_inf)
+            do j=1, size(dynamicMaskList(i)%factor)
+               do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                     dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
+                          + dynamicMaskList(i)%factor(j) &
+                          * dynamicMaskList(i)%srcElement(j)%ptr(k)
+                     renorm(k) = renorm(k) + dynamicMaskList(i)%factor(j)
+                     if (dynamicMaskList(i)%srcElement(j)%ptr(k) > max_input(k)) max_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
+                     if (dynamicMaskList(i)%srcElement(j)%ptr(k) < min_input(k)) min_input(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
+                  endif
+               end do
+            end do
+            where (renorm > 0.d0)
+               dynamicMaskList(i)%dstElement = dynamicMaskList(i)%dstElement / renorm
+            elsewhere
+               dynamicMaskList(i)%dstElement = mask_value
+            end where
+            where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement > max_input)
+               dynamicMaskList(i)%dstElement = max_input
+            end where
+            where (renorm > 0.d0 .and. dynamicMaskList(i)%dstElement < min_input)
+               dynamicMaskList(i)%dstElement = min_input
+            end where
+         enddo
+      endif
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
@@ -395,8 +416,14 @@ contains
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
+
       integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -408,8 +435,8 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -419,10 +446,10 @@ contains
             end do
             where (renorm > 0.d0)
             elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+               dynamicMaskList(i)%dstElement = mask_value
             end where
          enddo
-       endif
+      endif
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
@@ -434,8 +461,14 @@ contains
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
+
       integer :: i, j, k, n
+      logical :: has_mask
+      real(ESMF_KIND_R4) :: mask_value
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -447,8 +480,8 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -458,10 +491,10 @@ contains
             end do
             where (renorm > 0.d0)
             elsewhere
-               dynamicMaskList(i)%dstElement = dynamicSrcMaskValue
+               dynamicMaskList(i)%dstElement = mask_value
             end where
          enddo
-       endif
+      endif
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
@@ -473,7 +506,13 @@ contains
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R8),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
+
       integer :: i, j, k
+      logical :: has_mask
+      real(ESMF_KIND_R8) :: mask_value
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
 
@@ -482,8 +521,8 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -492,7 +531,7 @@ contains
                end do
             end do
          enddo
-       endif
+      endif
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
@@ -504,7 +543,13 @@ contains
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicSrcMaskValue
       real(ESMF_KIND_R4),            intent(in), optional :: dynamicDstMaskValue
       integer,                       intent(out)          :: rc
+
       integer :: i, j, k
+      logical :: has_mask
+      real(ESMF_KIND_R4) :: mask_value
+
+      has_mask = present(dynamicSrcMaskValue)
+      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
 
@@ -513,8 +558,8 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. &
-                       match(dynamicSrcMaskValue,dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. (has_mask .and. &
+                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -523,7 +568,7 @@ contains
                end do
             end do
          enddo
-       endif
+      endif
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(dynamicDstMaskValue)
@@ -600,21 +645,13 @@ contains
    end function not_equal_to_spec
 
    logical function match_r4(missing,b)
-      real(kind=ESMF_KIND_R4), intent(in), optional :: missing, b
-      if (present(missing)) then
-         match_r4 = (missing==b)
-      else
-         match_r4 = .false.
-      end if
+      real(kind=ESMF_KIND_R4), intent(in) :: missing, b
+      match_r4 = (missing==b)
    end function match_r4
 
    logical function match_r8(missing,b)
-      real(kind=ESMF_KIND_R8), intent(in), optional :: missing, b
-      if (present(missing)) then
-         match_r8 = (missing==b)
-      else
-         match_r8 = .false.
-      end if
+      real(kind=ESMF_KIND_R8), intent(in) :: missing, b
+      match_r8 = (missing==b)
    end function match_r8
 
 end module mapl3g_DynamicMask

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -213,12 +213,10 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -230,7 +228,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -257,12 +255,10 @@ contains
       integer,                       intent(out)  :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R4) :: mask_value
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -274,7 +270,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -303,12 +299,10 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:),max_input(:),min_input(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -322,7 +316,7 @@ contains
             min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -359,12 +353,10 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R4) :: mask_value
       real(ESMF_KIND_R4), allocatable  :: renorm(:),max_input(:),min_input(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -378,7 +370,7 @@ contains
             min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -414,12 +406,10 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R8) :: mask_value
       real(ESMF_KIND_R8), allocatable  :: renorm(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -431,7 +421,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -458,12 +448,10 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      logical :: has_mask
       real(ESMF_KIND_R4) :: mask_value
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
 
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
+      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -475,7 +463,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -502,11 +490,6 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k
-      logical :: has_mask
-      real(ESMF_KIND_R8) :: mask_value
-
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
 
@@ -515,7 +498,7 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -538,11 +521,6 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k
-      logical :: has_mask
-      real(ESMF_KIND_R4) :: mask_value
-
-      has_mask = present(dynamicSrcMaskValue)
-      if (has_mask) mask_value = dynamicSrcMaskValue
 
       if (associated(dynamicMaskList)) then
 
@@ -551,7 +529,7 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
+                  if (.not. match(dynamicSrcMaskValue, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -636,16 +614,16 @@ contains
       not_equal_to = .not. (a == b)
    end function not_equal_to_spec
 
-   logical function match_r4(has_mask, missing, b)
-      logical,                 intent(in) :: has_mask
-      real(kind=ESMF_KIND_R4), intent(in) :: missing, b
-      match_r4 = has_mask .and. (missing == b)
+   logical function match_r4(missing, b)
+      real(kind=ESMF_KIND_R4), intent(in), optional :: missing
+      real(kind=ESMF_KIND_R4), intent(in) :: b
+      match_r4 = present(missing) .and. (missing == b)
    end function match_r4
 
-   logical function match_r8(has_mask, missing, b)
-      logical,                 intent(in) :: has_mask
-      real(kind=ESMF_KIND_R8), intent(in) :: missing, b
-      match_r8 = has_mask .and. (missing == b)
+   logical function match_r8(missing, b)
+      real(kind=ESMF_KIND_R8), intent(in), optional :: missing
+      real(kind=ESMF_KIND_R8), intent(in) :: b
+      match_r8 = present(missing) .and. (missing == b)
    end function match_r8
 
 end module mapl3g_DynamicMask

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -11,33 +11,41 @@ module mapl3g_DynamicMask
 
 
    public :: DynamicMask
+   public :: DynamicMask_R4
+   public :: DynamicMask_R8
 
    public :: operator(==)
    public :: operator(/=)
 
-   type :: DynamicMaskSpec
-      character(:), allocatable :: mask_type
-      logical :: handleAllElements = .false.
-      real(kind=ESMF_KIND_R4), allocatable :: src_mask_value_r4
-      real(kind=ESMF_KIND_R4), allocatable :: dst_mask_value_r4
-      real(kind=ESMF_KIND_R8), allocatable :: src_mask_value_r8
-      real(kind=ESMF_KIND_R8), allocatable :: dst_mask_value_r8
-   end type DynamicMaskSpec
+   type :: DynamicMask_R4
+      real(kind=ESMF_KIND_R4) :: src_mask_value
+      real(kind=ESMF_KIND_R4), allocatable :: dst_mask_value
+      type(ESMF_DynamicMask), allocatable :: esmf_mask
+   end type DynamicMask_R4
+
+   type :: DynamicMask_R8
+      real(kind=ESMF_KIND_R8) :: src_mask_value
+      real(kind=ESMF_KIND_R8), allocatable :: dst_mask_value
+      type(ESMF_DynamicMask), allocatable :: esmf_mask
+   end type DynamicMask_R8
 
    type DynamicMask
-      type(DynamicMaskSpec) :: spec
-      type(ESMF_DynamicMask), allocatable :: esmf_mask_r4
-      type(ESMF_DynamicMask), allocatable :: esmf_mask_r8
+      character(:), allocatable :: mask_type
+      logical :: handleAllElements = .false.
+      type(DynamicMask_R4), allocatable :: mask_r4
+      type(DynamicMask_R8), allocatable :: mask_r8
    end type DynamicMask
 
    interface operator(==)
       procedure :: equal_to
-      procedure :: equal_to_spec
+      procedure :: equal_to_r4
+      procedure :: equal_to_r8
    end interface operator(==)
 
    interface operator(/=)
       procedure :: not_equal_to
-      procedure :: not_equal_to_spec
+      procedure :: not_equal_to_r4
+      procedure :: not_equal_to_r8
    end interface operator(/=)
 
    interface match
@@ -48,7 +56,6 @@ module mapl3g_DynamicMask
    interface DynamicMask
       procedure :: new_DynamicMask_r4
       procedure :: new_DynamicMask_r8
-      procedure :: new_DynamicMask_r4r8
    end interface DynamicMask
 
    abstract interface
@@ -81,21 +88,22 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      type(DynamicMaskSpec) :: spec
+      procedure(I_r4r8r4), pointer :: mask_routine_r4
 
-      spec%mask_type = mask_type
-      if (present(handleAllElements)) spec%handleAllElements = handleAllElements
+      mask%mask_type = mask_type
+      if (present(handleAllElements)) mask%handleAllElements = handleAllElements
 
-      spec%src_mask_value_r4 = src_mask_value
-      spec%src_mask_value_r8 = src_mask_value
+      allocate(mask%mask_r4)
+      mask%mask_r4%src_mask_value = src_mask_value
+      if (present(dst_mask_value)) mask%mask_r4%dst_mask_value = dst_mask_value
 
-      ! No default for dst_mask_value.  Usually left unallocated
-      if (present(dst_mask_value)) then
-         spec%dst_mask_value_r4 = dst_mask_value
-         spec%dst_mask_value_r8 = dst_mask_value
-      end if
-
-      mask = DynamicMask(spec, _RC)
+      allocate(mask%mask_r4%esmf_mask)
+      mask_routine_r4 => get_mask_routine_r4(mask_type, _RC)
+      call ESMF_DynamicMaskSetR4R8R4V(mask%mask_r4%esmf_mask, mask_routine_r4, &
+           dynamicSrcMaskValue=mask%mask_r4%src_mask_value, &
+           dynamicDstMaskValue=mask%mask_r4%dst_mask_value, &
+           handleAllElements=mask%handleAllElements, &
+           _RC)
 
       _RETURN(_SUCCESS)
    end function new_DynamicMask_r4
@@ -103,57 +111,31 @@ contains
    function new_DynamicMask_r8(mask_type, src_mask_value, dst_mask_value, handleAllElements, rc) result(mask)
       type(DynamicMask) :: mask
       character(*), intent(in) :: mask_type
-      real(kind=ESMF_KIND_R8), optional, intent(in) :: src_mask_value
+      real(kind=ESMF_KIND_R8), intent(in) :: src_mask_value
       real(kind=ESMF_KIND_R8), optional, intent(in) :: dst_mask_value
       logical, optional :: handleAllElements
       integer, optional, intent(out) :: rc
 
       integer :: status
-      type(DynamicMaskSpec) :: spec
+      procedure(I_r8r8r8), pointer :: mask_routine_r8
 
-      spec%mask_type = mask_type
-      if (present(handleAllElements)) spec%handleAllElements = handleAllElements
+      mask%mask_type = mask_type
+      if (present(handleAllElements)) mask%handleAllElements = handleAllElements
 
-      if (present(src_mask_value)) spec%src_mask_value_r8 = src_mask_value
+      allocate(mask%mask_r8)
+      mask%mask_r8%src_mask_value = src_mask_value
+      if (present(dst_mask_value)) mask%mask_r8%dst_mask_value = dst_mask_value
 
-      ! No default for dst_mask_value.  Usually left unallocated
-      if (present(dst_mask_value)) spec%dst_mask_value_r8 = dst_mask_value
-
-      mask = DynamicMask(spec, _RC)
+      allocate(mask%mask_r8%esmf_mask)
+      mask_routine_r8 => get_mask_routine_r8(mask_type, _RC)
+      call ESMF_DynamicMaskSetR8R8R8V(mask%mask_r8%esmf_mask, mask_routine_r8, &
+           dynamicSrcMaskValue=mask%mask_r8%src_mask_value, &
+           dynamicDstMaskValue=mask%mask_r8%dst_mask_value, &
+           handleAllElements=mask%handleAllElements, &
+           _RC)
 
       _RETURN(_SUCCESS)
    end function new_DynamicMask_r8
-
-   function new_DynamicMask_r4r8(spec, rc) result(mask)
-      type(DynamicMask) :: mask
-      type(DynamicMaskSpec), intent(in) :: spec
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      procedure(I_r4r8r4), pointer :: mask_routine_r4
-      procedure(I_r8r8r8), pointer :: mask_routine_r8
-
-      mask%spec = spec
-
-      allocate(mask%esmf_mask_r4)
-      mask_routine_r4 => get_mask_routine_r4(spec%mask_type, _RC)
-      call ESMF_DynamicMaskSetR4R8R4V(mask%esmf_mask_r4, mask_routine_r4, &
-           dynamicSrcMaskValue=spec%src_mask_value_r4, &
-           dynamicDstMaskValue=spec%dst_mask_value_r4, &
-           handleAllElements=spec%handleAllElements, &
-           _RC)
-
-      allocate(mask%esmf_mask_r8)
-      mask_routine_r8 => get_mask_routine_r8(spec%mask_type, _RC)
-      call ESMF_DynamicMaskSetR8R8R8V(mask%esmf_mask_r8, mask_routine_r8, &
-           dynamicSrcMaskValue=spec%src_mask_value_r8, &
-           dynamicDstMaskValue=spec%dst_mask_value_r8, &
-           handleAllElements=spec%handleAllElements, &
-           _RC)
-
-      _RETURN(_SUCCESS)
-   end function new_DynamicMask_r4r8
 
    function get_mask_routine_r4(mask_type, rc) result(mask_routine)
       procedure(I_r4r8r4), pointer :: mask_routine
@@ -456,10 +438,14 @@ contains
       integer,                       intent(out)          :: rc
 
       integer :: i, j, k, n
-      real(ESMF_KIND_R4) :: mask_value
+      real(ESMF_KIND_R4) :: dst_fill
       real(ESMF_KIND_R4), allocatable  :: renorm(:)
 
-      if (present(dynamicSrcMaskValue)) mask_value = dynamicSrcMaskValue
+      if (present(dynamicDstMaskValue)) then
+         dst_fill = dynamicDstMaskValue
+      else if (present(dynamicSrcMaskValue)) then
+         dst_fill = dynamicSrcMaskValue
+      end if
 
       if (associated(dynamicMaskList)) then
          n = size(dynamicMaskList(1)%srcElement(1)%ptr)
@@ -481,7 +467,7 @@ contains
             end do
             where (renorm > 0.d0)
             elsewhere
-               dynamicMaskList(i)%dstElement = mask_value
+               dynamicMaskList(i)%dstElement = dst_fill
             end where
          enddo
       endif
@@ -556,8 +542,33 @@ contains
       type(DynamicMask), intent(in) :: a
       type(DynamicMask), intent(in) :: b
 
-      equal_to = a%spec == b%spec
+      equal_to = allocated(a%mask_type) .eqv. allocated(b%mask_type)
       if (.not. equal_to) return
+
+      if (.not. allocated(a%mask_type)) then
+         equal_to = .true.
+         return
+      end if
+
+      equal_to = a%mask_type == b%mask_type
+      if (.not. equal_to) return
+
+      equal_to = a%handleAllElements .eqv. b%handleAllElements
+      if (.not. equal_to) return
+
+      equal_to = allocated(a%mask_r4) .eqv. allocated(b%mask_r4)
+      if (.not. equal_to) return
+      if (allocated(a%mask_r4)) then
+         equal_to = a%mask_r4 == b%mask_r4
+         if (.not. equal_to) return
+      end if
+
+      equal_to = allocated(a%mask_r8) .eqv. allocated(b%mask_r8)
+      if (.not. equal_to) return
+      if (allocated(a%mask_r8)) then
+         equal_to = a%mask_r8 == b%mask_r8
+      end if
+
    end function equal_to
 
    impure elemental logical function not_equal_to(a, b)
@@ -567,60 +578,47 @@ contains
       not_equal_to = .not. (a == b)
    end function not_equal_to
 
-   logical function equal_to_spec(a, b) result(equal_to)
-      type(DynamicMaskSpec), intent(in) :: a
-      type(DynamicMaskSpec), intent(in) :: b
+   logical function equal_to_r4(a, b) result(equal_to)
+      type(DynamicMask_R4), intent(in) :: a
+      type(DynamicMask_R4), intent(in) :: b
 
-      equal_to = allocated(a%mask_type) .eqv. allocated(b%mask_type)
+      equal_to = a%src_mask_value == b%src_mask_value
       if (.not. equal_to) return
 
-      if (.not. allocated(a%mask_type)) then
-         equal_to = .true. ! uninit
-         return
+      equal_to = allocated(a%dst_mask_value) .eqv. allocated(b%dst_mask_value)
+      if (.not. equal_to) return
+      if (allocated(a%dst_mask_value)) then
+         equal_to = a%dst_mask_value == b%dst_mask_value
       end if
+   end function equal_to_r4
 
-      equal_to = a%mask_type == b%mask_type
-      if (.not. equal_to) return
-
-      ! src_mask_value_r4/r8 are allocatable and may be unset when only one
-      ! precision was supplied to the constructor.  Check allocation status
-      ! before dereferencing.
-      equal_to = allocated(a%src_mask_value_r4) .eqv. allocated(b%src_mask_value_r4)
-      if (.not. equal_to) return
-      if (allocated(a%src_mask_value_r4)) then
-         equal_to = a%src_mask_value_r4 == b%src_mask_value_r4
-         if (.not. equal_to) return
-      end if
-
-      equal_to = allocated(a%dst_mask_value_r4) .eqv. allocated(b%dst_mask_value_r4)
-      if (.not. equal_to) return
-
-      if (allocated(a%dst_mask_value_r4)) then
-         equal_to = a%dst_mask_value_r4 == b%dst_mask_value_r4
-      end if
-      if (.not. equal_to) return
-
-      equal_to = allocated(a%src_mask_value_r8) .eqv. allocated(b%src_mask_value_r8)
-      if (.not. equal_to) return
-      if (allocated(a%src_mask_value_r8)) then
-         equal_to = a%src_mask_value_r8 == b%src_mask_value_r8
-         if (.not. equal_to) return
-      end if
-
-      equal_to = allocated(a%dst_mask_value_r8) .eqv. allocated(b%dst_mask_value_r8)
-      if (.not. equal_to) return
-
-      if (allocated(a%dst_mask_value_r8)) then
-         equal_to = a%dst_mask_value_r8 == b%dst_mask_value_r8
-      end if
-   end function equal_to_spec
-
-   logical function not_equal_to_spec(a, b) result(not_equal_to)
-      type(DynamicMaskSpec), intent(in) :: a
-      type(DynamicMaskSpec), intent(in) :: b
+   logical function not_equal_to_r4(a, b) result(not_equal_to)
+      type(DynamicMask_R4), intent(in) :: a
+      type(DynamicMask_R4), intent(in) :: b
 
       not_equal_to = .not. (a == b)
-   end function not_equal_to_spec
+   end function not_equal_to_r4
+
+   logical function equal_to_r8(a, b) result(equal_to)
+      type(DynamicMask_R8), intent(in) :: a
+      type(DynamicMask_R8), intent(in) :: b
+
+      equal_to = a%src_mask_value == b%src_mask_value
+      if (.not. equal_to) return
+
+      equal_to = allocated(a%dst_mask_value) .eqv. allocated(b%dst_mask_value)
+      if (.not. equal_to) return
+      if (allocated(a%dst_mask_value)) then
+         equal_to = a%dst_mask_value == b%dst_mask_value
+      end if
+   end function equal_to_r8
+
+   logical function not_equal_to_r8(a, b) result(not_equal_to)
+      type(DynamicMask_R8), intent(in) :: a
+      type(DynamicMask_R8), intent(in) :: b
+
+      not_equal_to = .not. (a == b)
+   end function not_equal_to_r8
 
    logical function match_r4(missing, b)
       real(kind=ESMF_KIND_R4), intent(in), optional :: missing

--- a/regridder_mgr/DynamicMask.F90
+++ b/regridder_mgr/DynamicMask.F90
@@ -230,8 +230,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -275,8 +274,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -324,8 +322,7 @@ contains
             min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -381,8 +378,7 @@ contains
             min_input = ieee_value(min_input, ieee_positive_inf)
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) &
                           + dynamicMaskList(i)%factor(j) &
                           * dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -435,8 +431,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -480,8 +475,7 @@ contains
             renorm = 0.d0 ! reset
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (dynamicMaskList(i)%factor(j) > renorm(k)) then
                         renorm(k) = dynamicMaskList(i)%factor(j)
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%srcElement(j)%ptr(k)
@@ -521,8 +515,7 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -558,8 +551,7 @@ contains
 
             do j=1, size(dynamicMaskList(i)%factor)
                do k = 1, size(dynamicMaskList(i)%srcElement(j)%ptr)
-                  if (.not. (has_mask .and. &
-                       match(mask_value,dynamicMaskList(i)%srcElement(j)%ptr(k)))) then
+                  if (.not. match(has_mask, mask_value, dynamicMaskList(i)%srcElement(j)%ptr(k))) then
                      if (nint(dynamicMaskList(i)%srcElement(j)%ptr(k)) == 0) then
                         dynamicMaskList(i)%dstElement(k) = dynamicMaskList(i)%dstElement(k) + &
                              & dynamicMaskList(i)%factor(j)
@@ -644,14 +636,16 @@ contains
       not_equal_to = .not. (a == b)
    end function not_equal_to_spec
 
-   logical function match_r4(missing,b)
+   logical function match_r4(has_mask, missing, b)
+      logical,                 intent(in) :: has_mask
       real(kind=ESMF_KIND_R4), intent(in) :: missing, b
-      match_r4 = (missing==b)
+      match_r4 = has_mask .and. (missing == b)
    end function match_r4
 
-   logical function match_r8(missing,b)
+   logical function match_r8(has_mask, missing, b)
+      logical,                 intent(in) :: has_mask
       real(kind=ESMF_KIND_R8), intent(in) :: missing, b
-      match_r8 = (missing==b)
+      match_r8 = has_mask .and. (missing == b)
    end function match_r8
 
 end module mapl3g_DynamicMask

--- a/regridder_mgr/EsmfRegridder.F90
+++ b/regridder_mgr/EsmfRegridder.F90
@@ -124,11 +124,11 @@ contains
 
         associate(param => this%regridder_param)
         if (typekind == ESMF_TYPEKIND_R4) then
-           has_dynamic_mask = allocated(param%dyn_mask%esmf_mask_r4)
-           if (has_dynamic_mask) mask = param%dyn_mask%esmf_mask_r4
+           has_dynamic_mask = allocated(param%dyn_mask%mask_r4)
+           if (has_dynamic_mask) mask = param%dyn_mask%mask_r4%esmf_mask
         elseif (typekind == ESMF_TYPEKIND_R8) then
-           has_dynamic_mask = allocated(param%dyn_mask%esmf_mask_r8)
-           if (has_dynamic_mask) mask = param%dyn_mask%esmf_mask_r8
+           has_dynamic_mask = allocated(param%dyn_mask%mask_r8)
+           if (has_dynamic_mask) mask = param%dyn_mask%mask_r8%esmf_mask
         end if
 
         if (has_dynamic_mask .and. has_ungridded_dims) then

--- a/regridder_mgr/tests/Test_RegridderManager.pf
+++ b/regridder_mgr/tests/Test_RegridderManager.pf
@@ -8,13 +8,14 @@ module Test_RegridderManager
    use mapl3g_regridder_mgr
    use mapl3g_Geom_API
    use mapl3g_FieldBundle_API
-   use mapl_Constants, only: MAPL_UNDEF
+   use mapl_Constants, only: MAPL_UNDEF, MAPL_UNDEFINED_REAL64
    use esmf_TestMethod_mod ! mapl
    use esmf
-   use, intrinsic :: iso_fortran_env, only: REAL64
+   use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
    implicit none(type,external)
 
-   real(kind=REAL64), parameter :: MASK = MAPL_UNDEF
+   real(kind=REAL32), parameter :: MASK    = MAPL_UNDEF
+   real(kind=REAL64), parameter :: MASK_R8 = MAPL_UNDEFINED_REAL64
 
 contains
 


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests` or `ctest`)

## Description

Updates `DynamicMask.F90` to eliminate cross-precision conversions of mask values:

- `new_DynamicMask_r4` now stores only R4 mask values; R8 members are left unallocated
- `new_DynamicMask_r8` now stores only R8 mask values; R4 members are left unallocated
- `equal_to_spec` now checks `allocated()` before dereferencing `src_mask_value_r4/r8`

Additional cleanup:
- Add missing `intent(in)` on `src_mask_value` in `new_DynamicMask_r4`
- Replace `±huge()` initializers in `monotonic` routines with `ieee_value(ieee_negative/positive_inf)`, and fix R4 literal used for R8 arrays
- Standardize all mask subroutines to use `_RETURN(_SUCCESS)` consistently
- Remove unused variable `n` from `fraction` routines

## Related Issue

Fixes #4654