### PR TITLE
feat(geom): add MAPL3 XYGeomSpec and XYGeomFactory

### DIFF
--- a/geom/API.F90
+++ b/geom/API.F90
@@ -10,6 +10,8 @@ module mapl3g_Geom_API
    use mapl3g_GridGetHorzIJIndex, only: mapl_GridGetHorzIJIndex => GridGetHorzIJIndex
    use mapl3g_GeomGetHorzIJIndex, only: mapl_GeomGetHorzIJIndex => GeomGetHorzIJIndex
    use mapl3g_Subgrid, only: mapl_Interval => Interval, mapl_make_subgrids => make_subgrids
+   use mapl3g_XYGeomSpec,    only: XYGeomSpec, make_XYGeomSpec, XY_COORD_STANDARD, XY_COORD_ABI
+   use mapl3g_XYGeomFactory, only: XYGeomFactory
    use esmf, only: ESMF_Grid, ESMF_Geom, ESMF_KIND_R4
 
    implicit none(type,external)
@@ -29,5 +31,7 @@ module mapl3g_Geom_API
    public :: GeomManager, geom_manager, get_geom_manager, get_mapl_geom
    public :: GeomSpec
    public :: mapl_Interval, mapl_make_subgrids
+   public :: XYGeomSpec, make_XYGeomSpec, XY_COORD_STANDARD, XY_COORD_ABI
+   public :: XYGeomFactory
 
 end module mapl3g_Geom_API

--- a/geom/CMakeLists.txt
+++ b/geom/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(VectorBasis)
 add_subdirectory(CubedSphere)
 add_subdirectory(LocStream)
 add_subdirectory(Mesh)
+add_subdirectory(XY)
 
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)

--- a/geom/GeomManager/initialize.F90
+++ b/geom/GeomManager/initialize.F90
@@ -9,14 +9,17 @@ contains
    module subroutine initialize(this)
       use mapl3g_LatLonGeomFactory
       use mapl3g_CubedSphereGeomFactory
+      use mapl3g_XYGeomFactory
       class(GeomManager), intent(inout) :: this
 
       ! Load default factories
       type(LatLonGeomFactory) :: latlon_factory
       type(CubedSphereGeomFactory) :: cs_factory
+      type(XYGeomFactory) :: xy_factory
 
       call this%add_factory(latlon_factory)
       call this%add_factory(cs_factory)
+      call this%add_factory(xy_factory)
 
    end subroutine initialize
 

--- a/geom/GeomManager/new_GeomManager.F90
+++ b/geom/GeomManager/new_GeomManager.F90
@@ -5,37 +5,33 @@ submodule (mapl3g_GeomManager) new_GeomManager_smod
    implicit none
 
 contains
-   
+
    module function new_GeomManager() result(mgr)
       use mapl3g_LatLonGeomFactory
       use mapl3g_CubedSphereGeomFactory
       use mapl3g_LocStreamGeomFactory
-!#      use mapl_CubedSphereGeomFactory
+      use mapl3g_XYGeomFactory
       type(GeomManager) :: mgr
 
-      ! Load default factories
-      type(LatLonGeomFactory) :: latlon_factory
+      type(LatLonGeomFactory)      :: latlon_factory
       type(CubedSphereGeomFactory) :: cs_factory
-      type(LocStreamGeomFactory) :: locstream_factory
-!#      type(FakeCubedSphereGeomFactory) :: fake_cs_factory 
+      type(LocStreamGeomFactory)   :: locstream_factory
+      type(XYGeomFactory)          :: xy_factory
 !#      type(TripolarGeomFactory) :: tripolar_factory
 !#      type(CustomGeomFactory) :: custom_geom_factory
-!#
-!#      call mgr%factories%push_back(latlon_factory)
-!#      call mgr%factories%push_back(cs_factory)
-!#      call mgr%factories%push_back(fake_cs_factory)
-!#      call mgr%factories%push_back(tripolar_factory)
-!#      call mgr%factories%push_back(custom_geom_factory)
-!#
-!#      ! Output only samplers.  These cannot be created from metadata.
-!#      ! And likely have a time dependence.
-!#      call mgr%factories%push_back(StationSampler_factory)
-!#      call mgr%factories%push_back(TrajectorySampler_factory)
-!#      call mgr%factories%push_back(SwathSampler_factory)
 
       call mgr%add_factory(latlon_factory)
       call mgr%add_factory(cs_factory)
-   call mgr%add_factory(locstream_factory)
+      call mgr%add_factory(locstream_factory)
+      call mgr%add_factory(xy_factory)
+!#      call mgr%add_factory(tripolar_factory)
+!#      call mgr%add_factory(custom_geom_factory)
+!#
+!#      ! Output only samplers.  These cannot be created from metadata.
+!#      ! And likely have a time dependence.
+!#      call mgr%add_factory(StationSampler_factory)
+!#      call mgr%add_factory(TrajectorySampler_factory)
+!#      call mgr%add_factory(SwathSampler_factory)
 
    end function new_GeomManager
 

--- a/geom/XY/CMakeLists.txt
+++ b/geom/XY/CMakeLists.txt
@@ -1,0 +1,30 @@
+target_sources(MAPL.geom PRIVATE
+
+  XYGeomSpec.F90
+  XYGeomFactory.F90
+
+)
+
+esma_add_fortran_submodules(
+  TARGET MAPL.geom
+  SUBDIRECTORY XYGeomSpec
+  SOURCES equal_to.F90
+          supports_hconfig.F90
+          supports_metadata.F90
+          make_XYGeomSpec_from_hconfig.F90
+          make_XYGeomSpec_from_metadata.F90
+          get_horz_ij_index.F90)
+
+esma_add_fortran_submodules(
+  TARGET MAPL.geom
+  SUBDIRECTORY XYGeomFactory
+  SOURCES make_geom.F90
+          typesafe_make_geom.F90
+          create_basic_grid.F90
+          fill_coordinates.F90
+          fill_coordinates_abi.F90
+          add_mask.F90
+          make_file_metadata.F90
+          typesafe_make_file_metadata.F90
+          make_gridded_dims.F90
+          make_variable_attributes.F90)

