### PR TITLE
Add mapl_ prefix to initialize_constants (#4976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add `mapl_` prefix to `initialize_constants` subroutine (#4976, part of #4975/#4969).
+  Renamed `initialize_constants()` → `mapl_initialize_constants()` in 
+  `utils/Constants/Constants.F90` to follow MAPL3 naming conventions (lowercase `mapl_` 
+  prefix for procedures). Breaking change if any external code was calling 
+  `initialize_constants` directly (unlikely as subroutine is currently empty/placeholder). 
+  All `MAPL_*` constants remain publicly accessible. Zero-diff.
 - Consolidate enums into `enums/` layer and introduce `MAPL_` API constants (#4973, part of #4969).
   Moved `StateItemAllocation` and `FieldBundleType_Flag` from `infrastructure/field/` and 
   `infrastructure/field_bundle/` respectively into the `enums/` layer. Created `enums/API.F90` 

--- a/utils/Constants/Constants.F90
+++ b/utils/Constants/Constants.F90
@@ -6,11 +6,13 @@ module MAPL_Constants
    use mapl_EarthConstants_mod
    use mapl_EarthAtmosphericConstants_mod
 
+   implicit none(type, external)
+
 contains
 
-   subroutine initialize_constants()
+   subroutine mapl_initialize_constants()
       implicit none
-   end subroutine initialize_constants
+   end subroutine mapl_initialize_constants
 
 end module MAPL_Constants
 


### PR DESCRIPTION
## Summary

Implements issue #4976 (part of #4975 - Add mapl_/MAPL_ prefix to all unprefixed public API entities, which is part of #4969 - MAPL Public API Cleanup and Code Organization).

This PR renames the single unprefixed public entity in the `MAPL_Constants` module to follow MAPL3 naming conventions.

## Changes

**File**: `utils/Constants/Constants.F90`

1. Renamed `initialize_constants()` → `mapl_initialize_constants()`
2. Added `implicit none(type, external)` for modern Fortran best practices
3. All `MAPL_*` constants from sub-modules remain publicly accessible (default public visibility maintained)

**File**: `CHANGELOG.md`

- Added entry documenting this breaking API change

## Breaking Change

This is a **BREAKING API CHANGE**. Any external code calling `initialize_constants()` directly will need to update to `mapl_initialize_constants()`.

**Impact**: Minimal. The subroutine is currently empty (placeholder for future initialization logic) and is not currently used in any client code.

## Testing

- [ ] Build MAPL successfully
- [ ] Run MAPL tests
- [ ] Build GEOSgcm against modified MAPL
- [ ] Run GEOSgcm tests

## Related Issues

Closes #4976
Part of #4975
Part of #4969

## Notes

- This is the smallest grandchild issue under #4975 - good starting point for the MAPL3 API prefix work
- All constants aggregated from sub-modules (InternalConstants, MathConstants, PhysicalConstants, EarthConstants, EarthAtmosphericConstants) already have proper `MAPL_` prefixes
- Only `initialize_constants` lacked the prefix
- During investigation, discovered many unused constants in InternalConstants.F90; created #4997 to track cleanup