### PR TITLE
Update to extdata2g compatibility with non-CF inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ESMA_cmake v4.37.0
     - Add `Coverage` CMake build type
 - Update CTest configuration for Coverage tests
+- Changed standard_name to long_name in handling of non-CF dimensionless vertical coordinate in ExtData2G
 
 ### Removed
 

--- a/vertical/VerticalCoordinate.F90
+++ b/vertical/VerticalCoordinate.F90
@@ -64,7 +64,7 @@ contains
       class(CoordinateVariable), pointer :: coord_var
       character(len=:), pointer :: dim_name
       logical :: is_vertical_coord_var, has_pressure_units, has_height_units
-      character(len=:), allocatable :: lev_name, temp_units, formula_terms, standard_name, bounds_var, ak_name, bk_name, ps_name, source_file
+      character(len=:), allocatable :: lev_name, temp_units, formula_terms, standard_name, long_name, bounds_var, ak_name, bk_name, ps_name, source_file
       type(NETCDF4_FileFormatter) :: file_formatter
       real, allocatable :: temp_ak(:,:), temp_bk(:,:)
    
@@ -110,16 +110,16 @@ contains
          ! for backwards compatibility with non-cf files
          if ((.not. coord_var%is_attribute_present("positive")) .and. &
               (.not. has_pressure_units)) then
-            standard_name = coord_var%get_attribute_string("standard_name")
+            long_name = coord_var%get_attribute_string("long_name")
             ! metadata combinations that imply integer levels
-            if ( any(standard_name == ["level ", "levels"])  .and. &
+            if ( any(long_name == ["level ", "levels"])  .and. &
                  any(temp_units == ["1    ", "level"])) then
                vertical_coord%positive = "up"
                if (vertical_coord%levels(1) >= vertical_coord%levels(2)) then
                   vertical_coord%positive = "down"
                endif
             else
-               _FAIL('lev positive attribute not in file and no rule defined for setting it from standard_name and units')
+               _FAIL('lev positive attribute not in file and no rule defined for setting it from long_name and units')
             endif
          endif
 


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description
This PR has a minor change in the criteria for determining if a non-CF file vertical dimension is positive up or down based on lev dimension attributes when using ExtData2G. Previously `standard_name` was used. However, I discovered that `standard_name` is not present in the processed GEOS-FP file used in GCHP. We do have `long_name` present across all of our processed meteorology input files so made this PR to change `standard_name` to `long_name` for the criteria. This should not impact GEOS users since the code block to check direction in non-CF files was introduced by me for GCHP.

## Related Issue

Supersedes #4787 (rebased from geoschem/MAPL fork to allow merge)