### PR TITLE
Remove MPI from ErrorHandling and Throw layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove direct MPI dependencies from `ErrorHandling.F90` and `MAPL_Throw.F90`
+  using a lazy-init procedure pointer pattern. Both modules now default to serial
+  `error stop` behavior and are fully MPI-free. MPI-aware error handling (rank in
+  error messages, `MPI_Abort`) is provided by the new `MAPL_MpiErrorHandling.F90`
+  module; call `MAPL_initialize_error_handling()` once after `MPI_Init` to
+  register MPI-aware handlers. Serial and pFUnit programs require no changes.
+  `MAPL_ExceptionHandling` is now an alias defined in `ErrorHandling.F90` rather
+  than a separate file. Closes #4917, part of #4905.
+
 - Create `enums/` directory (`MAPL.enums`, Tier 0) and relocate 11 enum-like
   type definitions into it from `esmf_utils/`, `generic3g/`, and `component/`.
   No module names or interfaces changed; this is a pure file relocation.

--- a/generic3g/tests/Test_2DConservativeRegrid.pf
+++ b/generic3g/tests/Test_2DConservativeRegrid.pf
@@ -1,10 +1,10 @@
 #include "MAPL_TestErr.h"
 
 module Test_2DConservativeRegrid
-   use mapl3g_QuantityType
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationType
-   use mapl3g_NormalizationMetadata
+   use mapl_QuantityType
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationType
+   use mapl_NormalizationMetadata
    use mapl3g_Field_API
    use mapl3g_regridder_mgr, only: EsmfRegridderParam
    use mapl3g_RoutehandleParam, only: RoutehandleParam

--- a/generic3g/tests/Test_3DConservativeMixingRatio.pf
+++ b/generic3g/tests/Test_3DConservativeMixingRatio.pf
@@ -9,10 +9,10 @@ module Test_3DConservativeMixingRatio
    use mapl3g_VerticalAlignment
    use mapl3g_ExtensionTransform, only: COUPLER_IMPORT_NAME, COUPLER_EXPORT_NAME, ExtensionTransform
    use mapl3g_FieldCreate, only: MAPL_FieldCreate
-   use mapl3g_QuantityType
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationType
-   use mapl3g_NormalizationMetadata
+   use mapl_QuantityType
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationType
+   use mapl_NormalizationMetadata
    use mapl3g_Field_API
    use mapl3g_RegridTransform
    use mapl3g_regridder_mgr, only: EsmfRegridderParam

--- a/generic3g/tests/Test_ConfigurableGridComp.pf
+++ b/generic3g/tests/Test_ConfigurableGridComp.pf
@@ -2,7 +2,7 @@
 
 module Test_ConfigurableGridComp
 
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_Generic
    use mapl3g_UserSetServices
    use mapl3g_GenericGridComp, only: MAPL_GridCompCreate

--- a/generic3g/tests/Test_ConservationAspect.pf
+++ b/generic3g/tests/Test_ConservationAspect.pf
@@ -4,7 +4,7 @@
 module Test_ConservationAspect
    use funit
    use mapl3g_ConservationAspect
-   use mapl3g_ConservationType
+   use mapl_ConservationType
    use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use mapl3g_ActualConnectionPt

--- a/generic3g/tests/Test_ConservationType.pf
+++ b/generic3g/tests/Test_ConservationType.pf
@@ -1,6 +1,6 @@
 #include "MAPL_TestErr.h"
 module Test_ConservationType
-   use mapl3g_ConservationType
+   use mapl_ConservationType
    use funit
    implicit none
 

--- a/generic3g/tests/Test_FieldDictionary.pf
+++ b/generic3g/tests/Test_FieldDictionary.pf
@@ -5,8 +5,8 @@ module Test_FieldDictionary
    use mapl3g_FieldDictionary
    use mapl3g_FieldDictionaryItem
    use mapl3g_FieldDictionaryConfig
-   use mapl3g_ValidationMode
-   use mapl3g_VerificationStatus
+   use mapl_ValidationMode
+   use mapl_VerificationStatus
    use mapl3g_StateItem
    implicit none
 

