### PR TITLE
Migrate internal MAPL callers of MAPL_AllocateCoupling to MAPL_FieldEmptyComplete

### DIFF
--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -34,6 +34,7 @@ module ESMFL_MOD
   use MAPL_Constants
   use MAPL_BaseMod
   use MAPL_CommsMod
+  use mapl3g_Field_API, only: MAPL_FieldEmptyComplete
   use MAPL_ExceptionHandling
   use, intrinsic :: iso_fortran_env, only: REAL32, REAL64
   implicit none
@@ -274,7 +275,7 @@ contains
       NeedNewField = NotInState .or. (NameInState/=NameInBundle)
 
       if (.not. NotInState) then
-         call MAPL_AllocateCoupling(stateField, rc=status)
+         call MAPL_FieldEmptyComplete(stateField, rc=status)
          _VERIFY(STATUS)
       end if
 

--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -16,6 +16,7 @@ module NCIOMod
   use ESMF
   use MAPL_BaseMod
   use MAPL_CommsMod
+  use mapl3g_Field_API, only: MAPL_FieldEmptyComplete
   use MAPL_SortMod
   use mapl3g_EASEConversion, only: MAPL_get_ease_gridname_by_cols => get_ease_gridname_by_cols
   !use MAPL_RangeMod
@@ -3056,7 +3057,7 @@ contains
          call ESMF_InfoGet(infoh, key='MAPL_RestoreExport', value=restore_export, _RC)
       end if
       if (restore_export) then
-         call MAPL_AllocateCoupling(field, _RC)
+         call MAPL_FieldEmptyComplete(field, _RC)
       end if
 
       call MAPL_FieldReadNCPar(formatter, FieldName, field, arrdes=arrdes, HomePE=mask, rc=status)


### PR DESCRIPTION
## Summary

- Replaces `call MAPL_AllocateCoupling(...)` with `call MAPL_FieldEmptyComplete(...)` in the two internal MAPL call sites: `base/ESMFL_Mod.F90` and `base/NCIO.F90`
- Adds `use mapl3g_Field_API, only: MAPL_FieldEmptyComplete` to both files
- Does **not** yet remove `MAPL_AllocateCoupling` from Base — external callers (GOCART, GEOSgigatraj) are being handled in separate PRs to those repos

## Context

Part of the MAPL3 migration (closes #4820). `MAPL_FieldEmptyComplete` (`field_empty_complete_from_info` overload) is the MAPL3 replacement: it reads all field metadata from `ESMF_Info` and has identical behavior to `MAPL_AllocateCoupling`.

The full removal of `MAPL_AllocateCoupling` from Base follows once external callers in GOCART and GEOSgigatraj are migrated.
