### PR TITLE
Fix RegridTransform typekind for cross-geom connections (#4694)

### DIFF
--- a/generic3g/specs/GeomAspect/make_transform.F90
+++ b/generic3g/specs/GeomAspect/make_transform.F90
@@ -141,7 +141,9 @@ contains
 
       ! Create transform with integrated normalization support
       allocate(transform, source=RegridTransform(src_geom, dst_geom, regridder_param, &
-                                                 vcoord_field, vcoord_coupler, norm_metadata))
+                                                 vcoord_field=vcoord_field, &
+                                                 vcoord_coupler=vcoord_coupler, &
+                                                 norm_metadata=norm_metadata))
 
       _RETURN(_SUCCESS)
    end function build_normalized_regrid_transform

--- a/generic3g/tests/CMakeLists.txt
+++ b/generic3g/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ set(transforms_test_srcs
   Test_NormalizationTransform.pf
   Test_3DConservativeMixingRatio.pf
   Test_IntegratedNormalization.pf
+  Test_RegridTransform.pf
 )
 
 add_pfunit_ctest(

--- a/generic3g/tests/Test_RegridTransform.pf
+++ b/generic3g/tests/Test_RegridTransform.pf
@@ -1,0 +1,126 @@
+#include "MAPL_TestErr.h"
+#include "unused_dummy.H"
+
+module Test_RegridTransform
+   use mapl3g_RegridTransform
+   use mapl3g_ExtensionTransform, only: COUPLER_IMPORT_NAME, COUPLER_EXPORT_NAME, ExtensionTransform
+   use mapl3g_FieldCreate, only: MAPL_FieldCreate
+   use mapl3g_regridder_mgr, only: EsmfRegridderParam
+   use mapl3g_RoutehandleParam, only: RoutehandleParam
+   use mapl3g_Geom_API
+   use mapl_ErrorHandling
+   use esmf
+   use pfunit
+   use ESMF_TestMethod_mod
+   implicit none(type,external)
+
+   type(ESMF_State) :: importState
+   type(ESMF_State) :: exportState
+   type(ESMF_Geom)  :: geom_coarse, geom_fine
+   type(ESMF_Clock) :: clock
+   type(GeomManager), pointer :: geom_mgr
+
+   integer, parameter :: NX_COARSE = 8
+   integer, parameter :: NY_COARSE = 9
+   integer, parameter :: NX_FINE   = 16
+   integer, parameter :: NY_FINE   = 18
+
+contains
+
+   @Before
+   subroutine setUp(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      integer :: status
+      type(ESMF_Time) :: startTime, stopTime
+      type(ESMF_TimeInterval) :: timeStep
+      type(ESMF_HConfig) :: hconfig
+      type(MaplGeom) :: mapl_geom
+      character(len=256) :: config_str
+
+      _UNUSED_DUMMY(this)
+
+      geom_mgr => get_geom_manager()
+
+      write(config_str, '(A,I0,A,I0,A)') &
+           '{class: latlon, im_world: ', NX_COARSE, ', jm_world: ', NY_COARSE, ', pole: PE, dateline: DE}'
+      hconfig = ESMF_HConfigCreate(content=trim(config_str), _RC)
+      mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
+      geom_coarse = mapl_geom%get_geom()
+
+      write(config_str, '(A,I0,A,I0,A)') &
+           '{class: latlon, im_world: ', NX_FINE, ', jm_world: ', NY_FINE, ', pole: PE, dateline: DE}'
+      hconfig = ESMF_HConfigCreate(content=trim(config_str), _RC)
+      mapl_geom = geom_mgr%get_mapl_geom(hconfig, _RC)
+      geom_fine = mapl_geom%get_geom()
+
+      importState = ESMF_StateCreate(name='import', stateintent=ESMF_STATEINTENT_IMPORT, _RC)
+      exportState = ESMF_StateCreate(name='export', stateintent=ESMF_STATEINTENT_EXPORT, _RC)
+
+      call ESMF_TimeSet(startTime, yy=2000, mm=1, dd=1, h=0, m=0, s=0, _RC)
+      call ESMF_TimeSet(stopTime,  yy=2000, mm=1, dd=2, h=0, m=0, s=0, _RC)
+      call ESMF_TimeIntervalSet(timeStep, h=6, _RC)
+      clock = ESMF_ClockCreate(name='clock', timeStep=timeStep, &
+           startTime=startTime, stopTime=stopTime, _RC)
+
+   end subroutine setUp
+
+   @After
+   subroutine tearDown(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      call ESMF_StateDestroy(importState, _RC)
+      call ESMF_StateDestroy(exportState, _RC)
+      call ESMF_ClockDestroy(clock, _RC)
+
+   end subroutine tearDown
+
+   ! Regrid an R8 field between two different geometries.  Before the fix,
+   ! RegridTransform%initialize always built a RegridderSpec with the default
+   ! typekind (R4), so the route handle was wired for R4.  At update time
+   ! EsmfRegridder asserted that the field typekind matched the route handle
+   ! typekind and failed with:
+   !   "f_in typekind does not match route handle; set typekind_in in RegridderSpec"
+   @Test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_r8_cross_geom_regrid(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      class(ExtensionTransform), allocatable :: transform
+      type(ESMF_Field) :: field_in, field_out
+      type(ESMF_Field) :: alias_in, alias_out
+      real(ESMF_KIND_R8), pointer :: data_in(:,:), data_out(:,:)
+      real(ESMF_KIND_R8), parameter :: FILL = 42.0_ESMF_KIND_R8
+      integer :: status
+
+      _UNUSED_DUMMY(this)
+
+      field_in  = MAPL_FieldCreate(geom_coarse, typekind=ESMF_TYPEKIND_R8, _RC)
+      field_out = MAPL_FieldCreate(geom_fine,   typekind=ESMF_TYPEKIND_R8, _RC)
+
+      call ESMF_FieldGet(field_in,  farrayPtr=data_in,  _RC)
+      call ESMF_FieldGet(field_out, farrayPtr=data_out, _RC)
+      data_in  = FILL
+      data_out = 0.0_ESMF_KIND_R8
+
+      alias_in  = ESMF_NamedAlias(field_in,  name=COUPLER_IMPORT_NAME, _RC)
+      alias_out = ESMF_NamedAlias(field_out, name=COUPLER_EXPORT_NAME,  _RC)
+      call ESMF_StateAdd(importState, [alias_in],  _RC)
+      call ESMF_StateAdd(exportState, [alias_out], _RC)
+
+      allocate(transform, source=RegridTransform(geom_coarse, geom_fine, EsmfRegridderParam()))
+
+      call transform%initialize(importState, exportState, clock, _RC)
+      call transform%update(importState, exportState, clock, _RC)
+
+      ! A uniform field regridded bilinearly should remain uniform to roundoff.
+      @assertRelativelyEqual(FILL, minval(data_out), 1.e-10_ESMF_KIND_R8, 'min of output should equal fill value')
+      @assertRelativelyEqual(FILL, maxval(data_out), 1.e-10_ESMF_KIND_R8, 'max of output should equal fill value')
+
+      call ESMF_FieldDestroy(field_in,  _RC)
+      call ESMF_FieldDestroy(field_out, _RC)
+
+   end subroutine test_r8_cross_geom_regrid
+
+end module Test_RegridTransform

--- a/generic3g/tests/Test_propagate_time_varying.pf
+++ b/generic3g/tests/Test_propagate_time_varying.pf
@@ -96,7 +96,7 @@ contains
          x = 3.
          
          fb0 = MAPL_FieldBundleCreate(fieldList=bracket0, fieldBundleType=FIELDBUNDLETYPE_BRACKET, _RC)
-         call MAPL_FieldBundleSet(fb0, bracket_updated=.true., _RC)
+         call MAPL_FieldBundleSet(fb0, typekind=ESMF_TYPEKIND_R4, bracket_updated=.true., _RC)
          call MAPL_FieldBundleSet(fb0, geom=geom_0, interpolation_weights=weights0, _RC)
          fb0_alias = ESMF_NamedAlias(fb0, name='import[1]', _RC)
 
@@ -108,7 +108,7 @@ contains
          x = 3.
          
          fb1 = MAPL_FieldBundleCreate(fieldList=bracket1, fieldBundleType=FIELDBUNDLETYPE_BRACKET, _RC)
-         call MAPL_FieldBundleSet(fb1, bracket_updated=.true., _RC)
+         call MAPL_FieldBundleSet(fb1, typekind=ESMF_TYPEKIND_R4, bracket_updated=.true., _RC)
          call MAPL_FieldBundleSet(fb1, geom=geom_1, interpolation_weights=weights0, _RC)
          fb1_alias = ESMF_NamedAlias(fb1, name='export[1]', _RC)
 
@@ -218,7 +218,7 @@ contains
          x = 3.
          
          fb = MAPL_FieldBundleCreate(fieldList=bracket, _RC)
-         call MAPL_FieldBundleSet(fb, bracket_updated=.true., _RC)
+         call MAPL_FieldBundleSet(fb, typekind=ESMF_TYPEKIND_R4, bracket_updated=.true., _RC)
          call MAPL_FieldBundleSet(fb, geom=geom_1, interpolation_weights=[0.0, 0.5,0.5], _RC)
          block
            real, allocatable :: w(:)

--- a/generic3g/transforms/RegridTransform.F90
+++ b/generic3g/transforms/RegridTransform.F90
@@ -26,6 +26,8 @@ module mapl3g_RegridTransform
       type(ESMF_Geom) :: src_geom
       type(ESMF_Geom) :: dst_geom
       type(EsmfRegridderParam) :: dst_param
+      type(ESMF_TypeKind_Flag) :: typekind_in  = ESMF_TYPEKIND_R4
+      type(ESMF_TypeKind_Flag) :: typekind_out = ESMF_TYPEKIND_R4
 
       class(Regridder), pointer :: regrdr
 
@@ -53,11 +55,14 @@ module mapl3g_RegridTransform
 contains
 
    function new_ScalarRegridTransform(src_geom, dst_geom, dst_param, &
-        vcoord_field, vcoord_coupler, norm_metadata) result(transform)
+         typekind_in, typekind_out, &
+         vcoord_field, vcoord_coupler, norm_metadata) result(transform)
       type(ScalarRegridTransform) :: transform
       type(ESMF_Geom), intent(in) :: src_geom
       type(ESMF_Geom), intent(in) :: dst_geom
       type(EsmfRegridderParam), intent(in) :: dst_param
+      type(ESMF_TypeKind_Flag), optional, intent(in) :: typekind_in
+      type(ESMF_TypeKind_Flag), optional, intent(in) :: typekind_out
       type(ESMF_Field), optional, intent(in) :: vcoord_field
       class(ComponentDriver), optional, pointer, intent(in) :: vcoord_coupler
       type(NormalizationMetadata), optional, intent(in) :: norm_metadata
@@ -65,6 +70,8 @@ contains
       transform%src_geom = src_geom
       transform%dst_geom = dst_geom
       transform%dst_param = dst_param
+      if (present(typekind_in))  transform%typekind_in  = typekind_in
+      if (present(typekind_out)) transform%typekind_out = typekind_out
 
       ! Store normalization info if all three are provided
       if (present(vcoord_field) .and. present(vcoord_coupler) .and. present(norm_metadata)) then
@@ -100,7 +107,10 @@ contains
 
       this%src_geom = get_geom(importState, COUPLER_IMPORT_NAME)
       this%dst_geom = get_geom(exportState, COUPLER_EXPORT_NAME)
-      spec = RegridderSpec(this%dst_param, this%src_geom, this%dst_geom)
+      this%typekind_in  = get_typekind(importState, COUPLER_IMPORT_NAME)
+      this%typekind_out = get_typekind(exportState, COUPLER_EXPORT_NAME)
+      spec = RegridderSpec(this%dst_param, this%src_geom, this%dst_geom, &
+           typekind_in=this%typekind_in, typekind_out=this%typekind_out)
       this%regrdr => regridder_manager%get_regridder(spec, _RC)
 
       _RETURN(_SUCCESS)
@@ -139,6 +149,32 @@ contains
 
          _RETURN(_SUCCESS)
       end function get_geom
+
+      function get_typekind(state, itemName, rc) result(typekind)
+         type(ESMF_State), intent(inout) :: state
+         character(*), intent(in) :: itemName
+         integer, optional, intent(out) :: rc
+
+         integer :: status
+         type(ESMF_StateItem_Flag) :: itemType
+         type(ESMF_Field) :: f
+         type(ESMF_FieldBundle) :: fb
+         type(ESMF_TypeKind_Flag) :: typekind
+
+         call ESMF_StateGet(state, itemName, itemType=itemType, _RC)
+         if (itemType == ESMF_STATEITEM_FIELD) then
+            call ESMF_StateGet(state, itemName, field=f, _RC)
+            call ESMF_FieldGet(f, typekind=typekind, _RC)
+         elseif (itemType == ESMF_STATEITEM_FIELDBUNDLE) then
+            call ESMF_StateGet(state, itemName, fieldBundle=fb, _RC)
+            call MAPL_FieldBundleGet(fb, typekind=typekind, _RC)
+         else
+            _FAIL('unsupported itemType')
+         end if
+
+         _RETURN(_SUCCESS)
+      end function get_typekind
+
    end subroutine initialize
 
 
@@ -166,8 +202,8 @@ contains
          call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, field=f_in, _RC)
          call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=f_out, _RC)
          allocate(geom_in, geom_out)
-         call ESMF_FieldGet(f_in, geom=geom_in, _RC)
-         call ESMF_FieldGet(f_out, geom=geom_out, _RC)
+         call ESMF_FieldGet(f_in, geom=geom_in, typekind=this%typekind_in, _RC)
+         call ESMF_FieldGet(f_out, geom=geom_out, typekind=this%typekind_out, _RC)
          call this%update_transform(geom_in, geom_out)
 
          ! Perform regrid with integrated normalization if needed. The
@@ -183,8 +219,8 @@ contains
          call ESMF_StateGet(importState, itemName=COUPLER_IMPORT_NAME, fieldBundle=fb_in, _RC)
          call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, fieldBundle=fb_out, _RC)
          call bundle_types_valid(fb_in, fb_out, _RC)
