### PR TITLE
feat(geom): add n_peri_dim to XYGeomSpec for tripolar support

### DIFF
--- a/geom/XY/XYGeomFactory/create_basic_grid.F90
+++ b/geom/XY/XYGeomFactory/create_basic_grid.F90
@@ -17,15 +17,28 @@ contains
       integer :: status
       type(ESMF_Info) :: infoh
 
-      grid = ESMF_GridCreateNoPeriDim( &
-           countsPerDEDim1=spec%get_ims(), &
-           countsPerDEDim2=spec%get_jms(), &
-           indexFlag=ESMF_INDEX_DELOCAL, &
-           gridEdgeLWidth=[0,0], &
-           gridEdgeUWidth=[0,1], &
-           coordDep1=[1,2], &
-           coordDep2=[1,2], &
-           coordSys=ESMF_COORDSYS_SPH_RAD, _RC)
+      if (spec%get_n_peri_dim() == 0) then
+         grid = ESMF_GridCreateNoPeriDim( &
+              countsPerDEDim1=spec%get_ims(), &
+              countsPerDEDim2=spec%get_jms(), &
+              indexFlag=ESMF_INDEX_DELOCAL, &
+              gridEdgeLWidth=[0,0], &
+              gridEdgeUWidth=[0,1], &
+              coordDep1=[1,2], &
+              coordDep2=[1,2], &
+              coordSys=ESMF_COORDSYS_SPH_RAD, _RC)
+      else
+         grid = ESMF_GridCreate1PeriDim( &
+              countsPerDEDim1=spec%get_ims(), &
+              countsPerDEDim2=spec%get_jms(), &
+              poleKindFlag=[ESMF_POLEKIND_MONOPOLE, ESMF_POLEKIND_BIPOLE], &
+              indexFlag=ESMF_INDEX_DELOCAL, &
+              gridEdgeLWidth=[0,0], &
+              gridEdgeUWidth=[0,1], &
+              coordDep1=[1,2], &
+              coordDep2=[1,2], &
+              coordSys=ESMF_COORDSYS_SPH_RAD, _RC)
+      end if
 
       ! Allocate centre coordinates
       call ESMF_GridAddCoord(grid, _RC)

--- a/geom/XY/XYGeomSpec.F90
+++ b/geom/XY/XYGeomSpec.F90
@@ -31,6 +31,8 @@ module mapl3g_XYGeomSpec
       integer, allocatable :: jms(:)   ! length ny
       ! Whether the file contains corner coordinates
       logical :: has_corners = .false.
+      ! Number of periodic dimensions (0=none, 1=periodic in X for tripolar)
+      integer :: n_peri_dim  = 0
       ! Coordinate mode
       integer :: coord_mode = XY_COORD_STANDARD
       ! ABI-specific metadata
@@ -62,6 +64,7 @@ module mapl3g_XYGeomSpec
       procedure :: get_jms
       procedure :: get_grid_file_name
       procedure :: get_has_corners
+      procedure :: get_n_peri_dim
       procedure :: get_coord_mode
       procedure :: get_thin_factor
       procedure :: get_xdim_true
@@ -142,7 +145,7 @@ contains
 
    function new_XYGeomSpec( &
         grid_file_name, im_world, jm_world, lm, ims, jms, &
-        has_corners, coord_mode, thin_factor, xdim_true, ydim_true, &
+        has_corners, n_peri_dim, coord_mode, thin_factor, xdim_true, ydim_true, &
         index_name_x, index_name_y, &
         var_name_x, var_name_y, var_name_proj, att_name_proj) result(spec)
       type(XYGeomSpec) :: spec
@@ -153,6 +156,7 @@ contains
       integer,          optional, intent(in) :: ims(:)
       integer,          optional, intent(in) :: jms(:)
       logical,          optional, intent(in) :: has_corners
+      integer,          optional, intent(in) :: n_peri_dim
       integer,          optional, intent(in) :: coord_mode
       integer,          optional, intent(in) :: thin_factor
       integer,          optional, intent(in) :: xdim_true