--- a/generic3g/tests/Test_IntegratedNormalization.pf
+++ b/generic3g/tests/Test_IntegratedNormalization.pf
@@ -11,10 +11,10 @@ module Test_IntegratedNormalization
    use mapl3g_VerticalGrid_API
    use mapl3g_ExtensionTransform, only: COUPLER_IMPORT_NAME, COUPLER_EXPORT_NAME, ExtensionTransform
    use mapl3g_FieldCreate, only: MAPL_FieldCreate
-   use mapl3g_QuantityType
-   use mapl3g_QuantityTypeMetadata
-   use mapl3g_NormalizationType
-   use mapl3g_NormalizationMetadata
+   use mapl_QuantityType
+   use mapl_QuantityTypeMetadata
+   use mapl_NormalizationType
+   use mapl_NormalizationMetadata
    use mapl3g_Field_API
    use mapl3g_regridder_mgr, only: EsmfRegridderParam
    use mapl3g_RoutehandleParam, only: RoutehandleParam

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -36,7 +36,7 @@ module Test_ModelVerticalGrid
    use mapl3g_QuantityTypeAspect
    use mapl3g_ConservationAspect
    use mapl3g_NormalizationAspect
-   use mapl3g_NormalizationType
+   use mapl_NormalizationType
    use gFTL2_StringVector
    use esmf
    ! testing framework

--- a/generic3g/tests/Test_ModelVerticalGrid.pf
+++ b/generic3g/tests/Test_ModelVerticalGrid.pf
@@ -25,7 +25,7 @@ module Test_ModelVerticalGrid
    use mapl3g_ComponentDriverPtrVector
    use mapl3g_MultiState
    use mapl3g_Geom_API
-   use mapl3g_CouplerPhases, only: GENERIC_COUPLER_UPDATE
+   use mapl_CouplerPhases, only: GENERIC_COUPLER_UPDATE
    use mapl3g_GeomAspect
    use mapl3g_TypekindAspect
    use mapl3g_UnitsAspect

--- a/generic3g/tests/Test_NormalizationAspect.pf
+++ b/generic3g/tests/Test_NormalizationAspect.pf
@@ -4,7 +4,7 @@
 module Test_NormalizationAspect
    use funit
    use mapl3g_NormalizationAspect
-   use mapl3g_NormalizationType
+   use mapl_NormalizationType
    use mapl3g_StateItemAspect
    use mapl3g_ActualConnectionPt
    use mapl3g_ExtensionTransform

--- a/generic3g/tests/Test_QuantityType.pf
+++ b/generic3g/tests/Test_QuantityType.pf
@@ -1,7 +1,7 @@
 #include "MAPL_TestErr.h"
 module Test_QuantityType
-   use mapl3g_QuantityType
-   use mapl3g_NormalizationType
+   use mapl_QuantityType
+   use mapl_NormalizationType
    use funit
    implicit none
 

--- a/generic3g/tests/Test_QuantityTypeAspect.pf
+++ b/generic3g/tests/Test_QuantityTypeAspect.pf
@@ -4,8 +4,8 @@
 module Test_QuantityTypeAspect
    use funit
    use mapl3g_QuantityTypeAspect
-   use mapl3g_QuantityType
-   use mapl3g_NormalizationType
+   use mapl_QuantityType
+   use mapl_NormalizationType
    use mapl3g_Field_API
    use mapl3g_FieldBundle_API
    use mapl3g_ActualConnectionPt

--- a/generic3g/tests/Test_Scenarios.pf
+++ b/generic3g/tests/Test_Scenarios.pf
@@ -3,7 +3,7 @@
 module Test_Scenarios
 
    use mapl3g_Generic
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_MultiState
    use mapl3g_OuterMetaComponent
    use mapl3g_GriddedComponentDriver

--- a/generic3g/tests/Test_VectorBasisKind.pf
+++ b/generic3g/tests/Test_VectorBasisKind.pf
@@ -1,6 +1,6 @@
 #include "MAPL_TestErr.h"
 module Test_VectorBasisKind
-   use mapl3g_VectorBasisKind
+   use mapl_VectorBasisKind
    use mapl3g_VariableSpec
    use mapl3g_StateItemSpec
    use mapl3g_StateItem

