### PR TITLE
v2: Prepare for 2.69.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- check before assign tilelons and tilelats in MAPL_Locstreamget
-
 ### Added
 
 ### Changed
@@ -18,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Deprecated
+
+## [2.69.1] - 2026-05-19
+
+### Fixed
+
+- Check before assigning tilelons and tilelats in `MAPL_Locstreamget`
 
 ## [2.69.0] - 2026-05-15
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.69.0
+  VERSION 2.69.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
Prepare for a 2.69.1 release as this change is needed by the LDAS