--- a/geom/XY/XYGeomFactory.F90
+++ b/geom/XY/XYGeomFactory.F90
@@ -1,0 +1,188 @@
+#include "MAPL.h"
+
+module mapl3g_XYGeomFactory
+
+   use mapl3g_GeomSpec
+   use mapl3g_GeomFactory
+   use mapl3g_XYGeomSpec
+   use mapl_KeywordEnforcerMod
+   use mapl_ErrorHandlingMod
+   use gftl2_StringVector
+   use mapl3g_StringDictionary
+   use pfio
+   use esmf
+   use mapl_KeywordEnforcer, only: KE => KeywordEnforcer
+
+   implicit none
+   private
+
+   public :: XYGeomFactory
+
+   type, extends(GeomFactory) :: XYGeomFactory
+      private
+   contains
+      ! Mandatory GeomFactory interface
+      procedure :: make_geom_spec_from_hconfig
+      procedure :: make_geom_spec_from_metadata
+      procedure :: supports_spec
+      procedure :: supports_hconfig
+      procedure :: supports_metadata
+      procedure :: make_geom
+      procedure :: make_file_metadata
+      procedure :: make_gridded_dims
+      procedure :: make_variable_attributes
+   end type XYGeomFactory
+
+   interface
+
+      module function make_geom(this, geom_spec, rc) result(geom)
+         use mapl3g_GeomSpec, only: GeomSpec
+         use esmf, only: ESMF_Geom
+         type(ESMF_Geom) :: geom
+         class(XYGeomFactory), intent(in) :: this
+         class(GeomSpec), intent(in) :: geom_spec
+         integer, optional, intent(out) :: rc
+      end function make_geom
+
+      module function typesafe_make_geom(spec, rc) result(geom)
+         use esmf, only: ESMF_Geom
+         type(ESMF_Geom) :: geom
+         type(XYGeomSpec), intent(in) :: spec
+         integer, optional, intent(out) :: rc
+      end function typesafe_make_geom
+
+      module function create_basic_grid(spec, unusable, rc) result(grid)
+         use esmf, only: ESMF_Grid
+         type(ESMF_Grid) :: grid
+         type(XYGeomSpec), intent(in) :: spec
+         class(KE), optional, intent(in) :: unusable
+         integer, optional, intent(out) :: rc
+      end function create_basic_grid
+
+      module subroutine fill_coordinates(spec, grid, unusable, rc)
+         use esmf, only: ESMF_Grid
+         type(XYGeomSpec), intent(in) :: spec
+         type(ESMF_Grid),  intent(inout) :: grid
+         class(KE), optional, intent(in) :: unusable
+         integer, optional, intent(out) :: rc
+      end subroutine fill_coordinates
+
+      module subroutine fill_coordinates_abi(spec, grid, unusable, rc)
+         use esmf, only: ESMF_Grid
+         type(XYGeomSpec), intent(in) :: spec
+         type(ESMF_Grid),  intent(inout) :: grid
+         class(KE), optional, intent(in) :: unusable
+         integer, optional, intent(out) :: rc
+      end subroutine fill_coordinates_abi
+
+      module subroutine add_mask(spec, grid, rc)
+         use esmf, only: ESMF_Grid
+         type(XYGeomSpec), intent(in) :: spec
+         type(ESMF_Grid),  intent(inout) :: grid
+         integer, optional, intent(out) :: rc
+      end subroutine add_mask
+
+      module function make_gridded_dims(this, geom_spec, rc) result(gridded_dims)
+         type(StringVector) :: gridded_dims
+         class(XYGeomFactory), intent(in) :: this
+         class(GeomSpec), intent(in) :: geom_spec
+         integer, optional, intent(out) :: rc
+      end function make_gridded_dims
+
+      module function make_variable_attributes(this, geom_spec, rc) result(variable_attributes)
+         type(StringDictionary) :: variable_attributes
+         class(XYGeomFactory), intent(in) :: this
+         class(GeomSpec), intent(in) :: geom_spec
+         integer, optional, intent(out) :: rc
+      end function make_variable_attributes
+
+      module function make_file_metadata(this, geom_spec, unusable, chunksizes, rc) result(file_metadata)
+         use mapl_KeywordEnforcerMod
+         type(FileMetadata) :: file_metadata
+         class(XYGeomFactory), intent(in) :: this
+         class(GeomSpec), intent(in) :: geom_spec
+         class(KeywordEnforcer), optional, intent(in) :: unusable
+         integer, optional, intent(in) :: chunksizes(:)
+         integer, optional, intent(out) :: rc
+      end function make_file_metadata
+
+      module function typesafe_make_file_metadata(spec, unusable, chunksizes, rc) result(file_metadata)
+         type(FileMetadata) :: file_metadata
+         type(XYGeomSpec), intent(in) :: spec
+         class(KE), optional, intent(in) :: unusable
+         integer, optional, intent(in) :: chunksizes(:)
+         integer, optional, intent(out) :: rc
+      end function typesafe_make_file_metadata
+
+   end interface
+
+contains
+
+   function make_geom_spec_from_hconfig(this, hconfig, rc) result(geom_spec)
+      class(GeomSpec), allocatable :: geom_spec
+      class(XYGeomFactory), intent(in) :: this
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      geom_spec = make_XYGeomSpec(hconfig, _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function make_geom_spec_from_hconfig
+
+   function make_geom_spec_from_metadata(this, file_metadata, rc) result(geom_spec)
+      class(GeomSpec), allocatable :: geom_spec
+      class(XYGeomFactory), intent(in) :: this
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      geom_spec = make_XYGeomSpec(file_metadata, _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function make_geom_spec_from_metadata
+
+   logical function supports_hconfig(this, hconfig, rc) result(supports)
+      class(XYGeomFactory), intent(in) :: this
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(XYGeomSpec) :: spec
+
+      supports = spec%supports(hconfig, _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function supports_hconfig
+
+   logical function supports_metadata(this, file_metadata, rc) result(supports)
+      class(XYGeomFactory), intent(in) :: this
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(XYGeomSpec) :: spec
+
+      supports = spec%supports(file_metadata, _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function supports_metadata
+
+   logical function supports_spec(this, geom_spec) result(supports)
+      class(XYGeomFactory), intent(in) :: this
+      class(GeomSpec), intent(in) :: geom_spec
+
+      type(XYGeomSpec) :: reference
+
+      supports = same_type_as(geom_spec, reference)
+
+      _UNUSED_DUMMY(this)
+   end function supports_spec
+
+end module mapl3g_XYGeomFactory

--- a/geom/XY/XYGeomFactory.F90
+++ b/geom/XY/XYGeomFactory.F90
@@ -97,11 +97,10 @@ module mapl3g_XYGeomFactory
       end function make_variable_attributes
 
       module function make_file_metadata(this, geom_spec, unusable, chunksizes, rc) result(file_metadata)
-         use mapl_KeywordEnforcerMod
          type(FileMetadata) :: file_metadata
          class(XYGeomFactory), intent(in) :: this
          class(GeomSpec), intent(in) :: geom_spec
-         class(KeywordEnforcer), optional, intent(in) :: unusable
+         class(KE), optional, intent(in) :: unusable
          integer, optional, intent(in) :: chunksizes(:)
          integer, optional, intent(out) :: rc
       end function make_file_metadata

--- a/geom/XY/XYGeomFactory/add_mask.F90
+++ b/geom/XY/XYGeomFactory/add_mask.F90
@@ -5,7 +5,7 @@ submodule (mapl3g_XYGeomFactory) add_mask_smod
    use mapl_InternalConstants, only: MAPL_UNDEFINED_REAL64, MAPL_MASK_IN, MAPL_MASK_OUT, &
         MAPL_DESTINATIONMASK
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/add_mask.F90
+++ b/geom/XY/XYGeomFactory/add_mask.F90
@@ -1,0 +1,56 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) add_mask_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants, only: MAPL_UNDEFINED_REAL64, MAPL_MASK_IN, MAPL_MASK_OUT, &
+        MAPL_DESTINATIONMASK
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   ! Add an ESMF item mask wherever coordinates equal MAPL_UNDEF.
+   ! Only needed when the coordinate arrays contain missing values
+   ! (e.g. scan lines that don't intersect the Earth disk for ABI).
+   module subroutine add_mask(spec, grid, rc)
+      type(XYGeomSpec), intent(in) :: spec
+      type(ESMF_Grid),  intent(inout) :: grid
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer(ESMF_KIND_I4), pointer :: mask(:,:)
+      real(ESMF_KIND_R8),    pointer :: fptr_lon(:,:), fptr_lat(:,:)
+      type(ESMF_VM) :: vm
+      integer :: has_undef, local_has_undef
+      type(ESMF_Info) :: infoh
+
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr_lon, _RC)
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr_lat, _RC)
+
+      local_has_undef = merge(1, 0, &
+           any(fptr_lon == MAPL_UNDEFINED_REAL64) .or. &
+           any(fptr_lat == MAPL_UNDEFINED_REAL64))
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMAllFullReduce(vm, [local_has_undef], has_undef, 1, ESMF_REDUCE_MAX, _RC)
+      _RETURN_IF(has_undef == 0)
+
+      call ESMF_GridAddItem(grid, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+           itemflag=ESMF_GRIDITEM_MASK, _RC)
+      call ESMF_GridGetItem(grid, localDE=0, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+           itemflag=ESMF_GRIDITEM_MASK, farrayPtr=mask, _RC)
+
+      mask = MAPL_MASK_IN
+      where (fptr_lon == MAPL_UNDEFINED_REAL64 .or. fptr_lat == MAPL_UNDEFINED_REAL64) &
+           mask = MAPL_MASK_OUT
+
+      call ESMF_InfoGetFromHost(grid, infoh, _RC)
+      call ESMF_InfoSet(infoh, key=MAPL_DESTINATIONMASK, values=[MAPL_MASK_OUT], _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(spec)
+   end subroutine add_mask
+
+end submodule add_mask_smod

--- a/geom/XY/XYGeomFactory/add_mask.F90
+++ b/geom/XY/XYGeomFactory/add_mask.F90
@@ -29,9 +29,11 @@ contains
       call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
            staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr_lat, _RC)
 
-      local_has_undef = merge(1, 0, &
-           any(fptr_lon == MAPL_UNDEFINED_REAL64) .or. &
-           any(fptr_lat == MAPL_UNDEFINED_REAL64))
+       if (any(fptr_lon == MAPL_UNDEFINED_REAL64) .or. any(fptr_lat == MAPL_UNDEFINED_REAL64)) then
+         local_has_undef = 1
+      else
+         local_has_undef = 0
+      end if
 
       call ESMF_VMGetCurrent(vm, _RC)
       call ESMF_VMAllFullReduce(vm, [local_has_undef], has_undef, 1, ESMF_REDUCE_MAX, _RC)

--- a/geom/XY/XYGeomFactory/create_basic_grid.F90
+++ b/geom/XY/XYGeomFactory/create_basic_grid.F90
@@ -1,0 +1,49 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) create_basic_grid_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   module function create_basic_grid(spec, unusable, rc) result(grid)
+      type(ESMF_Grid) :: grid
+      type(XYGeomSpec), intent(in) :: spec
+      class(KE), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Info) :: infoh
+
+      grid = ESMF_GridCreateNoPeriDim( &
+           countsPerDEDim1=spec%get_ims(), &
+           countsPerDEDim2=spec%get_jms(), &
+           indexFlag=ESMF_INDEX_DELOCAL, &
+           gridEdgeLWidth=[0,0], &
+           gridEdgeUWidth=[0,1], &
+           coordDep1=[1,2], &
+           coordDep2=[1,2], &
+           coordSys=ESMF_COORDSYS_SPH_RAD, _RC)
+
+      ! Allocate centre coordinates
+      call ESMF_GridAddCoord(grid, _RC)
+
+      ! Optionally allocate corner coordinates
+      if (spec%get_has_corners()) then
+         call ESMF_GridAddCoord(grid, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
+      end if
+
+      ! Tag the grid with type metadata for restart identification
+      call ESMF_InfoGetFromHost(grid, infoh, _RC)
+      if (spec%get_lm() /= MAPL_UNDEFINED_INTEGER) then
+         call ESMF_InfoSet(infoh, 'GRID_LM', spec%get_lm(), _RC)
+      end if
+      call ESMF_InfoSet(infoh, 'GridType', 'XY', _RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end function create_basic_grid
+
+end submodule create_basic_grid_smod

--- a/geom/XY/XYGeomFactory/create_basic_grid.F90
+++ b/geom/XY/XYGeomFactory/create_basic_grid.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_XYGeomFactory) create_basic_grid_smod
    use mapl_ErrorHandlingMod
    use mapl_InternalConstants
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/fill_coordinates.F90
+++ b/geom/XY/XYGeomFactory/fill_coordinates.F90
@@ -1,0 +1,150 @@
+#include "MAPL.h"
+
+! Fill lon/lat centre (and optionally corner) coordinates for a standard
+! XY grid whose coordinate arrays are stored as 2-D variables ('lons',
+! 'lats', 'corner_lons', 'corner_lats') in a NetCDF file.
+!
+! Shmem optimisation is intentionally omitted here (see issue #4685).
+! Root reads the full global arrays, then broadcasts to all PETs via
+! MPI_Bcast (ESMF_VMBroadcast has no R8 or 2-D interface), and each
+! PET copies its local tile into the ESMF coordinate arrays.
+
+submodule (mapl3g_XYGeomFactory) fill_coordinates_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants, only: MAPL_UNDEFINED_REAL64
+   use mapl_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
+   use mapl3g_Comms,   only: am_i_root, ROOT_PROCESS_ID
+   use NetCDF
+   use esmf
+   use mpi
+   implicit none (type, external)
+
+contains
+
+   module subroutine fill_coordinates(spec, grid, unusable, rc)
+      type(XYGeomSpec), intent(in) :: spec
+      type(ESMF_Grid),  intent(inout) :: grid
+      class(KE), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: im_world, jm_world
+      integer :: i1, in, j1, jn, ic1, icn, jc1, jcn
+      integer :: ncid, varid
+      integer :: comm
+      real(ESMF_KIND_R8), pointer     :: fptr(:,:)
+      real(ESMF_KIND_R8), allocatable :: centers(:,:), corners(:,:)
+      type(ESMF_VM) :: vm
+
+      im_world = spec%get_im_world()
+      jm_world = spec%get_jm_world()
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+
+      ! ---- centres ----
+      allocate(centers(im_world, jm_world))
+
+      call get_interior_bounds(grid, i1, in, j1, jn, _RC)
+      ! corner bounds: last PE row owns the extra corner row
+      ic1 = i1 ;  icn = in
+      jc1 = j1 ;  jcn = merge(jn+1, jn, jn == jm_world)
+
+      ! longitudes
+      if (am_i_root()) then
+         status = nf90_open(spec%get_grid_file_name(), NF90_NOWRITE, ncid)
+         _VERIFY(status)
+         status = nf90_inq_varid(ncid, 'lons', varid) ; _VERIFY(status)
+         status = nf90_get_var(ncid, varid, centers)  ; _VERIFY(status)
+         where (centers /= MAPL_UNDEFINED_REAL64) &
+              centers = centers * MAPL_DEGREES_TO_RADIANS_R8
+      end if
+      call MPI_Bcast(centers, im_world*jm_world, MPI_DOUBLE_PRECISION, &
+           ROOT_PROCESS_ID, comm, status)
+      _VERIFY(status)
+
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, _RC)
+      fptr = centers(i1:in, j1:jn)
+
+      ! latitudes
+      if (am_i_root()) then
+         status = nf90_inq_varid(ncid, 'lats', varid) ; _VERIFY(status)
+         status = nf90_get_var(ncid, varid, centers)  ; _VERIFY(status)
+         where (centers /= MAPL_UNDEFINED_REAL64) &
+              centers = centers * MAPL_DEGREES_TO_RADIANS_R8
+      end if
+      call MPI_Bcast(centers, im_world*jm_world, MPI_DOUBLE_PRECISION, &
+           ROOT_PROCESS_ID, comm, status)
+      _VERIFY(status)
+
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, _RC)
+      fptr = centers(i1:in, j1:jn)
+
+      deallocate(centers)
+
+      ! ---- corners (optional) ----
+      if (spec%get_has_corners()) then
+         allocate(corners(im_world+1, jm_world+1))
+
+         ! corner longitudes
+         if (am_i_root()) then
+            status = nf90_inq_varid(ncid, 'corner_lons', varid) ; _VERIFY(status)
+            status = nf90_get_var(ncid, varid, corners)         ; _VERIFY(status)
+            where (corners /= MAPL_UNDEFINED_REAL64) &
+                 corners = corners * MAPL_DEGREES_TO_RADIANS_R8
+         end if
+         call MPI_Bcast(corners, (im_world+1)*(jm_world+1), MPI_DOUBLE_PRECISION, &
+              ROOT_PROCESS_ID, comm, status)
+         _VERIFY(status)
+
+         call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+              staggerloc=ESMF_STAGGERLOC_CORNER, farrayPtr=fptr, _RC)
+         fptr = corners(ic1:icn, jc1:jcn)
+
+         ! corner latitudes
+         if (am_i_root()) then
+            status = nf90_inq_varid(ncid, 'corner_lats', varid) ; _VERIFY(status)
+            status = nf90_get_var(ncid, varid, corners)         ; _VERIFY(status)
+            where (corners /= MAPL_UNDEFINED_REAL64) &
+                 corners = corners * MAPL_DEGREES_TO_RADIANS_R8
+         end if
+         call MPI_Bcast(corners, (im_world+1)*(jm_world+1), MPI_DOUBLE_PRECISION, &
+              ROOT_PROCESS_ID, comm, status)
+         _VERIFY(status)
+
+         call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+              staggerloc=ESMF_STAGGERLOC_CORNER, farrayPtr=fptr, _RC)
+         fptr = corners(ic1:icn, jc1:jcn)
+
+         deallocate(corners)
+      end if
+
+      if (am_i_root()) then
+         status = nf90_close(ncid) ; _VERIFY(status)
+      end if
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+
+   end subroutine fill_coordinates
+
+   ! Helper: get local interior bounds from the ESMF grid
+   subroutine get_interior_bounds(grid, i1, in, j1, jn, rc)
+      type(ESMF_Grid), intent(in) :: grid
+      integer, intent(out) :: i1, in, j1, jn
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: cLBound(2), cUBound(2)
+
+      call ESMF_GridGet(grid, localDE=0, staggerloc=ESMF_STAGGERLOC_CENTER, &
+           exclusiveLBound=cLBound, exclusiveUBound=cUBound, _RC)
+      i1 = cLBound(1) ;  in = cUBound(1)
+      j1 = cLBound(2) ;  jn = cUBound(2)
+
+      _RETURN(_SUCCESS)
+   end subroutine get_interior_bounds
+
+end submodule fill_coordinates_smod

