### PR TITLE
Remove MAPL_GetPointer/GetPointer.H from Base; migrate internal callers to MAPL_StateGetPointer

### DIFF
--- a/state/StateMasking.F90
+++ b/state/StateMasking.F90
@@ -10,6 +10,7 @@ module MAPL_StateMaskMod
    use gFTL2_StringVector
    use MAPL_StateArithmeticParserMod
    use MAPL_Constants
+   use mapl3g_State_API, only: MAPL_StateGetPointer
    implicit none
    private
 
@@ -137,13 +138,13 @@ module MAPL_StateMaskMod
        vartomask = this%mask_arguments(:ib-1)
        maskname = this%mask_arguments(ib+1:ie-1)
 
-       call MAPL_GetPointer(state,rmask,maskName,_RC)
+       call MAPL_StateGetPointer(state,rmask,maskName,_RC)
        if (rank == 2) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var2d,_RC)
-          call MAPL_GetPointer(state,var2d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var2d, vartomask, _RC)
        else if (rank == 3) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var3d,_RC)
-          call MAPL_GetPointer(state,var3d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var3d, vartomask, _RC)
        else
           _FAIL('Rank must be 2 or 3')
        end if
@@ -227,10 +228,10 @@ module MAPL_StateMaskMod
 
        if (rank == 2) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var2d,_RC)
-          call MAPL_GetPointer(state,var2d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var2d, vartomask, _RC)
        else if (rank == 3) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var3d,_RC)
-          call MAPL_GetPointer(state,var3d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var3d, vartomask, _RC)
        else
           _FAIL('Rank must be 2 or 3')
        end if
@@ -374,10 +375,10 @@ module MAPL_StateMaskMod
 
        if (rank == 2) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var2d,_RC)
-          call MAPL_GetPointer(state,var2d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var2d, vartomask, _RC)
        else if (rank == 3) then
           call ESMF_FieldGet(field,0,farrayPtr=out_var3d,_RC)
-          call MAPL_GetPointer(state,var3d, vartomask, _RC)
+          call MAPL_StateGetPointer(state,var3d, vartomask, _RC)
        else
           _FAIL('Rank must be 2 or 3')
        end if


### PR DESCRIPTION
## Summary

- Migrates `state/StateMasking.F90` from `MAPL_GetPointer` to `MAPL_StateGetPointer` (7 active call sites)
- Adds `use mapl3g_State_API, only: MAPL_StateGetPointer` to `StateMasking.F90`

## Context

Part of the MAPL3 Base cleanup (closes #4825). `MAPL_GetPointer` is a legacy CPP macro alias for `ESMFL_StateGetPointerToData` (generated via `GetPointer.H`). `MAPL_StateGetPointer` is the MAPL3 replacement, already available via `use MAPL`.

This PR handles the single internal MAPL caller. The removal of `MAPL_GetPointer`/`GetPointer.H`/`ESMFL_StateGetPointerToData` from Base will follow in a subsequent commit to this branch once GEOS-ESM/GOCART#423 is merged.

**Note:** This PR is currently only the StateMasking migration. The full `GetPointer.H` removal will be added to this branch after GEOS-ESM/GOCART#422 merges.
