### PR TITLE
Delete legacy MAPL_PackTime, MAPL_UnpackTime, MAPL_UnpackDateTime from Base_Base

### DIFF
--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -39,9 +39,11 @@ module MAPL_Base
   public MAPL_IncYMD
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-   public MAPL_PackDateTime
-   public MAPL_RemapBounds
-
+  public MAPL_PackTime
+  public MAPL_PackDateTime
+  public MAPL_RemapBounds
+  public MAPL_UnpackTime
+  public MAPL_UnpackDateTime
   public MAPL_SetPointer
   public MAPL_FieldBundleAdd
   public MAPL_GetHorzIJIndex
@@ -116,13 +118,35 @@ module MAPL_Base
      end subroutine MAPL_SetPointer3DR4
 
 
-      module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+     module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
+       integer, intent (IN ) :: TIME
+       integer, intent (OUT) :: IYY
+       integer, intent (OUT) :: IMM
+       integer, intent (OUT) :: IDD
+     end subroutine MAPL_UnpackTime
+
+
+     module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
+       integer, intent (OUT) :: TIME
+       integer, intent (IN ) :: IYY
+       integer, intent (IN ) :: IMM
+       integer, intent (IN ) :: IDD
+     end subroutine MAPL_PackTime
+
+
+     module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
        integer, intent(in) :: yy, mm, dd, h, m, s
        integer, intent(out) :: date_time(:)
-      end subroutine MAPL_PackDateTime
+     end subroutine MAPL_PackDateTime
 
 
-      integer module function MAPL_incymd (NYMD,M)
+     module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
+       integer, intent(in) :: date_time(:)
+       integer, intent(out) :: yy, mm, dd, h, m, s
+     end subroutine MAPL_UnpackDateTime
+
+
+     integer module function MAPL_incymd (NYMD,M)
        integer nymd,m
      end function MAPL_incymd
 

--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -39,11 +39,9 @@ module MAPL_Base
   public MAPL_IncYMD
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-  public MAPL_PackTime
-  public MAPL_PackDateTime
-  public MAPL_RemapBounds
-  public MAPL_UnpackTime
-  public MAPL_UnpackDateTime
+   public MAPL_PackDateTime
+   public MAPL_RemapBounds
+
   public MAPL_SetPointer
   public MAPL_FieldBundleAdd
   public MAPL_GetHorzIJIndex
@@ -118,35 +116,13 @@ module MAPL_Base
      end subroutine MAPL_SetPointer3DR4
 
 
-     module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
-       integer, intent (IN ) :: TIME
-       integer, intent (OUT) :: IYY
-       integer, intent (OUT) :: IMM
-       integer, intent (OUT) :: IDD
-     end subroutine MAPL_UnpackTime
-
-
-     module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
-       integer, intent (OUT) :: TIME
-       integer, intent (IN ) :: IYY
-       integer, intent (IN ) :: IMM
-       integer, intent (IN ) :: IDD
-     end subroutine MAPL_PackTime
-
-
-     module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+      module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
        integer, intent(in) :: yy, mm, dd, h, m, s
        integer, intent(out) :: date_time(:)
-     end subroutine MAPL_PackDateTime
+      end subroutine MAPL_PackDateTime
 
 
-     module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-       integer, intent(in) :: date_time(:)
-       integer, intent(out) :: yy, mm, dd, h, m, s
-     end subroutine MAPL_UnpackDateTime
-
-
-     integer module function MAPL_incymd (NYMD,M)
+      integer module function MAPL_incymd (NYMD,M)
        integer nymd,m
      end function MAPL_incymd
 

--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -39,11 +39,8 @@ module MAPL_Base
   public MAPL_IncYMD
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-  public MAPL_PackTime
-  public MAPL_PackDateTime
-  public MAPL_RemapBounds
-  public MAPL_UnpackTime
-  public MAPL_UnpackDateTime
+   public MAPL_PackDateTime
+   public MAPL_RemapBounds
   public MAPL_SetPointer
   public MAPL_FieldBundleAdd
   public MAPL_GetHorzIJIndex
@@ -118,35 +115,13 @@ module MAPL_Base
      end subroutine MAPL_SetPointer3DR4
 
 
-     module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
-       integer, intent (IN ) :: TIME
-       integer, intent (OUT) :: IYY
-       integer, intent (OUT) :: IMM
-       integer, intent (OUT) :: IDD
-     end subroutine MAPL_UnpackTime
-
-
-     module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
-       integer, intent (OUT) :: TIME
-       integer, intent (IN ) :: IYY
-       integer, intent (IN ) :: IMM
-       integer, intent (IN ) :: IDD
-     end subroutine MAPL_PackTime
-
-
-     module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+      module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
        integer, intent(in) :: yy, mm, dd, h, m, s
        integer, intent(out) :: date_time(:)
