### PR TITLE
Remove MAPL_PackDateTime and MAPL_IncYMD from Base_Base (#4815)

### DIFF
--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -36,10 +36,8 @@ module MAPL_Base
   !public MAPL_ConnectCoupling
   public MAPL_FieldCreate
   public MAPL_GRID_INTERIOR
-  public MAPL_IncYMD
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-   public MAPL_PackDateTime
    public MAPL_RemapBounds
   public MAPL_SetPointer
   public MAPL_FieldBundleAdd
@@ -113,17 +111,6 @@ module MAPL_Base
        character(len=*),               intent(IN   ) :: name
        integer,              optional, intent(  OUT) :: rc
      end subroutine MAPL_SetPointer3DR4
-
-
-      module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
-       integer, intent(in) :: yy, mm, dd, h, m, s
-       integer, intent(out) :: date_time(:)
-      end subroutine MAPL_PackDateTime
-
-
-      integer module function MAPL_incymd (NYMD,M)
-       integer nymd,m
-     end function MAPL_incymd
 
 
      module subroutine MAPL_PICKEM(II,JJ,IM,JM,COUNT)

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -799,15 +799,6 @@ contains
 
    ! MAPL_Interp_Fac and MAPL_ClimInterpFac moved to MAPL_TimeInterpolation (base3g)
 
-   module subroutine MAPL_PackDateTime(date_time, yy, mm, dd, h, m, s)
-    integer, intent(in) :: yy, mm, dd, h, m, s
-    integer, intent(out) :: date_time(:)
-
-    date_time(1) = (10000 * yy) + (100 * mm) + dd
-    date_time(2) = (10000 * h) + (100 * m) + s
-   end subroutine MAPL_PackDateTime
-
-
    ! A year is a leap year if
   ! 1) it is divible by 4, and
   ! 2) it is not divisible by 100, unless
@@ -818,37 +809,6 @@ contains
     MAPL_LEAP = mod(NY,4)==0 .and. (mod(NY,100)/=0 .or. mod(NY,400)==0)
 
   end function MAPL_LEAP
-
-
-  integer module function MAPL_incymd (NYMD,M)
-    integer nymd,ny,nm,nd,m
-    INTEGER NDPM(12)
-    DATA    NDPM /31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31/
-    NY = NYMD / 10000
-    NM = MOD(NYMD,10000) / 100
-    ND = MOD(NYMD,100) + M
-    IF (ND.EQ.0) THEN
-       NM = NM - 1
-       IF (NM.EQ.0) THEN
-          NM = 12
-          NY = NY - 1
-       ENDIF
-       ND = NDPM(NM)
-       IF (NM.EQ.2 .AND. MAPL_LEAP(NY))  ND = 29
-    ENDIF
-    IF (ND.EQ.29 .AND. NM.EQ.2 .AND. MAPL_LEAP(NY))  GO TO 20
-    IF (ND.GT.NDPM(NM)) THEN
-       ND = 1
-       NM = NM + 1
-       IF (NM.GT.12) THEN
-          NM = 1
-          NY = NY + 1
-       ENDIF
-    ENDIF
-20  CONTINUE
-    MAPL_INCYMD = NY*10000 + NM*100 + ND
-    RETURN
-  end function MAPL_incymd
 
 
   module subroutine MAPL_PICKEM(II,JJ,IM,JM,COUNT)


### PR DESCRIPTION
## Summary

Remove `MAPL_PackDateTime` and `MAPL_IncYMD` from `base/Base/Base_Base.F90` and `base/Base/Base_Base_implementation.F90` as part of the MAPL3 migration.

Closes #4815

## Changes

- Remove `public MAPL_PackDateTime`, its `module subroutine` interface declaration, and its implementation (6 lines)
- Remove `public MAPL_IncYMD`, its `module function` interface declaration, and its implementation (29 lines)

## Rationale

Both symbols have **zero external callers** anywhere in the GEOSgcm ecosystem:

- `MAPL_PackDateTime`: no compiled callers found
- `MAPL_IncYMD`: the wider ecosystem carries ~12 independent private copies of the legacy GLA GCM `INCYMD` algorithm; none `USE MAPL_Base` for this

## Related

- Part of MAPL3 Base migration: #4805
- Companion to #4811 / #4814 (which removed `MAPL_PackTime`, `MAPL_UnpackTime`, `MAPL_UnpackDateTime`)
