### PR TITLE
Add real64 cases to FieldBundleGetPointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Extended StatisticsGridComp to support variance of a single field.
+- Extended `FieldBundleGetPointerToData` interface with REAL64 pointer overloads
+  for index/name and 2D/3D variants (PR #4948).
 
 ### Changed
 

--- a/infrastructure/fields/field_bundle/FieldBundleGetPointer.F90
+++ b/infrastructure/fields/field_bundle/FieldBundleGetPointer.F90
@@ -5,7 +5,7 @@ module mapl3g_FieldBundleGetPointer
 
    use ESMF
    use MAPL_ErrorHandling
-   use, intrinsic :: iso_fortran_env, only: real32, real64
+   use, intrinsic :: iso_fortran_env, only: REAL64
 
    implicit none(type,external)
    private
@@ -17,6 +17,10 @@ module mapl3g_FieldBundleGetPointer
       module procedure FieldBundleGetPointerToDataByIndex3
       module procedure FieldBundleGetPointerToDataByName2
       module procedure FieldBundleGetPointerToDataByName3
+      module procedure FieldBundleGetPointerToR8DataByIndex2
+      module procedure FieldBundleGetPointerToR8DataByIndex3
+      module procedure FieldBundleGetPointerToR8DataByName2
+      module procedure FieldBundleGetPointerToR8DataByName3
    end interface FieldBundleGetPointerToData
 
 contains
@@ -35,10 +39,9 @@ contains
 
       call ESMF_FieldBundleGet(bundle, index, field, _RC)
       call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
       if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
          call ESMF_FieldGet(field, 0, ptr, _RC)
-      else
-         nullify(ptr)
       end if
 
       _RETURN(_SUCCESS)
@@ -58,10 +61,9 @@ contains
 
       call ESMF_FieldBundleGet(bundle, index, field, _RC)
       call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
       if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
          call ESMF_FieldGet(field, 0, ptr, _RC)
-      else
-         nullify(ptr)
       end if
 
       _RETURN(_SUCCESS)
@@ -79,16 +81,15 @@ contains
 
       call ESMF_FieldBundleGet(bundle, name, field=field, _RC)
       call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
       if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
          call ESMF_FieldGet(field, 0, ptr, _RC)
-      else
-         nullify(ptr)
       end if
 
      _RETURN(_SUCCESS)
    end subroutine FieldBundleGetPointerToDataByName2
 
-   subroutine FieldBundleGetPointerToDataByName3(BUNDLE,NAME,PTR,RC)
+   subroutine FieldBundleGetPointerToDataByName3(bundle, name, ptr, rc)
       type(ESMF_FieldBundle), intent(inout) :: bundle !ALT: intent(in)
       character(len=*), intent(in) :: name
       real, pointer, intent(inout) :: ptr(:,:,:)
@@ -100,13 +101,96 @@ contains
 
       call ESMF_FieldBundleGet(bundle, name, field=field, _RC)
       call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
       if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
          call ESMF_FieldGet(field, 0, ptr, _RC)
-      else
-         nullify(ptr)
       end if
 
      _RETURN(_SUCCESS)
    end subroutine FieldBundleGetPointerToDataByName3
+
+   subroutine FieldBundleGetPointerToR8DataByIndex2(bundle, index, ptr, rc)
+      type(ESMF_FieldBundle), intent(inout) :: bundle !ALT: intent(in)
+      integer, intent(in) :: index
+      real(REAL64), pointer, intent(inout) :: ptr(:,:)
+      integer, optional, intent(out):: rc
+
+      type(ESMF_Field) :: field
+      type(ESMF_FieldStatus_Flag) :: field_status
+      integer :: status
+
+      ! ESMF 5 reorders items, be careful!
+
+      call ESMF_FieldBundleGet(bundle, index, field, _RC)
+      call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
+      if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
+         call ESMF_FieldGet(field, 0, ptr, _RC)
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine FieldBundleGetPointerToR8DataByIndex2
+
+   subroutine FieldBundleGetPointerToR8DataByIndex3(bundle, index, ptr, rc)
+      type(ESMF_FieldBundle), intent(inout) :: bundle !ALT: intent(in)
+      integer, intent(in) :: index
+      real(REAL64), pointer, intent(inout) :: ptr(:,:,:)
+      integer, optional, intent(out):: rc
+
+      type(ESMF_Field) :: field
+      type(ESMF_FieldStatus_Flag) :: field_status
+      integer :: status
+
+      ! ESMF 5 reorders items, be careful!
+
+      call ESMF_FieldBundleGet(bundle, index, field, _RC)
+      call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
+      if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
+         call ESMF_FieldGet(field, 0, ptr, _RC)
+      end if
+
+      _RETURN(_SUCCESS)
+   end subroutine FieldBundleGetPointerToR8DataByIndex3
+
+   subroutine FieldBundleGetPointerToR8DataByName2(bundle, name, ptr, rc)
+      type(ESMF_FieldBundle), intent(inout) :: bundle !ALT: intent(in)
+      character(len=*), intent(in) :: name
+      real(REAL64), pointer, intent(inout) :: ptr(:,:)
+      integer, optional, intent(out):: rc
+
+      type(ESMF_Field) :: field
+      type(ESMF_FieldStatus_Flag) :: field_status
+      integer :: status
+
+      call ESMF_FieldBundleGet(bundle, name, field=field, _RC)
+      call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
+      if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
+         call ESMF_FieldGet(field, 0, ptr, _RC)
+      end if
+
+     _RETURN(_SUCCESS)
+   end subroutine FieldBundleGetPointerToR8DataByName2
+
+   subroutine FieldBundleGetPointerToR8DataByName3(bundle, name, ptr, rc)
+      type(ESMF_FieldBundle), intent(inout) :: bundle !ALT: intent(in)
+      character(len=*), intent(in) :: name
+      real(REAL64), pointer, intent(inout) :: ptr(:,:,:)
+      integer, optional, intent(out):: rc
+
+      type(ESMF_Field) :: field
+      type(ESMF_FieldStatus_Flag) :: field_status
+      integer :: status
+
+      call ESMF_FieldBundleGet(bundle, name, field=field, _RC)
+      call ESMF_FieldGet(field, status=field_status, _RC)
+      nullify(ptr)
+      if (field_status == ESMF_FIELDSTATUS_COMPLETE) then
+         call ESMF_FieldGet(field, 0, ptr, _RC)
+      end if
+
+     _RETURN(_SUCCESS)
+   end subroutine FieldBundleGetPointerToR8DataByName3
 
 end module mapl3g_FieldBundleGetPointer

--- a/infrastructure/fields/field_bundle/tests/Test_FieldBundleGetPointer.pf
+++ b/infrastructure/fields/field_bundle/tests/Test_FieldBundleGetPointer.pf
@@ -332,4 +332,134 @@ contains
       _UNUSED_DUMMY(this)
    end subroutine test_GetPointerByName3D_Actual3D
 
+   ! Test getting REAL64 pointer by index for 2D field
+   @Test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_GetPointerByIndex2D_Real64(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field) :: field1, field2
+      real(REAL64), pointer :: ptr(:,:)
+      integer :: rc, status
+
+      ! Create fields
+      field1 = ESMF_FieldCreate(original, _RC)
+      field2 = ESMF_FieldCreate(original, _RC)
+      bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
+
+      ! Get pointer by index using REAL64
+      call FieldBundleGetPointerToData(bundle, 1, ptr, rc=status)
+      @assertEqual(status, _SUCCESS, 'Failed to get REAL64 pointer by index for 2D field')
+
+      ! Verify we got a pointer
+      @assertTrue(associated(ptr), 'REAL64 pointer should be associated')
+      nullify(ptr)
+
+      call ESMF_FieldDestroy(field1, _RC)
+      call ESMF_FieldDestroy(field2, _RC)
+      call ESMF_FieldBundleDestroy(bundle, _RC)
+
+      _UNUSED_DUMMY(this)
+   end subroutine test_GetPointerByIndex2D_Real64
+
+   ! Test getting REAL64 pointer by index for 3D field
+   @Test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_GetPointerByIndex3D_Real64(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field) :: field1, field2
+      type(ESMF_Grid) :: grid
+      type(ESMF_TypeKind_Flag) :: typekind
+      real(REAL64), pointer :: ptr(:,:,:)
+      integer :: rc, status
+
+      call ESMF_FieldGet(original, grid=grid, typekind=typekind, _RC)
+      ! Create actual 3D fields
+      field1 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[3], _RC)
+      field2 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[3], _RC)
+      bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
+
+      ! Get REAL64 pointer by index
+      call FieldBundleGetPointerToData(bundle, 1, ptr, rc=status)
+      @assertEqual(status, _SUCCESS, 'Failed to get REAL64 pointer by index for 3D field')
+
+      ! Verify we got a pointer
+      @assertTrue(associated(ptr), 'REAL64 pointer should be associated')
+      nullify(ptr)
+
+      call ESMF_FieldDestroy(field1, _RC)
+      call ESMF_FieldDestroy(field2, _RC)
+      call ESMF_FieldBundleDestroy(bundle, _RC)
+
+      _UNUSED_DUMMY(this)
+   end subroutine test_GetPointerByIndex3D_Real64
+
+   ! Test getting REAL64 pointer by name for 2D field
+   @Test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_GetPointerByName2D_Real64(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field) :: field1, field2
+      real(REAL64), pointer :: ptr(:,:)
+      integer :: rc, status
+
+      ! Create fields with names
+      field1 = ESMF_FieldCreate(original, _RC)
+      call ESMF_FieldSet(field1, name='temperature_r8', _RC)
+      field2 = ESMF_FieldCreate(original, _RC)
+      call ESMF_FieldSet(field2, name='pressure_r8', _RC)
+      bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
+
+      ! Get REAL64 pointer by name
+      call FieldBundleGetPointerToData(bundle, 'temperature_r8', ptr, rc=status)
+      @assertEqual(status, _SUCCESS, 'Failed to get REAL64 pointer by name for 2D field')
+
+      ! Verify we got a pointer
+      @assertTrue(associated(ptr), 'REAL64 pointer by name should be associated')
+      nullify(ptr)
+
+      call ESMF_FieldDestroy(field1, _RC)
+      call ESMF_FieldDestroy(field2, _RC)
+      call ESMF_FieldBundleDestroy(bundle, _RC)
+
+      _UNUSED_DUMMY(this)
+   end subroutine test_GetPointerByName2D_Real64
+
+   ! Test getting REAL64 pointer by name for 3D field
+   @Test(type=ESMF_TestMethod, npes=[1])
+   subroutine test_GetPointerByName3D_Real64(this)
+      class(ESMF_TestMethod), intent(inout) :: this
+
+      type(ESMF_FieldBundle) :: bundle
+      type(ESMF_Field) :: field1, field2
+      type(ESMF_Grid) :: grid
+      type(ESMF_TypeKind_Flag) :: typekind
+      real(REAL64), pointer :: ptr(:,:,:)
+      integer :: rc, status
+
+      call ESMF_FieldGet(original, grid=grid, typekind=typekind, _RC)
+      ! Create actual 3D fields with names
+      field1 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[2], _RC)
+      call ESMF_FieldSet(field1, name='velocity_r8', _RC)
+      field2 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[2], _RC)
+      call ESMF_FieldSet(field2, name='density_r8', _RC)
+      bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
+
+      ! Get REAL64 pointer by name
+      call FieldBundleGetPointerToData(bundle, 'velocity_r8', ptr, rc=status)
+      @assertEqual(status, _SUCCESS, 'Failed to get REAL64 pointer by name for 3D field')
+
+      ! Verify we got a pointer
+      @assertTrue(associated(ptr), 'REAL64 pointer by name should be associated')
+      nullify(ptr)
+
+      call ESMF_FieldDestroy(field1, _RC)
+      call ESMF_FieldDestroy(field2, _RC)
+      call ESMF_FieldBundleDestroy(bundle, _RC)
+
+      _UNUSED_DUMMY(this)
+   end subroutine test_GetPointerByName3D_Real64
+
  end module Test_FieldBundleGetPointer