--- a/geom/XY/XYGeomFactory/fill_coordinates.F90
+++ b/geom/XY/XYGeomFactory/fill_coordinates.F90
@@ -48,7 +48,12 @@ contains
       call get_interior_bounds(grid, i1, in, j1, jn, _RC)
       ! corner bounds: last PE row owns the extra corner row
       ic1 = i1 ;  icn = in
-      jc1 = j1 ;  jcn = merge(jn+1, jn, jn == jm_world)
+      jc1 = j1
+      if (jn == jm_world) then
+         jcn = jn + 1
+      else
+         jcn = jn
+      end if
 
       ! longitudes
       if (am_i_root()) then

--- a/geom/XY/XYGeomFactory/fill_coordinates.F90
+++ b/geom/XY/XYGeomFactory/fill_coordinates.F90
@@ -17,7 +17,7 @@ submodule (mapl3g_XYGeomFactory) fill_coordinates_smod
    use NetCDF
    use esmf
    use mpi
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/fill_coordinates_abi.F90
+++ b/geom/XY/XYGeomFactory/fill_coordinates_abi.F90
@@ -1,0 +1,135 @@
+#include "MAPL.h"
+
+! Fill lon/lat centre coordinates for an ABI/GOES-style XY grid.
+! The file contains 1-D scan-angle arrays (x, y) and a satellite
+! sub-longitude attribute.  Each PET computes its own tile of
+! (lon, lat) from those inputs using the standard ABI fixed-grid
+! projection (GOES-R series product definition).
+!
+! Shmem optimisation is intentionally omitted (see issue #4685).
+
+submodule (mapl3g_XYGeomFactory) fill_coordinates_abi_smod
+   use mapl_ErrorHandlingMod
+   use mapl_Constants, only: MAPL_DEGREES_TO_RADIANS_R8
+   use mapl3g_Comms,   only: am_i_root, ROOT_PROCESS_ID
+   use MAPL_EarthConstants, only: R_EQ  => MAPL_SEMIMAJOR_AXIS, &
+                                  R_POL => MAPL_SEMIMINOR_AXIS, &
+                                  H_SAT => MAPL_GEO_ORBIT_RADIUS
+   use NetCDF
+   use esmf
+   use mpi
+   use, intrinsic :: iso_fortran_env, only: REAL64
+   implicit none (type, external)
+
+   real(REAL64), parameter :: E2 = 1.0_REAL64 - (R_POL/R_EQ)**2
+
+contains
+
+   module subroutine fill_coordinates_abi(spec, grid, unusable, rc)
+      type(XYGeomSpec), intent(in) :: spec
+      type(ESMF_Grid),  intent(inout) :: grid
+      class(KE), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: xdim_true, ydim_true, thin_factor
+      integer :: i1, in, j1, jn, i, j, ix, jx
+      integer :: ncid, varid, comm
+      integer :: cLBound(2), cUBound(2)
+      ! ESMF_VMBroadcast has no REAL32/REAL64 array interface; use MPI_Bcast.
+      real(REAL64), allocatable :: x_scan(:), y_scan(:), lambda0(:)
+      real(REAL64) :: lambda0_deg, x0, y0, lam_sat
+      real(REAL64), pointer :: fptr_x(:,:), fptr_y(:,:)
+      character(len=:), allocatable :: fn, key_x, key_y, key_p, key_p_att
+      type(ESMF_VM) :: vm
+
+      xdim_true  = spec%get_xdim_true()
+      ydim_true  = spec%get_ydim_true()
+      thin_factor = spec%get_thin_factor()
+      fn         = spec%get_grid_file_name()
+      key_x      = spec%get_var_name_x()
+      key_y      = spec%get_var_name_y()
+      key_p      = spec%get_var_name_proj()
+      key_p_att  = spec%get_att_name_proj()
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, mpiCommunicator=comm, _RC)
+
+      allocate(x_scan(xdim_true), y_scan(ydim_true), lambda0(1))
+
+      if (am_i_root()) then
+         status = nf90_open(fn, NF90_NOWRITE, ncid) ; _VERIFY(status)
+
+         status = nf90_inq_varid(ncid, key_x, varid) ; _VERIFY(status)
+         status = nf90_get_var(ncid, varid, x_scan)  ; _VERIFY(status)
+
+         status = nf90_inq_varid(ncid, key_y, varid) ; _VERIFY(status)
+         status = nf90_get_var(ncid, varid, y_scan)  ; _VERIFY(status)
+
+         status = nf90_inq_varid(ncid, key_p, varid) ; _VERIFY(status)
+          status = nf90_get_att(ncid, varid, key_p_att, lambda0_deg) ; _VERIFY(status)
+          lambda0(1) = lambda0_deg * MAPL_DEGREES_TO_RADIANS_R8
+
+         status = nf90_close(ncid) ; _VERIFY(status)
+      end if
+
+      call MPI_Bcast(x_scan,  xdim_true, MPI_DOUBLE_PRECISION, ROOT_PROCESS_ID, comm, status) ; _VERIFY(status)
+      call MPI_Bcast(y_scan,  ydim_true, MPI_DOUBLE_PRECISION, ROOT_PROCESS_ID, comm, status) ; _VERIFY(status)
+      call MPI_Bcast(lambda0, 1,         MPI_DOUBLE_PRECISION, ROOT_PROCESS_ID, comm, status) ; _VERIFY(status)
+      lam_sat = lambda0(1)
+
+      ! Get local tile bounds
+      call ESMF_GridGet(grid, localDE=0, staggerloc=ESMF_STAGGERLOC_CENTER, &
+           exclusiveLBound=cLBound, exclusiveUBound=cUBound, _RC)
+      i1 = cLBound(1) ;  in = cUBound(1)
+      j1 = cLBound(2) ;  jn = cUBound(2)
+
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr_x, _RC)
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr_y, _RC)
+
+      do i = i1, in
+         ix = i - i1 + 1
+         do j = j1, jn
+            jx = j - j1 + 1
+             x0 = x_scan(i * thin_factor)
+             y0 = y_scan(j * thin_factor)
+            call abi_xy_to_lonlat(x0, y0, lam_sat, fptr_x(ix,jx), fptr_y(ix,jx))
+         end do
+      end do
+
+      deallocate(x_scan, y_scan, lambda0)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine fill_coordinates_abi
+
+   ! Standard ABI fixed-grid projection inverse (scan angle -> geodetic lon/lat).
+   ! Reference: GOES-R Series Product Definition and Users' Guide (PUG), Vol. 3.
+   pure subroutine abi_xy_to_lonlat(x, y, lambda0, lon, lat)
+      real(REAL64), intent(in)  :: x, y, lambda0   ! rad
+      real(REAL64), intent(out) :: lon, lat          ! rad
+
+      real(REAL64) :: a, b, c, rs, Sx, Sy, Sz
+
+      a  = sin(x)**2 + cos(x)**2 * (cos(y)**2 + (R_EQ/R_POL)**2 * sin(y)**2)
+      b  = -2.0_REAL64 * H_SAT * cos(x) * cos(y)
+      c  = H_SAT**2 - R_EQ**2
+
+      if (b**2 - 4.0_REAL64*a*c < 0.0_REAL64) then
+         lon = huge(1.0_REAL64)
+         lat = huge(1.0_REAL64)
+         return
+      end if
+
+      rs = (-b - sqrt(b**2 - 4.0_REAL64*a*c)) / (2.0_REAL64*a)
+      Sx = rs * cos(x) * cos(y)  - H_SAT
+      Sy = -rs * sin(x)
+      Sz = rs * cos(x) * sin(y)
+
+      lat = atan((R_EQ/R_POL)**2 * Sz / sqrt((-Sx)**2 + Sy**2))
+      lon = lambda0 - atan(Sy / (-Sx))
+   end subroutine abi_xy_to_lonlat
+
+end submodule fill_coordinates_abi_smod

--- a/geom/XY/XYGeomFactory/fill_coordinates_abi.F90
+++ b/geom/XY/XYGeomFactory/fill_coordinates_abi.F90
@@ -19,7 +19,7 @@ submodule (mapl3g_XYGeomFactory) fill_coordinates_abi_smod
    use esmf
    use mpi
    use, intrinsic :: iso_fortran_env, only: REAL64
-   implicit none (type, external)
+   implicit none
 
    real(REAL64), parameter :: E2 = 1.0_REAL64 - (R_POL/R_EQ)**2
 

--- a/geom/XY/XYGeomFactory/make_file_metadata.F90
+++ b/geom/XY/XYGeomFactory/make_file_metadata.F90
@@ -1,0 +1,35 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) make_file_metadata_smod
+   use mapl_ErrorHandlingMod
+   use pfio
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   module function make_file_metadata(this, geom_spec, unusable, chunksizes, rc) result(file_metadata)
+      type(FileMetadata) :: file_metadata
+      class(XYGeomFactory), intent(in) :: this
+      class(GeomSpec), intent(in) :: geom_spec
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(in) :: chunksizes(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      file_metadata = FileMetadata()
+
+      select type (geom_spec)
+      type is (XYGeomSpec)
+         file_metadata = typesafe_make_file_metadata(geom_spec, chunksizes=chunksizes, _RC)
+      class default
+         _FAIL('geom_spec is not of dynamic type XYGeomSpec.')
+      end select
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(unusable)
+   end function make_file_metadata
+
+end submodule make_file_metadata_smod

--- a/geom/XY/XYGeomFactory/make_file_metadata.F90
+++ b/geom/XY/XYGeomFactory/make_file_metadata.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_XYGeomFactory) make_file_metadata_smod
    use mapl_ErrorHandlingMod
    use pfio
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/make_file_metadata.F90
+++ b/geom/XY/XYGeomFactory/make_file_metadata.F90
@@ -2,6 +2,7 @@
 
 submodule (mapl3g_XYGeomFactory) make_file_metadata_smod
    use mapl_ErrorHandlingMod
+   use mapl_KeywordEnforcer, only: KE => KeywordEnforcer
    use pfio
    use esmf
    implicit none
@@ -12,7 +13,7 @@ contains
       type(FileMetadata) :: file_metadata
       class(XYGeomFactory), intent(in) :: this
       class(GeomSpec), intent(in) :: geom_spec
-      class(KeywordEnforcer), optional, intent(in) :: unusable
+      class(KE), optional, intent(in) :: unusable
       integer, optional, intent(in) :: chunksizes(:)
       integer, optional, intent(out) :: rc
 

--- a/geom/XY/XYGeomFactory/make_geom.F90
+++ b/geom/XY/XYGeomFactory/make_geom.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_XYGeomFactory) make_geom_smod
    use mapl_ErrorHandlingMod
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/make_geom.F90
+++ b/geom/XY/XYGeomFactory/make_geom.F90
@@ -1,0 +1,29 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) make_geom_smod
+   use mapl_ErrorHandlingMod
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   module function make_geom(this, geom_spec, rc) result(geom)
+      type(ESMF_Geom) :: geom
+      class(XYGeomFactory), intent(in) :: this
+      class(GeomSpec), intent(in) :: geom_spec
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      select type (geom_spec)
+      type is (XYGeomSpec)
+         geom = typesafe_make_geom(geom_spec, _RC)
+      class default
+         _FAIL("geom_spec type not supported by XYGeomFactory")
+      end select
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function make_geom
+
+end submodule make_geom_smod

--- a/geom/XY/XYGeomFactory/make_gridded_dims.F90
+++ b/geom/XY/XYGeomFactory/make_gridded_dims.F90
@@ -1,0 +1,29 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) make_gridded_dims_smod
+   use mapl_ErrorHandlingMod
+   use gftl2_StringVector
+   implicit none (type, external)
+
+contains
+
+   module function make_gridded_dims(this, geom_spec, rc) result(gridded_dims)
+      type(StringVector) :: gridded_dims
+      class(XYGeomFactory), intent(in) :: this
+      class(GeomSpec), intent(in) :: geom_spec
+      integer, optional, intent(out) :: rc
+
+      gridded_dims = StringVector()
+      select type (geom_spec)
+      type is (XYGeomSpec)
+         call gridded_dims%push_back('Xdim')
+         call gridded_dims%push_back('Ydim')
+      class default
+         _FAIL('geom_spec is not of dynamic type XYGeomSpec.')
+      end select
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function make_gridded_dims
+
+end submodule make_gridded_dims_smod

