### PR TITLE
Expose find_bounds publicly from mapl3g_OpenMP_Support

### DIFF
--- a/generic3g/OpenMP_Support.F90
+++ b/generic3g/OpenMP_Support.F90
@@ -15,6 +15,7 @@ module mapl3g_OpenMP_Support
 
     public :: Interval
     public :: make_subgrids
+    public :: find_bounds
     public :: make_subfields
     public :: make_subFieldBundles
     public :: make_substates


### PR DESCRIPTION
## Summary

Closes #4723

- `find_bounds` was imported from `mapl3g_Subgrid` into `mapl3g_OpenMP_Support` but was missing from the `public` statement, making it inaccessible to consumers outside the module.
- This one-line fix is needed to allow `GEOSgwd_GridComp` (and any other component) to migrate from `MAPL_OpenMP_Support` (in `generic/`) to `mapl3g_OpenMP_Support` (in `generic3g/`), which is a prerequisite for eventually deleting `generic/`.