### PR TITLE
Add componentDriverGridComp to build-tests dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added MAPL.componentDriverGridComp to build-tests dependency to ensure library is built with 'make tests'
 - Added ESMF_Mesh and Locstream to geom 
 - Added CDash nightly submission workflow (`.github/workflows/cdash-nightly.yml`),
   `CTestConfig.cmake`, `CTestDashboard.cmake`, and `CTestCustom.cmake` to support

--- a/gridcomps/componentDriverGridComp/CMakeLists.txt
+++ b/gridcomps/componentDriverGridComp/CMakeLists.txt
@@ -5,3 +5,6 @@ esma_add_library(${this}
   DEPENDENCIES MAPL.generic3g MAPL
   NOINSTALL
   TYPE SHARED)
+
+# Ensure this library is built when running 'make tests'
+add_dependencies(build-tests ${this})


### PR DESCRIPTION
Ensures MAPL.componentDriverGridComp shared library is built when running 'make tests'. This library is required at runtime by MAPL3G component tests.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

