### PR TITLE
Re-export PackedDateCreate, PackedTimeCreate, and StrTemplate from MAPL umbrella

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 <!-- mlc-enable -->
 
+### Added
+
+- Re-export `PackedDateCreate`, `PackedTimeCreate`, `PackedDateTimeCreate` (from
+  `MAPL_PackedTimeMod`) and `StrTemplate` (from `MAPL_StringTemplate`) via the
+  `mapl_mp_utils` API so they are accessible through `USE MAPL` without client
+  code needing to reference internal submodules directly (fixes #4963).
+
 ### Fixed
 
 - Fix NVHPC compiler build failure in `superstructure/generic/OpenMP_Support.F90`:

--- a/mp_utils/API.F90
+++ b/mp_utils/API.F90
@@ -7,6 +7,8 @@ module mapl_mp_utils
    use mapl_MemInfo, only: MAPL_MemInfoWrite => MemInfoWrite
    use mapl_TimeUtilities, only: MAPL_PackTime => PackTime, MAPL_UnpackTime => UnpackTime
    use mapl_OSUtilities, only: MAPL_GetCheckpointSubdir => get_checkpoint_subdir
+   use MAPL_PackedTimeMod, only: PackedDateCreate, PackedTimeCreate, PackedDateTimeCreate
+   use MAPL_StringTemplate, only: StrTemplate
 
    ! We use default PUBLIC to avoid explicitly listing exports from
    ! the other layers.  When the dust settles and such micro


### PR DESCRIPTION
## Summary

- Add `MAPL_PackedTimeMod` and `MAPL_StringTemplate` to `mp_utils/API.F90` so that `PackedDateCreate`, `PackedTimeCreate`, `PackedDateTimeCreate`, and `StrTemplate` are re-exported through the `MAPL` umbrella module
- Client code can now access these symbols via `USE MAPL` without reaching into internal submodules

Closes #4963