### PR TITLE
Remove MAPL_GenericMod and MAPL_OpenMP_Support from MAPL2 aggregate

### DIFF
--- a/MAPL/CMakeLists.txt
+++ b/MAPL/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this(OVERRIDE MAPL2)
 
 esma_add_library (${this}
   SRCS MAPL.F90
-  DEPENDENCIES MAPL MAPL.base MAPL.pfio MAPL.gridcomps MAPL.orbit MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
+  DEPENDENCIES MAPL MAPL.base MAPL.generic3g MAPL.pfio MAPL.gridcomps MAPL.orbit MAPL.field MAPL.python_bridge ${EXTDATA_TARGET}
                ESMF::ESMF NetCDF::NetCDF_Fortran MPI::MPI_Fortran
   TYPE SHARED
   )

--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -2,14 +2,14 @@
 ! of the legacy (MAPL2) underlying packages.
 module MAPL2
    use MAPLBase_mod
-   use MAPL_GenericMod
+   use Generic3g
    use MAPL_VarSpecMiscMod
    use pFIO
    use MAPL_GridCompsMod
-   use MAPL_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
-   use MAPL_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
-   use MAPL_OpenMP_Support, only : MAPL_find_bounds => find_bounds
-   use MAPL_OpenMP_Support, only : MAPL_Interval => Interval
+   use mapl3g_OpenMP_Support, only : MAPL_get_current_thread => get_current_thread
+   use mapl3g_OpenMP_Support, only : MAPL_get_num_threads => get_num_threads
+   use mapl3g_OpenMP_Support, only : MAPL_find_bounds => find_bounds
+   use mapl3g_OpenMP_Support, only : MAPL_Interval => Interval
    use MAPL_Profiler, initialize_profiler => initialize, finalize_profiler => finalize
    use MAPL_FieldUtils
    use MAPL_StateUtils


### PR DESCRIPTION
## Summary

Closes #4730

- Replace `use MAPL_GenericMod` with `use Generic3g` in `MAPL/MAPL.F90`
- Replace `use MAPL_OpenMP_Support` with `use mapl3g_OpenMP_Support` (4 lines)
- Update `MAPL/CMakeLists.txt`: `MAPL.generic` → `MAPL.generic3g` in link deps

This removes the last internal MAPL consumers of `generic/`, which is a prerequisite for eventually deleting `generic/` and `oomph/`.

## Dependencies

Depends on #4729 (exposes `find_bounds` from `mapl3g_OpenMP_Support`). Please merge #4729 first.