### PR TITLE
Move make_dim_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `components.yaml`
   - ESMA_env v5.22.0
     - Update to GEOSpyD 26.3.2 Python 3.14
-- Move make_dim_key function to mapl_UngriddedDims
 ### Fixed
 
 - Different bug introduced when fixing bug just below this entry.
@@ -100,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#ifndef __DARWIN` to fix a runtime error on macOS with NAG (`IEEE_SET_HALTING_MODE is not
   supported`). IEEE halting mode is not supported on macOS/ARM regardless of compiler. The
   `__DARWIN` macro is already defined on Apple builds. Fixes #5023.
+- make_dim_key function from mapl_esmf_info_keys_mod
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `components.yaml`
   - ESMA_env v5.22.0
     - Update to GEOSpyD 26.3.2 Python 3.14
-
+- Move make_dim_key function to mapl_UngriddedDims
 ### Fixed
 
 - Different bug introduced when fixing bug just below this entry.
@@ -152,6 +152,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   naming conflicts between esmf and history layers using selective `only:` imports. Created
   GitHub issue #5005 for deferred `utils/` sibling migration. Zero-diff for all passing tests.
 - Added support for MAPL_STATEITEM_VECTOR ITEMTYPE in ACG
+- Added to_string (integer_to_string) utility function of mapl_StringUtilities
+  to convert an integer to a string with optional variable width
 
 ### Changed
 

--- a/infrastructure/esmf/UngriddedDims.F90
+++ b/infrastructure/esmf/UngriddedDims.F90
@@ -3,7 +3,7 @@
 module mapl_UngriddedDims_mod
    use mapl_InfoUtilities_mod
    use mapl_StringUtilities_mod, only: to_string
-   use mapl_esmf_info_keys_mod, only: KEYSTUB_DIM, KEY_NUM_UNGRIDDED_DIMS, KEY_DIM_STRINGS
+   use mapl_esmf_info_keys_mod, only: KEYSTUB_DIM, KEY_NUM_UNGRIDDED_DIMS
    use mapl_UngriddedDimVector_mod
    use mapl_UngriddedDim_mod
    use mapl_LU_Bound_mod
@@ -205,8 +205,7 @@ contains
       do i = 1, this%get_num_ungridded()
          dim_spec => this%get_ith_dim_spec(i, _RC)
          dim_info = dim_spec%make_info(_RC)
-
-         dim_key = make_dim_key(i)
+         dim_key = KEYSTUB_DIM // to_string(i)
          call ESMF_InfoSet(info, key=dim_key, value=dim_info, _RC)
          call ESMF_InfoDestroy(dim_info, _RC)
       end do
@@ -248,7 +247,7 @@ contains
       allocate(dim_specs(num_ungridded_dims))
 
       do i = 1, num_ungridded_dims
-         dim_key = make_dim_key(i, _RC)
+         dim_key = KEYSTUB_DIM // to_string(i)
          if (present(key)) then
             dim_key = key // dim_key
          end if
@@ -267,23 +266,4 @@ contains
       is_mirror = this%is_mirror_
    end function is_mirror
 
-   function make_dim_key(n, rc) result(key)
-      character(len=:), allocatable :: key
-      integer, intent(in) :: n
-      integer, optional, intent(out) :: rc
-      integer :: status
-      character(len=32) :: raw
-
-      key = ''
-      _ASSERT(n > 0, 'Index must be positive.')
-      if(n <= size(KEY_DIM_STRINGS)) then
-         key = KEY_DIM_STRINGS(n)
-         _RETURN(_SUCCESS)
-      end if
-      raw = to_string(n)
-      key = KEYSTUB_DIM // raw
-      _RETURN(_SUCCESS)
-
-   end function make_dim_key
-   
 end module mapl_UngriddedDims_mod

--- a/infrastructure/esmf/UngriddedDims.F90
+++ b/infrastructure/esmf/UngriddedDims.F90
@@ -2,7 +2,8 @@
 
 module mapl_UngriddedDims_mod
    use mapl_InfoUtilities_mod
-   use mapl_esmf_info_keys_mod
+   use mapl_StringUtilities_mod, only: to_string
+   use mapl_esmf_info_keys_mod, only: KEYSTUB_DIM, KEY_NUM_UNGRIDDED_DIMS, KEY_DIM_STRINGS
    use mapl_UngriddedDimVector_mod
    use mapl_UngriddedDim_mod
    use mapl_LU_Bound_mod
@@ -266,5 +267,23 @@ contains
       is_mirror = this%is_mirror_
    end function is_mirror
 
-end module mapl_UngriddedDims_mod
+   function make_dim_key(n, rc) result(key)
+      character(len=:), allocatable :: key
+      integer, intent(in) :: n
+      integer, optional, intent(out) :: rc
+      integer :: status
+      character(len=32) :: raw
 
+      key = ''
+      _ASSERT(n > 0, 'Index must be positive.')
+      if(n <= size(KEY_DIM_STRINGS)) then
+         key = KEY_DIM_STRINGS(n)
+         _RETURN(_SUCCESS)
+      end if
+      raw = to_string(n)
+      key = KEYSTUB_DIM // raw
+      _RETURN(_SUCCESS)
+
+   end function make_dim_key
+   
+end module mapl_UngriddedDims_mod

--- a/utils/API.F90
+++ b/utils/API.F90
@@ -63,8 +63,7 @@ module mapl_utils_api
         KEY_VLOC, KEY_NUM_UNGRIDDED_DIMS, KEYSTUB_DIM, &
         KEY_UNGRIDDED_NAME, KEY_UNGRIDDED_UNITS, KEY_UNGRIDDED_COORD, &
         KEY_DIM_STRINGS, KEY_VERT_STAGGERLOC, &
-        KEY_BRACKET_UPDATED, KEY_VECTOR_BASIS_KIND, &
-        make_dim_key
+        KEY_BRACKET_UPDATED, KEY_VECTOR_BASIS_KIND
 
    ! Validation
    use mapl_Validation_mod

--- a/utils/MAPL_ESMF_InfoKeys.F90
+++ b/utils/MAPL_ESMF_InfoKeys.F90
@@ -26,7 +26,6 @@ module mapl_esmf_info_keys_mod
    public :: KEY_UNGRIDDED_UNITS
    public :: KEY_UNGRIDDED_COORD
    public :: KEY_DIM_STRINGS
-   public :: make_dim_key
    public :: KEY_VERT_STAGGERLOC
    public :: KEY_BRACKET_UPDATED
    public :: KEY_VECTOR_BASIS_KIND
@@ -75,27 +74,5 @@ module mapl_esmf_info_keys_mod
    character(len=*), parameter :: KEY_FIELD_PROTOTYPE = '/field_prototype'
    character(len=*), parameter :: KEY_INTERPOLATION_WEIGHTS = '/interpolation_weights'
    character(len=*), parameter :: KEY_FIELDBUNDLETYPE = '/fieldBundleType'
-
-contains
-
-   function make_dim_key(n, rc) result(key)
-      character(len=:), allocatable :: key
-      integer, intent(in) :: n
-      integer, optional, intent(out) :: rc
-      integer :: status
-      character(len=32) :: raw
-
-      key = ''
-      _ASSERT(n > 0, 'Index must be positive.')
-      if(n <= size(KEY_DIM_STRINGS)) then
-         key = KEY_DIM_STRINGS(n)
-         _RETURN(_SUCCESS)
-      end if
-      write(raw, fmt='(I0)', iostat=status) n
-      _ASSERT(status == 0, 'Write failed')
-      key = KEYSTUB_DIM // trim(raw)
-      _RETURN(_SUCCESS)
-
-   end function make_dim_key
 
 end module mapl_esmf_info_keys_mod

--- a/utils/StringUtilities.F90
+++ b/utils/StringUtilities.F90
@@ -46,6 +46,11 @@ module mapl_StringUtilities_mod
       module procedure :: capitalize_string
    end interface capitalize
 
+   interface to_string
+      module procedure :: array_to_string
+      module procedure :: integer_to_string
+   end interface to_string
+
    interface get_ascii_interval
       module procedure :: get_ascii_interval_array
       module procedure :: get_ascii_interval_string
@@ -118,7 +123,7 @@ contains
    ! Utility functions to convert strings (arbitrary character variables)
    !===============================================================================
 
-   function to_string(array) result(string)
+   function array_to_string(array) result(string)
       character(len=:), allocatable :: string
       character, intent(in) :: array(:)
       integer :: i
@@ -128,7 +133,7 @@ contains
          string(i:i) = array(i)
       end do
 
-   end function to_string
+   end function array_to_string
 
    function to_character_array(s) result(ch)
       character, allocatable :: ch(:)
@@ -141,6 +146,20 @@ contains
       end do
 
    end function to_character_array
+
+   function integer_to_string(n, w) result(s)
+      character(len=:), allocatable :: s
+      integer, intent(in) :: n
+      integer, optional, intent(in) :: w ! allow for zero padding
+
+      character(32) :: buf, fmt
+
+      fmt = '(I0)'
+      if(present(w)) write(fmt, "('(I',I0,')')") max(0, w)
+      write (buf, trim(fmt)) n
+      s = trim(buf)
+
+   end function integer_to_string
 
    !===============================================================================
    ! Inquiry functions - character


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
Add to_string function to convert an integer to a string (character) [mapl_StringUtilities]
Move the make_dim_key function to mapl_UngriddedDims_mod, which is the only module that uses the function, which is specific to UngriddedDims. GEOSgcm does not use make_dim_key, so it is removed from mapl_utils_api

## Related Issue
#5068
