### PR TITLE
Remove utils/TimeUtilities.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Different bug introduced when fixing bug just below this entry.
 - get_checkpoint_subdir() as causing dangling pointer for NAG compiler.
+### Removed
+
+- Remove unused `utils/TimeUtilities.F90` (#5011). The `mapl_TimeUtilities_mod` module
+  (defining `PackDate`, `UnpackDate`, `PackDateTime`, `UnpackDateTime`) had zero call sites
+  in the MAPL3 codebase. Time packing/unpacking functionality remains available via
+  `MAPL_UnpackDateTime` and related functions from `mp_utils/PackedTime.F90`.
+
 - Remove `FileMetadataUtils` dependency from `MAPL.vertical` (#5017). `VerticalCoordinate`
   now takes `FileMetadata` (pfio) directly instead of the `FileMetadataUtils` wrapper.
   `udunits2f` is now an explicit dependency of `MAPL.vertical`. Prerequisite for #5014.

--- a/utils/API.F90
+++ b/utils/API.F90
@@ -61,6 +61,7 @@ module mapl_utils_api
    ! Memory info
    use mapl_MemInfo_mod, only: mapl_MemInfo => MemInfo
    use mapl_MemInfo_mod, only: mapl_MemInfoWrite => MemInfoWrite
+   use mapl_TimeUtilities_mod
 
    implicit none
    private


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This PR removes the duplicate UnpackDateTime in utils/TimeUtilities.F90 which is not used.
mp_utils/PackTime.F90 provides that functionality. Because the other public entities in utils/TimeUtilities.F90 are not used elsewhere, utils/TimeUtilities.F90 is removed along with changes needed for that removal.

I will do a run of GEOSgcm with this branch.

## Related Issue
#5011
