### PR TITLE
Regularize MAPL.enums module names and cleanup

### DIFF
--- a/component/GriddedComponentDriver/run_export_couplers.F90
+++ b/component/GriddedComponentDriver/run_export_couplers.F90
@@ -2,7 +2,7 @@
 
 submodule(mapl3g_GriddedComponentDriver) run_export_couplers_smod
 
-   use mapl3g_CouplerPhases
+   use mapl_CouplerPhases
    use mapl_ErrorHandling
    implicit none(type,external)
 

--- a/component/GriddedComponentDriver/run_import_couplers.F90
+++ b/component/GriddedComponentDriver/run_import_couplers.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule(mapl3g_GriddedComponentDriver) run_import_couplers_smod
-   use mapl3g_CouplerPhases
+   use mapl_CouplerPhases
    use mapl_ErrorHandling
    implicit none(type,external)
 

--- a/enums/ConservationMetadata.F90
+++ b/enums/ConservationMetadata.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
-module mapl3g_ConservationMetadata
-   use mapl3g_ConservationType
+module mapl_ConservationMetadata
+   use mapl_ConservationType
    use mapl_ErrorHandling
    use esmf, only: ESMF_Info, ESMF_InfoCreate, ESMF_InfoIsPresent
    use esmf, only: ESMF_InfoSet, ESMF_InfoGet, ESMF_InfoGetCharAlloc
@@ -173,4 +173,4 @@ contains
       not_equals = .not. (lhs == rhs)
    end function not_equal_to
 
-end module mapl3g_ConservationMetadata
+end module mapl_ConservationMetadata

--- a/enums/ConservationType.F90
+++ b/enums/ConservationType.F90
@@ -1,4 +1,4 @@
-module mapl3g_ConservationType
+module mapl_ConservationType
    implicit none(type, external)
    private
    
@@ -103,4 +103,4 @@ contains
       if (present(rc)) rc = 0
    end function conservation_type_from_string
    
-end module mapl3g_ConservationType
+end module mapl_ConservationType

--- a/enums/CouplerPhases.F90
+++ b/enums/CouplerPhases.F90
@@ -1,9 +1,11 @@
-#include "MAPL.h"
+module mapl_CouplerPhases
 
-module mapl3g_CouplerPhases
-
-   implicit none
+   implicit none(type,external)
    private
+
+   ! enum, bind(c) is used (rather than integer parameters) so that
+   ! ESMF/NUOPC SetPhase routines receive C-interoperable integer kinds
+   ! without requiring an explicit kind= argument at every call site.
 
    ! Phase indices
    public :: GENERIC_COUPLER_INITIALIZE
@@ -18,4 +20,4 @@ module mapl3g_CouplerPhases
       enumerator :: GENERIC_COUPLER_CLOCK_ADVANCE
    end enum
 
-end module mapl3g_CouplerPhases
+end module mapl_CouplerPhases

--- a/enums/GenericPhases.F90
+++ b/enums/GenericPhases.F90
@@ -1,7 +1,11 @@
-module mapl3g_GenericPhases
+module mapl_GenericPhases
    implicit none(type,external)
    private
    
+   ! enum, bind(c) is used (rather than integer parameters) so that
+   ! ESMF/NUOPC SetPhase routines receive C-interoperable integer kinds
+   ! without requiring an explicit kind= argument at every call site.
+
    ! Named constants
    ! Init phases
    public :: GENERIC_INIT_PHASE_SEQUENCE
@@ -64,4 +68,4 @@ module mapl3g_GenericPhases
         GENERIC_INIT_USER &
         ]
 
-end module mapl3g_GenericPhases
+end module mapl_GenericPhases

--- a/enums/NormalizationMetadata.F90
+++ b/enums/NormalizationMetadata.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
-module mapl3g_NormalizationMetadata
-   use mapl3g_NormalizationType
+module mapl_NormalizationMetadata
+   use mapl_NormalizationType
    use mapl_ErrorHandling
    use esmf, only: ESMF_Info, ESMF_InfoCreate, ESMF_InfoIsPresent
    use esmf, only: ESMF_InfoSet, ESMF_InfoGet, ESMF_InfoGetCharAlloc