-     end subroutine MAPL_PackDateTime
+      end subroutine MAPL_PackDateTime
 
 
-     module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-       integer, intent(in) :: date_time(:)
-       integer, intent(out) :: yy, mm, dd, h, m, s
-     end subroutine MAPL_UnpackDateTime
-
-
-     integer module function MAPL_incymd (NYMD,M)
+      integer module function MAPL_incymd (NYMD,M)
        integer nymd,m
      end function MAPL_incymd
 

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -797,18 +797,51 @@ contains
 
   end subroutine MAPL_DecomposeDim
 
-   ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
+  ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
 
-   module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+  module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
+    integer, intent (IN ) :: TIME
+    integer, intent (OUT) :: IYY
+    integer, intent (OUT) :: IMM
+    integer, intent (OUT) :: IDD
+    IYY = TIME/10000
+    IMM = mod(TIME/100,100)
+    IDD = mod(TIME,100)
+  end subroutine MAPL_UnpackTime
+
+
+  module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
+    integer, intent (OUT) :: TIME
+    integer, intent (IN ) :: IYY
+    integer, intent (IN ) :: IMM
+    integer, intent (IN ) :: IDD
+    TIME=IYY*10000+IMM*100+IDD
+  end subroutine MAPL_PackTime
+
+
+  module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
     integer, intent(in) :: yy, mm, dd, h, m, s
     integer, intent(out) :: date_time(:)
 
     date_time(1) = (10000 * yy) + (100 * mm) + dd
     date_time(2) = (10000 * h) + (100 * m) + s
-   end subroutine MAPL_PackDateTime
+  end subroutine MAPL_PackDateTime
 
 
-   ! A year is a leap year if
+  module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
+    integer, intent(in) :: date_time(:)
+    integer, intent(out) :: yy, mm, dd, h, m, s
+
+    yy =     date_time(1) / 10000
+    mm = mod(date_time(1), 10000) / 100
+    dd = mod(date_time(1), 100)
+    h  =     date_time(2) / 10000
+    m  = mod(date_time(2), 10000) / 100
+    s  = mod(date_time(2), 100)
+  end subroutine MAPL_UnpackDateTime
+
+
+  ! A year is a leap year if
   ! 1) it is divible by 4, and
   ! 2) it is not divisible by 100, unless
   ! 3) it is also divisible by 400.

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -797,51 +797,18 @@ contains
 
   end subroutine MAPL_DecomposeDim
 
-  ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
+   ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
 
-  module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
-    integer, intent (IN ) :: TIME
-    integer, intent (OUT) :: IYY
-    integer, intent (OUT) :: IMM
-    integer, intent (OUT) :: IDD
-    IYY = TIME/10000
-    IMM = mod(TIME/100,100)
-    IDD = mod(TIME,100)
-  end subroutine MAPL_UnpackTime
-
-
-  module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
-    integer, intent (OUT) :: TIME
-    integer, intent (IN ) :: IYY
-    integer, intent (IN ) :: IMM
-    integer, intent (IN ) :: IDD
-    TIME=IYY*10000+IMM*100+IDD
-  end subroutine MAPL_PackTime
-
-
-  module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+   module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
     integer, intent(in) :: yy, mm, dd, h, m, s
     integer, intent(out) :: date_time(:)
 
     date_time(1) = (10000 * yy) + (100 * mm) + dd
     date_time(2) = (10000 * h) + (100 * m) + s
-  end subroutine MAPL_PackDateTime
+   end subroutine MAPL_PackDateTime
 
 
-  module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-    integer, intent(in) :: date_time(:)
-    integer, intent(out) :: yy, mm, dd, h, m, s
-
-    yy =     date_time(1) / 10000
-    mm = mod(date_time(1), 10000) / 100
-    dd = mod(date_time(1), 100)
-    h  =     date_time(2) / 10000
-    m  = mod(date_time(2), 10000) / 100
-    s  = mod(date_time(2), 100)
-  end subroutine MAPL_UnpackDateTime
-
-
-  ! A year is a leap year if
+   ! A year is a leap year if
   ! 1) it is divible by 4, and
   ! 2) it is not divisible by 100, unless
   ! 3) it is also divisible by 400.

--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -3,7 +3,9 @@ module mapl_base3g
                                    MAPL_PackedTimeCreate => PackedTimeCreate, &
                                    MAPL_PackedDateTimeCreate => PackedDateTimeCreate, &
                                    MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked, &
