### PR TITLE
Remove zero-caller symbols from Base_Base: MAPL_GenXYOffset, MAPL_SetPointer, MAPL_RemapBounds, MAPL_PinFlagSet/Get (#4817)

### DIFF
--- a/base/Base/Base_Base.F90
+++ b/base/Base/Base_Base.F90
@@ -19,7 +19,7 @@ module MAPL_Base
 
   ! !USES:
   !
-  use ESMF, only: ESMF_MAXSTR, ESMF_PIN_FLAG, ESMF_PIN_DE_TO_SSI_CONTIG
+  use ESMF, only: ESMF_MAXSTR
   use MAPL_Constants, only: MAPL_UNDEF
   use MAPL_TimeInterpolation, only: MAPL_Interp_Fac, MAPL_ClimInterpFac
   use, intrinsic :: iso_fortran_env, only: REAL64
@@ -38,19 +38,14 @@ module MAPL_Base
   public MAPL_GRID_INTERIOR
   public MAPL_Interp_Fac   ! re-exported from MAPL_TimeInterpolation (base3g)
   public MAPL_LatLonGridCreate   ! Creates regular Lat/Lon ESMF Grids
-   public MAPL_RemapBounds
-  public MAPL_SetPointer
-  public MAPL_FieldBundleAdd
+   public MAPL_FieldBundleAdd
   public MAPL_GetHorzIJIndex
   public MAPL_GetGlobalHorzIJIndex
   public MAPL_Reverse_Schmidt
   public MAPL_GenGridName
-  public MAPL_GenXYOffset
   public MAPL_GridGetCorners
   public MAPL_GridGetInterior
   public MAPL_FieldSplit
-  public MAPL_PinFlagSet
-  public MAPL_PinFlagGet
 
 
   !----------------------------------------------------------------------
@@ -60,17 +55,6 @@ module MAPL_Base
      module procedure MAPL_FieldCreateNewgrid
      module procedure MAPL_FieldCreateR4
   end interface MAPL_FieldCreate
-
-  interface MAPL_RemapBounds
-     module procedure MAPL_RemapBoundsFull_3dr4
-     module procedure MAPL_RemapBounds_3dr4
-     module procedure MAPL_RemapBounds_3dr8
-  end interface MAPL_RemapBounds
-
-  interface MAPL_SetPointer
-     module procedure MAPL_SetPointer2DR4
-     module procedure MAPL_SetPointer3DR4
-  end interface MAPL_SetPointer
 
   interface MAPL_FieldBundleAdd
      module procedure MAPL_FieldBundleAddField
@@ -95,23 +79,6 @@ module MAPL_Base
        type(ESMF_Field),  intent(INOUT) :: field
        integer, optional, intent(  OUT) :: rc
      end subroutine MAPL_FieldF90Deallocate
-
-     module subroutine MAPL_SetPointer2DR4(state, ptr, name, rc)
-       use ESMF, only: ESMF_State
-       type(ESMF_State),               intent(INOUT) :: state
-       real,                           pointer       :: ptr(:,:)
-       character(len=*),               intent(IN   ) :: name
-       integer,              optional, intent(  OUT) :: rc
-     end subroutine MAPL_SetPointer2DR4
-
-     module subroutine MAPL_SetPointer3DR4(state, ptr, name, rc)
-       use ESMF, only: ESMF_State
-       type(ESMF_State),               intent(INOUT) :: state
-       real,                           pointer       :: ptr(:,:,:)
-       character(len=*),               intent(IN   ) :: name
-       integer,              optional, intent(  OUT) :: rc
-     end subroutine MAPL_SetPointer3DR4
-
 
      module subroutine MAPL_PICKEM(II,JJ,IM,JM,COUNT)
        integer, intent(IN ) :: IM, JM, COUNT
@@ -144,20 +111,6 @@ module MAPL_Base
        integer, optional, intent(  OUT) :: RC
        type (ESMF_Field)                :: F
      end function MAPL_FieldCreateR4
-
-     !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-     module function MAPL_RemapBounds_3dr4(A, LB1, LB2, LB3) result(ptr)
-       integer,      intent(IN) :: LB1, LB2, LB3
-       real, target, intent(IN) :: A(LB1:,LB2:,LB3:)
-       real, pointer            :: ptr(:,:,:)
-     end function MAPL_RemapBounds_3dr4
-
-     !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-     module function MAPL_RemapBounds_3dr8(A, LB1, LB2, LB3) result(ptr)
-       integer,      intent(IN) :: LB1, LB2, LB3
-       real(kind=REAL64), target, intent(IN) :: A(LB1:,LB2:,LB3:)
-       real(kind=REAL64), pointer            :: ptr(:,:,:)
-     end function MAPL_RemapBounds_3dr8
 
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !>
@@ -379,11 +332,6 @@ module MAPL_Base
        logical,  optional :: geos_style
      end subroutine MAPL_GenGridName
 
-     module function MAPL_GenXYOffset(lon, lat) result(xy)
-       real        :: lon(:), lat(:)
-       integer     :: xy
-     end function MAPL_GenXYOffset
-
       module subroutine MAPL_FieldSplit(field, fields, aliasName, rc)
         use ESMF, only: ESMF_Field
         type(ESMF_Field),          intent(IN   ) :: field
@@ -431,32 +379,8 @@ module MAPL_Base
       module procedure MAPL_FieldBundleGetByIndex
    end interface MAPL_FieldBundleGet
 
-   type(ESMF_Pin_Flag), protected :: pinflag_global = ESMF_PIN_DE_TO_SSI_CONTIG
-
 contains
 
-  ! NAG and Intel need inconsistent workarounds for this function if moved
-  ! into the submodule.  So keeping it here.
-
-  function MAPL_RemapBoundsFull_3dr4(A,I1,IM,J1,JM,L1,LM)
-    integer,      intent(IN) :: I1,IM,J1,JM,L1,LM
-    real, target, intent(IN) :: A(I1:IM,J1:JM,L1:LM)
-    real, pointer            :: MAPL_RemapBoundsFull_3dr4(:,:,:)
-
-    MAPL_RemapBoundsFull_3dr4 => A
-  end function MAPL_RemapBoundsFull_3dr4
-
-  subroutine MAPL_PinFlagSet(pinflag)
-    type(ESMF_PIN_FLAG), intent(in) :: pinflag
-    pinflag_global = pinflag
-  end subroutine MAPL_PinFlagSet
-
-  function MAPL_PinFlagGet() result(pinflag)
-    type(ESMF_PIN_FLAG) :: pinflag
-
-    pinflag = pinflag_global
-  end function MAPL_PinFlagGet
-  
 end module MAPL_Base
 
 module MAPL_BaseMod

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -105,6 +105,7 @@ contains
     _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_AllocateCoupling
 
+
   subroutine MAPL_FieldAllocCommit(field, dims, location, typekind, &
        hw, ungrid, default_value, rc)
     type(ESMF_Field),               intent(INOUT) :: field
@@ -172,8 +173,8 @@ contains
 
     call ESMF_VMGet(vm, ssiSharedMemoryEnabledFlag=ssiSharedMemoryEnabled, _RC)
 
-    ! call pinflag getter
-    pinflag = MAPL_PinFlagGet()
+     ! call pinflag getter
+     pinflag = ESMF_PIN_DE_TO_SSI_CONTIG
 
     if (any(pinflag == [ESMF_PIN_DE_TO_SSI,ESMF_PIN_DE_TO_SSI_CONTIG])) then
        _ASSERT(ssiSharedMemoryEnabled, 'SSI shared memory is NOT supported')
@@ -562,131 +563,6 @@ contains
 
     _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_FieldF90Deallocate
-
-  module subroutine MAPL_SetPointer2DR4(state, ptr, name, rc)
-    type(ESMF_State),               intent(INOUT) :: state
-    real,                           pointer       :: ptr(:,:)
-    character(len=*),               intent(IN   ) :: name
-    integer,              optional, intent(  OUT) :: rc
-
-
-    integer                               :: status
-    character(len=ESMF_MAXSTR), parameter :: IAm='MAPL_SetPointer2DR4'
-
-    type(ESMF_Field)                      :: field
-    type(ESMF_FieldBundle)                :: bundle
-    type(ESMF_Grid)                       :: GRID
-    integer                               :: COUNTS(ESMF_MAXDIM)
-    integer                               :: gridRank
-    integer                               :: I
-    integer                               :: loc
-    integer, allocatable                  :: gridToFieldMap(:)
-    type(ESMF_FieldStatus_Flag)           :: fieldStatus
-
-    _ASSERT(associated(ptr), 'unassociated pointer')
-
-    ! Get Field from state
-
-    loc = index(name,';;')
-
-    if(loc/=0) then
-       call ESMF_StateGet(state, name(:loc-1), Bundle, _RC)
-       call ESMF_StateGet(state, name(loc+2:), Field, _RC)
-    else
-       call ESMF_StateGet(state, name, Field, _RC)
-    end if
-
-    call ESMF_FieldGet(field, status=fieldStatus, _RC)
-    _ASSERT(fieldStatus /= ESMF_FIELDSTATUS_COMPLETE, 'fieldStatus == ESMF_FIELDSTATUS_COMPLETE')
-
-    call ESMF_FieldGet(field, grid=GRID, _RC)
-    call MAPL_GridGet(GRID, localCellCountPerDim=COUNTS, _RC)
-
-    _ASSERT(size(ptr,1) == COUNTS(1), 'shape mismatch dim=1')
-    _ASSERT(size(ptr,2) == COUNTS(2), 'shape mismatch dim=2')
-    call ESMF_GridGet(GRID, dimCount=gridRank, _RC)
-    ! MAPL restriction (actually only the first 2 dims are distributted)
-    _ASSERT(gridRank <= 3, 'gridRank > 3 not supported')
-    allocate(gridToFieldMap(gridRank), _STAT)
-    do I = 1, gridRank
-       gridToFieldMap(I) = I
-    end do
-
-    ! this is 2d case
-    if (gridRank == 3) gridToFieldMap(3) = 0
-
-    call ESMF_FieldEmptyComplete(FIELD, farrayPtr=ptr, &
-         datacopyFlag = ESMF_DATACOPY_REFERENCE,       &
-         gridToFieldMap=gridToFieldMap,                &
-         _RC)
-
-    ! Clean up
-    deallocate(gridToFieldMap)
-
-
-    _RETURN(ESMF_SUCCESS)
-  end subroutine MAPL_SetPointer2DR4
-
-  module subroutine MAPL_SetPointer3DR4(state, ptr, name, rc)
-    type(ESMF_State),               intent(INOUT) :: state
-    real,                           pointer       :: ptr(:,:,:)
-    character(len=*),               intent(IN   ) :: name
-    integer,              optional, intent(  OUT) :: rc
-
-
-    integer                               :: status
-    character(len=ESMF_MAXSTR), parameter :: IAm='MAPL_SetPointer3DR4'
-
-    type(ESMF_Field)                      :: field
-    type(ESMF_FieldBundle)                :: bundle
-    type(ESMF_Grid)                       :: GRID
-    integer                               :: COUNTS(ESMF_MAXDIM)
-    integer                               :: gridRank
-    integer                               :: I
-    integer                               :: loc
-    integer, allocatable                  :: gridToFieldMap(:)
-    type(ESMF_FieldStatus_Flag)             :: fieldStatus
-
-    _ASSERT(associated(ptr), 'unassociated pointer')
-
-    ! Get Field from state
-
-    loc = index(name,';;')
-
-    if(loc/=0) then
-       call ESMF_StateGet(state, name(:loc-1), Bundle, _RC)
-       call ESMF_StateGet(state, name(loc+2:), Field, _RC)
-    else
-       call ESMF_StateGet(state, name, Field, _RC)
-    end if
-
-    call ESMF_FieldGet(field, status=fieldStatus, _RC)
-    _ASSERT(fieldStatus /= ESMF_FIELDSTATUS_COMPLETE, 'fieldStatus == ESMF_FIELDSTATUS_COMPLETE')
-
-    call ESMF_FieldGet(field, grid=GRID, _RC)
-    call MAPL_GridGet(GRID, localCellCountPerDim=COUNTS, _RC)
-
-    _ASSERT(size(ptr,1) == COUNTS(1), 'shape mismatch dim=1')
-    _ASSERT(size(ptr,2) == COUNTS(2), 'shape mismatch dim=2')
-    call ESMF_GridGet(GRID, dimCount=gridRank, _RC)
-    ! MAPL restriction (actually only the first 2 dims are distributted)
-    _ASSERT(gridRank <= 3, 'gridRank > 3 not supported')
-    allocate(gridToFieldMap(gridRank), _STAT)
-    do I = 1, gridRank
-       gridToFieldMap(I) = I
-    end do
-
-    call ESMF_FieldEmptyComplete(FIELD, farrayPtr=ptr, &
-         datacopyFlag = ESMF_DATACOPY_REFERENCE,       &
-         gridToFieldMap=gridToFieldMap,                &
-         _RC)
-
-    ! Clean up
-    deallocate(gridToFieldMap)
-
-
-    _RETURN(ESMF_SUCCESS)
-  end subroutine MAPL_SetPointer3DR4
 
   pure subroutine MAPL_DecomposeDim ( dim_world,dim,NDEs, unusable, symmetric, min_DE_extent )
     use MAPL_KeywordEnforcerMod
@@ -1146,24 +1022,6 @@ contains
 
      _RETURN(ESMF_SUCCESS)
   end subroutine MAPL_FieldCopyAttributes
-
-  !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  module function MAPL_RemapBounds_3dr4(A, LB1, LB2, LB3) result(ptr)
-    integer,      intent(IN) :: LB1, LB2, LB3
-    real, target, intent(IN) :: A(LB1:,LB2:,LB3:)
-    real, pointer            :: ptr(:,:,:)
-
-    ptr => A
-  end function MAPL_RemapBounds_3dr4
-
-  !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-  module function MAPL_RemapBounds_3dr8(A, LB1, LB2, LB3) result(ptr)
-    integer,      intent(IN) :: LB1, LB2, LB3
-    real(kind=REAL64), target, intent(IN) :: A(LB1:,LB2:,LB3:)
-    real(kind=REAL64), pointer            :: ptr(:,:,:)
-
-    ptr => A
-  end function MAPL_RemapBounds_3dr8
 
   module subroutine MAPL_GRID_INTERIOR(GRID,I1,IN,J1,JN)
     type (ESMF_Grid), intent(IN) :: grid
@@ -2453,35 +2311,6 @@ contains
     end if
 
   end subroutine MAPL_GenGridName
-
-  module function MAPL_GenXYOffset(lon, lat) result(xy)
-    real        :: lon(:), lat(:)
-    integer     :: xy
-
-    integer           :: I
-    integer           :: p, d
-    real, parameter   :: eps=1.0e-4
-
-    p = 0 ! default
-    d = 0 ! default
-
-    if(abs(LAT(1) + 90.0) < eps) then
-       p=0 ! 'PC'
-    else if (abs(LAT(1) + 90.0 - 0.5*(LAT(2)-LAT(1))) < eps) then
-       p=1 ! 'PE'
-    end if
-    do I=0,1
-       if(abs(LON(1) + 180.0*I) < eps) then
-          d=0 ! 'DC'
-          exit
-       else if (abs(LON(1) + 180.0*I - 0.5*(LON(2)-LON(1))) < eps) then
-          d=1 ! 'DE'
-          exit
-       end if
-    end do
-    xy = 2*p + d
-     return
-  end function MAPL_GenXYOffset
 
   module subroutine MAPL_FieldSplit(field, fields, aliasName, rc)
     type(ESMF_Field),          intent(IN   ) :: field


### PR DESCRIPTION
## Summary

Remove five public symbols (nine procedures total) from `base/Base/Base_Base.F90` and `base/Base/Base_Base_implementation.F90` — all confirmed to have zero external callers anywhere in the GEOSgcm ecosystem.

Closes #4817

## Symbols removed

- `MAPL_GenXYOffset` — detects PC/PE and DC/DE grid offset from lon/lat arrays
- `MAPL_SetPointer` (x2: `MAPL_SetPointer2DR4`, `MAPL_SetPointer3DR4`) — points R4 array pointer at named field in ESMF state
- `MAPL_RemapBounds` (x3: `MAPL_RemapBoundsFull_3dr4`, `MAPL_RemapBounds_3dr4`, `MAPL_RemapBounds_3dr8`) — remaps lower bounds of 3D array pointer
- `MAPL_PinFlagSet` / `MAPL_PinFlagGet` — get/set a module-level `ESMF_PIN_FLAG` variable; also removes the `pinflag_global` module variable

Also inlines the default pin flag value (`ESMF_PIN_DE_TO_SSI_CONTIG`) directly into `MAPL_FieldAllocCommit`, which was the only remaining internal caller of `MAPL_PinFlagGet`. If/when SSI pinning is needed in MAPL3 it should be properly integrated into v3 `FieldCreate`/`FieldEmptyComplete` rather than via a module variable.

## Related

- Part of MAPL3 Base migration: #4805
- Companion to #4816
