### PR TITLE
Remove spurious MAPL.generic link deps from Orbit, MAPL2, and base/tests

### DIFF
--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this(OVERRIDE MAPL2)
 
 esma_add_library (${this}
   SRCS MAPL.F90
-  DEPENDENCIES MAPL MAPL.base MAPL.generic MAPL.pfio MAPL.gridcomps MAPL.orbit MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
+  DEPENDENCIES MAPL MAPL.base MAPL.pfio MAPL.gridcomps MAPL.orbit MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE SHARED
   )

--- a/base/tests/CMakeLists.txt
+++ b/base/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ add_pfunit_ctest(MAPL.base.tests
                 TEST_SOURCES ${TEST_SRCS}
                 OTHER_SOURCES ${SRCS}
 #                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.pfio base_extras MAPL.pfunit
-                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.constants MAPL.generic MAPL.pfio MAPL.pfunit
+                LINK_LIBRARIES MAPL.base MAPL.shared MAPL.constants MAPL.pfio MAPL.pfunit
                 EXTRA_INITIALIZE Initialize
                 EXTRA_USE MAPL_pFUnit_Initialize
                 MAX_PES 8

--- a/gridcomps/Orbit/CMakeLists.txt
+++ b/gridcomps/Orbit/CMakeLists.txt
@@ -4,7 +4,7 @@ set (srcs
         MAPL_OrbGridCompMod.F90
     )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL MAPL.shared MAPL.constants MAPL.base MAPL.generic TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES MAPL MAPL.shared MAPL.constants MAPL.base TYPE SHARED)
 target_link_libraries (${this} PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared ESMF::ESMF NetCDF::NetCDF_Fortran
                                PRIVATE MPI::MPI_Fortran OpenMP::OpenMP_Fortran)
 target_include_directories (${this} PUBLIC $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)


### PR DESCRIPTION
## Summary

- Remove vestigial `MAPL.generic` link dependencies from three `CMakeLists.txt` files where the corresponding Fortran sources have already been fully migrated to `mapl3g_*` APIs or never directly used `MAPL_GenericMod` at all.
- Successful build confirmed prior to opening this PR.

## Changes

- `gridcomps/Orbit/CMakeLists.txt` — `MAPL_OrbGridCompMod.F90` uses only `mapl3g_*` modules; `MAPL.generic` dependency is vestigial.
- `MAPL/CMakeLists.txt` — removes `MAPL.generic` from the `MAPL2` aggregate link line.
- `base/tests/CMakeLists.txt` — none of the pFUnit test sources contain `use MAPL_GenericMod`; link dependency is unused.

## Related issues

Closes #4725

Part of the broader effort to delete the legacy `generic/` and `oomph/` directories:
- #4723 — expose `find_bounds` in `mapl3g_OpenMP_Support`
- #4724 — port Python bridge to MAPL3