### PR TITLE
Migrate internal MAPL callers of MAPL_BaseMod to source modules; export mapl_GridGetGlobalCellCountPerDim from geom API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export `mapl_GridGetGlobalCellCountPerDim` from `mapl3g_Geom_API` (`geom/API.F90`) via `mapl3g_GridGetGlobal` (#4857)
+- Migrate internal MAPL callers of `MAPL_BaseMod` in `base/` and `GeomIO/` and `state/` to use source modules directly, as preparation for eventual deletion of `Base_Base.F90` (#4857)
+
 - Added `EASEGeomSpec` and `EASEGeomFactory` to `MAPL.geom` (`geom/EASE/`),
   porting the legacy EASE (Equal-Area Scalable Earth) grid from `MAPL.base`.
   Supports EASEv1 and EASEv2 cylindrical ('M') grids for all standard resolutions

--- a/GeomIO/Grid_PFIO.F90
+++ b/GeomIO/Grid_PFIO.F90
@@ -9,7 +9,7 @@ module mapl3g_GridPFIO
    use mapl3g_SharedIO
    use ESMF
    use PFIO
-   use MAPL_BaseMod
+   use MAPL_Constants,  only: MAPL_RADIANS_TO_DEGREES
    use MAPL_FieldPointerUtilities
    use mapl3g_pFIOServerBounds, only: pFIOServerBounds, PFIO_BOUNDS_WRITE, PFIO_BOUNDS_READ
 

--- a/GeomIO/SharedIO.F90
+++ b/GeomIO/SharedIO.F90
@@ -12,8 +12,8 @@ module mapl3g_SharedIO
    use mapl3g_StringDictionary
    use gFTL2_StringSet
    use mapl3g_Geom_API
-   use MAPL_BaseMod
    use mapl3g_UngriddedDims
+   use, intrinsic :: iso_fortran_env, only: REAL64
    use mapl3g_UngriddedDim
    use mapl3g_CompressionSettings
    use esmf

--- a/GeomIO/pFIOServerBounds.F90
+++ b/GeomIO/pFIOServerBounds.F90
@@ -7,7 +7,7 @@ module mapl3g_pFIOServerBounds
    use pfio
    use gFTL2_StringVector
    use mapl3g_Geom_API, only: MAPL_GridGet
-   use MAPL_BaseMod, only: MAPL2_GridGet => MAPL_GridGet
+   use mapl_MaplGrid, only: MAPL2_GridGet => MAPL_GridGet
 
    implicit none
    private

--- a/base/Base.F90
+++ b/base/Base.F90
@@ -4,7 +4,7 @@ module MAPLBase_Mod
 
   use ESMFL_Mod         !  Stopgap
   use MAPL_ExceptionHandling
-  use MAPL_BaseMod
+
    use NCIOMod
   use MAPL_LocStreamMod
   use MAPL_ShmemMod

--- a/base/ESMFL_Mod.F90
+++ b/base/ESMFL_Mod.F90
@@ -31,8 +31,8 @@ module ESMFL_MOD
 
   !USES:
   use ESMF
-  use MAPL_Constants
-  use MAPL_BaseMod
+   use MAPL_Constants
+   use mapl_MaplGrid,  only: MAPL_GridGet, MAPL_DistGridGet, MAPL_GetImsJms, MAPL_GridHasDE
   use MAPL_CommsMod
    use mapl3g_Field_API, only: MAPL_FieldEmptyComplete, MAPL_FieldClone
   use MAPL_ExceptionHandling

--- a/base/MAPL_LocStreamMod.F90
+++ b/base/MAPL_LocStreamMod.F90
@@ -24,7 +24,7 @@ module MAPL_LocStreamMod
 
 use ESMF
 use ESMFL_Mod
-use MAPL_BaseMod
+use mapl_MaplGrid,  only: MAPL_GridGet
 use MAPL_Constants
 use mapl3g_GridGet, only: geom_GridGet => GridGet
 use NCIOMod, only: MAPL_ReadTilingNC4

--- a/base/MAPL_VerticalInterpMod.F90
+++ b/base/MAPL_VerticalInterpMod.F90
@@ -17,8 +17,8 @@
       module linearVerticalInterpolation_mod
 
       use ESMF
-      use MAPL_BaseMod
       use MAPL_Constants, only: MAPL_KAPPA, MAPL_RGAS, MAPL_CP, MAPL_GRAV
+      use mapl_MaplGrid,  only: MAPL_GridGet
       use MAPL_ExceptionHandling
       use, intrinsic :: iso_fortran_env, only: REAL64
 !

--- a/base/MAPL_VerticalMethods.F90
+++ b/base/MAPL_VerticalMethods.F90
@@ -2,8 +2,9 @@
 
 module MAPL_VerticalDataMod
   use ESMF
-  use MAPL_BaseMod
-  use MAPL_Profiler
+   use MAPL_Constants,  only: MAPL_UNDEF, MAPL_GRAV
+   use mapl_MaplGrid,   only: MAPL_GridGet, MAPL_GridHasDE
+   use MAPL_Profiler
   use pFIO
   use MAPL_ExceptionHandling
   use MAPL_Constants

--- a/geom/API.F90
+++ b/geom/API.F90
@@ -8,6 +8,7 @@ module mapl3g_Geom_API
    use mapl3g_GeomGet, only: mapl_GeomGet => GeomGet
    use mapl3g_GridGet, only: mapl_GridGet => GridGet, mapl_GridGetCoordinates => GridGetCoordinates
    use mapl3g_GridGetHorzIJIndex, only: mapl_GridGetHorzIJIndex => GridGetHorzIJIndex
+   use mapl3g_GridGetGlobal, only: mapl_GridGetGlobalCellCountPerDim => GridGetGlobalCellCountPerDim
    use mapl3g_GeomGetHorzIJIndex, only: mapl_GeomGetHorzIJIndex => GeomGetHorzIJIndex
    use mapl3g_Subgrid, only: mapl_Interval => Interval, mapl_make_subgrids => make_subgrids
    use mapl3g_XYGeomSpec,    only: XYGeomSpec, make_XYGeomSpec, XY_COORD_STANDARD, XY_COORD_ABI
@@ -23,6 +24,7 @@ module mapl3g_Geom_API
    public :: mapl_GridGet
    public :: mapl_GridGetCoordinates
    public :: mapl_GridGetHorzIJIndex, mapl_GeomGetHorzIJIndex
+   public :: mapl_GridGetGlobalCellCountPerDim
 
    ! Used internally by MAPL
    ! Users shouldn't need these

--- a/state/StateArithmeticParser.F90
+++ b/state/StateArithmeticParser.F90
@@ -51,8 +51,8 @@
 MODULE MAPL_StateArithmeticParserMod
 
   use ESMF
-  use MAPL_BaseMod
-  use MAPL_FieldUtils
+   use MAPL_Constants,  only: MAPL_UNDEF
+   use MAPL_FieldUtils
   use MAPL_CommsMod
   use MAPL_ExceptionHandling
   use gFTL2_StringVector

--- a/state/StateMasking.F90
+++ b/state/StateMasking.F90
@@ -5,7 +5,7 @@ module MAPL_StateMaskMod
    use ESMF
    use MAPL_KeywordEnforcerMod
    use ESMFL_Mod
-   use MAPL_BaseMod
+   use mapl_MaplGrid,   only: MAPL_GridGet
    use MAPL_ExceptionHandling
    use gFTL2_StringVector
    use MAPL_StateArithmeticParserMod


### PR DESCRIPTION
## Summary

Part of #4857 (and the broader #4847 effort to delete `Base_Base.F90`).

This PR migrates all internal MAPL callers of `use MAPL_BaseMod` in `base/`, `GeomIO/`, and `state/` to use the appropriate source modules directly, and exports `mapl_GridGetGlobalCellCountPerDim` from the `mapl3g_Geom_API` module so that client repos can use it without depending on `MAPL_BaseMod`.

### Changes

- `geom/API.F90`: export `mapl_GridGetGlobalCellCountPerDim` from `mapl3g_GridGetGlobal`
- `base/MAPL_LocStreamMod.F90`, `base/ESMFL_Mod.F90`, `base/MAPL_VerticalMethods.F90`, `base/MAPL_VerticalInterpMod.F90`, `base/Base.F90`: migrate `use MAPL_BaseMod` → `use mapl_MaplGrid` / `use MAPL_Constants` as appropriate
- `GeomIO/SharedIO.F90`, `GeomIO/Grid_PFIO.F90`, `GeomIO/pFIOServerBounds.F90`: same migration
- `state/StateArithmeticParser.F90`, `state/StateMasking.F90`: same migration
- `base/FileIOShared.F90`, `base/NCIO.F90`: these were superseded by #4858 which already did a more thorough migration for those two files

### Dependent / related PRs

- GEOS-ESM/GEOS_Util#222 ✅ merged
- GEOS-ESM/GMAO_Shared#429 ✅ merged
- GEOS-ESM/FVdycoreCubed_GridComp#371 — open, will be updated to use `mapl_GridGetGlobalCellCountPerDim` from `MAPL` after this merges
- GEOS-ESM/GOCART#430 — open, will be updated similarly