### PR TITLE
v3: Reduce CircleCI usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,22 +26,25 @@ orbs:
 workflows:
   build-and-test-MAPL:
     jobs:
-      # Builds MAPL in a "default" way
-      - ci/build:
-          name: build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-<< matrix.cmake_generator >>
-          context:
-            - docker-hub-creds
-          matrix:
-            parameters:
-              compiler: [gfortran, ifort, ifx]
-              cmake_generator: ['Unix Makefiles']
-              build_type: ['Debug']
-          baselibs_version: *baselibs_version
-          repo: MAPL
-          mepodevelop: false
-          run_unit_tests: true
-          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
-          persist_workspace: false # Needed for MAPL tutorials
+      # For now, we do MAPL builds in GitHub only
+      ########################################################################################################################
+      # # Builds MAPL in a "default" way                                                                                     #
+      # - ci/build:                                                                                                          #
+      #     name: build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-<< matrix.cmake_generator >> #
+      #     context:                                                                                                         #
+      #       - docker-hub-creds                                                                                             #
+      #     matrix:                                                                                                          #
+      #       parameters:                                                                                                    #
+      #         compiler: [gfortran, ifort, ifx]                                                                             #
+      #         cmake_generator: ['Unix Makefiles']                                                                          #
+      #         build_type: ['Debug']                                                                                        #
+      #     baselibs_version: *baselibs_version                                                                              #
+      #     repo: MAPL                                                                                                       #
+      #     mepodevelop: false                                                                                               #
+      #     run_unit_tests: true                                                                                             #
+      #     ctest_options: "-L 'ESSENTIAL' --output-on-failure"                                                              #
+      #     persist_workspace: false # Needed for MAPL tutorials                                                             #
+      ########################################################################################################################
 
       # Tutorials have been removed (for now) from MAPL3
       # NOTE: When we restore tutorials, change persist_workspace to true above!!!
@@ -67,25 +70,6 @@ workflows:
       #     baselibs_version: *baselibs_version                                                                         #
       ###################################################################################################################
 
-      # Builds MAPL without pFlogger and fargparse and pFUnit
-      - ci/build:
-          name: build-MAPL-without-pFlogger-and-fArgParse-and-pFUnit-as-<< matrix.build_type >>-on-<< matrix.compiler >>
-          context:
-            - docker-hub-creds
-          matrix:
-            parameters:
-              compiler: [ifort]
-              build_type: ['Debug']
-          baselibs_version: *baselibs_version
-          repo: MAPL
-          mepodevelop: false
-          remove_flap: true
-          remove_pflogger: true
-          remove_pfunit: true
-          extra_cmake_options: "-DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF"
-          run_unit_tests: true
-          ctest_options: "-L 'ESSENTIAL' --output-on-failure"
-
   # MAPL3 will soon break GEOSgcm builds. We believe it can build, but not currently run
   #build-and-run-GEOSgcm:
   build-GEOSgcm:
@@ -97,7 +81,9 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort, ifx]
+              # To save CircleCI resources, we build only with ifx for now
+              #compiler: [gfortran, ifort, ifx]
+              compiler: [ifx]
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
@@ -148,7 +134,9 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort, ifx]
+              # To save CircleCI resources, we run GOCART tests only with ifx for now
+              #compiler: [gfortran, ifort, ifx]
+              compiler: [ifx]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,51 +24,52 @@ orbs:
   ci: geos-esm/circleci-tools@4
 
 workflows:
