### PR TITLE
Delete empty Base_Base_implementation.F90 and base/Base/ directory (#4865)

### DIFF
--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -1,1 +1,0 @@
-! Intentionally empty - all procedures removed in favor of v3 geom equivalents.


### PR DESCRIPTION
## Summary

- Deletes `base/Base/Base_Base_implementation.F90`, which was intentionally left empty after all procedures were migrated to v3 geom equivalents
- Removes the now-empty `base/Base/` directory
- File was already removed from `CMakeLists.txt` in a prior PR; this is purely a source tree cleanup

Closes #4865