### PR TITLE
Delete legacy MAPL_PackTime, MAPL_UnpackTime, MAPL_UnpackDateTime from Base_Base

### DIFF
--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -39,11 +39,8 @@ module MAPL_Base
   public MAPL_IncYMD
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-  public MAPL_PackTime
-  public MAPL_PackDateTime
-  public MAPL_RemapBounds
-  public MAPL_UnpackTime
-  public MAPL_UnpackDateTime
+   public MAPL_PackDateTime
+   public MAPL_RemapBounds
   public MAPL_SetPointer
   public MAPL_FieldBundleAdd
   public MAPL_GetHorzIJIndex
@@ -118,35 +115,13 @@ module MAPL_Base
      end subroutine MAPL_SetPointer3DR4
 
 
-     module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
-       integer, intent (IN ) :: TIME
-       integer, intent (OUT) :: IYY
-       integer, intent (OUT) :: IMM
-       integer, intent (OUT) :: IDD
-     end subroutine MAPL_UnpackTime
-
-
-     module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
-       integer, intent (OUT) :: TIME
-       integer, intent (IN ) :: IYY
-       integer, intent (IN ) :: IMM
-       integer, intent (IN ) :: IDD
-     end subroutine MAPL_PackTime
-
-
-     module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+      module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
        integer, intent(in) :: yy, mm, dd, h, m, s
        integer, intent(out) :: date_time(:)
-     end subroutine MAPL_PackDateTime
+      end subroutine MAPL_PackDateTime
 
 
-     module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-       integer, intent(in) :: date_time(:)
-       integer, intent(out) :: yy, mm, dd, h, m, s
-     end subroutine MAPL_UnpackDateTime
-
-
-     integer module function MAPL_incymd (NYMD,M)
+      integer module function MAPL_incymd (NYMD,M)
        integer nymd,m
      end function MAPL_incymd
 

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -797,51 +797,18 @@ contains
 
   end subroutine MAPL_DecomposeDim
 
-  ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
+   ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
 
-  module subroutine MAPL_UnpackTime(TIME,IYY,IMM,IDD)
-    integer, intent (IN ) :: TIME
-    integer, intent (OUT) :: IYY
-    integer, intent (OUT) :: IMM
-    integer, intent (OUT) :: IDD
-    IYY = TIME/10000
-    IMM = mod(TIME/100,100)
-    IDD = mod(TIME,100)
-  end subroutine MAPL_UnpackTime
-
-
-  module subroutine MAPL_PackTime(TIME,IYY,IMM,IDD)
-    integer, intent (OUT) :: TIME
-    integer, intent (IN ) :: IYY
-    integer, intent (IN ) :: IMM
-    integer, intent (IN ) :: IDD
-    TIME=IYY*10000+IMM*100+IDD
-  end subroutine MAPL_PackTime
-
-
-  module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
+   module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
     integer, intent(in) :: yy, mm, dd, h, m, s
     integer, intent(out) :: date_time(:)
 
     date_time(1) = (10000 * yy) + (100 * mm) + dd
     date_time(2) = (10000 * h) + (100 * m) + s
-  end subroutine MAPL_PackDateTime
+   end subroutine MAPL_PackDateTime
 
 
-  module subroutine MAPL_UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-    integer, intent(in) :: date_time(:)
-    integer, intent(out) :: yy, mm, dd, h, m, s
-
-    yy =     date_time(1) / 10000
-    mm = mod(date_time(1), 10000) / 100
-    dd = mod(date_time(1), 100)
-    h  =     date_time(2) / 10000
-    m  = mod(date_time(2), 10000) / 100
-    s  = mod(date_time(2), 100)
-  end subroutine MAPL_UnpackDateTime
-
-
-  ! A year is a leap year if
+   ! A year is a leap year if
   ! 1) it is divible by 4, and
   ! 2) it is not divisible by 100, unless
   ! 3) it is also divisible by 400.

--- a/base3g/API.F90
+++ b/base3g/API.F90
@@ -3,7 +3,9 @@ module mapl_base3g
                                    MAPL_PackedTimeCreate => PackedTimeCreate, &
                                    MAPL_PackedDateTimeCreate => PackedDateTimeCreate, &
                                    MAPL_ESMFTimeFromPacked => ESMFTimeFromPacked, &
-                                   MAPL_UnpackDate => UnpackDate
+                                   MAPL_UnpackDate => UnpackDate, &
+                                   MAPL_UnpackTime => UnpackTime, &
+                                   MAPL_UnpackDateTime => UnpackDateTime
    use mapl_SimulationTime, only: set_reference_clock, fill_time_dict
    use MAPL_CommsMod, only: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV, &
                             mapl_CommsAllGather, mapl_CommsAllGatherV, &
@@ -33,7 +35,7 @@ module mapl_base3g
 
    public :: MAPL_PackedDateCreate, MAPL_PackedTimeCreate, &
               MAPL_PackedDateTimeCreate, MAPL_ESMFTimeFromPacked, &
-              MAPL_UnpackDate
+              MAPL_UnpackDate, MAPL_UnpackTime, MAPL_UnpackDateTime
    public :: set_reference_clock, fill_time_dict
    public :: mapl_CommsBcast, mapl_CommsScatterV, mapl_CommsGatherV
    public :: mapl_CommsAllGather, mapl_CommsAllGatherV


### PR DESCRIPTION
Supersedes #4813.

## Summary
- Removes MAPL_PackTime, MAPL_UnpackTime, and MAPL_UnpackDateTime from Base_Base.F90 and Base_Base_implementation.F90
- Re-exports MAPL_UnpackTime and MAPL_UnpackDateTime via API.F90 from MAPL_PackedTimeMod (no ambiguity now that Base_Base no longer defines them)

## Prerequisites (all merged)
- GEOS-ESM/MAPL#4812 -- added MAPL_PackedTimeMod
- GEOS-ESM/GOCART#419 -- migrated consumers
- GEOS-ESM/GMAO_Shared#426 -- migrated consumers
- GEOS-ESM/GEOSgcm_App#866 -- migrated consumers

Closes #4811