### PR TITLE
Fix NAG OpenMP per-DSO lazy initialization crash in profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Workaround to satisfy NAG's lazy initialization of openmp region
 - Workaround to pass ifx 2025.1 tests in debug mode
 - Profile reporting has been relocated into the `./profile` directory.
 - Improved diagnostic message for profiler imbalances at end of run.

--- a/profiler/DistributedProfiler.F90
+++ b/profiler/DistributedProfiler.F90
@@ -38,6 +38,16 @@ contains
       integer, intent(in) :: comm
       integer, optional, intent(in) :: comm_world
 
+      ! NAG OpenMP runtime workaround: Initialize per-DSO OpenMP state
+      !
+      ! NAG's optimized OpenMP runtime uses per-DSO lazy initialization. Each
+      ! shared library gets its own OpenMP state block that is not populated until
+      ! the first !$omp parallel region executes. When !$omp master directives in
+      ! BaseProfiler.F90 run before initialization, they dereference a null pointer
+      ! and crash. This no-op parallel region ensures the state is initialized.
+      !$omp parallel
+      !$omp end parallel
+
       distributed_profiler%gauge = gauge
       distributed_profiler%comm = comm
       

--- a/profiler/MemoryProfiler.F90
+++ b/profiler/MemoryProfiler.F90
@@ -33,6 +33,16 @@ contains
       character(*), intent(in) :: name
       integer, optional, intent(in) :: comm_world
 
+      ! NAG OpenMP runtime workaround: Initialize per-DSO OpenMP state
+      !
+      ! NAG's optimized OpenMP runtime uses per-DSO lazy initialization. Each
+      ! shared library gets its own OpenMP state block that is not populated until
+      ! the first !$omp parallel region executes. When !$omp master directives in
+      ! BaseProfiler.F90 run before initialization, they dereference a null pointer
+      ! and crash. This no-op parallel region ensures the state is initialized.
+      !$omp parallel
+      !$omp end parallel
+
       call prof%set_comm_world(comm_world = comm_world)
       call prof%set_node(MeterNode(name, prof%make_meter()))
 

--- a/profiler/TimeProfiler.F90
+++ b/profiler/TimeProfiler.F90
@@ -32,6 +32,16 @@ contains
       character(*), intent(in) :: name
       integer, optional,intent(in) :: comm_world
 
+      ! NAG OpenMP runtime workaround: Initialize per-DSO OpenMP state
+      !
+      ! NAG's optimized OpenMP runtime uses per-DSO lazy initialization. Each
+      ! shared library gets its own OpenMP state block that is not populated until
+      ! the first !$omp parallel region executes. When !$omp master directives in
+      ! BaseProfiler.F90 run before initialization, they dereference a null pointer
+      ! and crash. This no-op parallel region ensures the state is initialized.
+      !$omp parallel
+      !$omp end parallel
+
       call prof%set_comm_world(comm_world = comm_world)
       call prof%set_node(MeterNode(name, prof%make_meter()))
 


### PR DESCRIPTION
NAG's optimized OpenMP runtime uses per-DSO lazy initialization where each shared library gets its own OpenMP state block that is not populated until the first ! parallel region executes within that DSO.

When ! master directives in BaseProfiler.F90 ran before the state was initialized, __NAGf90_OpenMP_filter2 would dereference a null pointer at offset 0x4, causing segmentation faults.

This fix adds a no-op ! parallel region at the beginning of each profiler constructor (TimeProfiler, MemoryProfiler, DistributedProfiler) to ensure the OpenMP state is initialized before any ! master directives are encountered.

This approach is minimal and optimal because:
- Constructors are the true entry points for all profiler objects
- Once initialized, the OpenMP state persists for the DSO
- No redundant initialization overhead in frequently-called methods
- Works for both production code and unit tests

The debug runtime does not exhibit this crash because it either initializes eagerly or includes null-check guards.

## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