-                                   MAPL_UnpackDate => UnpackDate
+                                   MAPL_UnpackDate => UnpackDate, &
+                                   MAPL_UnpackTime => UnpackTime, &
+                                   MAPL_UnpackDateTime => UnpackDateTime
    use mapl_SimulationTime, only: set_reference_clock, fill_time_dict
    use MAPL_CommsMod, only: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV, &
                             mapl_CommsAllGather, mapl_CommsAllGatherV, &
@@ -33,7 +35,7 @@ module mapl_base3g
 
    public :: MAPL_PackedDateCreate, MAPL_PackedTimeCreate, &
               MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked, &
-              MAPL_UnpackDate
+              MAPL_UnpackDate, MAPL_UnpackTime, MAPL_UnpackDateTime
    public :: set_reference_clock, fill_time_dict
    public :: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV
    public :: mapl_CommsAllGather, mapl_CommsAllGatherV

--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -1,4 +1,8 @@
 module mapl_base3g
+   use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
+                                   MAPL_PackedTimeCreate => PackedTimeCreate, &
+                                   MAPL_PackedDateTimeCreate => PackedDateTimeCreate, &
+                                   MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked
    use mapl_SimulationTime, only: set_reference_clock, fill_time_dict
    use MAPL_CommsMod, only: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV, &
                             mapl_CommsAllGather, mapl_CommsAllGatherV, &
@@ -26,6 +30,8 @@ module mapl_base3g
    implicit none(type,external)
    private
 
+   public :: MAPL_PackedDateCreate, MAPL_PackedTimeCreate, &
+             MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked
    public :: set_reference_clock, fill_time_dict
    public :: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV
    public :: mapl_CommsAllGather, mapl_CommsAllGatherV

--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -3,9 +3,7 @@ module mapl_base3g
                                    MAPL_PackedTimeCreate => PackedTimeCreate, &
                                    MAPL_PackedDateTimeCreate => PackedDateTimeCreate, &
                                    MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked, &
-                                   MAPL_UnpackDate => UnpackDate, &
-                                   MAPL_UnpackTime => UnpackTime, &
-                                   MAPL_UnpackDateTime => UnpackDateTime
+                                   MAPL_UnpackDate => UnpackDate
    use mapl_SimulationTime, only: set_reference_clock, fill_time_dict
    use MAPL_CommsMod, only: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV, &
                             mapl_CommsAllGather, mapl_CommsAllGatherV, &
@@ -34,8 +32,8 @@ module mapl_base3g
    private
 
    public :: MAPL_PackedDateCreate, MAPL_PackedTimeCreate, &
-             MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked, &
-             MAPL_UnpackDate, MAPL_UnpackTime, MAPL_UnpackDateTime
+              MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked, &
+              MAPL_UnpackDate
    public :: set_reference_clock, fill_time_dict
    public :: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV
    public :: mapl_CommsAllGather, mapl_CommsAllGatherV

--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -2,7 +2,10 @@ module mapl_base3g
    use MAPL_PackedTimeMod, only: MAPL_PackedDateCreate => PackedDateCreate, &
                                    MAPL_PackedTimeCreate => PackedTimeCreate, &
                                    MAPL_PackedDateTimeCreate => PackedDateTimeCreate, &
-                                   MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked
+                                   MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked, &
+                                   MAPL_UnpackDate => UnpackDate, &
+                                   MAPL_UnpackTime => UnpackTime, &
+                                   MAPL_UnpackDateTime => UnpackDateTime
    use mapl_SimulationTime, only: set_reference_clock, fill_time_dict
    use MAPL_CommsMod, only: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV, &
                             mapl_CommsAllGather, mapl_CommsAllGatherV, &
@@ -31,7 +34,8 @@ module mapl_base3g
    private
 
    public :: MAPL_PackedDateCreate, MAPL_PackedTimeCreate, &
-             MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked
+             MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked, &
+             MAPL_UnpackDate, MAPL_UnpackTime, MAPL_UnpackDateTime
    public :: set_reference_clock, fill_time_dict
    public :: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV
    public :: mapl_CommsAllGather, mapl_CommsAllGatherV