-  build-and-test-MAPL:
-    jobs:
-      # For now, we do MAPL builds in GitHub only
-      ########################################################################################################################
-      # # Builds MAPL in a "default" way                                                                                     #
-      # - ci/build:                                                                                                          #
-      #     name: build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-<< matrix.cmake_generator >> #
-      #     context:                                                                                                         #
-      #       - docker-hub-creds                                                                                             #
-      #     matrix:                                                                                                          #
-      #       parameters:                                                                                                    #
-      #         compiler: [gfortran, ifort, ifx]                                                                             #
-      #         cmake_generator: ['Unix Makefiles']                                                                          #
-      #         build_type: ['Debug']                                                                                        #
-      #     baselibs_version: *baselibs_version                                                                              #
-      #     repo: MAPL                                                                                                       #
-      #     mepodevelop: false                                                                                               #
-      #     run_unit_tests: true                                                                                             #
-      #     ctest_options: "-L 'ESSENTIAL' --output-on-failure"                                                              #
-      #     persist_workspace: false # Needed for MAPL tutorials                                                             #
-      ########################################################################################################################
-
-      # Tutorials have been removed (for now) from MAPL3
-      # NOTE: When we restore tutorials, change persist_workspace to true above!!!
-      ###################################################################################################################
-      # # Run MAPL Tutorials                                                                                            #
-      # - ci/run_mapl_tutorial:                                                                                         #
-      #     name: run-<< matrix.tutorial_name >>-Tutorial-with-<< matrix.compiler >>-built-with-<< matrix.build_type >> #
-      #     context:                                                                                                    #
-      #       - docker-hub-creds                                                                                        #
-      #     matrix:                                                                                                     #
-      #       parameters:                                                                                               #
-      #         compiler: [ifort]                                                                                       #
-      #         build_type: ['Debug']                                                                                   #
-      #         tutorial_name:                                                                                          #
-      #           - hello_world                                                                                         #
-      #           - parent_no_children                                                                                  #
-      #           - parent_one_child_import_via_extdata                                                                 #
-      #           - parent_one_child_no_imports                                                                         #
-      #           - parent_two_siblings_connect_import_export                                                           #
-      #     # We will only run the tutorials with GNU make. No need to double up as Ninja is a build test only          #
-      #     requires:                                                                                                   #
-      #       - build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-Unix Makefiles            #
-      #     baselibs_version: *baselibs_version                                                                         #
-      ###################################################################################################################
+  ############################################################################################################################
+  # build-and-test-MAPL:                                                                                                     #
+  #   jobs:                                                                                                                  #
+  #     # For now, we do MAPL builds in GitHub only                                                                          #
+  #     # Builds MAPL in a "default" way                                                                                     #
+  #     - ci/build:                                                                                                          #
+  #         name: build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-<< matrix.cmake_generator >> #
+  #         context:                                                                                                         #
+  #           - docker-hub-creds                                                                                             #
+  #         matrix:                                                                                                          #
+  #           parameters:                                                                                                    #
+  #             compiler: [gfortran, ifort, ifx]                                                                             #
+  #             cmake_generator: ['Unix Makefiles']                                                                          #
+  #             build_type: ['Debug']                                                                                        #
+  #         baselibs_version: *baselibs_version                                                                              #
+  #         repo: MAPL                                                                                                       #
+  #         mepodevelop: false                                                                                               #
+  #         run_unit_tests: true                                                                                             #
+  #         ctest_options: "-L 'ESSENTIAL' --output-on-failure"                                                              #
+  #         persist_workspace: false # Needed for MAPL tutorials                                                             #
+  #                                                                                                                          #
+  #     # Tutorials have been removed (for now) from MAPL3                                                                   #
+  #     # NOTE: When we restore tutorials, change persist_workspace to true above!!!                                         #
+  #     ###################################################################################################################  #
+  #     # # Run MAPL Tutorials                                                                                            #  #
+  #     # - ci/run_mapl_tutorial:                                                                                         #  #
+  #     #     name: run-<< matrix.tutorial_name >>-Tutorial-with-<< matrix.compiler >>-built-with-<< matrix.build_type >> #  #
+  #     #     context:                                                                                                    #  #
+  #     #       - docker-hub-creds                                                                                        #  #
+  #     #     matrix:                                                                                                     #  #
+  #     #       parameters:                                                                                               #  #
+  #     #         compiler: [ifort]                                                                                       #  #
+  #     #         build_type: ['Debug']                                                                                   #  #
+  #     #         tutorial_name:                                                                                          #  #
+  #     #           - hello_world                                                                                         #  #
+  #     #           - parent_no_children                                                                                  #  #
+  #     #           - parent_one_child_import_via_extdata                                                                 #  #
+  #     #           - parent_one_child_no_imports                                                                         #  #
+  #     #           - parent_two_siblings_connect_import_export                                                           #  #
+  #     #     # We will only run the tutorials with GNU make. No need to double up as Ninja is a build test only          #  #
+  #     #     requires:                                                                                                   #  #
+  #     #       - build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-Unix Makefiles            #  #
+  #     #     baselibs_version: *baselibs_version                                                                         #  #
+  #     ###################################################################################################################  #
+  #                                                                                                                          #
+  ############################################################################################################################
 
   # MAPL3 will soon break GEOSgcm builds. We believe it can build, but not currently run
   #build-and-run-GEOSgcm:

