### PR TITLE
v3: Update CI to Baselibs 8.32.0, v5 orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
 baselibs_version: &baselibs_version v8.32.0
-bcs_version: &bcs_version v11.6.0
+bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,12 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.27.0
+baselibs_version: &baselibs_version v8.32.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@4
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   ############################################################################################################################

--- a/.github/workflows/cdash-nightly.yml
+++ b/.github/workflows/cdash-nightly.yml
@@ -59,26 +59,26 @@ jobs:
         include:
           - compiler: gfortran-15
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+            image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
             fc: gfortran
             extra-cmake-args: >-
               -DUSE_F2PY=OFF
               -DMPIEXEC_PREFLAGS=--oversubscribe
           - compiler: gfortran-15-coverage
             cmake-build-type: Coverage
-            image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+            image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
             fc: gfortran
             extra-cmake-args: >-
               -DUSE_F2PY=OFF
               -DMPIEXEC_PREFLAGS=--oversubscribe
           - compiler: ifort
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+            image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
             fc: ifort
             extra-cmake-args: -DUSE_F2PY=OFF
           - compiler: ifx
             cmake-build-type: ${{ inputs.build_type || 'Debug' }}
-            image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
+            image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.17-ifx_2025.3
             fc: ifx
             extra-cmake-args: -DUSE_F2PY=OFF
     env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
   #   if: github.event.pull_request.draft == false                                    #
   #   runs-on: ubuntu-latest                                                          #
   #   container:                                                                      #
-  #     image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_14.2.0            #
+  #     image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_14.2.0            #
   #   strategy:                                                                       #
   #     fail-fast: false                                                              #
   #     matrix:                                                                       #
@@ -78,7 +78,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env-mkl:v8.27.0-openmpi_5.0.5-gcc_15.2.0
+      image: gmao/ubuntu24-geos-env-mkl:v8.32.0-openmpi_5.0.5-gcc_15.2.0
     strategy:
       fail-fast: false
       matrix:
@@ -108,7 +108,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +133,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.17-ifx_2025.3
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.17-ifx_2025.3
     strategy:
       fail-fast: false
       matrix:
