### PR TITLE
FieldCreate: Add FieldFill call to initialize field after creation

### DIFF
--- a/field/FieldCreate.F90
+++ b/field/FieldCreate.F90
@@ -202,6 +202,7 @@ contains
            ungriddedLBound=bounds%lower, &
            ungriddedUBound=bounds%upper, &
            _RC)
+      call FieldFill(field, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine field_empty_complete_from_info


### PR DESCRIPTION
Ensures fields are properly initialized when created through `field_empty_complete_from_info` subroutine, similar to how fields are initialized in `field_empty_complete` routine.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