--- a/base3g/CMakeLists.txt
+++ b/base3g/CMakeLists.txt
@@ -1,6 +1,7 @@
 esma_set_this (OVERRIDE MAPL.base3g)
 
 set (srcs
+  PackedTime.F90
   SimulationTime.F90
   Comms.F90
   SatVapor.F90

--- a/base3g/PackedTime.F90
+++ b/base3g/PackedTime.F90
@@ -1,0 +1,181 @@
+#include "MAPL.h"
+
+!> Provides named constructors for legacy integer-packed date/time representations,
+!> with overloads accepting either individual integer components or an ESMF_Time.
+!>
+!> ### Packed-integer conventions
+!>   - **Packed date**:     YYYYMMDD integer  (e.g. 20050215 → 2005-02-15)
+!>   - **Packed time**:     HHMMSS   integer  (e.g.  130000  → 13:00:00)
+!>   - **Packed datetime**: integer(2), element 1 = YYYYMMDD, element 2 = HHMMSS
+!>
+!> These constructors exist as a migration bridge so that callers interfacing
+!> with routines that still require packed integers do not need to inline
+!> arithmetic.  The canonical representation of time in MAPL3 is ESMF_Time;
+!> the packed forms will be retired once all consumers have migrated.
+
+module MAPL_PackedTimeMod
+   use ESMF
+   use mapl_ErrorHandling, only: MAPL_Verify, MAPL_Return
+   implicit none(type, external)
+   private
+
+   public :: PackedDateCreate
+   public :: PackedTimeCreate
+   public :: PackedDateTimeCreate
+   public :: ESMFTimeFromPacked
+
+   !> Create a packed date integer (YYYYMMDD) from either integer components
+   !> (yy, mm, dd) or an ESMF_Time.
+   interface PackedDateCreate
+      module procedure packed_date_from_integers
+      module procedure packed_date_from_esmf
+   end interface PackedDateCreate
+
+   !> Create a packed time-of-day integer (HHMMSS) from either integer components
+   !> (h, m, s) or an ESMF_Time.
+   interface PackedTimeCreate
+      module procedure packed_time_from_integers
+      module procedure packed_time_from_esmf
+   end interface PackedTimeCreate
+
+   !> Create a packed datetime array (integer(2): [YYYYMMDD, HHMMSS]) from either
+   !> integer components (yy, mm, dd, h, m, s), a pair of already-packed integers
+   !> (nymd, nhms), or an ESMF_Time.
+   interface PackedDateTimeCreate
+      module procedure packed_datetime_from_integers
+      module procedure packed_datetime_from_packed
+      module procedure packed_datetime_from_esmf
+   end interface PackedDateTimeCreate
+
+   !> Convert a pair of packed integers (YYYYMMDD, HHMMSS) to an ESMF_Time.
+   interface ESMFTimeFromPacked
+      module procedure esmf_time_from_packed
+   end interface ESMFTimeFromPacked
+
+contains
+
+   ! ---------------------------------------------------------------------------
+   ! Private helpers — shared packing/unpacking logic
+   ! ---------------------------------------------------------------------------
+
+   pure integer function pack_date_(yy, mm, dd)
+      integer, intent(in) :: yy, mm, dd
+      pack_date_ = yy*10000 + mm*100 + dd
+   end function pack_date_
+
+   pure integer function pack_time_(h, m, s)
+      integer, intent(in) :: h, m, s
+      pack_time_ = h*10000 + m*100 + s
+   end function pack_time_
+
+   ! ---------------------------------------------------------------------------
+   ! PackedDateCreate overloads
+   ! ---------------------------------------------------------------------------
+
+   function packed_date_from_integers(yy, mm, dd, rc) result(nymd)
+      integer,           intent(in)  :: yy, mm, dd
+      integer, optional, intent(out) :: rc
+      integer :: nymd
+      nymd = pack_date_(yy, mm, dd)
+      if (present(rc)) rc = ESMF_SUCCESS
+   end function packed_date_from_integers
+
+   function packed_date_from_esmf(time, rc) result(nymd)
+      type(ESMF_Time),   intent(in)  :: time
+      integer, optional, intent(out) :: rc
+      integer :: nymd
+
+      integer :: status
+      integer :: yy, mm, dd
+
+      call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, _RC)
+      nymd = pack_date_(yy, mm, dd)
+      _RETURN(ESMF_SUCCESS)
+   end function packed_date_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! PackedTimeCreate overloads
+   ! ---------------------------------------------------------------------------
+
+   function packed_time_from_integers(h, m, s, rc) result(nhms)
+      integer,           intent(in)  :: h, m, s
+      integer, optional, intent(out) :: rc
+      integer :: nhms
+      nhms = pack_time_(h, m, s)
+      if (present(rc)) rc = ESMF_SUCCESS
+   end function packed_time_from_integers
+
+   function packed_time_from_esmf(time, rc) result(nhms)
+      type(ESMF_Time),   intent(in)  :: time
+      integer, optional, intent(out) :: rc
+      integer :: nhms
+
+      integer :: status
+      integer :: h, m, s
+
+      call ESMF_TimeGet(time, h=h, m=m, s=s, _RC)
+      nhms = pack_time_(h, m, s)
+      _RETURN(ESMF_SUCCESS)
+   end function packed_time_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! PackedDateTimeCreate overloads
+   ! ---------------------------------------------------------------------------
+
+   function packed_datetime_from_integers(yy, mm, dd, h, m, s, rc) result(date_time)
+      integer,           intent(in)  :: yy, mm, dd, h, m, s
+      integer, optional, intent(out) :: rc
+      integer :: date_time(2)
+      date_time(1) = pack_date_(yy, mm, dd)
+      date_time(2) = pack_time_(h, m, s)
+      if (present(rc)) rc = ESMF_SUCCESS
+   end function packed_datetime_from_integers
+
+   function packed_datetime_from_packed(nymd, nhms, rc) result(date_time)
+      integer,           intent(in)  :: nymd, nhms
+      integer, optional, intent(out) :: rc
+      integer :: date_time(2)
+      date_time(1) = nymd
+      date_time(2) = nhms
+      if (present(rc)) rc = ESMF_SUCCESS
+   end function packed_datetime_from_packed
+
+   function packed_datetime_from_esmf(time, rc) result(date_time)
+      type(ESMF_Time),   intent(in)  :: time
+      integer, optional, intent(out) :: rc
+      integer :: date_time(2)
+
+      integer :: status
+      integer :: yy, mm, dd, h, m, s
+
+      call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      date_time(1) = pack_date_(yy, mm, dd)
+      date_time(2) = pack_time_(h, m, s)
+      _RETURN(ESMF_SUCCESS)
+   end function packed_datetime_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! ESMFTimeFromPacked
+   ! ---------------------------------------------------------------------------
+
+   function esmf_time_from_packed(nymd, nhms, rc) result(time)
+      integer,           intent(in)  :: nymd   !< Date as YYYYMMDD
+      integer,           intent(in)  :: nhms   !< Time of day as HHMMSS
+      integer, optional, intent(out) :: rc
+      type(ESMF_Time) :: time
+
+      integer :: status
+      integer :: yy, mm, dd, h, m, s
+
+      yy = nymd / 10000
+      mm = mod(nymd, 10000) / 100
+      dd = mod(nymd, 100)
+      h  = nhms / 10000
+      m  = mod(nhms, 10000) / 100
+      s  = mod(nhms, 100)
+
+      call ESMF_TimeSet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      _RETURN(ESMF_SUCCESS)
+   end function esmf_time_from_packed
+
+end module MAPL_PackedTimeMod