@@ -158,7 +158,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.27.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.32.0-intelmpi_2021.13-ifort_2021.13
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GENERIC_COUPLER_*` → `MAPL_GENERIC_COUPLER_*`,
   `VectorBasisKind`/`VECTOR_BASIS_KIND_*` → `MAPL_VectorBasisKind`/`MAPL_VECTOR_BASIS_KIND_*`,
   `FieldBundleType_Flag` → `MAPL_FieldBundleType_Flag`.
+- Update CI to use Baselibs 8.32.0 and circleci-tools orb v5
+- Update `components.yaml`
+  - ESMA_env v5.22.0
+    - Update to GEOSpyD 26.3.2 Python 3.14
 
 ### Fixed
 
@@ -91,22 +95,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement two-tier umbrella module pattern across all MAPL subdirectories (#5004).
-  Created `Internal.F90` (internal MAPL API) and `Export.F90` (public external API) umbrella 
-  modules for 10 major subdirectories: `mp_utils/`, `enums/`, `utils/`, `base/`, 
-  `infrastructure/esmf/`, `infrastructure/field/` (aggregate of field/, field_bundle/, state/), 
-  `infrastructure/geom/`, `infrastructure/vertical/vertical_grid/`, 
-  `infrastructure/regridder_mgr/`, and `superstructure/generic/`. Each `Internal.F90` aggregates 
-  all leaf modules from its subdirectory with no `private` statement, allowing all symbols to 
-  flow through for use by MAPL sibling subdirectories. Each `Export.F90` selectively re-exports 
-  only MAPL-prefixed public API symbols, providing a clean interface for external consumers. 
-  Updated top-level `mapl/MAPL.F90` to import all new `*_export` modules alongside legacy API 
-  modules for backward compatibility. This establishes the foundation for future API cleanup 
-  and symbol namespace management. Sibling consumers of `enums/` leaf modules migrated to use 
-  `mapl_Enums_internal` with MAPL-prefixed names (~48 files across infrastructure/ and 
-  superstructure/). Cleaned up duplicate symbols: deleted unused `utils/TimeUtils.F90` module 
-  and its tests (had zero consumers), consolidated duplicate `is_digit` implementation, removed 
-  duplicate `UnpackDateTime` from `Regrid_Util.F90`, and resolved `KEY_UNITS`/`KEY_TYPEKIND` 
-  naming conflicts between esmf and history layers using selective `only:` imports. Created 
+  Created `Internal.F90` (internal MAPL API) and `Export.F90` (public external API) umbrella
+  modules for 10 major subdirectories: `mp_utils/`, `enums/`, `utils/`, `base/`,
+  `infrastructure/esmf/`, `infrastructure/field/` (aggregate of field/, field_bundle/, state/),
+  `infrastructure/geom/`, `infrastructure/vertical/vertical_grid/`,
+  `infrastructure/regridder_mgr/`, and `superstructure/generic/`. Each `Internal.F90` aggregates
+  all leaf modules from its subdirectory with no `private` statement, allowing all symbols to
+  flow through for use by MAPL sibling subdirectories. Each `Export.F90` selectively re-exports
+  only MAPL-prefixed public API symbols, providing a clean interface for external consumers.
+  Updated top-level `mapl/MAPL.F90` to import all new `*_export` modules alongside legacy API
+  modules for backward compatibility. This establishes the foundation for future API cleanup
+  and symbol namespace management. Sibling consumers of `enums/` leaf modules migrated to use
+  `mapl_Enums_internal` with MAPL-prefixed names (~48 files across infrastructure/ and
+  superstructure/). Cleaned up duplicate symbols: deleted unused `utils/TimeUtils.F90` module
+  and its tests (had zero consumers), consolidated duplicate `is_digit` implementation, removed
+  duplicate `UnpackDateTime` from `Regrid_Util.F90`, and resolved `KEY_UNITS`/`KEY_TYPEKIND`
+  naming conflicts between esmf and history layers using selective `only:` imports. Created
   GitHub issue #5005 for deferred `utils/` sibling migration. Zero-diff for all passing tests.
 - Added support for MAPL_STATEITEM_VECTOR ITEMTYPE in ACG
 
@@ -128,30 +132,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   All removed entities were unused in gridcomps. Breaking change for external code using removed
   entities - must import leaf modules directly. Zero-diff for ported client repos.
 - Create utils API umbrella to limit exported unprefixed entities (#4999, part of #4975/#4969).
-  Created `utils/API.F90` that exports only used entities from String, StringUtilities, and OS 
-  utilities. Removed from public API: unused StringUtilities functions (to_lower, to_upper, 
-  capitalize, is_alpha, is_alpha_only, is_numeric, is_alphanumeric, to_string, to_character_array, 
-  is_digit, get_ascii_interval, is_alphanum_character, is_lower_character, is_upper_character), 
-  all FileSystemUtilities functions (get_file_extension, get_file_basename), all DSO_Utilities 
-  functions (is_valid_dso_name, is_valid_dso_extension, is_supported_dso_name, 
-  is_supported_dso_extension, adjust_dso_name, SYSTEM_DSO_EXTENSION), and all DirPath entities 
-  (DirPath type, dirpaths variable). Updated MAPL.F90 to use utils API umbrella instead of 
-  individual leaf modules. Breaking change for any external code using removed entities. 
-  Still exported: String (type), split, lowercase, uppercase, and all mapl_os_mod functions. 
+  Created `utils/API.F90` that exports only used entities from String, StringUtilities, and OS
+  utilities. Removed from public API: unused StringUtilities functions (to_lower, to_upper,
+  capitalize, is_alpha, is_alpha_only, is_numeric, is_alphanumeric, to_string, to_character_array,
+  is_digit, get_ascii_interval, is_alphanum_character, is_lower_character, is_upper_character),
+  all FileSystemUtilities functions (get_file_extension, get_file_basename), all DSO_Utilities
+  functions (is_valid_dso_name, is_valid_dso_extension, is_supported_dso_name,
+  is_supported_dso_extension, adjust_dso_name, SYSTEM_DSO_EXTENSION), and all DirPath entities
+  (DirPath type, dirpaths variable). Updated MAPL.F90 to use utils API umbrella instead of
+  individual leaf modules. Breaking change for any external code using removed entities.
+  Still exported: String (type), split, lowercase, uppercase, and all mapl_os_mod functions.
   Zero-diff for ported client repos (removed entities were unused).
 - Add `mapl_` prefix to `initialize_constants` subroutine (#4976, part of #4975/#4969).
-  Renamed `initialize_constants()` → `mapl_initialize_constants()` in 
-  `utils/Constants/Constants.F90` to follow MAPL3 naming conventions (lowercase `mapl_` 
-  prefix for procedures). Breaking change if any external code was calling 
-  `initialize_constants` directly (unlikely as subroutine is currently empty/placeholder). 
+  Renamed `initialize_constants()` → `mapl_initialize_constants()` in
+  `utils/Constants/Constants.F90` to follow MAPL3 naming conventions (lowercase `mapl_`
+  prefix for procedures). Breaking change if any external code was calling
+  `initialize_constants` directly (unlikely as subroutine is currently empty/placeholder).
   All `MAPL_*` constants remain publicly accessible. Zero-diff.
 - Consolidate enums into `enums/` layer and introduce `MAPL_` API constants (#4973, part of #4969).
-  Moved `StateItemAllocation` and `FieldBundleType_Flag` from `infrastructure/field/` and 
-  `infrastructure/field_bundle/` respectively into the `enums/` layer. Created `enums/API.F90` 
-  that exports all enum constants with a `MAPL_` prefix (e.g., `MAPL_STATEITEM_ALLOCATION_ACTIVE`, 
-  `MAPL_FIELDBUNDLETYPE_BASIC`), establishing the public API pattern for MAPL enums. Updated 
-  internal MAPL clients to use enum modules directly. Breaking change for external clients using 
-  unprefixed type names (`StateItemAllocation`, `FieldBundleType_Flag`) - these are no longer 
+  Moved `StateItemAllocation` and `FieldBundleType_Flag` from `infrastructure/field/` and
+  `infrastructure/field_bundle/` respectively into the `enums/` layer. Created `enums/API.F90`
+  that exports all enum constants with a `MAPL_` prefix (e.g., `MAPL_STATEITEM_ALLOCATION_ACTIVE`,
+  `MAPL_FIELDBUNDLETYPE_BASIC`), establishing the public API pattern for MAPL enums. Updated
+  internal MAPL clients to use enum modules directly. Breaking change for external clients using
+  unprefixed type names (`StateItemAllocation`, `FieldBundleType_Flag`) - these are no longer
   exported; use MAPL_-prefixed constants instead. Zero-diff.
 - Flatten `infrastructure/` directory tree (#4972, part of #4969).
   Removes one level of nesting from the fields and geom sublayers:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ MAPL:
 ESMA_env:
   local: ./ESMA_env
   remote: ../ESMA_env.git
-  tag: v5.21.0
+  tag: v5.22.0
   develop: main
 
 ESMA_cmake:


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This updates the CI to use Baselibs v8.32.0 and the v5 orb. We also update ESMA_env to match GEOSgcm

## Related Issue