--- a/generic3g/tests/Test_propagate_time_varying.pf
+++ b/generic3g/tests/Test_propagate_time_varying.pf
@@ -3,7 +3,7 @@
 module Test_propagate_time_varying
    use mapl3g_regridder_mgr, only: EsmfRegridderParam
    use mapl3g_GriddedComponentDriver
-   use mapl3g_CouplerPhases
+   use mapl_CouplerPhases
    use mapl3g_ExtensionTransform
    use mapl3g_RegridTransform
    use mapl3g_CopyTransform

--- a/generic3g/tests/Test_timestep_propagation.pf
+++ b/generic3g/tests/Test_timestep_propagation.pf
@@ -4,7 +4,7 @@ module Test_timestep_propagation
    use mapl3g_Generic
    use mapl3g_ComponentSpecParser
    use mapl3g_ChildSpec
-   use mapl3g_GenericPhases
+   use mapl_GenericPhases
    use mapl3g_GenericGridComp, generic_setservices => setServices
    use mapl3g_ComponentDriver
    use mapl3g_GriddedComponentDriver

--- a/pfio/BaseThread.F90
+++ b/pfio/BaseThread.F90
@@ -8,7 +8,6 @@ module pFIO_BaseThreadMod
    use pFIO_IntegerRequestMapMod
    use pFIO_MessageVisitorMod
    use pfio_base
-   use mpi
 
    implicit none
    private

--- a/pfio/ForwardDataAndMessage.F90
+++ b/pfio/ForwardDataAndMessage.F90
@@ -2,7 +2,6 @@
 #include "unused_dummy.H"
 
 module pFIO_ForwardDataAndMessageMod
-   use mpi
    use MAPL_ExceptionHandling
    use pFIO_AbstractMessageMod
    use pFIO_UtilitiesMod

--- a/shared/AbstractCommSplitter.F90
+++ b/shared/AbstractCommSplitter.F90
@@ -1,7 +1,6 @@
 #include "MAPL.h"
 
 module MAPL_AbstractCommSplitterMod
