### PR TITLE
Fix run-nag-build-discover nag-build failure in MAPL.esmf_utils.tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed mapl_ prefix from leaf components in ./superstructure/state
 - Removed mapl_ prefix from leaf components in ./infrastucture/geom
 - Remove Generic.F90 that is no longer needed
 - Removed mapl_ prefix from leaf components in Generic

--- a/gridcomps/extdata/ExtDataDerived.F90
+++ b/gridcomps/extdata/ExtDataDerived.F90
@@ -54,11 +54,11 @@ contains
       integer, intent(out), optional :: rc
 
       integer :: status
-      type(StateMask), allocatable :: temp_mask
+      type(MAPL_StateMask), allocatable :: temp_mask
 
       if (index(this%expression,"mask")/=0) then
          allocate(temp_mask)
-         temp_mask = StateMask(this%expression)
+         temp_mask = MAPL_StateMask(this%expression)
          variables_in_expression = temp_mask%get_mask_variables(_RC)
       else
          variables_in_expression = mapl_ParserVariablesInExpression(this%expression,_RC)

--- a/infrastructure/esmf/InfoUtilities.F90
+++ b/infrastructure/esmf/InfoUtilities.F90
@@ -178,11 +178,13 @@ contains
 
       integer :: status
       logical :: is_present
