### PR TITLE
Remove FileMetadataUtils dep from MAPL.vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove `FileMetadataUtils` dependency from `MAPL.vertical` (#5017). `VerticalCoordinate`
+  now takes `FileMetadata` (pfio) directly instead of the `FileMetadataUtils` wrapper.
+  `udunits2f` is now an explicit dependency of `MAPL.vertical`. Prerequisite for #5014.
+
 - Wrap `ieee_is_nan` calls in `Test_FieldFill.pf` with `ieee_set_halting_mode`/`ieee_set_flag`
   to suppress and clear the IEEE invalid-operation trap around sNaN queries. Without this,
   `-Ktrap=fp` (nvfortran) causes SIGFPE when a signaling NaN is loaded for inspection.

--- a/gridcomps/extdata/PrimaryExport.F90
+++ b/gridcomps/extdata/PrimaryExport.F90
@@ -153,7 +153,7 @@ module mapl_PrimaryExport_mod
       esmfgeom = geom%get_geom()
 
       variable_name => this%file_vars%of(1)
-      this%vcoord = verticalCoordinate(metadata, variable_name, _RC)
+      this%vcoord = verticalCoordinate(metadata%metadata, variable_name, _RC)
       regridder_param = generate_esmf_regrid_param(regrid_method_string_to_int(this%regridding_method), &
          ESMF_TYPEKIND_R4, _RC)
       regridder_param_info = regridder_param%make_info(_RC)
@@ -202,7 +202,7 @@ module mapl_PrimaryExport_mod
       esmfgeom = geom%get_geom()
 
       variable_name => this%file_vars%of(1)
-      this%vcoord = verticalCoordinate(metadata, variable_name, _RC)
+      this%vcoord = verticalCoordinate(metadata%metadata, variable_name, _RC)
 
       call ESMF_StateGet(exportState, item_name, bundle, _RC)
       if (this%vcoord%vertical_type == NO_COORD) then

--- a/infrastructure/vertical/vertical/CMakeLists.txt
+++ b/infrastructure/vertical/vertical/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.utils MAPL.shared MAPL.base MAPL.pfio PFLOGGER::pflogger
+  DEPENDENCIES MAPL.utils MAPL.shared MAPL.pfio udunits2f PFLOGGER::pflogger
   TYPE SHARED
 )
 

--- a/infrastructure/vertical/vertical/VerticalCoordinate.F90
+++ b/infrastructure/vertical/vertical/VerticalCoordinate.F90
@@ -4,7 +4,6 @@ module VerticalCoordinateMod
 
    use PFIO
    use mapl_ExceptionHandling_mod
-   use mapl_FileMetadataUtils_mod
    use gFTL2_StringVector
    use udunits2f, UDUNITS_are_convertible => are_convertible, &
       initialize_udunits => initialize, finalize_udunits => finalize
@@ -56,7 +55,7 @@ contains
 
    function new_verticalCoordinate(metadata, var_name, rc) result(vertical_coord)
       type(VerticalCoordinate) :: vertical_coord
-      type(FileMetaDataUtils), intent(in) :: metadata
+      type(FileMetaData), intent(in) :: metadata
       character(len=*), intent(in) :: var_name
       integer, optional, intent(out) :: rc
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests` or `ctest`)

## Description

`VerticalCoordinate.F90` previously depended on `mapl_FileMetadataUtils_mod`
(from `MAPL.base`) solely to receive a `FileMetadataUtils` argument in its
constructor. All methods called on that argument (`get_variable`, `has_variable`,
`get_coordinate_variable`, `get_source_file`) are native `pfio::FileMetadata`
methods — `FileMetadataUtils` added no value here.

The constructor now takes `type(FileMetadata)` directly, and `udunits2f` is
declared as an explicit dependency of `MAPL.vertical` rather than relying on
transitive linkage through `MAPL.base`.

## Related Issues

Fixes #5017
Prerequisite for #5014