--- a/.github/actions/ci-build-and-test-mapl/action.yml
+++ b/.github/actions/ci-build-and-test-mapl/action.yml
@@ -15,6 +15,10 @@ inputs:
   extra-cmake-args:
     description: "Extra CMake arguments"
     required: false
+  skip-tests:
+    description: "Skip running tests (useful when test frameworks are disabled)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -55,6 +59,7 @@ runs:
         cmake --install build
 
     - name: Run MAPL Tests
+      if: inputs.skip-tests != 'true'
       shell: bash
       run: |
         cmake --build build --target build-tests --parallel 4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,35 +41,37 @@ jobs:
           doc-folder: docs/Ford/ci-doc
           deploy-token: ${{ secrets.DOCS_DEPLOY_PAT }}
 
-  build_test_mapl_gnu:
-    name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0
-    strategy:
-      fail-fast: false
-      matrix:
-        cmake-build-type: [Debug, Release]
-        cmake-generator: [Unix Makefiles]
-    env:
-      OMPI_ALLOW_RUN_AS_ROOT: 1
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          filter: blob:none
-
-      - name: Build and Test MAPL
-        uses: ./.github/actions/ci-build-and-test-mapl
-        with:
-          cmake-build-type: ${{ matrix.cmake-build-type }}
-          cmake-generator: ${{ matrix.cmake-generator }}
-          fortran-compiler: gfortran
-          extra-cmake-args: -DMPIEXEC_PREFLAGS='--oversubscribe'
+  #####################################################################################
+  # build_test_mapl_gnu:                                                              #
+  #   name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }} #
+  #   if: github.event.pull_request.draft == false                                    #
+  #   runs-on: ubuntu-latest                                                          #
+  #   container:                                                                      #
+  #     image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0            #
+  #   strategy:                                                                       #
+  #     fail-fast: false                                                              #
+  #     matrix:                                                                       #
+  #       cmake-build-type: [Debug, Release]                                          #
+  #       cmake-generator: [Unix Makefiles]                                           #
+  #   env:                                                                            #
+  #     OMPI_ALLOW_RUN_AS_ROOT: 1                                                     #
+  #     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1                                             #
+  #     OMPI_MCA_btl_vader_single_copy_mechanism: none                                #
+  #   steps:                                                                          #
+  #     - name: Checkout                                                              #
+  #       uses: actions/checkout@v6                                                   #
+  #       with:                                                                       #
+  #         fetch-depth: 1                                                            #
+  #         filter: blob:none                                                         #
+  #                                                                                   #
+  #     - name: Build and Test MAPL                                                   #
+  #       uses: ./.github/actions/ci-build-and-test-mapl                              #
+  #       with:                                                                       #
+  #         cmake-build-type: ${{ matrix.cmake-build-type }}                          #
+  #         cmake-generator: ${{ matrix.cmake-generator }}                            #
+  #         fortran-compiler: gfortran                                                #
+  #         extra-cmake-args: -DMPIEXEC_PREFLAGS='--oversubscribe'                    #
+  #####################################################################################
 
   build_test_mapl_gnu15:
     name: gfortran-15 / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
@@ -150,6 +152,28 @@ jobs:
           cmake-build-type: ${{ matrix.cmake-build-type }}
           cmake-generator: ${{ matrix.cmake-generator }}
           fortran-compiler: ifx