@@ -171,6 +175,7 @@ contains
       if (present(ims))         spec%ims         = ims
       if (present(jms))         spec%jms         = jms
       if (present(has_corners)) spec%has_corners  = has_corners
+      if (present(n_peri_dim))  spec%n_peri_dim   = n_peri_dim
       if (present(coord_mode))  spec%coord_mode   = coord_mode
       if (present(thin_factor)) spec%thin_factor  = thin_factor
       if (present(xdim_true))   spec%xdim_true    = xdim_true
@@ -223,6 +228,11 @@ contains
       class(XYGeomSpec), intent(in) :: this
       v = this%has_corners
    end function get_has_corners
+
+   integer function get_n_peri_dim(this) result(v)
+      class(XYGeomSpec), intent(in) :: this
+      v = this%n_peri_dim
+   end function get_n_peri_dim
 
    integer function get_coord_mode(this) result(v)
       class(XYGeomSpec), intent(in) :: this

--- a/geom/XY/XYGeomSpec/equal_to.F90
+++ b/geom/XY/XYGeomSpec/equal_to.F90
@@ -12,10 +12,11 @@ contains
 
       select type (b)
       type is (XYGeomSpec)
-         equal_to = (a%im_world   == b%im_world)   .and. &
-                    (a%jm_world   == b%jm_world)    .and. &
-                    (a%lm         == b%lm)           .and. &
-                    (a%coord_mode == b%coord_mode)   .and. &
+         equal_to = (a%im_world    == b%im_world)    .and. &
+                    (a%jm_world    == b%jm_world)    .and. &
+                    (a%lm          == b%lm)          .and. &
+                    (a%n_peri_dim  == b%n_peri_dim)  .and. &
+                    (a%coord_mode  == b%coord_mode)  .and. &
                     (a%thin_factor == b%thin_factor) .and. &
                     (a%grid_file_name == b%grid_file_name)
       class default

--- a/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
+++ b/geom/XY/XYGeomSpec/make_XYGeomSpec_from_hconfig.F90
@@ -26,10 +26,17 @@ contains
       character(len=:), allocatable :: var_name_x, var_name_y
       character(len=:), allocatable :: var_name_proj, att_name_proj
       integer :: coord_mode
+      integer :: n_peri_dim
 
       ! Required: grid_file_name
       grid_file_name = ESMF_HConfigAsString(hconfig, keyString='grid_file_name', _RC)
       spec%grid_file_name = grid_file_name
+
+      ! Optional: n_peri_dim (0=non-periodic, 1=periodic in X for tripolar)
+      n_peri_dim = 0
+      found = ESMF_HConfigIsDefined(hconfig, keyString='n_peri_dim', _RC)
+      if (found) n_peri_dim = ESMF_HConfigAsI4(hconfig, keyString='n_peri_dim', _RC)
+      spec%n_peri_dim = n_peri_dim
 
       ! Optional vertical extent
       has_lm = ESMF_HConfigIsDefined(hconfig, keystring='LM', _RC)

--- a/geom/tests/Test_XYGeomFactory.pf
+++ b/geom/tests/Test_XYGeomFactory.pf
@@ -161,6 +161,63 @@ contains
    end subroutine test_make_geom_adds_mask
 
    ! -----------------------------------------------------------------------