--- a/infrastructure/fields/field_bundle/tests/Test_FieldBundleGetPointer.pf
+++ b/infrastructure/fields/field_bundle/tests/Test_FieldBundleGetPointer.pf
@@ -8,6 +8,7 @@ module Test_FieldBundleGetPointer
    use mapl3g_FieldBundleGetPointer
    use MAPL_ErrorHandling, only: MAPL_Verify
    use ESMF
+   use, intrinsic :: iso_fortran_env, only: REAL64
    use pfunit
    use ESMF_TestMethod_mod
 
@@ -339,12 +340,15 @@ contains
 
       type(ESMF_FieldBundle) :: bundle
       type(ESMF_Field) :: field1, field2
+      type(ESMF_Grid) :: grid
       real(REAL64), pointer :: ptr(:,:)
       integer :: rc, status
+      type(ESMF_TypeKind_Flag), parameter :: typekind = ESMF_TYPEKIND_R8
 
       ! Create fields
-      field1 = ESMF_FieldCreate(original, _RC)
-      field2 = ESMF_FieldCreate(original, _RC)
+      call ESMF_FieldGet(original, grid=grid, _RC)
+      field1 = ESMF_FieldCreate(grid, typekind, _RC)
+      field2 = ESMF_FieldCreate(grid, typekind, _RC)
       bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
 
       ! Get pointer by index using REAL64