@@ -171,4 +171,4 @@ contains
       not_equals = .not. (lhs == rhs)
    end function not_equal_to
 
-end module mapl3g_NormalizationMetadata
+end module mapl_NormalizationMetadata

--- a/enums/NormalizationType.F90
+++ b/enums/NormalizationType.F90
@@ -1,4 +1,4 @@
-module mapl3g_NormalizationType
+module mapl_NormalizationType
    implicit none(type, external)
    private
    
@@ -114,4 +114,4 @@ contains
       if (present(rc)) rc = 0
    end function normalization_type_from_string
 
-end module mapl3g_NormalizationType
+end module mapl_NormalizationType

--- a/enums/QuantityType.F90
+++ b/enums/QuantityType.F90
@@ -1,4 +1,4 @@
-module mapl3g_QuantityType
+module mapl_QuantityType
    implicit none(type, external)
    private
    
@@ -193,4 +193,4 @@ contains
        if (present(rc)) rc = 0
     end function mixing_ratio_basis_from_string
     
-end module mapl3g_QuantityType
+end module mapl_QuantityType

--- a/enums/QuantityTypeMetadata.F90
+++ b/enums/QuantityTypeMetadata.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
-module mapl3g_QuantityTypeMetadata
-   use mapl3g_QuantityType
+module mapl_QuantityTypeMetadata
+   use mapl_QuantityType
    use mapl_ErrorHandling
    use mapl_Constants, only: MAPL_UNDEF => MAPL_UNDEFINED_REAL
    use esmf, only: ESMF_Info, ESMF_InfoCreate, ESMF_InfoIsPresent
@@ -244,4 +244,4 @@ contains
       not_equal_to = .not. (a == b)
    end function not_equal_to
    
-end module mapl3g_QuantityTypeMetadata
+end module mapl_QuantityTypeMetadata

--- a/enums/ValidationMode.F90
+++ b/enums/ValidationMode.F90
@@ -1,4 +1,4 @@
-module mapl3g_ValidationMode
+module mapl_ValidationMode
    use mapl_StringUtilities, only: to_lower
    implicit none(type, external)
    private
@@ -76,4 +76,4 @@ contains
       not_equal = .not. (a%id == b%id)
    end function not_equal
 
-end module mapl3g_ValidationMode
+end module mapl_ValidationMode

--- a/enums/VectorBasisKind.F90
+++ b/enums/VectorBasisKind.F90
@@ -1,4 +1,4 @@
-module mapl3g_VectorBasisKind
+module mapl_VectorBasisKind
    implicit none(type, external)
    private
    
@@ -76,4 +76,4 @@ contains
       not_equal = .not. (a%id == b%id)
    end function not_equal
 
-end module mapl3g_VectorBasisKind
+end module mapl_VectorBasisKind

--- a/enums/VerificationStatus.F90
+++ b/enums/VerificationStatus.F90
@@ -1,4 +1,4 @@
-module mapl3g_VerificationStatus
+module mapl_VerificationStatus
    use mapl_StringUtilities, only: to_lower
    implicit none(type, external)
    private
@@ -82,4 +82,4 @@ contains
       not_equal = .not. (a%id == b%id)
    end function not_equal
 
-end module mapl3g_VerificationStatus
+end module mapl_VerificationStatus

--- a/field/FieldGet.F90
+++ b/field/FieldGet.F90
@@ -6,9 +6,9 @@ module mapl3g_FieldGet
    use mapl3g_VerticalAlignment
    use mapl3g_FieldInfo
    use mapl3g_StateItemAllocation
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl_KeywordEnforcer
    use mapl_ErrorHandling
    use mapl3g_UngriddedDims

--- a/field/FieldInfo.F90
+++ b/field/FieldInfo.F90
@@ -9,9 +9,9 @@ module mapl3g_FieldInfo
    use mapl3g_InfoUtilities
    use mapl3g_VerticalGrid_API
    use mapl3g_UngriddedDims
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl3g_VerticalStaggerLoc
    use mapl3g_VerticalAlignment
    use mapl3g_StateItemAllocation