--- a/geom/XY/XYGeomFactory/make_gridded_dims.F90
+++ b/geom/XY/XYGeomFactory/make_gridded_dims.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_XYGeomFactory) make_gridded_dims_smod
    use mapl_ErrorHandlingMod
    use gftl2_StringVector
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/make_variable_attributes.F90
+++ b/geom/XY/XYGeomFactory/make_variable_attributes.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_XYGeomFactory) make_variable_attributes_smod
    use mapl_ErrorHandlingMod
    use mapl3g_StringDictionary
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/make_variable_attributes.F90
+++ b/geom/XY/XYGeomFactory/make_variable_attributes.F90
@@ -1,0 +1,23 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) make_variable_attributes_smod
+   use mapl_ErrorHandlingMod
+   use mapl3g_StringDictionary
+   implicit none (type, external)
+
+contains
+
+   module function make_variable_attributes(this, geom_spec, rc) result(variable_attributes)
+      type(StringDictionary) :: variable_attributes
+      class(XYGeomFactory), intent(in) :: this
+      class(GeomSpec), intent(in) :: geom_spec
+      integer, optional, intent(out) :: rc
+
+      variable_attributes = StringDictionary()
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(geom_spec)
+   end function make_variable_attributes
+
+end submodule make_variable_attributes_smod

--- a/geom/XY/XYGeomFactory/typesafe_make_file_metadata.F90
+++ b/geom/XY/XYGeomFactory/typesafe_make_file_metadata.F90
@@ -5,7 +5,7 @@ submodule (mapl3g_XYGeomFactory) typesafe_make_file_metadata_smod
    use pfio
    use esmf
    use, intrinsic :: iso_fortran_env, only: REAL64
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomFactory/typesafe_make_file_metadata.F90
+++ b/geom/XY/XYGeomFactory/typesafe_make_file_metadata.F90
@@ -1,0 +1,86 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) typesafe_make_file_metadata_smod
+   use mapl_ErrorHandlingMod
+   use pfio
+   use esmf
+   use, intrinsic :: iso_fortran_env, only: REAL64
+   implicit none (type, external)
+
+contains
+
+   module function typesafe_make_file_metadata(spec, unusable, chunksizes, rc) result(file_metadata)
+      type(FileMetadata) :: file_metadata
+      type(XYGeomSpec), intent(in) :: spec
+      class(KE), optional, intent(in) :: unusable
+      integer, optional, intent(in) :: chunksizes(:)
+      integer, optional, intent(out) :: rc
+
+      integer :: im, jm, i
+      type(Variable) :: v
+      real(kind=REAL64), allocatable :: fake_coord(:)
+
+      im = spec%get_im_world()
+      jm = spec%get_jm_world()
+
+      call file_metadata%add_dimension('Xdim', im)
+      call file_metadata%add_dimension('Ydim', jm)
+
+      if (spec%get_has_corners()) then
+         call file_metadata%add_dimension('XCdim', im+1)
+         call file_metadata%add_dimension('YCdim', jm+1)
+      end if
+
+      ! Fake 1-D coordinate variables for GrADS/Panoply compatibility
+      allocate(fake_coord(im))
+      do i = 1, im
+         fake_coord(i) = dble(i)
+      end do
+      v = Variable(type=PFIO_REAL64, dimensions='Xdim', chunksizes=chunksizes)
+      call v%add_attribute('long_name', 'Fake Longitude for GrADS Compatibility')
+      call v%add_attribute('units', 'degrees_east')
+      call v%add_const_value(UnlimitedEntity(fake_coord))
+      call file_metadata%add_variable('Xdim', v)
+      deallocate(fake_coord)
+
+      allocate(fake_coord(jm))
+      do i = 1, jm
+         fake_coord(i) = dble(i)
+      end do
+      v = Variable(type=PFIO_REAL64, dimensions='Ydim', chunksizes=chunksizes)
+      call v%add_attribute('long_name', 'Fake Latitude for GrADS Compatibility')
+      call v%add_attribute('units', 'degrees_north')
+      call v%add_const_value(UnlimitedEntity(fake_coord))
+      call file_metadata%add_variable('Ydim', v)
+      deallocate(fake_coord)
+
+      ! 2-D actual coordinate variables
+      v = Variable(type=PFIO_REAL64, dimensions='Xdim,Ydim', chunksizes=chunksizes)
+      call v%add_attribute('long_name', 'longitude')
+      call v%add_attribute('units', 'degrees_east')
+      call file_metadata%add_variable('lons', v)
+
+      v = Variable(type=PFIO_REAL64, dimensions='Xdim,Ydim', chunksizes=chunksizes)
+      call v%add_attribute('long_name', 'latitude')
+      call v%add_attribute('units', 'degrees_north')
+      call file_metadata%add_variable('lats', v)
+
+      if (spec%get_has_corners()) then
+         v = Variable(type=PFIO_REAL64, dimensions='XCdim,YCdim', chunksizes=chunksizes)
+         call v%add_attribute('long_name', 'longitude')
+         call v%add_attribute('units', 'degrees_east')
+         call file_metadata%add_variable('corner_lons', v)
+
+         v = Variable(type=PFIO_REAL64, dimensions='XCdim,YCdim', chunksizes=chunksizes)
+         call v%add_attribute('long_name', 'latitude')
+         call v%add_attribute('units', 'degrees_north')
+         call file_metadata%add_variable('corner_lats', v)
+      end if
+
+      call file_metadata%add_attribute('grid_type', 'XY')
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end function typesafe_make_file_metadata
+
+end submodule typesafe_make_file_metadata_smod

--- a/geom/XY/XYGeomFactory/typesafe_make_geom.F90
+++ b/geom/XY/XYGeomFactory/typesafe_make_geom.F90
@@ -1,0 +1,37 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomFactory) typesafe_make_geom_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   module function typesafe_make_geom(spec, rc) result(geom)
+      type(ESMF_Geom) :: geom
+      type(XYGeomSpec), intent(in) :: spec
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      type(ESMF_Grid) :: grid
+      character(:), allocatable :: name
+
+      if (spec%has_name()) name = spec%get_name()
+      grid = create_basic_grid(spec, _RC)
+
+      select case (spec%get_coord_mode())
+      case (XY_COORD_ABI)
+         call fill_coordinates_abi(spec, grid, _RC)
+      case default
+         call fill_coordinates(spec, grid, _RC)
+      end select
+
+      call add_mask(spec, grid, _RC)
+
+      geom = ESMF_GeomCreate(grid=grid, _RC)
+
+      _RETURN(_SUCCESS)
+   end function typesafe_make_geom
+
+end submodule typesafe_make_geom_smod