--- a/base3g/PackedTime.F90
+++ b/base3g/PackedTime.F90
@@ -209,37 +209,7 @@ contains
       s  = mod(nhms, 100)
 
       call ESMF_TimeSet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
-      _RETURN(ESMF_SUCCESS)
+       _RETURN(ESMF_SUCCESS)
    end function esmf_time_from_packed
-
-   ! ---------------------------------------------------------------------------
-   ! ESMFTimeFromPacked
-   ! ---------------------------------------------------------------------------
-
-   !> Unpack a YYYYMMDD integer into year, month, day components.
-   pure subroutine UnpackDate(nymd, yy, mm, dd)
-      integer, intent(in)  :: nymd
-      integer, intent(out) :: yy, mm, dd
-      yy = nymd / 10000
-      mm = mod(nymd, 10000) / 100
-      dd = mod(nymd, 100)
-   end subroutine UnpackDate
-
-   !> Unpack a HHMMSS integer into hour, minute, second components.
-   pure subroutine UnpackTime(nhms, h, m, s)
-      integer, intent(in)  :: nhms
-      integer, intent(out) :: h, m, s
-      h = nhms / 10000
-      m = mod(nhms, 10000) / 100
-      s = mod(nhms, 100)
-   end subroutine UnpackTime
-
-   !> Unpack an integer(2) packed datetime ([YYYYMMDD, HHMMSS]) into six components.
-   pure subroutine UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-      integer, intent(in)  :: date_time(2)
-      integer, intent(out) :: yy, mm, dd, h, m, s
-      call UnpackDate(date_time(1), yy, mm, dd)
-      call UnpackTime(date_time(2), h,  m,  s)
-   end subroutine UnpackDateTime
 
 end module MAPL_PackedTimeMod

--- a/base3g/PackedTime.F90
+++ b/base3g/PackedTime.F90
@@ -8,7 +8,7 @@
 !>   - **Packed time**:     HHMMSS   integer  (e.g.  130000  → 13:00:00)
 !>   - **Packed datetime**: integer(2), element 1 = YYYYMMDD, element 2 = HHMMSS
 !>