-   use MPI
    implicit none
    private
 

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -13,12 +13,12 @@ set (srcs
     MAPL_Range.F90
     MAPL_Sort.F90
     MAPL_Throw.F90
+    MAPL_MpiErrorHandling.F90
     AbstractCommSplitter.F90
     CommGroupDescription.F90
     SplitCommunicator.F90
     SimpleCommSplitter.F90
     sort.c
-    MAPL_ExceptionHandling.F90
     String.F90
     StringUtilities.F90
     MaplShared.F90

--- a/shared/ErrorHandling.F90
+++ b/shared/ErrorHandling.F90
@@ -2,7 +2,6 @@
 
 module mapl_ErrorHandling
    use MAPL_ThrowMod
-   use MPI
    implicit none
    private
 
@@ -16,6 +15,14 @@ module mapl_ErrorHandling
    public :: MAPL_Vrfy
    public :: MAPL_ASRT
    public :: MAPL_abort
+   public :: MAPL_set_abort_handler
+
+   abstract interface
+      subroutine abort_handler_interface()
+      end subroutine abort_handler_interface
+   end interface
+
+   procedure(abort_handler_interface), pointer :: abort_handler => null()
 
 
    public :: MAPL_SUCCESS
@@ -277,11 +284,18 @@ contains
         !$omp end critical (MAPL_ErrorHandling10)
    end function MAPL_VRFYT
 
+   subroutine MAPL_set_abort_handler(handler)
+      procedure(abort_handler_interface) :: handler
+      abort_handler => handler
+   end subroutine MAPL_set_abort_handler
+
    subroutine MAPL_abort()
-      integer :: status
-      integer :: error_code = -1
-      call MPI_Abort(MPI_COMM_WORLD,error_code,status)
-  end subroutine MAPL_abort
+      if (associated(abort_handler)) then
+         call abort_handler()
+      else
+         error stop 'MAPL_abort: fatal error'
+      end if
+   end subroutine MAPL_abort
 
   function get_error_message(error_code) result(description)
      use gFTL_IntegerStringMap
@@ -328,3 +342,6 @@ end module mapl_ErrorHandling
 module mapl_ErrorHandlingMod
    use mapl_ErrorHandling
 end module mapl_ErrorHandlingMod
+module MAPL_ExceptionHandling
+   use mapl_ErrorHandling
+end module MAPL_ExceptionHandling

--- a/shared/MAPL_ExceptionHandling.F90
+++ b/shared/MAPL_ExceptionHandling.F90
@@ -1,5 +1,0 @@
-module MAPL_ExceptionHandling
-   use MAPL_ThrowMod
-   use MAPL_ErrorHandlingMod
-   implicit none
-end module MAPL_ExceptionHandling

--- a/shared/MAPL_MpiErrorHandling.F90
+++ b/shared/MAPL_MpiErrorHandling.F90
@@ -1,0 +1,93 @@
+! MPI-aware error and abort handlers for MAPL_ThrowMod and mapl_ErrorHandling.
+! Call MAPL_initialize_error_handling() once after MPI_Init to replace the
+! serial (error stop) defaults with MPI-aware implementations.
+! Serial programs do not need to call this.
+module MAPL_MpiErrorHandlingMod
+   use MAPL_ThrowMod,       only: MAPL_set_throw_method
+   use mapl_ErrorHandling,  only: MAPL_set_abort_handler
+   implicit none
+   private
+
+   public :: MAPL_initialize_error_handling
+
+contains
+
+   subroutine MAPL_initialize_error_handling()
+      call MAPL_set_throw_method(MAPL_mpi_fail)
+      call MAPL_set_abort_handler(MAPL_mpi_abort)
+   end subroutine MAPL_initialize_error_handling
+
+
+   ! MPI-aware throw: prints PE rank then aborts via MPI_Abort
+   subroutine MAPL_mpi_fail(filename, line, message)
+      use MPI
+      use, intrinsic :: iso_fortran_env, only: ERROR_UNIT
+      character(*), intent(in) :: filename
+      integer, intent(in) :: line
+      character(*), optional, intent(in) :: message
+
+      integer, parameter :: FIELD_WIDTH = 40
+      character(FIELD_WIDTH) :: use_name
+      character(3) :: prefix
+      character(:), allocatable :: base_name
+
+      integer :: rank, ierror
+      logical :: is_mpi_initialized
+
+      call MPI_Initialized(is_mpi_initialized, ierror)
+
+      base_name = get_base_name(filename)
+      if (len(base_name) > FIELD_WIDTH) then
+         prefix = '...'
+         use_name = base_name(2:)
+      else
+         prefix = '   '
+         use_name = base_name
+      end if
+
+      if (is_mpi_initialized) then
+         call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
+         !$omp critical (MAPL_MpiError1)
+         write(ERROR_UNIT,'(a,i5.5,1x,a,i5.5,1x,a3,a40,1x,a)') &
+              & 'pe=', rank, 'FAIL at line=', line, prefix, use_name, &
+              & '<'//adjustl(trim(message))//'>'
+         !$omp end critical (MAPL_MpiError1)
+         call MPI_Abort(MPI_COMM_WORLD, 1, ierror)
+      else
+         !$omp critical (MAPL_MpiError1)
+         write(ERROR_UNIT,'(a,i5.5,1x,a3,a40,1x,a)') &
+              & 'FAIL at line=', line, prefix, use_name, &
+              & '<'//adjustl(trim(message))//'>'
+         !$omp end critical (MAPL_MpiError1)
+         error stop 1
+      end if
+
+   end subroutine MAPL_mpi_fail
+
+
+   ! MPI-aware abort: calls MPI_Abort on MPI_COMM_WORLD
+   subroutine MAPL_mpi_abort()
+      use MPI
+      integer :: ierror
+      call MPI_Abort(MPI_COMM_WORLD, -1, ierror)
+   end subroutine MAPL_mpi_abort
+
+
+   function get_base_name(filename) result(base_name)
+      character(:), allocatable :: base_name
+      character(*), intent(in) :: filename
+
+      integer :: idx, idx2
+
+      idx = scan(filename, '/', back=.true.)
+      if (idx /= 0) then
+         idx2 = scan(filename(:idx-1), '/', back=.true.)
+      else
+         idx2 = idx
+      end if
+
+      base_name = filename(idx2+1:)
+
+   end function get_base_name
+
+end module MAPL_MpiErrorHandlingMod

--- a/shared/MAPL_Throw.F90
+++ b/shared/MAPL_Throw.F90
@@ -25,7 +25,7 @@ contains
    end subroutine MAPL_set_throw_method
 
    subroutine initialize()
-      throw_method => MAPL_Fail
+      throw_method => MAPL_serial_fail
       initialized = .true.
    end subroutine initialize
 
@@ -44,23 +44,17 @@ contains
    end subroutine MAPL_throw_exception
 
 
-   subroutine MAPL_Fail(filename, line, message)
-      use MPI
+   subroutine MAPL_serial_fail(filename, line, message)
       use, intrinsic :: iso_fortran_env, only: ERROR_UNIT
       character(*), intent(in) :: filename
       integer, intent(in) :: line
       character(*), optional, intent(in) :: message
 
-      integer, parameter :: FIELD_WIDTH=40
+      integer, parameter :: FIELD_WIDTH = 40
       character(FIELD_WIDTH) :: use_name
       character(3) :: prefix
       character(:), allocatable :: base_name
-      
-      integer :: rank, ierror
-      logical :: is_mpi_initialized
 
-      call MPI_Initialized(is_mpi_initialized,ierror)
-  
       base_name = get_base_name(filename)
       if (len(base_name) > FIELD_WIDTH) then
          prefix = '...'
@@ -70,27 +64,15 @@ contains
          use_name = base_name
       end if
 
-      ! Could use ADVANCE='no', but this may increase the chance
-      ! that the output lines are not interrupted by messages from
-      ! other PEs
-      if (is_mpi_initialized) then
-         call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierror)
-         !$omp critical (MAPL_Throw1)
-         write(ERROR_UNIT,'(a,i5.5,1x,a,i5.5,1x,a3,a40,1x,a)') &
-              & 'pe=', rank, 'FAIL at line=', line, prefix, use_name, &
-              & '<'//adjustl(trim(message))//'>'
-         !$omp end critical (MAPL_Throw1)
-      else
-         !$omp critical (MAPL_Throw1)
-         write(ERROR_UNIT,'(a,i5.5,1x,a3,a40,1x,a)') &
-              & 'FAIL at line=', line, prefix, use_name, &
-              & '<'//adjustl(trim(message))//'>'
-         !$omp end critical (MAPL_Throw1)
-      end if
+      !$omp critical (MAPL_Throw1)
+      write(ERROR_UNIT,'(a,i5.5,1x,a3,a40,1x,a)') &
+           & 'FAIL at line=', line, prefix, use_name, &
+           & '<'//adjustl(trim(message))//'>'
+      !$omp end critical (MAPL_Throw1)
 