--- a/field/FieldSet.F90
+++ b/field/FieldSet.F90
@@ -9,9 +9,9 @@ module mapl3g_FieldSet
    use mapl3g_FieldGet
    use mapl3g_FieldDelta
    use mapl3g_StateItemAllocation
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl_KeywordEnforcer
    use mapl_ErrorHandling
    use mapl_FieldPointerUtilities, only: FieldGetLocalElementCount

--- a/field_bundle/API.F90
+++ b/field_bundle/API.F90
@@ -2,7 +2,7 @@ module mapl3g_FieldBundle_API
 
    use ESMF, only: MAPL_FieldBundleAdd => ESMF_FieldBundleAdd
    use mapl3g_FieldBundleType_Flag
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_FieldBundleCreate, only: MAPL_FieldBundleCreate => FieldBundleCreate
    use mapl3g_FieldBundleCreate, only: MAPL_FieldBundlesAreAliased => FieldBundlesAreAliased
    use mapl3g_FieldBundleDestroy, only: MAPL_FieldBundleDestroy

--- a/field_bundle/FieldBundleCreate.F90
+++ b/field_bundle/FieldBundleCreate.F90
@@ -4,7 +4,7 @@ module mapl3g_FieldBundleCreate
 
    use mapl3g_FieldBundleType_Flag
    use mapl3g_FieldBundleSet
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl_ErrorHandling
    use mapl_KeywordEnforcer
    use esmf

--- a/field_bundle/FieldBundleGet.F90
+++ b/field_bundle/FieldBundleGet.F90
@@ -7,11 +7,11 @@ module mapl3g_FieldBundleGet
    use mapl_ErrorHandling
    use mapl3g_Field_API
    use mapl3g_UngriddedDims
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl3g_FieldBundleType_Flag
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_FieldBundleInfo
    use mapl3g_InfoUtilities
    use mapl3g_LU_Bound

--- a/field_bundle/FieldBundleInfo.F90
+++ b/field_bundle/FieldBundleInfo.F90
@@ -7,11 +7,11 @@ module mapl3g_FieldBundleInfo
    use mapl3g_Field_API
    use mapl3g_FieldInfo
    use mapl3g_UngriddedDims
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl3g_FieldBundleType_Flag
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_VerticalAlignment
    use mapl3g_VerticalGrid_API
    use mapl_KeywordEnforcer

--- a/field_bundle/FieldBundleSet.F90
+++ b/field_bundle/FieldBundleSet.F90
@@ -4,11 +4,11 @@ module mapl3g_FieldBundleSet
    use mapl3g_VerticalGrid_API
    use mapl3g_Field_API
    use mapl3g_UngriddedDims
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationMetadata
-   use mapl3g_ConservationMetadata
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationMetadata
+   use mapl_ConservationMetadata
    use mapl3g_FieldBundleType_Flag
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_FieldBundleInfo
    use mapl3g_InfoUtilities
    use mapl3g_FieldBundleGet

--- a/generic3g/FieldDictionary.F90
+++ b/generic3g/FieldDictionary.F90
@@ -21,7 +21,7 @@ module mapl3g_FieldDictionary
    use gftl2_StringStringMap
    use mapl3g_FieldDictionaryItem
    use mapl3g_FieldDictionaryItemMap
-   use mapl3g_VerificationStatus
+   use mapl_VerificationStatus
 
    implicit none(type,external)
    private

--- a/generic3g/FieldDictionaryConfig.F90
+++ b/generic3g/FieldDictionaryConfig.F90
@@ -14,7 +14,7 @@ module mapl3g_FieldDictionaryConfig
 
    use esmf
    use mapl_ErrorHandling
-   use mapl3g_ValidationMode
+   use mapl_ValidationMode
    use mapl3g_StateItem
 
    implicit none(type, external)

--- a/generic3g/FieldDictionaryItem.F90
+++ b/generic3g/FieldDictionaryItem.F90
@@ -2,7 +2,7 @@ module mapl3g_FieldDictionaryItem
 
    use gftl2_StringVector
    use esmf
-   use mapl3g_VerificationStatus
+   use mapl_VerificationStatus
 
    implicit none(type,external)
    private

