### PR TITLE
Switch lightweight workflows to ubuntu-slim

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: dangoslen/changelog-enforcer@v3
       with:

--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pull_request:
     name: Create Pull Request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pull_request:
     name: Create Pull Request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/scheduled_workflows.yml
+++ b/.github/workflows/scheduled_workflows.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   dispatch_workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - run: gh workflow run spack-ci.yml --repo GEOS-ESM/MAPL --ref main
       - run: gh workflow run spack-ci.yml --repo GEOS-ESM/MAPL --ref develop

--- a/.github/workflows/trigger-circleci-pipeline-on-release.yml
+++ b/.github/workflows/trigger-circleci-pipeline-on-release.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 jobs:
   trigger-circleci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: CircleCI Trigger on Release
         id: docker-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switch 6 lightweight CI workflows to `ubuntu-slim` runner to reduce concurrency pressure on `ubuntu-latest` (#4841)
+
 - Update `components.yaml`
   - ESMA_cmake v4.37.0
     - Add `Coverage` CMake build type


### PR DESCRIPTION
## Types of change(s)
- [x] CI/workflow change

## Description

Migrate 6 automation-only workflows from `ubuntu-latest` to the new `ubuntu-slim` (1 vCPU, 5 GB RAM) runner to reduce concurrency pressure.

Workflows migrated:
- `changelog-enforcer.yml`
- `cron-stale.yml`
- `push-to-develop.yml`
- `push-to-main.yml`
- `scheduled_workflows.yml`
- `trigger-circleci-pipeline-on-release.yml`

Note: Docker-based actions (`markup-link-checker`, `validate_yaml_files`) are excluded — `ubuntu-slim` runs inside a container with no Docker daemon, so Docker-in-Docker actions fail.

Closes #4841