### PR TITLE
v2: Test using gen2 circleci resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name maplversion
 
 orbs:
-  ci: geos-esm/circleci-tools@5
+  ci: geos-esm/circleci-tools@dev:cf45abb3382826efc5fa25c957c9d17c8be141d6
 
 workflows:
   build-and-test-MAPL:
@@ -36,6 +36,7 @@ workflows:
               compiler: [ifort]
               cmake_generator: ['Unix Makefiles']
               build_type: ['Debug']
+          resource_class: large.gen2
           baselibs_version: *baselibs_version
           repo: MAPL
           mepodevelop: false
@@ -58,6 +59,7 @@ workflows:
                 - parent_one_child_import_via_extdata
                 - parent_one_child_no_imports
                 - parent_two_siblings_connect_import_export
+          resource_class: large.gen2
           # We will only run the tutorials with GNU make. No need to double up as Ninja is a build test only
           requires:
             - build-and-test-MAPL-as-<< matrix.build_type >>-on-<< matrix.compiler >>-using-Unix Makefiles
@@ -73,6 +75,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          resource_class: large.gen2
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
@@ -88,6 +91,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          resource_class: xlarge.gen2
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
@@ -102,6 +106,7 @@ workflows:
           matrix:
             parameters:
               compiler: [ifort]
+          resource_class: xlarge.gen2
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
@@ -120,6 +125,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
+          resource_class: large.gen2
           baselibs_version: *baselibs_version
           repo: GEOSldas
           mepodevelop: false


### PR DESCRIPTION
I want to test out the new gen2 resources at CircleCI:

https://circleci.com/docs/guides/execution-managed/using-docker/#docker-gen2-benefits

See if they are worth the cost.

Per that page, gen2 is 1.4x faster, but they are also 1.2x more costly...