### PR TITLE
Re-export FileIOSharedMod symbols through MAPL umbrella module

### DIFF
--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -2,6 +2,7 @@
 ! of the legacy (MAPL2) underlying packages.
 module MAPL2
    use MAPL_ExceptionHandling
+   use FileIOSharedMod
    use NCIOMod
    use MAPL_LocStreamMod
    use MAPL_ShmemMod


### PR DESCRIPTION
Adds 'use FileIOSharedMod' to MAPL/MAPL.F90 so that its public symbols (WRITE_PARALLEL, ArrDescr, ArrDescrInit, ArrDescrSet) are re-exported through 'use MAPL'. This is a prerequisite for updating external callers (e.g. FVdycoreCubed in GEOSgcm) to get these symbols via 'use MAPL' rather than directly using FileIOSharedMod. Refs #4879, #4874