+
+  build_test_mapl_ifort_no_optional:
+    name: ifort / Debug / no pFlogger+fArgParse+pFUnit
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    container:
+      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          filter: blob:none
+
+      - name: Build MAPL without optional packages
+        uses: ./.github/actions/ci-build-and-test-mapl
+        with:
+          cmake-build-type: Debug
+          cmake-generator: Unix Makefiles
+          fortran-compiler: ifort
+          extra-cmake-args: -DBUILD_WITH_PFLOGGER=OFF -DBUILD_WITH_FARGPARSE=OFF -DBUILD_WITH_PFUNIT=OFF
+          skip-tests: "true"
 
   build_gcm:
     if: github.event.pull_request.draft == false

--- a/base3g/MemUtils.F90
+++ b/base3g/MemUtils.F90
@@ -383,7 +383,7 @@ module MAPL_MemUtilsMod
 
 
      call get_unit(mem_unit)
-     open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',IOSTAT=STATUS)
+     open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',ACTION='READ',IOSTAT=STATUS)
      !_VERIFY(STATUS)
 
      ! Note: On at least one CircleCI compute machine, this was returning IOSTAT=9, with an IOMSG of:
@@ -454,7 +454,7 @@ integer :: status
   multiplier = 1.0
 
   call get_unit(mem_unit)
-  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',IOSTAT=STATUS)
+  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',ACTION='READ',IOSTAT=STATUS)
   !_VERIFY(STATUS)
 
   ! Note: On at least one CircleCI compute machine, this was returning IOSTAT=9, with an IOMSG of:
@@ -513,7 +513,7 @@ integer :: status
   multiplier = 1.0
 
   call get_unit(mem_unit)
-  open(UNIT=mem_unit,FILE=proc_self,FORM='formatted',IOSTAT=STATUS)
+  open(UNIT=mem_unit,FILE=proc_self,FORM='formatted',ACTION='READ',IOSTAT=STATUS)
   _VERIFY(STATUS)
   do; read (mem_unit,'(a)', end=10) string
     if ( INDEX ( string, 'VmHWM:' ) == 1 ) then  ! High Water Mark
@@ -532,7 +532,7 @@ integer :: status
 10 close(mem_unit)
 
   call get_unit(mem_unit)
-  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',IOSTAT=STATUS)
+  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',ACTION='READ',IOSTAT=STATUS)
   _VERIFY(STATUS)
   do; read (mem_unit,'(a)', end=20) string
     if ( INDEX ( string, 'MemTotal:' ) == 1 ) then  ! High Water Mark
@@ -604,7 +604,7 @@ integer :: status
   multiplier = 1.0
 
   call get_unit(mem_unit)
-  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',IOSTAT=STATUS)
+  open(UNIT=mem_unit,FILE=meminfo,FORM='formatted',ACTION='READ',IOSTAT=STATUS)
   _VERIFY(STATUS)
   do; read (mem_unit,'(a)', end=20) string
     if ( INDEX ( string, 'MemFree:' ) == 1 ) then  ! Free memory

--- a/utilities/MemInfo.F90
+++ b/utilities/MemInfo.F90
@@ -86,7 +86,7 @@ contains
       real :: hwm, rss
       integer :: unit, status
 
-      open(newunit=unit, file=process_mem_file, form='formatted', iostat=status)
+      open(newunit=unit, file=process_mem_file, form='formatted', action='READ', iostat=status)
       _VERIFY(status)
       do; read (unit, '(a)', end=10) line
          if (index(line, 'VmHWM:') == 1) then  ! High Water Mark
@@ -124,7 +124,7 @@ contains
       integer :: unit, status
 
       ! Read local memory information
-      open(newunit=unit, file=system_mem_file, form='formatted', iostat=status)
+      open(newunit=unit, file=system_mem_file, form='formatted', action='READ', iostat=status)
       _VERIFY(STATUS)
       do; read (unit, '(a)', end=20) line
          if (index(line, 'MemTotal:') == 1) then  ! High Water Mark


### PR DESCRIPTION
I'm trying to see if I can reduce our CircleCI usage in MAPL. What this PR does is turns off all MAPL builds with CircleCI and we now only build and test GEOSgcm with ifx. 

Not perfect, but should save funds.