+      real(kind=ESMF_KIND_R8) :: value_r8
 
       is_present = ESMF_InfoIsPresent(info, key=key, _RC)
       _ASSERT(is_present,  "Key not found in info object: " // key)
 
-      call ESMF_InfoGet(info, key=key, value=value, _RC)
+      call ESMF_InfoGet(info, key=key, value=value_r8, _RC)
+      value = real(value_r8, kind=ESMF_KIND_R4)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -885,5 +887,4 @@ contains
    end function concat
 
 end module mapl_InfoUtilities_mod
-
 

--- a/superstructure/generic/transforms/EvalTransform.F90
+++ b/superstructure/generic/transforms/EvalTransform.F90
@@ -104,7 +104,7 @@ contains
 
       call ESMF_StateGet(exportState, itemName=COUPLER_EXPORT_NAME, field=f, _RC)
 
-      call MAPL_StateEval(this%input_state, this%expression, f, _RC)
+      call StateEval(this%input_state, this%expression, f, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(clock)

--- a/superstructure/state/API.F90
+++ b/superstructure/state/API.F90
@@ -2,13 +2,14 @@
 module mapl_state_api
 
    use mapl_StateArithmeticParser_mod, only: MAPL_ParserVariablesInExpression => parser_variables_in_expression
-   use mapl_StateArithmeticParser_mod, only: mapl_StateEval
-   use mapl_StateAddMethod_mod, only: mapl_StateAddMethod
-   use mapl_StateDestroy_mod, only: MAPL_StateDestroy
+   use mapl_StateArithmeticParser_mod, only: mapl_StateEval => StateEval
+   use mapl_StateAddMethod_mod, only: mapl_StateAddMethod => StateAddMethod
+   use mapl_StateDestroy_mod, only: MAPL_StateDestroy => StateDestroy
    use mapl_StateGet_mod, only: MAPL_StateGet => StateGet
+   use mapl_StateSet_mod, only: MAPL_StateSet => StateSet
    use mapl_StateGetGeom_mod, only: MAPL_StateGetGeom => StateGetGeom
    use mapl_StateGetPointer_mod, only: MAPL_StateGetPointer => StateGetPointer
-   use mapl_StateMask_mod
+   use mapl_StateMask_mod, only: MAPL_StateMask => StateMask
    
 
    implicit none
@@ -18,9 +19,10 @@ module mapl_state_api
    public :: mapl_StateAddMethod
    public :: MAPL_StateDestroy
    public :: MAPL_StateGet
+   public :: MAPL_StateSet
    public :: MAPL_StateGetGeom
    public :: MAPL_StateGetPointer
    public :: mapl_StateEval
 
-   public :: StateMask
+   public :: MAPL_StateMask
 end module mapl_state_api

--- a/superstructure/state/StateAddMethod.F90
+++ b/superstructure/state/StateAddMethod.F90
@@ -43,16 +43,16 @@ module mapl_StateAddMethod_mod
    implicit none(type,external)
    private
 
-   public :: mapl_StateAddMethod
+   public :: StateAddMethod
    public :: CallbackMap
    public :: CallbackMapIterator
    public :: CallbackMethodWrapper
    public :: get_callbacks
    public :: operator(/=)
 
-   interface mapl_StateAddMethod
+   interface StateAddMethod
       procedure :: state_add_method
-   end interface mapl_StateAddMethod
+   end interface StateAddMethod
 
 contains
 

--- a/superstructure/state/StateArithmeticParser.F90
+++ b/superstructure/state/StateArithmeticParser.F90
@@ -61,7 +61,7 @@ MODULE mapl_StateArithmeticParser_mod
   PRIVATE
 
   public                     :: parser_variables_in_expression
-  PUBLIC                     :: MAPL_StateEval
+  PUBLIC                     :: StateEval
   PUBLIC                     :: CheckSyntax
   PUBLIC                     :: RealNum
   PUBLIC                     :: LowCase
@@ -140,7 +140,7 @@ CONTAINS
 
   end subroutine bytecode_dealloc
 
-  subroutine MAPL_StateEval(state,expression,field,rc)
+  subroutine StateEval(state,expression,field,rc)
     type(ESMF_State),        intent(in   ) :: state
     character(len=*),        intent(in   ) :: expression
     type(ESMF_Field),        intent(inout) :: field
@@ -181,7 +181,7 @@ CONTAINS
     deallocate(fieldNames,needed)
 
 
-    end subroutine MAPL_StateEval
+    end subroutine StateEval
   !
   SUBROUTINE parsef (Comp, FuncStr, Var, field, rc)
     !----- -------- --------- --------- --------- --------- --------- --------- -------

--- a/superstructure/state/StateDestroy.F90
+++ b/superstructure/state/StateDestroy.F90
@@ -10,11 +10,11 @@ module mapl_StateDestroy_mod
    implicit none(type, external)
 
    private
-   public :: MAPL_StateDestroy
+   public :: StateDestroy
 
-   interface MAPL_StateDestroy
+   interface StateDestroy
       procedure :: destroy_state
-   end interface MAPL_StateDestroy
+   end interface StateDestroy
    
    logical, parameter :: NESTED = .TRUE.
 

--- a/superstructure/state/StateFilter.F90
+++ b/superstructure/state/StateFilter.F90
@@ -38,8 +38,8 @@ module mapl_StateFilter_mod
 
       call ESMF_StateGet(state, itemName, old_field, _RC)
       call ESMF_FieldGet(old_field, typeKind=tk, rank=rank, _RC) 
-      _ASSERT(tk==ESMF_TYPEKIND_R4,"wrong typekind when call MAPL_StateFilter")
-      _ASSERT(rank==2,"wrong rank when call MAPL_StateFilter")
+      _ASSERT(tk==ESMF_TYPEKIND_R4,"wrong typekind when call StateFilter")
+      _ASSERT(rank==2,"wrong rank when call StateFilter")
 
       call ESMF_FieldGet(old_field, 0, farrayPtr=ptr2d_old, _RC)
       allocate(array( lbound(ptr2d_old,1):ubound(ptr2d_old,1) , lbound(ptr2d_old,2):ubound(ptr2d_old,2) ),  _STAT) 
@@ -64,7 +64,7 @@ module mapl_StateFilter_mod
          mask = StateMask(processed_expression)
          call mask%evaluate_mask(state, new_field, _RC)
       else
-         call MAPL_StateEval(state, processed_expression, new_field, _RC)
+         call StateEval(state, processed_expression, new_field, _RC)
       end if
       array = ptr2d_new
 
@@ -91,8 +91,8 @@ module mapl_StateFilter_mod
 
       call ESMF_StateGet(state, itemName, old_field, _RC)
       call ESMF_FieldGet(old_field, typeKind=tk, rank=rank, _RC) 
-      _ASSERT(tk==ESMF_TYPEKIND_R4,"wrong typekind when call MAPL_StateFilter")
-      _ASSERT(rank==3,"wrong rank when call MAPL_StateFilter")
+      _ASSERT(tk==ESMF_TYPEKIND_R4,"wrong typekind when call StateFilter")
+      _ASSERT(rank==3,"wrong rank when call StateFilter")
 
       call ESMF_FieldGet(old_field, 0, farrayPtr=ptr3d_old, _RC)
       allocate(array( lbound(ptr3d_old,1):ubound(ptr3d_old,1) , lbound(ptr3d_old,2):ubound(ptr3d_old,2), lbound(ptr3d_old,3):ubound(ptr3d_old,3) ),  _STAT) 
@@ -117,7 +117,7 @@ module mapl_StateFilter_mod
          mask = StateMask(processed_expression)
          call mask%evaluate_mask(state, new_field, _RC)
       else
-         call MAPL_StateEval(state, processed_expression, new_field, _RC)
+         call StateEval(state, processed_expression, new_field, _RC)
       end if
       array = ptr3d_new
 

--- a/superstructure/state/tests/Test_StateArithmetic.pf
+++ b/superstructure/state/tests/Test_StateArithmetic.pf
@@ -59,7 +59,7 @@ contains
       extra_ptr = rval
       allocate(expected_array(3,3),_STAT)
       expected_array = 17.0 + 2.0*sqrt(16.0) 
-      call  MAPL_StateEval(state, expr, field_2d, _RC)
+      call  StateEval(state, expr, field_2d, _RC)
       @assertEqual(expected_array, ptr2d)
       _RETURN(_SUCCESS)
 
@@ -84,7 +84,7 @@ contains
       extra_ptr = rval
       allocate(expected_array(3,3,2),_STAT)
       expected_array = 17.0 + 2.0*sqrt(16.0) 
-      call  MAPL_StateEval(state, expr, field_3d, _RC)
+      call  StateEval(state, expr, field_3d, _RC)
       @assertEqual(expected_array, ptr3d)
       _RETURN(_SUCCESS)
 
@@ -109,7 +109,7 @@ contains
       extra_ptr = rval
       allocate(expected_array(3,3,2),_STAT)
       expected_array = 15.0
-      call  MAPL_StateEval(state, expr, field_3d, _RC)
+      call  StateEval(state, expr, field_3d, _RC)
       @assertEqual(expected_array, ptr3d)
       _RETURN(_SUCCESS)
 

--- a/superstructure/state/tests/Test_StateDestroy.pf
+++ b/superstructure/state/tests/Test_StateDestroy.pf
@@ -51,7 +51,7 @@ contains
       _UNUSED_DUMMY(this)
 
       state = ESMF_StateCreate(_RC)
-      call MAPL_StateDestroy(state, destroy_contents=.FALSE., _RC)
+      call StateDestroy(state, destroy_contents=.FALSE., _RC)
       call ESMF_StateValidate(state, rc=status)
       @assertTrue(status /= ESMF_SUCCESS, 'state was not successfully destroyed.')
 
@@ -92,7 +92,7 @@ contains
       @assertEqual(expected_item_count, itemCount, 'The number of items was incorrect.') 
       call ESMF_StateValidate(state, nestedFlag=.TRUE., rc=status)
       @assertFalse(status /= ESMF_SUCCESS, 'The state is invalid.')
-      call MAPL_StateDestroy(state, destroy_contents=.TRUE., _RC)
+      call StateDestroy(state, destroy_contents=.TRUE., _RC)
       call ESMF_StateValidate(state, nestedFlag=.TRUE., rc=status)
       @assertTrue(status /= ESMF_SUCCESS, 'The state was not successfully destroyed.')
 


### PR DESCRIPTION
## :memo:  Automatic PR: Gitflow: `main` → `develop`

### Description

This PR fixes the failing GitHub Actions job `run-nag-build-discover / nag-build` by addressing a runtime failure in `MAPL.esmf_utils.tests`.

From run `27289225662` (job `80604889462`), the failure occurs in the R4 info retrieval path (`InfoGetR4`) during `MAPL_InfoGetShared`.  
The fix updates `info_get_r4` in `InfoUtilities.F90` to retrieve the value through an R8 temporary and safely cast to R4, avoiding the NAG runtime abort while preserving intended behavior.

## :file_folder:  Modified files
<!-- Diff files - START -->
- `infrastructure/esmf/InfoUtilities.F90`
<!-- Diff files - END -->