--- a/generic3g/Generic3g.F90
+++ b/generic3g/Generic3g.F90
@@ -3,7 +3,7 @@ module Generic3g
    use mapl3g_Generic
    use mapl3g_Field_API
    use mapl3g_VariableSpec
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_OuterMetaComponent
    use mapl3g_GenericGridComp, only: MAPL_GridCompCreate
    use mapl3g_VerticalGrid

--- a/generic3g/GenericGridComp.F90
+++ b/generic3g/GenericGridComp.F90
@@ -13,7 +13,7 @@ module mapl3g_GenericGridComp
    use :: mapl3g_OuterMetaComponent, only: OuterMetaComponent
    use :: mapl3g_OuterMetaComponent, only: get_outer_meta
    use :: mapl3g_OuterMetaComponent, only: attach_outer_meta
-   use :: mapl3g_GenericPhases
+   use :: mapl_GenericPhases
    use :: mapl3g_GriddedComponentDriver
    use esmf
    use :: mapl_KeywordEnforcer, only: KeywordEnforcer

--- a/generic3g/MethodPhasesMap.F90
+++ b/generic3g/MethodPhasesMap.F90
@@ -65,7 +65,7 @@ end module mapl3g_MethodPhasesMap_private
 module mapl3g_MethodPhasesMapUtils
    use mapl3g_MethodPhasesMap_private
    use mapl_ErrorHandling
-   use :: mapl3g_GenericPhases, only: GENERIC_RUN_OFFSET
+   use :: mapl_GenericPhases, only: GENERIC_RUN_OFFSET
    use :: mapl_KeywordEnforcer
    use :: esmf, only: ESMF_Method_Flag, operator(==)
    use :: esmf, only: ESMF_METHOD_INITIALIZE

--- a/generic3g/OuterMetaComponent/finalize.F90
+++ b/generic3g/OuterMetaComponent/finalize.F90
@@ -3,7 +3,7 @@
 submodule (mapl3g_OuterMetaComponent) finalize_smod
 
    use mapl3g_GriddedComponentDriverMap
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl_ErrorHandling
    use MAPL_Profiler, only: ProfileReporter
    use MAPL_Profiler, only: MultiColumn, NameColumn, FormattedTextColumn, PercentageColumn

--- a/generic3g/OuterMetaComponent/initialize_advertise.F90
+++ b/generic3g/OuterMetaComponent/initialize_advertise.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl3g_OuterMetaComponent) initialize_advertise_smod
-   use mapl3g_GenericPhases, only: GENERIC_INIT_ADVERTISE
+   use mapl_GenericPhases, only: GENERIC_INIT_ADVERTISE
    use mapl3g_VirtualConnectionPt
    use mapl3g_StateItem
    use mapl3g_VariableSpec

--- a/generic3g/OuterMetaComponent/initialize_geom_a.F90
+++ b/generic3g/OuterMetaComponent/initialize_geom_a.F90
@@ -2,7 +2,7 @@
 
 submodule (mapl3g_OuterMetaComponent) initialize_geom_a_smod
 
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_GeometrySpec
    use mapl3g_Geom_API
    use mapl3g_GriddedComponentDriver

--- a/generic3g/OuterMetaComponent/initialize_geom_b.F90
+++ b/generic3g/OuterMetaComponent/initialize_geom_b.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl3g_OuterMetaComponent) initialize_geom_b_smod
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_GeometrySpec
    use mapl_ErrorHandling
    implicit none(type,external)

--- a/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
+++ b/generic3g/OuterMetaComponent/initialize_modify_advertised.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl3g_OuterMetaComponent) initialize_modify_advertised_smod
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_MultiState
    use mapl3g_Connection
    use mapl3g_ConnectionVector, only: ConnectionVectorIterator

--- a/generic3g/OuterMetaComponent/initialize_read_restart.F90
+++ b/generic3g/OuterMetaComponent/initialize_read_restart.F90
@@ -2,7 +2,7 @@
 
 submodule (mapl3g_OuterMetaComponent) initialize_read_restart_smod
 
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl_ErrorHandling
    use mapl3g_MultiState
    use mapl3g_RestartHandler, only: RestartHandler

