### PR TITLE
Remove MAPL_GetPointer, GET_POINTER, MAPL_FieldGetPointer macros and implementations from Base

### DIFF
--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -48,8 +48,6 @@ module ESMFL_MOD
   !PUBLIC MEMBER FUNCTIONS:
   public ESMFL_StateGetField
   public ESMFL_StateGetFieldArray
-  public ESMFL_StateGetPointerToData
-  public ESMFL_FieldGetPointerToData
   public ESMFL_BundleGetPointerToData
   public ESMFL_BundleCpyField
   public ESMFL_GridCoordGet
@@ -118,28 +116,6 @@ module ESMFL_MOD
 
   interface ESMFL_BundleAddState
     module procedure BundleAddState_
-  end interface
-
-  interface ESMFL_StateGetPointerToData
-     module procedure ESMFL_StateGetPtrToDataR4_1
-     module procedure ESMFL_StateGetPtrToDataR4_2
-     module procedure ESMFL_StateGetPtrToDataR4_3
-     module procedure ESMFL_StateGetPtrToDataR4_4
-     module procedure ESMFL_StateGetPtrToDataR8_1
-     module procedure ESMFL_StateGetPtrToDataR8_2
-     module procedure ESMFL_StateGetPtrToDataR8_3
-     module procedure ESMFL_StateGetPtrToDataR8_4
-  end interface
-
-  interface ESMFL_FieldGetPointerToData
-     module procedure ESMFL_FieldGetPtrToDataR4_1
-     module procedure ESMFL_FieldGetPtrToDataR4_2
-     module procedure ESMFL_FieldGetPtrToDataR4_3
-     module procedure ESMFL_FieldGetPtrToDataR4_4
-     module procedure ESMFL_FieldGetPtrToDataR8_1
-     module procedure ESMFL_FieldGetPtrToDataR8_2
-     module procedure ESMFL_FieldGetPtrToDataR8_3
-     module procedure ESMFL_FieldGetPtrToDataR8_4
   end interface
 
   interface ESMFL_BundleGetPointerToData
@@ -606,32 +582,6 @@ function ESMFL_StateFieldIsNeeded(STATE, NAME, RC) result(NEEDED)
 
 #undef VARTYPE_
 
-
-#define VARTYPE_ 3
-
-#define RANK_ 1
-#include "GetPointer.H"
-#define RANK_ 2
-#include "GetPointer.H"
-#define RANK_ 3
-#include "GetPointer.H"
-#define RANK_ 4
-#include "GetPointer.H"
-
-#undef VARTYPE_
-
-#define VARTYPE_ 4
-
-#define RANK_ 1
-#include "GetPointer.H"
-#define RANK_ 2
-#include "GetPointer.H"
-#define RANK_ 3
-#include "GetPointer.H"
-#define RANK_ 4
-#include "GetPointer.H"
-
-#undef VARTYPE_
 
  subroutine AdjustPtrBounds1dr4(PTR, A, I1, IN)
    real(KIND=ESMF_KIND_R4), pointer :: PTR(:)

--- a/include/MAPL.h
+++ b/include/MAPL.h
@@ -3,13 +3,6 @@
 #include "MAPL_ErrLog.h"
 #include "unused_dummy.H"
 
-#undef  GET_POINTER
-#define GET_POINTER     ESMFL_StateGetPointerToData
-#undef  MAPL_GetPointer
-#define MAPL_GetPointer ESMFL_StateGetPointerToData
-#undef  MAPL_FieldGetPointer
-#define MAPL_FieldGetPointer ESMFL_FieldGetPointerToData
-
 #ifdef  GR8
 
 #define MAPL_real  real(MAPL_R8)


### PR DESCRIPTION
## Summary

Remove legacy GetPointer symbols from MAPL Base now that all external callers have been migrated:

- `GET_POINTER` / `MAPL_GetPointer` → `ESMFL_StateGetPointerToData`: last external caller (`GEOS_GigatrajGridComp`) migrated in GEOSgcm_GridComp#1404
- `MAPL_FieldGetPointer` → `ESMFL_FieldGetPointerToData`: zero callers anywhere

## Changes

**`include/MAPL.h`**: remove `GET_POINTER`, `MAPL_GetPointer`, `MAPL_FieldGetPointer` macro definitions

**`base/ESMFL_Mod.F90`**: remove
- `public ESMFL_StateGetPointerToData`
- `public ESMFL_FieldGetPointerToData`
- `ESMFL_StateGetPointerToData` interface block and 8× `GetPointer.H` includes
- `ESMFL_FieldGetPointerToData` interface block and 8× `GetFieldArray.H` includes

`ESMFL_BundleGetPointerToData` is **retained** — active callers remain.

Closes #4825