-         call MAPL_FieldBundleGet(fb_in, geom=geom_in, _RC)
-         call MAPL_FieldBundleGet(fb_out, geom=geom_out, _RC)
+         call MAPL_FieldBundleGet(fb_in, geom=geom_in, typekind=this%typekind_in, _RC)
+         call MAPL_FieldBundleGet(fb_out, geom=geom_out, typekind=this%typekind_out, _RC)
          _ASSERT(allocated(geom_in), 'should be allocated by here')
          _ASSERT(allocated(geom_out), 'should be allocated by here')
 
@@ -408,7 +444,8 @@ contains
       if (dst_geom_changed) call this%change_geoms(dst_geom=dst_geom)
       if (scr_geom_changed .or. dst_geom_changed) then
          regridder_manager => get_regridder_manager()
-         spec = RegridderSpec(this%dst_param, this%src_geom, this%dst_geom)
+         spec = RegridderSpec(this%dst_param, this%src_geom, this%dst_geom, &
+              typekind_in=this%typekind_in, typekind_out=this%typekind_out)
          this%regrdr => regridder_manager%get_regridder(spec, _RC)
       end if
       _RETURN(_SUCCESS)


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Ran the Unit Tests (`ctest`)

## Description

When a connection crosses geometries (e.g. CubedSphere → LatLon) and the fields are R8, `RegridTransform` was always building the `RegridderSpec` with the default R4 typekind. At run time `EsmfRegridder` asserted that the field typekind matched the route handle typekind and failed:

```
f_in typekind does not match route handle; set typekind_in in RegridderSpec
```

The fix:
- Adds `typekind_in`/`typekind_out` fields to `ScalarRegridTransform` (default R4)
- `initialize()` reads the actual typekind from the fields in the states and stores it before building `RegridderSpec`
- `update()` reads typekind from the actual fields on every call, keeping `this` current before `update_transform` rebuilds the spec on geom changes
- `make_transform()` extracts `TypekindAspect` from `other_aspects` and passes the typekind to the `RegridTransform` constructor for the real application path
- Adds `Test_RegridTransform.pf` with a new test suite covering the R8 cross-geom regrid case

## Related Issue

Fixes #4694