--- a/generic3g/OuterMetaComponent/initialize_realize.F90
+++ b/generic3g/OuterMetaComponent/initialize_realize.F90
@@ -2,7 +2,7 @@
 
 submodule (mapl3g_OuterMetaComponent) initialize_realize_smod
    use mapl3g_Multistate
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl_ErrorHandling
    implicit none(type,external)
 

--- a/generic3g/OuterMetaComponent/initialize_set_clock.F90
+++ b/generic3g/OuterMetaComponent/initialize_set_clock.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl3g_OuterMetaComponent) initialize_set_clock_smod
-   use mapl3g_GenericPhases, only: GENERIC_INIT_SET_CLOCK
+   use mapl_GenericPhases, only: GENERIC_INIT_SET_CLOCK
    use mapl3g_ComponentDriver
    use mapl3g_GriddedComponentDriverMap
    use mapl3g_ESMF_Time_Utilities

--- a/generic3g/OuterMetaComponent/initialize_user.F90
+++ b/generic3g/OuterMetaComponent/initialize_user.F90
@@ -2,10 +2,10 @@
 
 submodule (mapl3g_OuterMetaComponent) initialize_user_smod
 
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_ComponentDriver
    use mapl3g_ComponentDriverPtrVector
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_INITIALIZE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_INITIALIZE
    use mapl_ErrorHandling
    use pflogger, only: logger_t => logger
 

--- a/generic3g/OuterMetaComponent/run_clock_advance.F90
+++ b/generic3g/OuterMetaComponent/run_clock_advance.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl3g_OuterMetaComponent) run_clock_advance_smod
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_GriddedComponentDriverMap
    use mapl_ErrorHandling
    implicit none(type,external)

--- a/generic3g/OuterMetaComponent/run_user.F90
+++ b/generic3g/OuterMetaComponent/run_user.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_OuterMetaComponent) run_user_smod
 
    use mapl3g_ComponentDriver
    use mapl3g_ComponentDriverPtrVector
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_INVALIDATE, GENERIC_COUPLER_UPDATE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_INVALIDATE, GENERIC_COUPLER_UPDATE
    use mapl_ErrorHandling
    use pflogger, only: logger_t => logger
 

--- a/generic3g/couplers/CouplerMetaComponent.F90
+++ b/generic3g/couplers/CouplerMetaComponent.F90
@@ -4,7 +4,7 @@ module mapl3g_CouplerMetaComponent
 
    use mapl3g_TransformId
    use mapl3g_esmf_info_keys, only: INFO_SHARED_NAMESPACE
-   use mapl3g_CouplerPhases
+   use mapl_CouplerPhases
    use mapl3g_ComponentDriver, only: ComponentDriver, ComponentDriverPtr
    use mapl3g_GriddedComponentDriver, only: GriddedComponentDriver
    use mapl3g_ComponentDriverVector, only: ComponentDriverVector

--- a/generic3g/couplers/GenericCoupler.F90
+++ b/generic3g/couplers/GenericCoupler.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 module mapl3g_GenericCoupler
-   use mapl3g_CouplerPhases
+   use mapl_CouplerPhases
    use mapl3g_CouplerMetaComponent
    use mapl3g_ExtensionTransform
    use mapl3g_TransformId

--- a/generic3g/specs/ConservationAspect.F90
+++ b/generic3g/specs/ConservationAspect.F90
@@ -7,10 +7,10 @@ module mapl3g_ConservationAspect
    use mapl3g_StateItemAspect
    use mapl3g_ExtensionTransform
    use mapl3g_NullTransform
-   use mapl3g_ConservationType
-   use mapl3g_ConservationMetadata
-   use mapl3g_QuantityType
-   use mapl3g_QuantityTypeMetadata
+   use mapl_ConservationType
+   use mapl_ConservationMetadata
+   use mapl_QuantityType
+   use mapl_QuantityTypeMetadata
    use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use mapl_KeywordEnforcer

--- a/generic3g/specs/GeomAspect.F90
+++ b/generic3g/specs/GeomAspect.F90
@@ -16,8 +16,8 @@ module mapl3g_GeomAspect
    use mapl3g_FieldBundle_API
    use mapl3g_EsmfRegridder
    use mapl3g_NormalizationAspect, only: NormalizationAspect, to_NormalizationAspect