-!> These constructors exist as a migration bridge so that callers interfacing
+!> These routines exist as a migration bridge so that callers interfacing
 !> with routines that still require packed integers do not need to inline
 !> arithmetic.  The canonical representation of time in MAPL3 is ESMF_Time;
 !> the packed forms will be retired once all consumers have migrated.
@@ -23,6 +23,9 @@ module MAPL_PackedTimeMod
    public :: PackedTimeCreate
    public :: PackedDateTimeCreate
    public :: ESMFTimeFromPacked
+   public :: UnpackDate
+   public :: UnpackTime
+   public :: UnpackDateTime
 
    !> Create a packed date integer (YYYYMMDD) from either integer components
    !> (yy, mm, dd) or an ESMF_Time.
@@ -152,7 +155,38 @@ contains
       date_time(1) = pack_date_(yy, mm, dd)
       date_time(2) = pack_time_(h, m, s)
       _RETURN(ESMF_SUCCESS)
-   end function packed_datetime_from_esmf
+    end function packed_datetime_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! UnpackDate / UnpackTime / UnpackDateTime
+   ! Pure-integer inverses of the pack operations; no ESMF dependency.
+   ! ---------------------------------------------------------------------------
+
+   !> Unpack a YYYYMMDD integer into year, month, day components.
+   pure subroutine UnpackDate(nymd, yy, mm, dd)
+      integer, intent(in)  :: nymd
+      integer, intent(out) :: yy, mm, dd
+      yy = nymd / 10000
+      mm = mod(nymd, 10000) / 100
+      dd = mod(nymd, 100)
+   end subroutine UnpackDate
+
+   !> Unpack a HHMMSS integer into hour, minute, second components.
+   pure subroutine UnpackTime(nhms, h, m, s)
+      integer, intent(in)  :: nhms
+      integer, intent(out) :: h, m, s
+      h = nhms / 10000
+      m = mod(nhms, 10000) / 100
+      s = mod(nhms, 100)
+   end subroutine UnpackTime
+
+   !> Unpack an integer(2) packed datetime ([YYYYMMDD, HHMMSS]) into six components.
+   pure subroutine UnpackDateTime(date_time, yy, mm, dd, h, m, s)
+      integer, intent(in)  :: date_time(2)
+      integer, intent(out) :: yy, mm, dd, h, m, s
+      call UnpackDate(date_time(1), yy, mm, dd)
+      call UnpackTime(date_time(2), h,  m,  s)
+   end subroutine UnpackDateTime
 
    ! ---------------------------------------------------------------------------
    ! ESMFTimeFromPacked
@@ -177,5 +211,35 @@ contains
       call ESMF_TimeSet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
       _RETURN(ESMF_SUCCESS)
    end function esmf_time_from_packed
+
+   ! ---------------------------------------------------------------------------
+   ! ESMFTimeFromPacked
+   ! ---------------------------------------------------------------------------
+
+   !> Unpack a YYYYMMDD integer into year, month, day components.
+   pure subroutine UnpackDate(nymd, yy, mm, dd)
+      integer, intent(in)  :: nymd
+      integer, intent(out) :: yy, mm, dd
+      yy = nymd / 10000
+      mm = mod(nymd, 10000) / 100
+      dd = mod(nymd, 100)
+   end subroutine UnpackDate
+
+   !> Unpack a HHMMSS integer into hour, minute, second components.
+   pure subroutine UnpackTime(nhms, h, m, s)
+      integer, intent(in)  :: nhms
+      integer, intent(out) :: h, m, s
+      h = nhms / 10000
+      m = mod(nhms, 10000) / 100
+      s = mod(nhms, 100)
+   end subroutine UnpackTime
+
+   !> Unpack an integer(2) packed datetime ([YYYYMMDD, HHMMSS]) into six components.
+   pure subroutine UnpackDateTime(date_time, yy, mm, dd, h, m, s)
+      integer, intent(in)  :: date_time(2)
+      integer, intent(out) :: yy, mm, dd, h, m, s
+      call UnpackDate(date_time(1), yy, mm, dd)
+      call UnpackTime(date_time(2), h,  m,  s)
+   end subroutine UnpackDateTime
 
 end module MAPL_PackedTimeMod

--- a/base3g/tests/CMakeLists.txt
+++ b/base3g/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(MODULE_DIRECTORY "${esma_include}/MAPL.base3g/tests")
+
+set(TEST_SRCS
+  Test_PackedTime.pf
+)
+
+add_pfunit_ctest(MAPL.base3g.tests
+  TEST_SOURCES ${TEST_SRCS}
+  LINK_LIBRARIES MAPL.base3g MAPL.pfunit
+  EXTRA_INITIALIZE Initialize
+  EXTRA_USE MAPL_pFUnit_Initialize
+  MAX_PES 1
+)
+set_target_properties(MAPL.base3g.tests PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY})
+
+add_dependencies(build-tests MAPL.base3g.tests)

