### PR TITLE
Export WRITE_PARALLEL from mapl_base3g umbrella module (#4771)

### DIFF
--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -22,6 +22,7 @@ module mapl_base3g
           MAPL_SunGetDaylightDuration, MAPL_SunGetDaylightDurationMax, &
           MAPL_SunGetLocalSolarHourAngle, MAPL_SunOrbit
    use MAPL_TimeInterpolation, only: MAPL_Interp_Fac, MAPL_ClimInterpFac
+   use mapl3g_FileIO, only: WRITE_PARALLEL
    implicit none(type,external)
    private
 
@@ -48,5 +49,6 @@ module mapl_base3g
    public :: MAPL_SunGetDaylightDuration, MAPL_SunGetDaylightDurationMax
    public :: MAPL_SunGetLocalSolarHourAngle, MAPL_SunOrbit
    public :: MAPL_Interp_Fac, MAPL_ClimInterpFac
+   public :: WRITE_PARALLEL
 
 end module mapl_base3g


### PR DESCRIPTION
## Summary
- Adds `WRITE_PARALLEL` from `mapl3g_FileIO` to `mapl_base3g` (base3g/API.F90)
- Makes `WRITE_PARALLEL` accessible via `use MAPL` without requiring direct use of internal `mapl3g_*` modules

## Motivation
Components migrating from MAPL2 to MAPL3 need access to `WRITE_PARALLEL` through the `MAPL` umbrella module. Previously it was only available by importing `mapl3g_FileIO` directly, violating the intended API boundary.

## Depends on
Nothing — this can merge independently.

## Blocked by
None.

Closes #4771