### PR TITLE
Feature/wdboggs/#4695 acg3 nondefault tk

### DIFF
--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -23,6 +23,7 @@ UNIT = ()
 INDENT = SPACE * SIZE_INDENT
 DIMSTR = ':'
 DIMDELIM = ','
+DEFAULT_TYPEKIND = 'ESMF_TYPEKIND_R4'
 
 # str flags
 AS = 'as'
@@ -79,6 +80,7 @@ STATES = 'states'
 STATE_ARG = 'state_arg'
 STATE_INTENT = 'state_intent'
 STRINGVECTOR = 'string_vector'
+TYPEKIND = 'typekind'
 UNGRIDDED_DIMS = 'ungridded_dims'
 USE_FIELD_DICTIONARY = 'use_field_dictionary'
 VSTAGGER = 'vstagger'
@@ -182,8 +184,8 @@ def get_options(args):
             'REQUIRED': 'MAPL_RESTART_REQUIRED',
             'BOOT': 'MAPL_RESTART_BOOT',
             'SKIP_INITIAL': 'MAPL_RESTART_SKIP_INITIAL'}},
-        STATE: {FLAGS: {MANDATORY, STORE}},
-        'typekind': {MAPPING: {
+        STATE: {FLAGS: {MANDATORY, STORE}}, 
+        TYPEKIND: {MAPPING: { 
             'R4': 'ESMF_Typekind_R4',
             'R8': 'ESMF_Typekind_R8',
             'I4': 'ESMF_Typekind_I4',
@@ -264,17 +266,28 @@ def emit_declare_pointers(specs, states=None):
     """Emit pointer declarations from Iterable of spec instances."""
     # filter on state
     f = state_filter(states)
-    return DECLARE, [emit_declare_pointer(spec) for spec in specs if f(spec)]
+    declarations = []
+    for spec in specs:
+        if not f(spec):
+            continue
+        try:
+            declaration = emit_declare_pointer(spec)
+        except RuntimeError as ex:
+            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)')
+        declarations.append(declaration)
+    return DECLARE, declarations
 
 def emit_declare_pointer(spec):
     """Emit individual pointer declartion."""
-    # get precision of pointer
-    precision = spec.get(PRECISION)
-    # declaration preamble
-    decl = 'real{}, pointer'.format('(kind={})'.format(precision) if precision else EMPTY)
+    # get fortran type and kind of pointer
+    typekind = spec.get(TYPEKIND, DEFAULT_TYPEKIND)
+    try:
+        ftypekind = fortran_type_esmf_kind(typekind)
+    except RuntimeError as ex:
+        raise RuntimeError(f'Error in pointer declaration for typekind {typekind}: {str(ex)}')
     # pointer variable
     var = f'{spec[INTERNAL_NAME]}({DIMDELIM.join(DIMSTR*spec[RANK])})'
-    return ' :: '.join([decl, var])
+    return ' :: '.join([ftypekind, var])
 
 def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
@@ -401,7 +414,7 @@ def get_from_values(keys, values, args):
 
 def digest_spec(spec, options):
     """Process an individual spec."""
-    # Get the key/value pairs that have a matching option key and a value that evaluates False.
+    # Get the key/value pairs that have a matching option key and a value that evaluates True.
     tuples = [(k, spec[k]) for k, v in spec.items() if k in options and spec[k]]
     # Get the options corresponding to the spec keys.
     spec_options = [options[k] for k, _ in tuples]
@@ -574,6 +587,21 @@ def compute_rank(dims, ungridded):
             return None
         extra_rank = r0
     return base_rank + extra_rank
+
+def fortran_type_esmf_kind(typekind):
+    match (typekind.upper() if typekind else None):
+        case None:
+            raise RuntimeError('typekind has no value.')
+        case 'ESMF_TYPEKIND_R4':
+            return 'real(kind=ESMF_KIND_R4)'
+        case 'ESMF_TYPEKIND_R8':
+            return 'real(kind=ESMF_KIND_R8)'
+        case 'ESMF_TYPEKIND_I4':
+            return 'integer(kind=ESMF_KIND_I4)'
+        case 'ESMF_TYPEKIND_I8':
+            return 'integer(kind=ESMF_KIND_I4)'
+        case _:
+            raise RuntimeError('Unrecognized typekind: {}'.format(typekind))
 
 def header():
     """

--- a/Apps/MAPL_GridCompSpecs_ACGv3.py
+++ b/Apps/MAPL_GridCompSpecs_ACGv3.py
@@ -8,6 +8,30 @@ from collections.abc import Sequence
 from functools import partial, reduce
 from operator import concat
 from re import compile
+from enum import Enum
+import logging
+import io
+
+# ESMF_TYPEKIND enum
+class TYPEKIND_Type:
+    __slots__=('type', 'kind', 'variable_type')
+    def __init__(self, ftype: str, kind: str):
+        self.type = ftype
+        self.kind = kind
+        self.variable_type = '{}(kind={})'.format(ftype, kind)
+    
+class ESMF_Typekind(TYPEKIND_Type, Enum):
+    R4 = ('real', 'ESMF_KIND_R4')
+    R8 = ('real', 'ESMF_KIND_R8')
+    I4 = ('integer', 'ESMF_KIND_I4')
+    I8 = ('integer', 'ESMF_KIND_I8')
+    ESMF_TYPEKIND_R4 = R4
+    ESMF_TYPEKIND_R8 = R8
+    ESMF_TYPEKIND_I4 = I4
+    ESMF_TYPEKIND_I8 = I8
+
+    def __str__(self):
+        return self.variable_type
 
 ################################# CONSTANTS ####################################
 # str constants internal to script
@@ -44,7 +68,8 @@ GC_ARGNAME = 'gridcomp'
 GET = 'get'
 MAKE_BLOCK = 'make_block'
 INTENT_PREFIX = 'ESMF_STATEINTENT_'
-MAPPED = 'mapped'
+KIND = 'kind'
+MAPPED = 'mapped' 
 MAPPING = 'mapping'
 MISSING_MANDATORY = 'missing_mandatory'
 NONES = 'nones'
@@ -55,6 +80,7 @@ SPEC_ALIASES = 'spec_aliases'
 STORE = 'store'
 STRING = 'string'
 STRLOGICAL = 'strlogical'
+TYPE = 'type'
 VALUES_NOT_FOUND = 'values_not_found'
 
 # These are column names. A few are "special" column names used internally.
@@ -273,7 +299,7 @@ def emit_declare_pointers(specs, states=None):
         try:
             declaration = emit_declare_pointer(spec)
         except RuntimeError as ex:
-            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)')
+            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)}')
         declarations.append(declaration)
     return DECLARE, declarations
 
@@ -281,13 +307,12 @@ def emit_declare_pointer(spec):
     """Emit individual pointer declartion."""
     # get fortran type and kind of pointer
     typekind = spec.get(TYPEKIND, DEFAULT_TYPEKIND)
-    try:
-        ftypekind = fortran_type_esmf_kind(typekind)
-    except RuntimeError as ex:
-        raise RuntimeError(f'Error in pointer declaration for typekind {typekind}: {str(ex)}')
+    if not hasattr(ESMF_Typekind, typekind):
+        raise RuntimeError(f'Unsupported typekind: {typekind}')
+    ftypekind = "{}, pointer".format(str(ESMF_Typekind[typekind]))
     # pointer variable
     var = f'{spec[INTERNAL_NAME]}({DIMDELIM.join(DIMSTR*spec[RANK])})'
-    return ' :: '.join([ftypekind, var])
+    return f'{ftypekind} :: {var}'
 
 def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
@@ -543,7 +568,10 @@ def emit_values(specs, options):
     # Emit all get_pointer calls and pointer declartions.
     emitters = {DECLARE: emit_declare_pointers, GET: emit_get_pointers}
     for key in set(emitters) & set(args):
-        _, emitted = emitters[key](specs, states)
+        try:
+            _, emitted = emitters[key](specs, states)
+        except Exception as ex:
+            raise RuntimeError
         with open_file(component, args[key], key, 'pointer') as f:
             f.writelines(add_newlines(emitted))
 
@@ -587,21 +615,6 @@ def compute_rank(dims, ungridded):
             return None
         extra_rank = r0
     return base_rank + extra_rank
-
-def fortran_type_esmf_kind(typekind):
-    match (typekind.upper() if typekind else None):
-        case None:
-            raise RuntimeError('typekind has no value.')
-        case 'ESMF_TYPEKIND_R4':
-            return 'real(kind=ESMF_KIND_R4)'
-        case 'ESMF_TYPEKIND_R8':
-            return 'real(kind=ESMF_KIND_R8)'
-        case 'ESMF_TYPEKIND_I4':
-            return 'integer(kind=ESMF_KIND_I4)'
-        case 'ESMF_TYPEKIND_I8':
-            return 'integer(kind=ESMF_KIND_I4)'
-        case _:
-            raise RuntimeError('Unrecognized typekind: {}'.format(typekind))
 
 def header():
     """
@@ -739,7 +752,7 @@ def make_mapping(m, func_sequence=None, func_dict=None, flags=UNIT):
             return inner
 
 # Main Procedure (Added to facilitate testing.)
-def main():
+def main(logger):
     exit_code = ERROR
 
 # Process command line arguments
@@ -774,6 +787,12 @@ def main():
 #############################################
 
 if __name__ == "__main__":
-    main()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.WARNING)
+    log_stream = io.StringIO()
+    streamHandler = logging.StreamHandler(log_stream)
+    logger.addHandler(streamHandler)
+    main(logger)
+    messages = log_stream.getvalue().splitlines()
 # FIN
     sys.exit(SUCCESS)

--- a/Apps/tests/acg3/acg3_unittests.py
+++ b/Apps/tests/acg3/acg3_unittests.py
@@ -293,8 +293,55 @@ class TestHelpers(unittest.TestCase):
             r = acg3.make_else_block(name)
             with self.subTest(test=test, msg=msg):
                 test(r, msg)
-    
-test_cases = (TestMappings, TestHelpers, TestColumns)
+
+    def test_emit_declare_pointer(self):
+        INTERNAL_NAME = 'GX'
+        RANK = 4
+        make_spec = lambda tk: {acg3.TYPEKIND: tk, acg3.INTERNAL_NAME: INTERNAL_NAME,
+                acg3.RANK: RANK}
+        equal_test = lambda expected: make_equal_test(self, expected)
+        typekinds = ('ESMF_TYPEKIND_R4',)
+        expecteds = (f'real(kind=ESMF_KIND_R4), pointer :: {INTERNAL_NAME}(:,:,:,:)',)
+        params = zip(typekinds, expecteds)
+        for tk, ex in params:
+            spec = make_spec(tk)
+            msg = general_msg('Pointer declaration', ex)
+            test = equal_test(ex)
+            value = acg3.emit_declare_pointer(spec)
+            with self.subTest(value=value, test=test, msg=msg):
+                test(value, msg)
+
+    def test_emit_declare_pointer_unsupported_type(self):
+        spec = {acg3.TYPEKIND: 'X4', acg3.INTERNAL_NAME: 'GX', acg3.RANK: 4}
+        self.assertRaises(RuntimeError, acg3.emit_declare_pointer, spec)
+
+class TestTypes(unittest.TestCase):
+
+    def test_ESMF_Typekind(self):
+        ESMF_Typekind = acg3.ESMF_Typekind
+        equal_test = lambda expected: make_equal_test(self, expected)
+        params = zip(('R4 R8 I4 I8'
+                + ' ESMF_TYPEKIND_R4 ESMF_TYPEKIND_R8'
+                + ' ESMF_TYPEKIND_I4 ESMF_TYPEKIND_I8').split(),
+                (ESMF_Typekind.R4, ESMF_Typekind.R8, ESMF_Typekind.I4, ESMF_Typekind.I8,
+                ESMF_Typekind.R4, ESMF_Typekind.R8, ESMF_Typekind.I4, ESMF_Typekind.I8))
+        test_params = (TestParams(v, equal_test(e), general_msg('Enum member', e))
+                for v, e in params)
+
+        for value, test, msg in test_params:
+            with self.subTest(value=value, test=test, msg=msg):
+                test(ESMF_Typekind[value], msg)
+
+    def test_ESMF_Typekind_variable_type(self):
+        ESMF_Typekind = acg3.ESMF_Typekind
+        equal_test = lambda expected: make_equal_test(self, expected)
+        params = ((ESMF_Typekind[t], e) for t, e in (('R4', 'real(kind=ESMF_KIND_R4)'),))
+        for en, ex in params:
+            value, test, msg = str(en), equal_test(ex), general_msg('Variable type', ex)
+            with self.subTest(value=value, test=test, msg=msg):
+                test(value, msg)
+
+test_cases = (TestMappings, TestHelpers, TestColumns, TestTypes)
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workaround for GCC 15 bug (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120179)
 - Fixed handling of invalid value for RESTART column in ACG3
 - Fixed initialization of field in test_min_accumulate_R4` in `Test_MinTransform.pf`
+- Fixed the precision of the pointer variable in ACG3
 
 ## [Unreleased]
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
In ACG2, the column PRECISION provided the precision for the pointer variable. That column does not exist for ACG3. However, ACG3 has a column TYPEKIND that provides the necessary information. This PR uses that information to correctly set the type and kind (precision) for the pointer variable.
## Related Issue
#4695