+   ! make_geom: n_peri_dim=1 (tripolar) — exercises ESMF_GridCreate1PeriDim path
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_make_geom_tripolar(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      integer, parameter :: IM = 8, JM = 4
+      type(XYGeomFactory) :: factory
+      class(GeomSpec), allocatable :: spec
+      type(ESMF_HConfig) :: hconfig
+      type(ESMF_Geom) :: geom
+      type(ESMF_Grid) :: grid
+      type(ESMF_GeomType_Flag) :: geomtype
+      real(ESMF_KIND_R8), pointer :: fptr(:,:)
+      integer :: status
+      real(ESMF_KIND_R8), parameter :: PI = acos(-1.0_ESMF_KIND_R8)
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_tripolar.nc', IM, JM, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_tripolar.nc, n_peri_dim: 1}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = factory%make_spec(hconfig, rc=status)
+      @assert_that(status, is(0))
+
+      geom = factory%make_geom(spec, rc=status)
+      @assert_that(status, is(0))
+
+      call ESMF_GeomGet(geom, geomtype=geomtype, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(geomtype == ESMF_GEOMTYPE_GRID)
+
+      call ESMF_GeomGet(geom, grid=grid, rc=status)
+      @assert_that(status, is(0))
+
+      ! Verify centre coordinates are populated and in radians
+      call ESMF_GridGetCoord(grid, coordDim=1, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(all(fptr >= -PI))
+      @assertTrue(all(fptr <=  PI))
+
+      call ESMF_GridGetCoord(grid, coordDim=2, localDE=0, &
+           staggerloc=ESMF_STAGGERLOC_CENTER, farrayPtr=fptr, rc=status)
+      @assert_that(status, is(0))
+      @assertTrue(all(fptr >= -PI/2.0_ESMF_KIND_R8))
+      @assertTrue(all(fptr <=  PI/2.0_ESMF_KIND_R8))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_make_geom_tripolar
+
+   ! -----------------------------------------------------------------------
    ! make_file_metadata round-trip: metadata produced is recognized by supports_metadata
    ! -----------------------------------------------------------------------
 

--- a/geom/tests/Test_XYGeomSpec.pf
+++ b/geom/tests/Test_XYGeomSpec.pf
@@ -212,4 +212,61 @@ contains
       call ESMF_HConfigDestroy(hconfig_b, rc=status)
    end subroutine test_equal_to_different_file
 
+   ! -----------------------------------------------------------------------
+   ! n_peri_dim: hconfig round-trip and equal_to distinguish by n_peri_dim
+   ! -----------------------------------------------------------------------
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_n_peri_dim_from_hconfig(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: spec
+      type(ESMF_HConfig) :: hconfig
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_peri.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_peri.nc, n_peri_dim: 1}', rc=status)
+      @assert_that(status, is(0))
+
+      spec = make_XYGeomSpec(hconfig, rc=status)
+      @assert_that(status, is(0))
+      @assert_that(spec%get_n_peri_dim(), is(1))
+
+      call ESMF_HConfigDestroy(hconfig, rc=status)
+   end subroutine test_n_peri_dim_from_hconfig
+
+   @test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_equal_to_different_n_peri_dim(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      type(XYGeomSpec) :: a, b
+      type(ESMF_HConfig) :: hconfig_a, hconfig_b
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call create_xy_file('test_xy_peri2.nc', 4, 4, rc=status)
+      @assert_that(status, is(0))
+
+      hconfig_a = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_peri2.nc}', rc=status)
+      @assert_that(status, is(0))
+      hconfig_b = ESMF_HConfigCreate( &
+           content='{class: xy, grid_file_name: test_xy_peri2.nc, n_peri_dim: 1}', rc=status)
+      @assert_that(status, is(0))
+
+      a = make_XYGeomSpec(hconfig_a, rc=status)
+      @assert_that(status, is(0))
+      b = make_XYGeomSpec(hconfig_b, rc=status)
+      @assert_that(status, is(0))
+
+      @assertFalse(a == b)
+
+      call ESMF_HConfigDestroy(hconfig_a, rc=status)
+      call ESMF_HConfigDestroy(hconfig_b, rc=status)
+   end subroutine test_equal_to_different_n_peri_dim
+
 end module Test_XYGeomSpec


### PR DESCRIPTION
## Summary

- Adds `n_peri_dim` field (default 0) to `XYGeomSpec`; when set to 1, `XYGeomFactory` calls `ESMF_GridCreate1PeriDim` with `poleKindFlag=[ESMF_POLEKIND_MONOPOLE, ESMF_POLEKIND_BIPOLE]` instead of `ESMF_GridCreateNoPeriDim`
- Tripolar is a first-class subcase of the XY geometry family — no separate `TripolarGeomSpec` needed
- `n_peri_dim: 1` is specified in the grid hconfig; `equal_to` includes the field; two new pfUnit tests cover the round-trip and inequality by `n_peri_dim`

## Related issue
Closes #4691