### PR TITLE
MAPL: fix vector component naming lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Relaxed the comparison standard for grid_is_ok in case a grid is r4
+- Fix vector component naming lifecycle in `superstructure/generic/specs/VariableSpec.F90`
+  and `superstructure/generic/specs/VectorClassAspect.F90` by using resolved
+  `vector_component_names` when constructing `VectorClassAspect` and setting
+  component field names during create-time rather than deferring in add-to-state
+  (PR #4946).
 
 ### Added
 - Extended StatisticsGridComp to support variance of a single field.

--- a/superstructure/generic/specs/VariableSpec.F90
+++ b/superstructure/generic/specs/VariableSpec.F90
@@ -679,7 +679,7 @@ contains
          else
             basis_kind = VECTOR_BASIS_KIND_NS
          end if
-         aspect = VectorClassAspect(this%vector_component_names, &
+         aspect = VectorClassAspect(vector_component_names, &
               [ &
               FieldClassAspect(standard_name=std_name_1, fill_value=this%fill_value), &
               FieldClassAspect(standard_name=std_name_2, fill_value=this%fill_value) &

--- a/superstructure/generic/specs/VectorClassAspect.F90
+++ b/superstructure/generic/specs/VectorClassAspect.F90
@@ -155,14 +155,17 @@ contains
       type(AspectMap), intent(in) :: other_aspects
       integer, optional, intent(out) :: rc
 
-      integer :: status
-      integer :: i
+      type(ESMF_Field), allocatable :: field
+      integer :: i, status
 
       do i = 1, NUM_COMPONENTS
          call this%component_specs(i)%create(other_aspects, _RC)
          call update_payload(this%component_specs(i), other_aspects, _RC)
          call this%component_specs(i)%allocate(other_aspects, _RC)
          call this%component_specs(i)%add_to_bundle(this%payload, _RC)
+         ! update the name of the component
+         call this%component_specs(i)%get_payload(field=field, _RC)
+         call ESMF_FieldSet(field, name=trim(this%short_names%at(i)), _RC)
       end do
 
       _RETURN(ESMF_SUCCESS)
@@ -337,13 +340,6 @@ contains
          end if
       end if
       call ESMF_StateAddReplace(substate, [alias], _RC)
-
-      ! Also update the names of the components
-      call MAPL_FieldBundleGet(this%payload, fieldList=field_list, _RC)
-      if (size(field_list) > 0) then ! might be empty if import item
-         call ESMF_FieldSet(field_list(1), name=trim(this%short_names%at(1)), _RC)
-         call ESMF_FieldSet(field_list(2), name=trim(this%short_names%at(2)), _RC)
-      end if
 
       _RETURN(_SUCCESS)
    end subroutine add_to_state


### PR DESCRIPTION
## Summary
Fix vector component naming flow so VectorClassAspect consistently uses resolved component names.

## Changes
- In VariableSpec, pass resolved vector_component_names into VectorClassAspect instead of this%vector_component_names.
- In VectorClassAspect create path, set each component field name immediately after payload retrieval using this%short_names.
- Remove deferred component renaming from add_to_state.

## Why
This prevents incorrect or missing component names when fallback/default vector names are used and keeps naming behavior consistent across lifecycle stages.

## Testing
- Verified staged diff for VariableSpec and VectorClassAspect changes.
- No full build/test run performed in this step.