+      error stop 1
 
-      
-   end subroutine MAPL_Fail
+   end subroutine MAPL_serial_fail
 
 
 


### PR DESCRIPTION
## Types of change(s)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests` or `ctest`)

## Description

`ErrorHandling.F90` and `MAPL_Throw.F90` previously had direct MPI dependencies, blocking their use in a serial/MPI-free tier. This PR applies the lazy-init procedure pointer pattern to make both modules fully MPI-free:

- **`MAPL_Throw.F90`**: serial `error stop` default; MPI-aware throw injected via `MAPL_set_throw_method`
- **`ErrorHandling.F90`**: `use MPI` removed; `MAPL_abort` now calls through a procedure pointer defaulting to `error stop`; `MAPL_ExceptionHandling` alias collapsed into bottom of file; separate `MAPL_ExceptionHandling.F90` deleted
- **`MAPL_MpiErrorHandling.F90`** (new): owns both MPI-aware handlers and `MAPL_initialize_error_handling()` — call once after `MPI_Init` for MPI programs; serial and pFUnit programs use serial defaults automatically
- Dead `use MPI` removed from `AbstractCommSplitter.F90`, `pfio/BaseThread.F90`, `pfio/ForwardDataAndMessage.F90`

A follow-on issue (#4920) tracks consolidation of the three error handling module name aliases to a single canonical `mapl_ErrorHandling`.

## Related Issues

Closes #4917
Part of #4905
See also: #4918, #4919, #4920