### PR TITLE
Re-export FileIOSharedMod symbols through MAPL umbrella module

### DIFF
--- a/MAPL/MAPL.F90
+++ b/MAPL/MAPL.F90
@@ -2,6 +2,7 @@
 ! of the legacy (MAPL2) underlying packages.
 module MAPL2
    use MAPL_ExceptionHandling
+   use FileIOSharedMod
    use NCIOMod
    use MAPL_LocStreamMod
    use MAPL_ShmemMod


### PR DESCRIPTION
## Summary

Adds `use FileIOSharedMod` to `MAPL/MAPL.F90` so that `FileIOSharedMod` symbols (`WRITE_PARALLEL`, `ArrDescr`, `ArrDescrInit`, `ArrDescrSet`, etc.) are re-exported through the `MAPL` umbrella module.

This is a prerequisite for updating `FVdycoreCubed_GridComp` to get these symbols via `use MAPL` instead of `use FileIOSharedMod` directly, which in turn is required before the files can be moved from `base/` to `base3g/` as part of the `base/` elimination effort.

No circular dependency: `FileIOSharedMod` only depends on `ESMF`, `mapl3g_*` internals, `MAPL_CommsMod`, `MAPL_ShmemMod`, and `MAPL_ExceptionHandling` — none of which depend on `MAPL2`.

Closes #4879
Refs #4874