### PR TITLE
Remove MAPL_CommsMod and MAPL_SatVaporMod from MAPLBase_Mod

### DIFF
--- a/base/Base.F90
+++ b/base/Base.F90
@@ -9,7 +9,6 @@ module MAPLBase_Mod
 ! For temporary backward compatibility after moving/renaming:
   use MAPL_BaseMod, only: ESMF_GRID_INTERIOR => MAPL_GRID_INTERIOR
    use MAPL_IOMod
-   use MAPL_CommsMod
 ! For temporary backward compatibility after Constants Library
   use MAPL_Constants
   use MAPL_Constants, only: MAPL_PI_R8
@@ -19,7 +18,6 @@ module MAPLBase_Mod
   use MAPL_SunMod
   use MAPL_LocStreamMod
   use MAPL_InterpMod
-  use MAPL_SatVaporMod
   use MAPL_MemUtilsMod
   use MAPL_HashMod
   use MAPL_LoadBalanceMod


### PR DESCRIPTION
## Summary

- Removes `use MAPL_CommsMod` and `use MAPL_SatVaporMod` from `base/Base.F90` (`MAPLBase_Mod`)
- These symbols are now exported via the `MAPL` (MAPL3) umbrella module through `base3g`
- Closes #4752

## Prerequisites

The following PRs must merge first:
- GEOS-ESM/GMAO_Shared#422
- GEOS-ESM/FVdycoreCubed_GridComp#360