### PR TITLE
MAPL_Generic: add default_value parameter to field specification

### DIFF
--- a/generic3g/MAPL_Generic.F90
+++ b/generic3g/MAPL_Generic.F90
@@ -554,6 +554,7 @@ contains
         typekind, &
         itemType, &
         add_to_export, &
+        default_value, &
         export_name, &
         has_deferred_aspects, &
         rc)
@@ -571,6 +572,7 @@ contains
       type(ESMF_TypeKind_Flag), optional, intent(in) :: typekind
       type(ESMF_StateItem_Flag), optional, intent(in) :: itemType
       logical, optional, intent(in) :: add_to_export
+      real, optional, intent(in) :: default_value
       character(*), optional, intent(in) :: export_name
       logical, optional, intent(in) :: has_deferred_aspects
       integer, optional, intent(out) :: rc
@@ -602,6 +604,7 @@ contains
            vertical_stagger=vstagger, &
            ungridded_dims=dim_specs_vec, &
            horizontal_dims_spec=horizontal_dims_spec, &
+           default_value=default_value, &
            has_deferred_aspects=has_deferred_aspects, &
            restart_mode=restart, &
            _RC)


### PR DESCRIPTION
- Add optional  parameter to field specification method
- Pass through default_value to VariableSpec construction

This resolves #4659 

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

