### PR TITLE
v2: Update CI to Baselibs 8.32.0, v5 orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,12 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.27.0
-bcs_version: &bcs_version v11.6.0
+baselibs_version: &baselibs_version v8.32.0
+bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@4
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-and-test-MAPL:

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -59,26 +59,26 @@ jobs:
         include:
           - compiler: gfortran-15
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+            image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
             fc: gfortran
             extra-cmake-args: >-
               -DUSE_F2PY=OFF
               -DMPIEXEC_PREFLAGS=--oversubscribe
           - compiler: gfortran-15-coverage
             cmake-build-type: Coverage
-            image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+            image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
             fc: gfortran
             extra-cmake-args: >-
               -DUSE_F2PY=OFF
               -DMPIEXEC_PREFLAGS=--oversubscribe
           - compiler: ifort
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+            image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
             fc: ifort
             extra-cmake-args: -DUSE_F2PY=OFF
           - compiler: ifx
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
+            image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.17-ifx_2025.3
             fc: ifx
             extra-cmake-args: -DUSE_F2PY=OFF
     env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,7 +46,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_14.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +76,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +106,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -131,7 +131,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.17-ifx_2025.3
     strategy:
       fail-fast: false
       matrix:
@@ -156,7 +156,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update CI to use Baselibs 8.32.0 and circleci-tools orb v5
+- Update `components.yaml`
+  - ESMA_env v5.22.0
+    - Update to GEOSpyD 26.3.2 Python 3.14
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update CI to use Baselibs 8.32.0 and circleci-tools orb v5
+
 ### Removed
 
 ### Deprecated

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v5.21.0
+  tag: v5.22.0
   develop: main
 
 ESMA_cmake:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR updates v2 to use Baselibs 8.32.0 in CI and the v5 orb.

Also tick up the ESMA_env version to match GEOSgcm

## Related Issue