-   use mapl3g_NormalizationMetadata, only: NormalizationMetadata
-   use mapl3g_NormalizationType, only: NormalizationType
+   use mapl_NormalizationMetadata, only: NormalizationMetadata
+   use mapl_NormalizationType, only: NormalizationType
    use mapl3g_VerticalGrid
    use mapl3g_ComponentDriver, only: ComponentDriver
    use mapl_ErrorHandling

--- a/generic3g/specs/GeomAspect/make_transform.F90
+++ b/generic3g/specs/GeomAspect/make_transform.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_GeomAspect) make_transform_smod
 
    use mapl3g_VerticalGridAspect
    use mapl3g_VerticalStaggerLoc
-   use mapl3g_NormalizationType, only: NORMALIZE_NONE, operator(==)
+   use mapl_NormalizationType, only: NORMALIZE_NONE, operator(==)
 
    implicit none(type,external)
 contains

--- a/generic3g/specs/NormalizationAspect.F90
+++ b/generic3g/specs/NormalizationAspect.F90
@@ -8,8 +8,8 @@ module mapl3g_NormalizationAspect
    use mapl3g_ExtensionTransform
    use mapl3g_NullTransform
    use mapl3g_QuantityTypeAspect
-   use mapl3g_NormalizationType
-   use mapl3g_NormalizationMetadata
+   use mapl_NormalizationType
+   use mapl_NormalizationMetadata
    use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use mapl_KeywordEnforcer

--- a/generic3g/specs/QuantityTypeAspect.F90
+++ b/generic3g/specs/QuantityTypeAspect.F90
@@ -7,10 +7,10 @@ module mapl3g_QuantityTypeAspect
    use mapl3g_StateItemAspect
    use mapl3g_ExtensionTransform
    use mapl3g_NullTransform
-   use mapl3g_QuantityType
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationType
-   use mapl3g_NormalizationMetadata
+   use mapl_QuantityType
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationType
+   use mapl_NormalizationMetadata
    use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use mapl_KeywordEnforcer

--- a/generic3g/specs/VariableSpec.F90
+++ b/generic3g/specs/VariableSpec.F90
@@ -27,10 +27,10 @@ module mapl3g_VariableSpec
    use mapl3g_QuantityTypeAspect
    use mapl3g_ConservationAspect
    use mapl3g_NormalizationAspect
-   use mapl3g_NormalizationType
+   use mapl_NormalizationType
    use mapl3g_UngriddedDims
    use mapl3g_VerticalStaggerLoc
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_HorizontalDimsSpec
    use mapl3g_VirtualConnectionPt
    use mapl3g_ActualConnectionPt

--- a/generic3g/specs/VectorBracketClassAspect.F90
+++ b/generic3g/specs/VectorBracketClassAspect.F90
@@ -16,7 +16,7 @@ module mapl3g_VectorBracketClassAspect
    use mapl3g_TypekindAspect
    use mapl3g_UngriddedDimsAspect
    use mapl3g_FieldBundleInfo, only: FieldBundleInfoSetInternal
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
 
    use mapl3g_VerticalGrid
    use mapl3g_VerticalStaggerLoc

--- a/generic3g/specs/VectorClassAspect.F90
+++ b/generic3g/specs/VectorClassAspect.F90
@@ -13,7 +13,7 @@ module mapl3g_VectorClassAspect
    use mapl3g_UnitsAspect
    use mapl3g_TypekindAspect
    use mapl3g_UngriddedDimsAspect
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_FieldBundleInfo, only: FieldBundleInfoSetInternal
 
    use mapl3g_VerticalGrid

--- a/generic3g/specs/VerticalGridAspect.F90
+++ b/generic3g/specs/VerticalGridAspect.F90
@@ -17,7 +17,7 @@ module mapl3g_VerticalGridAspect
    use mapl3g_TypekindAspect
    use mapl3g_UnitsAspect
    use mapl3g_NormalizationAspect
-   use mapl3g_NormalizationType
+   use mapl_NormalizationType
    use mapl3g_VerticalRegridMethod
    use mapl3g_VerticalStaggerLoc
    use mapl3g_VerticalRegridMethod