--- a/geom/XY/XYGeomFactory/typesafe_make_geom.F90
+++ b/geom/XY/XYGeomFactory/typesafe_make_geom.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_XYGeomFactory) typesafe_make_geom_smod
    use mapl_ErrorHandlingMod
    use mapl_InternalConstants
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomSpec.F90
+++ b/geom/XY/XYGeomSpec.F90
@@ -1,0 +1,271 @@
+#include "MAPL.h"
+
+module mapl3g_XYGeomSpec
+
+   use mapl3g_GeomSpec
+   use MAPL_InternalConstants
+   use esmf, only: ESMF_KIND_R4, ESMF_KIND_R8, ESMF_HConfig
+
+   implicit none
+   private
+
+   public :: XYGeomSpec
+   public :: make_XYGeomSpec
+
+   ! Coordinate mode: whether coordinates come from a standard XY file
+   ! (2D lon/lat arrays) or an ABI/GOES file (1D scan-angle arrays +
+   ! satellite longitude attribute).
+   integer, public, parameter :: XY_COORD_STANDARD = 0
+   integer, public, parameter :: XY_COORD_ABI      = 1
+
+   type, extends(GeomSpec) :: XYGeomSpec
+      private
+      ! Grid file
+      character(len=:), allocatable :: grid_file_name
+      ! Global dimensions
+      integer :: im_world = MAPL_UNDEFINED_INTEGER
+      integer :: jm_world = MAPL_UNDEFINED_INTEGER
+      integer :: lm       = MAPL_UNDEFINED_INTEGER
+      ! Decomposition (counts per DE in each dimension)
+      integer, allocatable :: ims(:)   ! length nx
+      integer, allocatable :: jms(:)   ! length ny
+      ! Whether the file contains corner coordinates
+      logical :: has_corners = .false.
+      ! Coordinate mode
+      integer :: coord_mode = XY_COORD_STANDARD
+      ! ABI-specific metadata
+      integer :: thin_factor   = 1
+      integer :: xdim_true     = MAPL_UNDEFINED_INTEGER
+      integer :: ydim_true     = MAPL_UNDEFINED_INTEGER
+      character(len=:), allocatable :: index_name_x
+      character(len=:), allocatable :: index_name_y
+      character(len=:), allocatable :: var_name_x
+      character(len=:), allocatable :: var_name_y
+      character(len=:), allocatable :: var_name_proj
+      character(len=:), allocatable :: att_name_proj
+   contains
+      ! Mandatory GeomSpec interface
+      procedure :: equal_to
+      procedure :: get_horz_ij_index_r4
+      procedure :: get_horz_ij_index_r8
+
+      ! XY-specific supports checks
+      procedure :: supports_hconfig  => supports_hconfig_
+      procedure :: supports_metadata => supports_metadata_
+      generic   :: supports => supports_hconfig, supports_metadata
+
+      ! Accessors
+      procedure :: get_im_world
+      procedure :: get_jm_world
+      procedure :: get_lm
+      procedure :: get_ims
+      procedure :: get_jms
+      procedure :: get_grid_file_name
+      procedure :: get_has_corners
+      procedure :: get_coord_mode
+      procedure :: get_thin_factor
+      procedure :: get_xdim_true
+      procedure :: get_ydim_true
+      procedure :: get_var_name_x
+      procedure :: get_var_name_y
+      procedure :: get_var_name_proj
+      procedure :: get_att_name_proj
+   end type XYGeomSpec
+
+   interface XYGeomSpec
+      module procedure new_XYGeomSpec
+   end interface XYGeomSpec
+
+   interface make_XYGeomSpec
+      procedure make_XYGeomSpec_from_hconfig
+      procedure make_XYGeomSpec_from_metadata
+   end interface make_XYGeomSpec
+
+   integer, parameter :: R4 = ESMF_KIND_R4
+   integer, parameter :: R8 = ESMF_KIND_R8
+
+interface
+
+   pure logical module function equal_to(a, b)
+      class(XYGeomSpec), intent(in) :: a
+      class(GeomSpec),   intent(in) :: b
+   end function equal_to
+
+   module function make_XYGeomSpec_from_hconfig(hconfig, rc) result(spec)
+      use esmf, only: ESMF_HConfig
+      type(XYGeomSpec) :: spec
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+   end function make_XYGeomSpec_from_hconfig
+
+   module function make_XYGeomSpec_from_metadata(file_metadata, rc) result(spec)
+      use pfio, only: FileMetadata
+      type(XYGeomSpec) :: spec
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+   end function make_XYGeomSpec_from_metadata
+
+   logical module function supports_hconfig_(this, hconfig, rc) result(supports)
+      class(XYGeomSpec), intent(in) :: this
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+   end function supports_hconfig_
+
+   logical module function supports_metadata_(this, file_metadata, rc) result(supports)
+      use pfio, only: FileMetadata
+      class(XYGeomSpec), intent(in) :: this
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+   end function supports_metadata_
+
+   module subroutine get_horz_ij_index_r4(this, lon, lat, ii, jj, rc)
+      class(XYGeomSpec), intent(in) :: this
+      real(R4), intent(in) :: lon(:)
+      real(R4), intent(in) :: lat(:)
+      integer, allocatable, intent(out) :: ii(:)
+      integer, allocatable, intent(out) :: jj(:)
+      integer, optional, intent(out) :: rc
+   end subroutine get_horz_ij_index_r4
+
+   module subroutine get_horz_ij_index_r8(this, lon, lat, ii, jj, rc)
+      class(XYGeomSpec), intent(in) :: this
+      real(R8), intent(in) :: lon(:)
+      real(R8), intent(in) :: lat(:)
+      integer, allocatable, intent(out) :: ii(:)
+      integer, allocatable, intent(out) :: jj(:)
+      integer, optional, intent(out) :: rc
+   end subroutine get_horz_ij_index_r8
+
+end interface
+
+contains
+
+   function new_XYGeomSpec( &
+        grid_file_name, im_world, jm_world, lm, ims, jms, &
+        has_corners, coord_mode, thin_factor, xdim_true, ydim_true, &
+        index_name_x, index_name_y, &
+        var_name_x, var_name_y, var_name_proj, att_name_proj) result(spec)
+      type(XYGeomSpec) :: spec
+      character(len=*),           intent(in) :: grid_file_name
+      integer,                    intent(in) :: im_world
+      integer,                    intent(in) :: jm_world
+      integer,          optional, intent(in) :: lm
+      integer,          optional, intent(in) :: ims(:)
+      integer,          optional, intent(in) :: jms(:)
+      logical,          optional, intent(in) :: has_corners
+      integer,          optional, intent(in) :: coord_mode
+      integer,          optional, intent(in) :: thin_factor
+      integer,          optional, intent(in) :: xdim_true
+      integer,          optional, intent(in) :: ydim_true
+      character(len=*), optional, intent(in) :: index_name_x
+      character(len=*), optional, intent(in) :: index_name_y
+      character(len=*), optional, intent(in) :: var_name_x
+      character(len=*), optional, intent(in) :: var_name_y
+      character(len=*), optional, intent(in) :: var_name_proj
+      character(len=*), optional, intent(in) :: att_name_proj
+
+      spec%grid_file_name = grid_file_name
+      spec%im_world       = im_world
+      spec%jm_world       = jm_world
+      if (present(lm))          spec%lm          = lm
+      if (present(ims))         spec%ims         = ims
+      if (present(jms))         spec%jms         = jms
+      if (present(has_corners)) spec%has_corners  = has_corners
+      if (present(coord_mode))  spec%coord_mode   = coord_mode
+      if (present(thin_factor)) spec%thin_factor  = thin_factor
+      if (present(xdim_true))   spec%xdim_true    = xdim_true
+      if (present(ydim_true))   spec%ydim_true    = ydim_true
+      if (present(index_name_x))  spec%index_name_x  = index_name_x
+      if (present(index_name_y))  spec%index_name_y  = index_name_y
+      if (present(var_name_x))    spec%var_name_x    = var_name_x
+      if (present(var_name_y))    spec%var_name_y    = var_name_y
+      if (present(var_name_proj)) spec%var_name_proj = var_name_proj
+      if (present(att_name_proj)) spec%att_name_proj = att_name_proj
+
+   end function new_XYGeomSpec
+
+   ! --- Accessors ---
+
+   integer function get_im_world(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%im_world
+   end function get_im_world
+
+   integer function get_jm_world(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%jm_world
+   end function get_jm_world
+
+   integer function get_lm(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%lm
+   end function get_lm
+
+   function get_ims(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      integer, allocatable :: v(:)
+      v = this%ims
+   end function get_ims
+
+   function get_jms(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      integer, allocatable :: v(:)
+      v = this%jms
+   end function get_jms
+
+   function get_grid_file_name(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      character(len=:), allocatable :: v
+      v = this%grid_file_name
+   end function get_grid_file_name
+
+   logical function get_has_corners(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%has_corners
+   end function get_has_corners
+
+   integer function get_coord_mode(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%coord_mode
+   end function get_coord_mode
+
+   integer function get_thin_factor(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%thin_factor
+   end function get_thin_factor
+
+   integer function get_xdim_true(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%xdim_true
+   end function get_xdim_true
+
+   integer function get_ydim_true(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%ydim_true
+   end function get_ydim_true
+
+   function get_var_name_x(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      character(len=:), allocatable :: v
+      v = this%var_name_x
+   end function get_var_name_x
+
+   function get_var_name_y(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      character(len=:), allocatable :: v
+      v = this%var_name_y
+   end function get_var_name_y
+
+   function get_var_name_proj(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      character(len=:), allocatable :: v
+      v = this%var_name_proj
+   end function get_var_name_proj
+
+   function get_att_name_proj(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      character(len=:), allocatable :: v
+      v = this%att_name_proj
+   end function get_att_name_proj
+
+end module mapl3g_XYGeomSpec

--- a/geom/XY/XYGeomSpec/equal_to.F90
+++ b/geom/XY/XYGeomSpec/equal_to.F90
@@ -2,7 +2,7 @@
 
 submodule (mapl3g_XYGeomSpec) equal_to_smod
    use mapl_ErrorHandlingMod
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomSpec/equal_to.F90
+++ b/geom/XY/XYGeomSpec/equal_to.F90
@@ -1,0 +1,27 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) equal_to_smod
+   use mapl_ErrorHandlingMod
+   implicit none (type, external)
+
+contains
+
+   pure logical module function equal_to(a, b)
+      class(XYGeomSpec), intent(in) :: a
+      class(GeomSpec),   intent(in) :: b
+
+      select type (b)
+      type is (XYGeomSpec)
+         equal_to = (a%im_world   == b%im_world)   .and. &
+                    (a%jm_world   == b%jm_world)    .and. &
+                    (a%lm         == b%lm)           .and. &
+                    (a%coord_mode == b%coord_mode)   .and. &
+                    (a%thin_factor == b%thin_factor) .and. &
+                    (a%grid_file_name == b%grid_file_name)
+      class default
+         equal_to = .false.
+      end select
+
+   end function equal_to
+
+end submodule equal_to_smod

--- a/geom/XY/XYGeomSpec/get_horz_ij_index.F90
+++ b/geom/XY/XYGeomSpec/get_horz_ij_index.F90
@@ -2,7 +2,7 @@
 
 submodule (mapl3g_XYGeomSpec) get_horz_ij_index_smod
    use mapl_ErrorHandlingMod
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomSpec/get_horz_ij_index.F90
+++ b/geom/XY/XYGeomSpec/get_horz_ij_index.F90
@@ -1,0 +1,43 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) get_horz_ij_index_smod
+   use mapl_ErrorHandlingMod
+   implicit none (type, external)
+
+contains
+
+   ! XY grids are arbitrary-projection grids; there is no analytic
+   ! formula to invert (lon,lat) -> (i,j).  Return an error.
+   module subroutine get_horz_ij_index_r4(this, lon, lat, ii, jj, rc)
+      class(XYGeomSpec), intent(in) :: this
+      real(R4), intent(in) :: lon(:)
+      real(R4), intent(in) :: lat(:)
+      integer, allocatable, intent(out) :: ii(:)
+      integer, allocatable, intent(out) :: jj(:)
+      integer, optional, intent(out) :: rc
+
+      _FAIL('get_horz_ij_index not supported for XYGeomSpec')
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(lon)
+      _UNUSED_DUMMY(lat)
+      _UNUSED_DUMMY(ii)
+      _UNUSED_DUMMY(jj)
+   end subroutine get_horz_ij_index_r4
+
+   module subroutine get_horz_ij_index_r8(this, lon, lat, ii, jj, rc)
+      class(XYGeomSpec), intent(in) :: this
+      real(R8), intent(in) :: lon(:)
+      real(R8), intent(in) :: lat(:)
+      integer, allocatable, intent(out) :: ii(:)
+      integer, allocatable, intent(out) :: jj(:)
+      integer, optional, intent(out) :: rc
+
+      _FAIL('get_horz_ij_index not supported for XYGeomSpec')
+      _UNUSED_DUMMY(this)
+      _UNUSED_DUMMY(lon)
+      _UNUSED_DUMMY(lat)
+      _UNUSED_DUMMY(ii)
+      _UNUSED_DUMMY(jj)
+   end subroutine get_horz_ij_index_r8
+
+end submodule get_horz_ij_index_smod

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -1,0 +1,218 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) make_XYGeomSpec_from_hconfig_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants
+   use mapl3g_Comms, only: am_i_root, ROOT_PROCESS_ID
+   use NetCDF
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   module function make_XYGeomSpec_from_hconfig(hconfig, rc) result(spec)
+      type(XYGeomSpec) :: spec
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: arr(2)
+      type(ESMF_VM) :: vm
+      character(len=:), allocatable :: grid_file_name
+      character(len=:), allocatable :: coord_class
+      integer :: thin_factor, n1, n2, ncid, dimid
+      integer :: lm
+      logical :: has_lm, found
+      character(len=:), allocatable :: index_name_x, index_name_y
+      character(len=:), allocatable :: var_name_x, var_name_y
+      character(len=:), allocatable :: var_name_proj, att_name_proj
+      integer :: coord_mode
+      integer, allocatable :: ims(:), jms(:)
+
+      ! Required: grid_file_name
+      grid_file_name = ESMF_HConfigAsString(hconfig, keyString='grid_file_name', _RC)
+      spec%grid_file_name = grid_file_name
+
+      ! Optional vertical extent
+      has_lm = ESMF_HConfigIsDefined(hconfig, keystring='LM', _RC)
+      if (has_lm) then
+         spec%lm = ESMF_HConfigAsI4(hconfig, keyString='LM', _RC)
+      end if
+
+      ! ABI/GOES scan-angle metadata (default to standard XY)
+      coord_class = 'standard'
+      found = ESMF_HConfigIsDefined(hconfig, keyString='coord_class', _RC)
+      if (found) coord_class = ESMF_HConfigAsString(hconfig, keyString='coord_class', _RC)
+      if (coord_class == 'ABI') then
+          coord_mode = XY_COORD_ABI
+      else
+          coord_mode = XY_COORD_STANDARD
+      end if
+      spec%coord_mode = coord_mode
+
+      if (coord_mode == XY_COORD_ABI) then
+         index_name_x  = 'x' ;  index_name_y  = 'y'
+         var_name_x    = 'x' ;  var_name_y    = 'y'
+         var_name_proj = ''  ;  att_name_proj = ''
+         thin_factor   = 1
+         found = ESMF_HConfigIsDefined(hconfig, keyString='index_name_x', _RC)
+         if (found) index_name_x = ESMF_HConfigAsString(hconfig, keyString='index_name_x', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='index_name_y', _RC)
+         if (found) index_name_y = ESMF_HConfigAsString(hconfig, keyString='index_name_y', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='var_name_x', _RC)
+         if (found) var_name_x = ESMF_HConfigAsString(hconfig, keyString='var_name_x', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='var_name_y', _RC)
+         if (found) var_name_y = ESMF_HConfigAsString(hconfig, keyString='var_name_y', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='var_name_proj', _RC)
+         if (found) var_name_proj = ESMF_HConfigAsString(hconfig, keyString='var_name_proj', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='att_name_proj', _RC)
+         if (found) att_name_proj = ESMF_HConfigAsString(hconfig, keyString='att_name_proj', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='thin_factor', _RC)
+         if (found) thin_factor = ESMF_HConfigAsI4(hconfig, keyString='thin_factor', _RC)
+         spec%index_name_x  = index_name_x
+         spec%index_name_y  = index_name_y
+         spec%var_name_x    = var_name_x
+         spec%var_name_y    = var_name_y
+         spec%var_name_proj = var_name_proj
+         spec%att_name_proj = att_name_proj
+         spec%thin_factor   = thin_factor
+      else
+         index_name_x = 'Xdim' ;  index_name_y = 'Ydim'
+         found = ESMF_HConfigIsDefined(hconfig, keyString='index_name_x', _RC)
+         if (found) index_name_x = ESMF_HConfigAsString(hconfig, keyString='index_name_x', _RC)
+         found = ESMF_HConfigIsDefined(hconfig, keyString='index_name_y', _RC)
+         if (found) index_name_y = ESMF_HConfigAsString(hconfig, keyString='index_name_y', _RC)
+         spec%index_name_x = index_name_x
+         spec%index_name_y = index_name_y
+         thin_factor = 1
+      end if
+
+      ! Read grid dimensions from file on root, then broadcast
+      call ESMF_VMGetCurrent(vm, _RC)
+      if (am_i_root()) then
+         status = nf90_open(grid_file_name, NF90_NOWRITE, ncid)
+         _VERIFY(status)
+         status = nf90_inq_dimid(ncid, index_name_x, dimid)
+         _VERIFY(status)
+         status = nf90_inquire_dimension(ncid, dimid, len=n1)
+         _VERIFY(status)
+         status = nf90_inq_dimid(ncid, index_name_y, dimid)
+         _VERIFY(status)
+         status = nf90_inquire_dimension(ncid, dimid, len=n2)
+         _VERIFY(status)
+         status = nf90_close(ncid)
+         _VERIFY(status)
+         arr(1) = n1
+         arr(2) = n2
+      end if
+      call ESMF_VMBroadcast(vm, arr, 2, ROOT_PROCESS_ID, _RC)
+      n1 = arr(1)
+      n2 = arr(2)
+
+      spec%xdim_true = n1
+      spec%ydim_true = n2
+      spec%im_world  = n1 / thin_factor
+      spec%jm_world  = n2 / thin_factor
+
+      ! Check for corner coordinates (standard mode only)
+      if (coord_mode == XY_COORD_STANDARD) then
+         call check_has_corners(grid_file_name, spec%has_corners, vm, _RC)
+      end if
+
+      ! Compute decomposition
+      call make_decomposition(spec, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end function make_XYGeomSpec_from_hconfig
+
+   ! -----------------------------------------------------------------------
+
+   subroutine check_has_corners(filename, has_corners, vm, rc)
+      character(len=*), intent(in)    :: filename
+      logical,          intent(out)   :: has_corners
+      type(ESMF_VM),    intent(in)    :: vm
+      integer, optional, intent(out)  :: rc
+
+      integer :: status, ncid, varid
+      integer :: log_array(1)
+
+      if (am_i_root()) then
+         status = nf90_open(filename, NF90_NOWRITE, ncid)
+         _VERIFY(status)
+         status = NF90_inq_varid(ncid, 'corner_lons', varid)
+         log_array(1) = merge(1, 0, status == NF90_NOERR)
+         status = nf90_close(ncid)
+         _VERIFY(status)
+      end if
+      call ESMF_VMBroadcast(vm, log_array, 1, ROOT_PROCESS_ID, _RC)
+      has_corners = (log_array(1) == 1)
+
+      _RETURN(_SUCCESS)
+   end subroutine check_has_corners
+
+   subroutine make_decomposition(spec, rc)
+      type(XYGeomSpec), intent(inout) :: spec
+      integer, optional, intent(out)  :: rc
+
+      integer :: status
+      integer :: petCount, nx, ny
+      integer :: im, jm
+      type(ESMF_VM) :: vm
+      integer, allocatable :: ims(:), jms(:)
+
+      im = spec%im_world
+      jm = spec%jm_world
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, petCount=petCount, _RC)
+
+      ! Square-ish decomposition: factor petCount into nx * ny
+      call compute_layout(petCount, im, jm, nx, ny)
+
+      allocate(ims(nx), jms(ny))
+      call distribute_dim(im, nx, ims)
+      call distribute_dim(jm, ny, jms)
+
+      spec%ims = ims
+      spec%jms = jms
+
+      _RETURN(_SUCCESS)
+   end subroutine make_decomposition
+
+   ! Distribute n elements across k DEs as evenly as possible,
+   ! with minimum extent of 2 (required by ESMF_FieldRegrid).
+   subroutine distribute_dim(n, k, counts)
+      integer, intent(in)  :: n, k
+      integer, intent(out) :: counts(k)
+      integer :: base, remainder, i
+      base      = n / k
+      remainder = mod(n, k)
+      do i = 1, k
+         counts(i) = base + merge(1, 0, i <= remainder)
+      end do
+   end subroutine distribute_dim
+
+   ! Factor petCount into nx * ny such that domains are as square as possible.
+   subroutine compute_layout(petCount, im, jm, nx, ny)
+      integer, intent(in)  :: petCount, im, jm
+      integer, intent(out) :: nx, ny
+      real    :: ratio, best, candidate
+      integer :: i
+      best  = huge(1.0)
+      nx    = 1
+      ny    = petCount
+      ratio = real(im) / real(jm)
+      do i = 1, petCount
+         if (mod(petCount, i) == 0) then
+            candidate = abs(real(i) / real(petCount/i) - ratio)
+            if (candidate < best) then
+               best = candidate
+               nx   = i
+               ny   = petCount / i
+            end if
+         end if
+      end do
+   end subroutine compute_layout
+
+end submodule make_XYGeomSpec_from_hconfig_smod

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -139,7 +139,11 @@ contains
          status = nf90_open(filename, NF90_NOWRITE, ncid)
          _VERIFY(status)
          status = NF90_inq_varid(ncid, 'corner_lons', varid)
-         log_array(1) = merge(1, 0, status == NF90_NOERR)
+         if (status == NF90_NOERR) then
+            log_array(1) = 1
+         else
+            log_array(1) = 0
+         end if
          status = nf90_close(ncid)
          _VERIFY(status)
       end if
@@ -187,7 +191,11 @@ contains
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k
-         counts(i) = base + merge(1, 0, i <= remainder)
+         if (i <= remainder) then
+            counts(i) = base + 1
+         else
+            counts(i) = base
+         end if
       end do
    end subroutine distribute_dim
 

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -6,7 +6,7 @@ submodule (mapl3g_XYGeomSpec) make_XYGeomSpec_from_hconfig_smod
    use mapl3g_Comms, only: am_i_root, ROOT_PROCESS_ID
    use NetCDF
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 
@@ -139,11 +139,7 @@ contains
          status = nf90_open(filename, NF90_NOWRITE, ncid)
          _VERIFY(status)
          status = NF90_inq_varid(ncid, 'corner_lons', varid)
-         if (status == NF90_NOERR) then
-            log_array(1) = 1
-         else
-            log_array(1) = 0
-         end if
+         log_array(1) = merge(1, 0, status == NF90_NOERR)
          status = nf90_close(ncid)
          _VERIFY(status)
       end if
@@ -191,11 +187,7 @@ contains
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k
-         if (i <= remainder) then
-            counts(i) = base + 1
-         else
-            counts(i) = base
-         end if
+         counts(i) = base + merge(1, 0, i <= remainder)
       end do
    end subroutine distribute_dim
 

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -134,14 +134,16 @@ contains
 
       integer :: status, ncid, varid
       integer :: log_array(1)
-      intrinsic :: merge
-      intrinsic :: merge
 
       if (am_i_root()) then
          status = nf90_open(filename, NF90_NOWRITE, ncid)
          _VERIFY(status)
          status = NF90_inq_varid(ncid, 'corner_lons', varid)
-         log_array(1) = merge(1, 0, status == NF90_NOERR)
+         if (status == NF90_NOERR) then
+            log_array(1) = 1
+         else
+            log_array(1) = 0
+         end if
          status = nf90_close(ncid)
          _VERIFY(status)
       end if
@@ -186,12 +188,14 @@ contains
       integer, intent(in)  :: n, k
       integer, intent(out) :: counts(k)
       integer :: base, remainder, i
-      intrinsic :: merge
-      intrinsic :: merge
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k
-         counts(i) = base + merge(1, 0, i <= remainder)
+         if (i <= remainder) then
+            counts(i) = base + 1
+         else
+            counts(i) = base
+         end if
       end do
    end subroutine distribute_dim
 

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -21,13 +21,11 @@ contains
       character(len=:), allocatable :: grid_file_name
       character(len=:), allocatable :: coord_class
       integer :: thin_factor, n1, n2, ncid, dimid
-      integer :: lm
       logical :: has_lm, found
       character(len=:), allocatable :: index_name_x, index_name_y
       character(len=:), allocatable :: var_name_x, var_name_y
       character(len=:), allocatable :: var_name_proj, att_name_proj
       integer :: coord_mode
-      integer, allocatable :: ims(:), jms(:)
 
       ! Required: grid_file_name
       grid_file_name = ESMF_HConfigAsString(hconfig, keyString='grid_file_name', _RC)
@@ -136,6 +134,8 @@ contains
 
       integer :: status, ncid, varid
       integer :: log_array(1)
+      intrinsic :: merge
+      intrinsic :: merge
 
       if (am_i_root()) then
          status = nf90_open(filename, NF90_NOWRITE, ncid)
@@ -186,6 +186,8 @@ contains
       integer, intent(in)  :: n, k
       integer, intent(out) :: counts(k)
       integer :: base, remainder, i
+      intrinsic :: merge
+      intrinsic :: merge
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
@@ -70,7 +70,11 @@ contains
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k
-         counts(i) = base + merge(1, 0, i <= remainder)
+         if (i <= remainder) then
+            counts(i) = base + 1
+         else
+            counts(i) = base
+         end if
       end do
    end subroutine distribute_dim
 

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
@@ -7,7 +7,7 @@ submodule (mapl3g_XYGeomSpec) make_XYGeomSpec_from_metadata_smod
    use NetCDF
    use pfio, only: FileMetadata
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 
@@ -70,11 +70,7 @@ contains
       base      = n / k
       remainder = mod(n, k)
       do i = 1, k
-         if (i <= remainder) then
-            counts(i) = base + 1
-         else
-            counts(i) = base
-         end if
+         counts(i) = base + merge(1, 0, i <= remainder)
       end do
    end subroutine distribute_dim
 

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_metadata.F90
@@ -1,0 +1,98 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) make_XYGeomSpec_from_metadata_smod
+   use mapl_ErrorHandlingMod
+   use mapl_InternalConstants
+   use mapl3g_Comms, only: am_i_root, ROOT_PROCESS_ID
+   use NetCDF
+   use pfio, only: FileMetadata
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   ! Build an XYGeomSpec from a pFIO FileMetadata object.
+   ! The metadata must have 'Xdim' and 'Ydim' dimensions (as written
+   ! by the MAPL2 XYGridFactory append_metadata), and a 'grid_type'
+   ! attribute equal to 'XY'.
+   module function make_XYGeomSpec_from_metadata(file_metadata, rc) result(spec)
+      type(XYGeomSpec) :: spec
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+
+      spec%im_world = file_metadata%get_dimension('Xdim', _RC)
+      spec%jm_world = file_metadata%get_dimension('Ydim', _RC)
+
+      if (file_metadata%has_dimension('lev')) then
+         spec%lm = file_metadata%get_dimension('lev', _RC)
+      end if
+
+      spec%grid_file_name = file_metadata%get_source_file()
+      spec%coord_mode     = XY_COORD_STANDARD
+
+      ! Check for corner coordinates
+      spec%has_corners = file_metadata%has_dimension('XCdim')
+
+      call make_decomposition(spec, _RC)
+
+      _RETURN(_SUCCESS)
+
+   end function make_XYGeomSpec_from_metadata
+
+   subroutine make_decomposition(spec, rc)
+      type(XYGeomSpec), intent(inout) :: spec
+      integer, optional, intent(out)  :: rc
+
+      integer :: status
+      integer :: petCount, nx, ny
+      type(ESMF_VM) :: vm
+      integer, allocatable :: ims(:), jms(:)
+
+      call ESMF_VMGetCurrent(vm, _RC)
+      call ESMF_VMGet(vm, petCount=petCount, _RC)
+
+      call compute_layout(petCount, spec%im_world, spec%jm_world, nx, ny)
+      allocate(ims(nx), jms(ny))
+      call distribute_dim(spec%im_world, nx, ims)
+      call distribute_dim(spec%jm_world, ny, jms)
+      spec%ims = ims
+      spec%jms = jms
+
+      _RETURN(_SUCCESS)
+   end subroutine make_decomposition
+
+   subroutine distribute_dim(n, k, counts)
+      integer, intent(in)  :: n, k
+      integer, intent(out) :: counts(k)
+      integer :: base, remainder, i
+      base      = n / k
+      remainder = mod(n, k)
+      do i = 1, k
+         counts(i) = base + merge(1, 0, i <= remainder)
+      end do
+   end subroutine distribute_dim
+
+   subroutine compute_layout(petCount, im, jm, nx, ny)
+      integer, intent(in)  :: petCount, im, jm
+      integer, intent(out) :: nx, ny
+      real    :: ratio, best, candidate
+      integer :: i
+      best  = huge(1.0)
+      nx    = 1
+      ny    = petCount
+      ratio = real(im) / real(jm)
+      do i = 1, petCount
+         if (mod(petCount, i) == 0) then
+            candidate = abs(real(i) / real(petCount/i) - ratio)
+            if (candidate < best) then
+               best = candidate
+               nx   = i
+               ny   = petCount / i
+            end if
+         end if
+      end do
+   end subroutine compute_layout
+
+end submodule make_XYGeomSpec_from_metadata_smod

--- a/geom/XY/XYGeomSpec/supports_hconfig.F90
+++ b/geom/XY/XYGeomSpec/supports_hconfig.F90
@@ -1,0 +1,31 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) supports_hconfig_smod
+   use mapl_ErrorHandlingMod
+   use esmf
+   implicit none (type, external)
+
+contains
+
+   ! An hconfig block is an XY grid if it has:
+   !   class: xy
+   !   grid_file_name: <path>
+   logical module function supports_hconfig_(this, hconfig, rc) result(supports)
+      class(XYGeomSpec), intent(in) :: this
+      type(ESMF_HConfig), intent(in) :: hconfig
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      character(len=:), allocatable :: geom_class
+
+      supports = ESMF_HConfigIsDefined(hconfig, keystring='class', _RC)
+      _RETURN_UNLESS(supports)
+
+      geom_class = ESMF_HConfigAsString(hconfig, keyString='class', _RC)
+      supports = (geom_class == 'xy')
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function supports_hconfig_
+
+end submodule supports_hconfig_smod

--- a/geom/XY/XYGeomSpec/supports_hconfig.F90
+++ b/geom/XY/XYGeomSpec/supports_hconfig.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_XYGeomSpec) supports_hconfig_smod
    use mapl_ErrorHandlingMod
    use esmf
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomSpec/supports_metadata.F90
+++ b/geom/XY/XYGeomSpec/supports_metadata.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_XYGeomSpec) supports_metadata_smod
    use mapl_ErrorHandlingMod
    use pfio, only: FileMetadata, Attribute
-   implicit none (type, external)
+   implicit none
 
 contains
 

--- a/geom/XY/XYGeomSpec/supports_metadata.F90
+++ b/geom/XY/XYGeomSpec/supports_metadata.F90
@@ -20,7 +20,9 @@ contains
       type(Attribute), pointer :: attr
 
       supports = file_metadata%has_attribute('grid_type')
-      if (.not. supports) return
+      if (.not. supports) then
+         _RETURN(_SUCCESS)
+      end if
 
       attr => file_metadata%get_attribute('grid_type', _RC)
       grid_type = attr%get_string(_RC)

--- a/geom/XY/XYGeomSpec/supports_metadata.F90
+++ b/geom/XY/XYGeomSpec/supports_metadata.F90
@@ -1,0 +1,33 @@
+#include "MAPL.h"
+
+submodule (mapl3g_XYGeomSpec) supports_metadata_smod
+   use mapl_ErrorHandlingMod
+   use pfio, only: FileMetadata, Attribute
+   implicit none (type, external)
+
+contains
+
+   ! A file metadata object represents an XY grid if it has a
+   ! 'grid_type' global attribute equal to 'XY' (set by the MAPL2
+   ! XYGridFactory via append_metadata).
+   logical module function supports_metadata_(this, file_metadata, rc) result(supports)
+      class(XYGeomSpec), intent(in) :: this
+      type(FileMetadata), intent(in) :: file_metadata
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      character(len=:), allocatable :: grid_type
+      type(Attribute), pointer :: attr
+
+      supports = file_metadata%has_attribute('grid_type')
+      if (.not. supports) return
+
+      attr => file_metadata%get_attribute('grid_type', _RC)
+      grid_type = attr%get_string(_RC)
+      supports = (grid_type == 'XY')
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(this)
+   end function supports_metadata_
+
+end submodule supports_metadata_smod

--- a/geom/XY/XYGeomSpec/supports_metadata.F90
+++ b/geom/XY/XYGeomSpec/supports_metadata.F90
@@ -20,9 +20,7 @@ contains
       type(Attribute), pointer :: attr
 
       supports = file_metadata%has_attribute('grid_type')
-      if (.not. supports) then
-         _RETURN(_SUCCESS)
-      end if
+      _RETURN_UNLESS(supports)
 
       attr => file_metadata%get_attribute('grid_type', _RC)
       grid_type = attr%get_string(_RC)

--- a/geom/tests/CMakeLists.txt
+++ b/geom/tests/CMakeLists.txt
@@ -20,10 +20,13 @@ set (TEST_SRCS
   Test_MeshGeomFactory_Metadata.pf
   Test_MeshGeomFactory_File.pf
   Test_MeshGeomFactory_Distribution.pf
+  Test_XYGeomSpec.pf
+  Test_XYGeomFactory.pf
 )
 
 set (OTHER_SRCS
   MeshTestHelper.F90
+  XYTestHelper.F90
 )
 
 add_pfunit_ctest(MAPL.geom.tests

--- a/geom/tests/Test_XYGeomFactory.pf
+++ b/geom/tests/Test_XYGeomFactory.pf
@@ -1,0 +1,206 @@
+#define I_AM_PFUNIT
+#include "MAPL_ErrLog.h"
+
+module Test_XYGeomFactory
+
+   use pfunit
+   use esmf_TestMethod_mod
+   use mapl3g_XYGeomFactory
+   use mapl3g_GeomSpec
+   use mapl3g_XYTestHelper
+   use mapl_ErrorHandlingMod
+   use pfio, only: FileMetadata
+   use esmf
+   implicit none
+
+contains
+
+   ! -----------------------------------------------------------------------
+   ! make_geom: standard mode, centre coordinates only
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_make_geom_standard(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      integer, parameter :: IM = 8, JM = 4
+      type(XYGeomFactory) :: factory
+      class(GeomSpec), allocatable :: spec
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Geom) :: geom
+      type(ESMF_Grid) :: grid
+      type(ESMF_GeomType_Flag) :: geomtype
+      real(ESMF_KIND_R8), pointer :: fptr(:,:)
+      integer :: status
+      real(ESMF_KIND_R8), parameter :: PI = acos(-1.0_ESMF_KIND_R8)
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_standard.nc', IM, JM, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_standard.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = factory%make_spec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      geom = factory%make_geom(spec, rc=status)
+      @assert_that(status, is(0))
+
+      call ESMF_GeomGet(geom, geomtype=geomtype, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(geomtype == ESMF_GEOMTYPE_GRID)
+
+      call ESMF_GeomGet(geom, grid=grid, rc=status)
+      @assert_that(status, is(0))
+
+      ! Verify coordinate range is in radians
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(all(fptr >= -PI))
+      @assertTrue(all(fptr <=  PI))
+
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(all(fptr >= -PI/2.0_ESMF_KIND_R8))
+      @assertTrue(all(fptr <=  PI/2.0_ESMF_KIND_R8))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_make_geom_standard
+
+   ! -----------------------------------------------------------------------
+   ! make_geom: with corners
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_make_geom_with_corners(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      integer, parameter :: IM = 6, JM = 4
+      type(XYGeomFactory) :: factory
+      class(GeomSpec), allocatable :: spec
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Geom) :: geom
+      type(ESMF_Grid) :: grid
+      real(ESMF_KIND_R8), pointer :: fptr(:,:)
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file_with_corners('test_xy_corners.nc', IM, JM, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_corners.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = factory%make_spec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      geom = factory%make_geom(spec, rc=status)
+      @assert_that(status, is(0))
+
+      call ESMF_GeomGet(geom, grid=grid, rc=status)
+      @assert_that(status, is(0))
+
+      ! Corner stagger should be populated
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CORNER, farrayPtr=fptr, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(associated(fptr))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_make_geom_with_corners
+
+   ! -----------------------------------------------------------------------
+   ! make_geom: undef values trigger mask
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_make_geom_adds_mask(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      integer, parameter :: IM = 8, JM = 4
+      type(XYGeomFactory) :: factory
+      class(GeomSpec), allocatable :: spec
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Geom) :: geom
+      type(ESMF_Grid) :: grid
+      integer(ESMF_KIND_I4), pointer :: mask(:,:)
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file_with_undef('test_xy_undef.nc', IM, JM, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_undef.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = factory%make_spec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      geom = factory%make_geom(spec, rc=status)
+      @assert_that(status, is(0))
+
+      call ESMF_GeomGet(geom, grid=grid, rc=status)
+      @assert_that(status, is(0))
+
+      call ESMF_GridGetItem(grid, localDE=0, staggerLoc=ESMF_STAGGERLOC_CENTER, &
+           itemflag=ESMF_GRIDITEM_MASK, farrayPtr=mask, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(associated(mask))
+      @assertTrue(any(mask == 0))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_make_geom_adds_mask
+
+   ! -----------------------------------------------------------------------
+   ! make_file_metadata round-trip: metadata produced is recognized by supports_metadata
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_make_file_metadata_round_trip(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      integer, parameter :: IM = 4, JM = 4
+      type(XYGeomFactory) :: factory
+      class(GeomSpec), allocatable :: spec
+      type(ESMF_HConfig) :: hconfig
+      type(FileMetadata) :: file_metadata
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_meta.nc', IM, JM, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_meta.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = factory%make_spec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      file_metadata = factory%make_file_metadata(spec, rc=status)
+      @assert_that(status, is(0))
+
+      ! Metadata produced should be recognized as XY by supports_metadata
+      supports = factory%supports_metadata(file_metadata, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(supports)
+
+      ! Correct dimensions
+      @assert_that(file_metadata%get_dimension('Xdim'), is(IM))
+      @assert_that(file_metadata%get_dimension('Ydim'), is(JM))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_make_file_metadata_round_trip
+
+end module Test_XYGeomFactory

--- a/geom/tests/Test_XYGeomSpec.pf
+++ b/geom/tests/Test_XYGeomSpec.pf
@@ -1,0 +1,215 @@
+#define I_AM_PFUNIT
+#include "MAPL_ErrLog.h"
+
+module Test_XYGeomSpec
+
+   use pfunit
+   use esmf_TestMethod_mod
+   use mapl3g_XYGeomSpec
+   use mapl3g_XYTestHelper
+   use mapl_ErrorHandlingMod
+   use pfio, only: FileMetadata, Attribute
+   use esmf
+   implicit none
+
+contains
+
+   ! -----------------------------------------------------------------------
+   ! supports_hconfig
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_supports_hconfig_xy(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(ESMF_HConfig) :: hconfig
+      type(XYGeomSpec) :: spec
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: dummy.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      supports = spec%supports_hconfig(hconfig, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(supports)
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_supports_hconfig_xy
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_supports_hconfig_rejects_latlon(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(ESMF_HConfig) :: hconfig
+      type(XYGeomSpec) :: spec
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: latlon, im_world: 4, jm_world: 4, pole: PC, dateline: DC}', &
+           rc=status)
+      @assert_that(status, is(0))
+
+      supports = spec%supports_hconfig(hconfig, rc=status)
+      @assert_that(status, is(0))
+      @assertFalse(supports)
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_supports_hconfig_rejects_latlon
+
+   ! -----------------------------------------------------------------------
+   ! supports_metadata
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_supports_metadata_xy(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: spec
+      type(FileMetadata) :: file_metadata
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      file_metadata = FileMetadata()
+      call file_metadata%add_attribute('grid_type', Attribute('XY'))
+
+      supports = spec%supports_metadata(file_metadata, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(supports)
+   end subroutine test_supports_metadata_xy
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_supports_metadata_rejects_latlon(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: spec
+      type(FileMetadata) :: file_metadata
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      file_metadata = FileMetadata()
+      call file_metadata%add_attribute('grid_type', Attribute('LatLon'))
+
+      supports = spec%supports_metadata(file_metadata, rc=status)
+      @assert_that(status, is(0))
+      @assertFalse(supports)
+   end subroutine test_supports_metadata_rejects_latlon
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_supports_metadata_no_attribute(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: spec
+      type(FileMetadata) :: file_metadata
+      logical :: supports
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      file_metadata = FileMetadata()
+
+      supports = spec%supports_metadata(file_metadata, rc=status)
+      @assert_that(status, is(0))
+      @assertFalse(supports)
+   end subroutine test_supports_metadata_no_attribute
+
+   ! -----------------------------------------------------------------------
+   ! equal_to: build specs from hconfig+file, test via generic ==
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_equal_to_same_spec(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: a, b
+      type(ESMF_HConfig) :: hconfig
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_eq1.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_eq1.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      a = make_XYGeomSpec(hconfig, rc=status)
+      @assert_that(status, is(0))
+      b = make_XYGeomSpec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      @assertTrue(a == b)
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_equal_to_same_spec
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_equal_to_different_dims(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: a, b
+      type(ESMF_HConfig) :: hconfig_a, hconfig_b
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_eq4.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+      call create_xy_file('test_xy_eq8.nc', 8, 4, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig_a = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_eq4.nc}', rc=status)
+      @assert_that(status, is(0))
+      hconfig_b = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_eq8.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      a = make_XYGeomSpec(hconfig_a, rc=status)
+      @assert_that(status, is(0))
+      b = make_XYGeomSpec(hconfig_b, rc=status)
+      @assert_that(status, is(0))
+
+      @assertFalse(a == b)
+
+      call ESMF_HConfigDestroy(hconfig_a, rc=status)
+      call ESMF_HConfigDestroy(hconfig_b, rc=status)
+   end subroutine test_equal_to_different_dims
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_equal_to_different_file(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: a, b
+      type(ESMF_HConfig) :: hconfig_a, hconfig_b
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_eqA.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+      call create_xy_file('test_xy_eqB.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig_a = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_eqA.nc}', rc=status)
+      @assert_that(status, is(0))
+      hconfig_b = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_eqB.nc}', rc=status)
+      @assert_that(status, is(0))
+
+      a = make_XYGeomSpec(hconfig_a, rc=status)
+      @assert_that(status, is(0))
+      b = make_XYGeomSpec(hconfig_b, rc=status)
+      @assert_that(status, is(0))
+
+      @assertFalse(a == b)
+
+      call ESMF_HConfigDestroy(hconfig_a, rc=status)
+      call ESMF_HConfigDestroy(hconfig_b, rc=status)
+   end subroutine test_equal_to_different_file
+
+end module Test_XYGeomSpec

--- a/geom/tests/XYTestHelper.F90
+++ b/geom/tests/XYTestHelper.F90
@@ -1,0 +1,193 @@
+#include "MAPL_ErrLog.h"
+
+module mapl3g_XYTestHelper
+   use pfio
+   use mapl_ErrorHandlingMod
+   use, intrinsic :: iso_fortran_env, only: REAL64
+   implicit none
+   private
+
+   public :: create_xy_file
+   public :: create_xy_file_with_corners
+   public :: create_xy_file_with_undef
+
+contains
+
+   ! Create a simple regular XY grid file with 'lons' and 'lats' variables.
+   ! Coordinates are in degrees; the factory converts to radians on read.
+   ! Grid spans -180..180 in lon, -90..90 in lat.
+   subroutine create_xy_file(filename, im, jm, rc)
+      character(len=*), intent(in)  :: filename
+      integer,          intent(in)  :: im, jm
+      integer, optional, intent(out) :: rc
+
+      integer :: status, i, j
+      type(FileMetadata)       :: file_metadata
+      type(NetCDF4_FileFormatter) :: formatter
+      type(Variable)           :: var
+      real(REAL64), allocatable :: lons(:,:), lats(:,:)
+      real(REAL64) :: dlon, dlat
+
+      dlon = 360.0_REAL64 / im
+      dlat = 180.0_REAL64 / jm
+
+      allocate(lons(im,jm), lats(im,jm))
+      do j = 1, jm
+         do i = 1, im
+            lons(i,j) = -180.0_REAL64 + (i - 0.5_REAL64) * dlon
+            lats(i,j) = -90.0_REAL64  + (j - 0.5_REAL64) * dlat
+         end do
+      end do
+
+      file_metadata = FileMetadata()
+      call file_metadata%add_dimension('Xdim', im)
+      call file_metadata%add_dimension('Ydim', jm)
+      call file_metadata%add_attribute('grid_type', Attribute('XY'))
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_east'))
+      call file_metadata%add_variable('lons', var)
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_north'))
+      call file_metadata%add_variable('lats', var)
+
+      call formatter%create(file=filename, mode=pFIO_CLOBBER, rc=status)
+      _VERIFY(status)
+      call formatter%write(file_metadata, rc=status)
+      _VERIFY(status)
+      call formatter%put_var('lons', lons, rc=status)
+      _VERIFY(status)
+      call formatter%put_var('lats', lats, rc=status)
+      _VERIFY(status)
+      call formatter%close(rc=status)
+      _VERIFY(status)
+
+      _RETURN(_SUCCESS)
+   end subroutine create_xy_file
+
+   ! As above, but also writes corner_lons and corner_lats (im+1 x jm+1).
+   subroutine create_xy_file_with_corners(filename, im, jm, rc)
+      character(len=*), intent(in)  :: filename
+      integer,          intent(in)  :: im, jm
+      integer, optional, intent(out) :: rc
+
+      integer :: status, i, j
+      type(FileMetadata)        :: file_metadata
+      type(NetCDF4_FileFormatter) :: formatter
+      type(Variable)            :: var
+      real(REAL64), allocatable :: lons(:,:), lats(:,:)
+      real(REAL64), allocatable :: corner_lons(:,:), corner_lats(:,:)
+      real(REAL64) :: dlon, dlat
+
+      dlon = 360.0_REAL64 / im
+      dlat = 180.0_REAL64 / jm
+
+      allocate(lons(im,jm), lats(im,jm))
+      allocate(corner_lons(im+1,jm+1), corner_lats(im+1,jm+1))
+
+      do j = 1, jm
+         do i = 1, im
+            lons(i,j) = -180.0_REAL64 + (i - 0.5_REAL64) * dlon
+            lats(i,j) = -90.0_REAL64  + (j - 0.5_REAL64) * dlat
+         end do
+      end do
+      do j = 1, jm+1
+         do i = 1, im+1
+            corner_lons(i,j) = -180.0_REAL64 + (i - 1) * dlon
+            corner_lats(i,j) = -90.0_REAL64  + (j - 1) * dlat
+         end do
+      end do
+
+      file_metadata = FileMetadata()
+      call file_metadata%add_dimension('Xdim',  im)
+      call file_metadata%add_dimension('Ydim',  jm)
+      call file_metadata%add_dimension('XCdim', im+1)
+      call file_metadata%add_dimension('YCdim', jm+1)
+      call file_metadata%add_attribute('grid_type', Attribute('XY'))
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_east'))
+      call file_metadata%add_variable('lons', var)
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_north'))
+      call file_metadata%add_variable('lats', var)
+
+      var = Variable(type=pFIO_REAL64, dimensions='XCdim,YCdim')
+      call var%add_attribute('units', Attribute('degrees_east'))
+      call file_metadata%add_variable('corner_lons', var)
+
+      var = Variable(type=pFIO_REAL64, dimensions='XCdim,YCdim')
+      call var%add_attribute('units', Attribute('degrees_north'))
+      call file_metadata%add_variable('corner_lats', var)
+
+      call formatter%create(file=filename, mode=pFIO_CLOBBER, rc=status)
+      _VERIFY(status)
+      call formatter%write(file_metadata, rc=status)
+      _VERIFY(status)
+      call formatter%put_var('lons',        lons,        rc=status) ; _VERIFY(status)
+      call formatter%put_var('lats',        lats,        rc=status) ; _VERIFY(status)
+      call formatter%put_var('corner_lons', corner_lons, rc=status) ; _VERIFY(status)
+      call formatter%put_var('corner_lats', corner_lats, rc=status) ; _VERIFY(status)
+      call formatter%close(rc=status)
+      _VERIFY(status)
+
+      _RETURN(_SUCCESS)
+   end subroutine create_xy_file_with_corners
+
+   ! As create_xy_file but sets some lons/lats to MAPL_UNDEFINED_REAL64
+   ! so that add_mask is exercised.
+   subroutine create_xy_file_with_undef(filename, im, jm, rc)
+      use mapl_InternalConstants, only: MAPL_UNDEFINED_REAL64
+      character(len=*), intent(in)  :: filename
+      integer,          intent(in)  :: im, jm
+      integer, optional, intent(out) :: rc
+
+      integer :: status, i, j
+      type(FileMetadata)        :: file_metadata
+      type(NetCDF4_FileFormatter) :: formatter
+      type(Variable)            :: var
+      real(REAL64), allocatable :: lons(:,:), lats(:,:)
+      real(REAL64) :: dlon, dlat
+
+      dlon = 360.0_REAL64 / im
+      dlat = 180.0_REAL64 / jm
+
+      allocate(lons(im,jm), lats(im,jm))
+      do j = 1, jm
+         do i = 1, im
+            lons(i,j) = -180.0_REAL64 + (i - 0.5_REAL64) * dlon
+            lats(i,j) = -90.0_REAL64  + (j - 0.5_REAL64) * dlat
+         end do
+      end do
+      ! Mark the first column as undefined (e.g. off-Earth-disk as in ABI)
+      lons(1,:) = MAPL_UNDEFINED_REAL64
+      lats(1,:) = MAPL_UNDEFINED_REAL64
+
+      file_metadata = FileMetadata()
+      call file_metadata%add_dimension('Xdim', im)
+      call file_metadata%add_dimension('Ydim', jm)
+      call file_metadata%add_attribute('grid_type', Attribute('XY'))
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_east'))
+      call file_metadata%add_variable('lons', var)
+
+      var = Variable(type=pFIO_REAL64, dimensions='Xdim,Ydim')
+      call var%add_attribute('units', Attribute('degrees_north'))
+      call file_metadata%add_variable('lats', var)
+
+      call formatter%create(file=filename, mode=pFIO_CLOBBER, rc=status)
+      _VERIFY(status)
+      call formatter%write(file_metadata, rc=status)
+      _VERIFY(status)
+      call formatter%put_var('lons', lons, rc=status) ; _VERIFY(status)
+      call formatter%put_var('lats', lats, rc=status) ; _VERIFY(status)
+      call formatter%close(rc=status)
+      _VERIFY(status)
+
+      _RETURN(_SUCCESS)
+   end subroutine create_xy_file_with_undef
+
+end module mapl3g_XYTestHelper

--- a/shared/Constants/EarthConstants.F90
+++ b/shared/Constants/EarthConstants.F90
@@ -20,7 +20,9 @@ module MAPL_EarthConstants
         2.0*MAPL_PI/MAPL_SECONDS_PER_SIDEREAL_DAY                                    ! rotation rate (REAL32)  1/s
    real(kind=REAL64), parameter :: MAPL_ECCENTRICITY              = &
         8.181919084262200d-2                                                          ! WGS84 first eccentricity  --
-   real(kind=REAL64), parameter :: MAPL_SEMIMAJOR_AXIS            = 6378137.0_REAL64 ! WGS84 semi-major axis  m
+   real(kind=REAL64), parameter :: MAPL_SEMIMAJOR_AXIS            = 6378137.0_REAL64    ! WGS84 semi-major axis  m
+   real(kind=REAL64), parameter :: MAPL_SEMIMINOR_AXIS            = 6356752.3142_REAL64 ! WGS84 semi-minor axis  m
+   real(kind=REAL64), parameter :: MAPL_GEO_ORBIT_RADIUS          = 42164160.0_REAL64   ! mean GEO orbital radius  m
    real(kind=REAL64), parameter :: MAPL_KM_PER_DEGREE             = &
         (1.0_REAL64 / (MAPL_RADIUS / 1000.0_REAL64)) * MAPL_RADIANS_TO_DEGREES      ! km per degree of arc  km/deg
    real(kind=REAL64), parameter :: MAPL_DEGREE_PER_KM             = &


### PR DESCRIPTION
## Summary

Implements a MAPL3 geom-layer replacement for the MAPL2 \`MAPL_XYGridFactory\`, following the established patterns from \`LatLonGeomFactory\`, \`CubedSphereGeomFactory\`, etc.

- Adds \`XYGeomSpec\` — supports standard lon/lat-from-file grids and ABI/GOES-R scan-angle grids
- Adds \`XYGeomFactory\` — reads coordinates from NetCDF, broadcasts via MPI, fills ESMF grid; adds mask where coordinates are undefined
- Registers \`XYGeomFactory\` in \`GeomManager\`
- Adds \`MAPL_SEMIMINOR_AXIS\` and \`MAPL_GEO_ORBIT_RADIUS\` to \`EarthConstants.F90\`
- Adds pFUnit tests (\`Test_XYGeomSpec.pf\`, \`Test_XYGeomFactory.pf\`) with synthetic NetCDF file generation via \`XYTestHelper.F90\`