### PR TITLE
Feature/#5011 make unpackdatetime unambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- get_checkpoint_subdir() as causing dangling pointer for NAG compiler.
 - Remove `FileMetadataUtils` dependency from `MAPL.vertical` (#5017). `VerticalCoordinate`
   now takes `FileMetadata` (pfio) directly instead of the `FileMetadataUtils` wrapper.
   `udunits2f` is now an explicit dependency of `MAPL.vertical`. Prerequisite for #5014.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,7 @@ by opencode
 - Rename apps/MAPL_GridCompSpecs_ACGv3.py to MAPL_GridCompSpecs_ACG.py
 
 ### Removed
+- Remove `UnpackDateTime` from utils/TimeUtilities.F90
 
 ### Deprecated
 

--- a/superstructure/generic/OuterMetaComponent/get_checkpoint_dir.F90
+++ b/superstructure/generic/OuterMetaComponent/get_checkpoint_dir.F90
@@ -48,11 +48,9 @@ contains
       character(:), allocatable :: filename
 
       character(len=:), allocatable :: checkpoint_dir
-      type(GriddedComponentDriver), pointer :: driver
       integer :: status
 
-      driver => this%get_user_gc_driver()
-      filename = driver%get_name()
+      filename = this%get_name()
 
       select case (state_intent%state)
       case (ESMF_STATEINTENT_IMPORT%state)

--- a/utils/API.F90
+++ b/utils/API.F90
@@ -56,8 +56,6 @@ module mapl_utils_api
    public :: PackDate
    public :: PackDateTime
    public :: UnpackDate
-   ! UnpackDateTime removed - conflicts with mp_utils version, see issue #5011
-   ! public :: UnpackDateTime
 
    ! ISO8601 date/time conversion
    public :: convert_ISO8601_to_integer_time

--- a/utils/TimeUtilities.F90
+++ b/utils/TimeUtilities.F90
@@ -8,7 +8,6 @@ module mapl_TimeUtilities_mod
    public PackDate
    public PackDateTime
    public UnpackDate
-   !public UnpackDateTime
 
 contains
 
@@ -37,17 +36,5 @@ contains
       date_time(1) = (10000 * yy) + (100 * mm) + dd
       date_time(2) = (10000 * h) + (100 * m) + s
    end subroutine PackDateTime
-
-   subroutine UnpackDateTime(date_time, yy, mm, dd, h, m, s)
-      integer, intent(in) :: date_time(:)
-      integer, intent(out) :: yy, mm, dd, h, m, s
-
-      yy = date_time(1) / 10000
-      mm = mod(date_time(1), 10000) / 100
-      dd = mod(date_time(1), 100)
-      h = date_time(2) / 10000
-      m = mod(date_time(2), 10000) / 100
-      s = mod(date_time(2), 100)
-   end subroutine UnpackDateTime
 
 end module mapl_TimeUtilities_mod

--- a/utils/TimeUtilities.F90
+++ b/utils/TimeUtilities.F90
@@ -8,7 +8,7 @@ module mapl_TimeUtilities_mod
    public PackDate
    public PackDateTime
    public UnpackDate
-   public UnpackDateTime
+   !public UnpackDateTime
 
 contains
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This PR removes the version of UnpackDateTime in `utils/TimeUtilities.F90`. It is part of the implementation of Issue 5011.

## Related Issue
#5011
