### PR TITLE
Export mapl3g_Field_API from MAPL umbrella module

### DIFF
--- a/mapl3g/MAPL.F90
+++ b/mapl3g/MAPL.F90
@@ -10,6 +10,7 @@ module MAPL
    use mapl3g_hconfig_API
    use mapl3g_VerticalGrid_API
    use mapl3g_UngriddedDims, only: UngriddedDims
+   use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use MAPL_PythonBridge
    use mapl_base3g


### PR DESCRIPTION
## Summary

- Adds `use mapl3g_Field_API` to `mapl3g/MAPL.F90` alongside the existing `use mapl3g_FieldBundle_API`

## Context

`mapl3g_FieldBundle_API` was already exported from the `MAPL` umbrella module, making all FieldBundle MAPL3 symbols available transitively via `use MAPL`. However, `mapl3g_Field_API` (which provides `MAPL_FieldEmptyComplete` and other Field symbols) was missing, forcing callers to add an explicit `use mapl3g_Field_API` — an unnecessary burden and inconsistency.

Discovered while migrating callers of `MAPL_AllocateCoupling` to `MAPL_FieldEmptyComplete` (see #4820).

Closes #4822.