@@ -370,11 +374,11 @@ contains
       type(ESMF_FieldBundle) :: bundle
       type(ESMF_Field) :: field1, field2
       type(ESMF_Grid) :: grid
-      type(ESMF_TypeKind_Flag) :: typekind
       real(REAL64), pointer :: ptr(:,:,:)
       integer :: rc, status
+      type(ESMF_TypeKind_Flag), parameter :: typekind = ESMF_TYPEKIND_R8
 
-      call ESMF_FieldGet(original, grid=grid, typekind=typekind, _RC)
+      call ESMF_FieldGet(original, grid=grid, _RC)
       ! Create actual 3D fields
       field1 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[3], _RC)
       field2 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[3], _RC)
@@ -402,13 +406,16 @@ contains
 
       type(ESMF_FieldBundle) :: bundle
       type(ESMF_Field) :: field1, field2
+      type(ESMF_Grid) :: grid
       real(REAL64), pointer :: ptr(:,:)
       integer :: rc, status
+      type(ESMF_TypeKind_Flag), parameter :: typekind = ESMF_TYPEKIND_R8
 
       ! Create fields with names
-      field1 = ESMF_FieldCreate(original, _RC)
+      call ESMF_FieldGet(original, grid=grid, _RC)
+      field1 = ESMF_FieldCreate(grid, typekind, _RC)
       call ESMF_FieldSet(field1, name='temperature_r8', _RC)