--- a/base3g/tests/Test_PackedTime.pf
+++ b/base3g/tests/Test_PackedTime.pf
@@ -1,0 +1,156 @@
+#include "MAPL_TestErr.h"
+
+module Test_PackedTime
+
+   use MAPL_PackedTimeMod, only: PackedDateCreate, PackedTimeCreate, &
+                                  PackedDateTimeCreate, ESMFTimeFromPacked
+   use ESMF
+   use funit
+
+   implicit none(type, external)
+
+contains
+
+   ! ---------------------------------------------------------------------------
+   ! PackedDateCreate
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_packed_date_from_integers()
+      integer :: nymd
+      integer :: status
+
+      nymd = PackedDateCreate(2005, 2, 15, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(20050215, nymd)
+   end subroutine test_packed_date_from_integers
+
+   @test
+   subroutine test_packed_date_from_esmf()
+      type(ESMF_Time) :: time
+      integer :: nymd
+      integer :: status
+
+      call ESMF_TimeSet(time, yy=2005, mm=2, dd=15, h=0, m=0, s=0, _RC)
+      nymd = PackedDateCreate(time, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(20050215, nymd)
+   end subroutine test_packed_date_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! PackedTimeCreate
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_packed_time_from_integers()
+      integer :: nhms
+      integer :: status
+
+      nhms = PackedTimeCreate(13, 30, 45, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(133045, nhms)
+   end subroutine test_packed_time_from_integers
+
+   @test
+   subroutine test_packed_time_from_esmf()
+      type(ESMF_Time) :: time
+      integer :: nhms
+      integer :: status
+
+      call ESMF_TimeSet(time, yy=2005, mm=2, dd=15, h=13, m=30, s=45, _RC)
+      nhms = PackedTimeCreate(time, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(133045, nhms)
+   end subroutine test_packed_time_from_esmf
+
+   @test
+   subroutine test_packed_time_midnight()
+      integer :: nhms
+      integer :: status
+
+      nhms = PackedTimeCreate(0, 0, 0, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(0, nhms)
+   end subroutine test_packed_time_midnight
+
+   ! ---------------------------------------------------------------------------
+   ! PackedDateTimeCreate
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_packed_datetime_from_integers()
+      integer :: date_time(2)
+      integer :: status
+
+      date_time = PackedDateTimeCreate(2005, 2, 15, 13, 30, 45, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(20050215, date_time(1))
+      @assertEqual(133045,   date_time(2))
+   end subroutine test_packed_datetime_from_integers
+
+   @test
+   subroutine test_packed_datetime_from_packed()
+      integer :: date_time(2)
+      integer :: status
+
+      date_time = PackedDateTimeCreate(nymd=20050215, nhms=133045, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(20050215, date_time(1))
+      @assertEqual(133045,   date_time(2))
+   end subroutine test_packed_datetime_from_packed
+
+   @test
+   subroutine test_packed_datetime_from_esmf()
+      type(ESMF_Time) :: time
+      integer :: date_time(2)
+      integer :: status
+
+      call ESMF_TimeSet(time, yy=2005, mm=2, dd=15, h=13, m=30, s=45, _RC)
+      date_time = PackedDateTimeCreate(time, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(20050215, date_time(1))
+      @assertEqual(133045,   date_time(2))
+   end subroutine test_packed_datetime_from_esmf
+
+   ! ---------------------------------------------------------------------------
+   ! ESMFTimeFromPacked
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_esmf_time_from_packed()
+      type(ESMF_Time) :: time
+      integer :: yy, mm, dd, h, m, s
+      integer :: status
+
+      time = ESMFTimeFromPacked(20050215, 133045, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+
+      call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, _RC)
+      @assertEqual(2005, yy)
+      @assertEqual(2,    mm)
+      @assertEqual(15,   dd)
+      @assertEqual(13,   h)
+      @assertEqual(30,   m)
+      @assertEqual(45,   s)
+   end subroutine test_esmf_time_from_packed
+
+   ! ---------------------------------------------------------------------------
+   ! Round-trip: ESMF_Time -> packed -> ESMF_Time
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_round_trip()
+      type(ESMF_Time) :: time_in, time_out
+      integer :: date_time(2)
+      integer :: status
+
+      call ESMF_TimeSet(time_in, yy=2024, mm=11, dd=3, h=6, m=0, s=0, _RC)
+      date_time = PackedDateTimeCreate(time_in, rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+
+      time_out = ESMFTimeFromPacked(date_time(1), date_time(2), rc=status)
+      @assertEqual(ESMF_SUCCESS, status)
+      @assertEqual(time_in, time_out)
+   end subroutine test_round_trip
+
+end module Test_PackedTime

--- a/base3g/tests/Test_PackedTime.pf
+++ b/base3g/tests/Test_PackedTime.pf
@@ -3,7 +3,8 @@
 module Test_PackedTime
 
    use MAPL_PackedTimeMod, only: PackedDateCreate, PackedTimeCreate, &
-                                  PackedDateTimeCreate, ESMFTimeFromPacked
+                                   PackedDateTimeCreate, ESMFTimeFromPacked, &
+                                   UnpackDate, UnpackTime, UnpackDateTime
    use ESMF
    use funit
 
@@ -152,5 +153,89 @@ contains
       @assertEqual(ESMF_SUCCESS, status)
       @assertEqual(time_in, time_out)
    end subroutine test_round_trip
+
+   ! ---------------------------------------------------------------------------
+   ! UnpackDate
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_unpack_date()
+      integer :: yy, mm, dd
+
+      call UnpackDate(20050215, yy, mm, dd)
+      @assertEqual(2005, yy)
+      @assertEqual(2,    mm)
+      @assertEqual(15,   dd)
+   end subroutine test_unpack_date
+
+   @test
+   subroutine test_unpack_date_epoch()
+      integer :: yy, mm, dd
+
+      call UnpackDate(19000101, yy, mm, dd)
+      @assertEqual(1900, yy)
+      @assertEqual(1,    mm)
+      @assertEqual(1,    dd)
+   end subroutine test_unpack_date_epoch
+
+   ! ---------------------------------------------------------------------------
+   ! UnpackTime
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_unpack_time()
+      integer :: h, m, s
+
+      call UnpackTime(133045, h, m, s)
+      @assertEqual(13, h)
+      @assertEqual(30, m)
+      @assertEqual(45, s)
+   end subroutine test_unpack_time
+
+   @test
+   subroutine test_unpack_time_midnight()
+      integer :: h, m, s
+
+      call UnpackTime(0, h, m, s)
+      @assertEqual(0, h)
+      @assertEqual(0, m)
+      @assertEqual(0, s)
+   end subroutine test_unpack_time_midnight
+
+   ! ---------------------------------------------------------------------------
+   ! UnpackDateTime
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_unpack_datetime()
+      integer :: yy, mm, dd, h, m, s
+      integer :: date_time(2)
+
+      date_time = [20050215, 133045]
+      call UnpackDateTime(date_time, yy, mm, dd, h, m, s)
+      @assertEqual(2005, yy)
+      @assertEqual(2,    mm)
+      @assertEqual(15,   dd)
+      @assertEqual(13,   h)
+      @assertEqual(30,   m)
+      @assertEqual(45,   s)
+   end subroutine test_unpack_datetime
+
+   ! ---------------------------------------------------------------------------
+   ! Round-trip: pack -> unpack -> pack
+   ! ---------------------------------------------------------------------------
+
+   @test
+   subroutine test_pack_unpack_round_trip()
+      integer :: yy, mm, dd, h, m, s
+      integer :: nymd, nhms
+
+      nymd = PackedDateCreate(2005, 2, 15)
+      nhms = PackedTimeCreate(13, 30, 45)
+      call UnpackDate(nymd, yy, mm, dd)
+      call UnpackTime(nhms, h,  m,  s)
+      @assertEqual(2005, yy); @assertEqual(2,  mm); @assertEqual(15, dd)
+      @assertEqual(13,   h);  @assertEqual(30, m);  @assertEqual(45, s)
+   end subroutine test_pack_unpack_round_trip
 
 end module Test_PackedTime


### PR DESCRIPTION
## Summary
- Removes MAPL_PackTime, MAPL_UnpackTime, and MAPL_UnpackDateTime from Base_Base.F90 and Base_Base_implementation.F90
- These are now provided by MAPL_PackedTimeMod (added in #4812)

## Merge order
This PR must merge last, after all downstream consumers have migrated:
- GEOS-ESM/MAPL#4812 (add MAPL_PackedTimeMod) -- merge first
- GEOS-ESM/GOCART#419 -- merge after #4812
- GEOS-ESM/GMAO_Shared#426 -- merge after #4812
- GEOS-ESM/GEOSgcm_App#866 -- merge after #4812
- This PR -- merge last

Closes #4811