--- a/generic3g/transforms/EvalTransform.F90
+++ b/generic3g/transforms/EvalTransform.F90
@@ -6,7 +6,7 @@ module mapl3g_EvalTransform
    use mapl3g_StateItem
    use mapl3g_ComponentDriver
    use mapl3g_ComponentDriverVector
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE, GENERIC_COUPLER_INITIALIZE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_UPDATE, GENERIC_COUPLER_INITIALIZE
    use mapl_ErrorHandling
    use MAPL_StateArithmeticParserMod
    use esmf

--- a/generic3g/transforms/RegridTransform.F90
+++ b/generic3g/transforms/RegridTransform.F90
@@ -9,10 +9,10 @@ module mapl3g_RegridTransform
    use mapl3g_regridder_mgr
    use mapl3g_StateItem
    use mapl3g_ExtensionTransformUtils, only: bundle_types_valid
-   use mapl3g_NormalizationMetadata
-   use mapl3g_NormalizationType
+   use mapl_NormalizationMetadata
+   use mapl_NormalizationType
    use mapl3g_ComponentDriver, only: ComponentDriver
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_UPDATE
    use mapl_ErrorHandling
    use mapl3g_FieldCondensedArray, only: assign_fptr_condensed_array
    use esmf

--- a/generic3g/transforms/VerticalRegridTransform.F90
+++ b/generic3g/transforms/VerticalRegridTransform.F90
@@ -8,7 +8,7 @@ module mapl3g_VerticalRegridTransform
    use mapl3g_StateItem
    use mapl3g_ExtensionTransform
    use mapl3g_ComponentDriver
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_UPDATE
    use mapl3g_VerticalRegridMethod
    use mapl3g_VerticalStaggerLoc
    use mapl3g_VerticalLinearMap, only: compute_linear_map

--- a/geom/MaplGeom.F90
+++ b/geom/MaplGeom.F90
@@ -99,7 +99,7 @@ module mapl3g_MaplGeom
       end function get_variable_attributes
 
       recursive module function get_basis(this, basis_kind, rc) result(basis)
-         use mapl3g_VectorBasisKind
+         use mapl_VectorBasisKind
          type(VectorBasis), pointer :: basis
          class(MaplGeom), target, intent(inout) :: this
          type(VectorBasisKind), optional, intent(in) :: basis_kind

--- a/geom/MaplGeom/get_basis.F90
+++ b/geom/MaplGeom/get_basis.F90
@@ -4,7 +4,7 @@ submodule (mapl3g_MaplGeom) get_basis_smod
 
 use mapl3g_GeomSpec
    use mapl3g_VectorBasis
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_GeomUtilities
    use mapl_ErrorHandlingMod
    use pfio_FileMetadataMod, only: FileMetadata

--- a/regridder_mgr/Regridder.F90
+++ b/regridder_mgr/Regridder.F90
@@ -4,7 +4,7 @@ module mapl3g_Regridder
    use esmf
    use mapl_FieldUtils
    use mapl3g_FieldBundle_API
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl_ErrorHandlingMod
    use mapl3g_Geom_API
    use mapl3g_RegridderSpec


### PR DESCRIPTION
## Types of change(s)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests` or `ctest`)

## Description

Regularization of the `MAPL.enums` library created in #4909 (Phase 1a).

**Module prefix rename** (`mapl3g_` → `mapl_`) in all 11 enum module declarations and across ~55 files of `use` statements throughout the codebase. No public type names, parameters, or interfaces changed — only the module name used in `use` statements.

**`CouplerPhases.F90` cleanup:**
- Remove stale `#include "MAPL.h"` (leftover from its old location in `component/`)
- Strengthen `implicit none` to `implicit none(type,external)` to match `GenericPhases`

**Rationale comments** added to `CouplerPhases.F90` and `GenericPhases.F90` explaining why `enum, bind(c)` is used instead of integer parameters.

## Notes

This branch is based on `feature/#4907-enums-relocation` and will be rebased onto `develop` after that PR merges.

## Related Issues

Closes #4908
Part of #4905 (Phase 1b)