-      field2 = ESMF_FieldCreate(original, _RC)
+      field2 = ESMF_FieldCreate(grid, typekind, _RC)
       call ESMF_FieldSet(field2, name='pressure_r8', _RC)
       bundle = ESMF_FieldBundleCreate(fieldList=[field1, field2], _RC)
 
@@ -435,11 +442,11 @@ contains
       type(ESMF_FieldBundle) :: bundle
       type(ESMF_Field) :: field1, field2
       type(ESMF_Grid) :: grid
-      type(ESMF_TypeKind_Flag) :: typekind
       real(REAL64), pointer :: ptr(:,:,:)
       integer :: rc, status
+      type(ESMF_TypeKind_Flag), parameter :: typekind = ESMF_TYPEKIND_R8
 
-      call ESMF_FieldGet(original, grid=grid, typekind=typekind, _RC)
+      call ESMF_FieldGet(original, grid=grid, _RC)
       ! Create actual 3D fields with names
       field1 = ESMF_FieldCreate(grid, typekind, ungriddedLBound=[1], ungriddedUBound=[2], _RC)
       call ESMF_FieldSet(field1, name='velocity_r8', _RC)


### PR DESCRIPTION
Extends FieldBundleGetPointerToData generic interface with REAL64 pointer overloads for index/name and 2D/3D variants