### PR TITLE
Remove ESMF_HCONFIGSET_HAS_INTENT_INOUT ifdefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed `ESMF_HCONFIGSET_HAS_INTENT_INOUT` preprocessor conditionals now that
+  ESMF 9.0.0 is required (≥ 8.9.0, where `ESMF_HConfigSet` gained `intent(inout)`).
+  The `intent(inout)` declarations in `HConfigUtilities.F90`, `OuterMetaComponent.F90`,
+  `add_child_by_spec.F90`, and `MAPL_Generic.F90` are now unconditional.
+  Updated `INSTALL.md` to reflect the ESMF 9.0.0 minimum requirement.
+  Closes [#3477](https://github.com/GEOS-ESM/MAPL/issues/3477).
+
 <!-- mlc-disable -->
 ## [v3.0.0-alpha.2] - 2026-06-12
 <!-- mlc-enable -->

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,17 +162,6 @@ endif ()
 # spack sets modification times on files when using binary-caches
 include(cmake/NAGModtimeWorkaround.cmake)
 
-# There is an interface change in ESMF_HConfig in ESMF 8.9.0,
-# so we need to check the version and if it is 8.9.0 or later,
-# set a variable.
-# NOTE: When we move to requiring ESMF 8.9.0 we can
-#       remove all this code and use the updated interface!
-if(ESMF_VERSION VERSION_GREATER_EQUAL 8.9.0)
-  set (ESMF_HCONFIGSET_HAS_INTENT_INOUT TRUE)
-  message(STATUS "ESMF_HConfig has intent(inout) in ESMF 8.9.0 or later")
-else()
-  set (ESMF_HCONFIGSET_HAS_INTENT_INOUT FALSE)
-endif()
 
 # We wish to add extra flags when compiling as Debug. We should only
 # do this if we are using esma_cmake since the flags are defined

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,13 +53,12 @@ MAPL is currently tested with the following library versions:
 | netCDF-C       | v4.9.2         |
 | netCDF-Fortran | v4.6.1         |
 | UDUNITS2       | v2.2.28        |
-| ESMF           | v8.9.0         |
+| ESMF           | v9.0.0         |
 | GFE            | v1.19.0        |
 
 #### ESMF Versions
 
-NOTE: MAPL only requires ESMF 8.6.1, but we currently build with
-ESMF 8.9.0 and have support for ESMF 9 betas.
+NOTE: MAPL requires ESMF 9.0.0 or later.
 
 #### ESMA Baselibs
 

--- a/gridcomps/extdata/CMakeLists.txt
+++ b/gridcomps/extdata/CMakeLists.txt
@@ -30,9 +30,6 @@ esma_add_library(${this}
   SRCS ${srcs}
   DEPENDENCIES MAPL ESMF::ESMF PFLOGGER::pflogger TYPE SHARED)
 
-if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-  target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-endif()
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/infrastructure/esmf/CMakeLists.txt
+++ b/infrastructure/esmf/CMakeLists.txt
@@ -57,9 +57,6 @@ target_include_directories (${this} PUBLIC
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
 
-if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-    target_compile_definitions (${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-endif()
 
 if (PFUNIT_FOUND)
     add_subdirectory (tests EXCLUDE_FROM_ALL)

--- a/infrastructure/esmf/hconfig_utils/HConfigUtilities.F90
+++ b/infrastructure/esmf/hconfig_utils/HConfigUtilities.F90
@@ -24,11 +24,7 @@ contains
    function merge_hconfig(parent_hconfig, child_hconfig, rc) result(total_hconfig)
       type(ESMF_HConfig) :: total_hconfig
       type(ESMF_HConfig), intent(in) :: parent_hconfig
-#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
       type(ESMF_HConfig), intent(inout) :: child_hconfig
-#else
-      type(ESMF_HConfig), intent(in) :: child_hconfig
-#endif
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/superstructure/generic/CMakeLists.txt
+++ b/superstructure/generic/CMakeLists.txt
@@ -96,9 +96,6 @@ esma_add_fortran_submodules(
 target_include_directories (${this} PUBLIC
   $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 
-if(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-  target_compile_definitions(${this} PRIVATE ESMF_HCONFIGSET_HAS_INTENT_INOUT)
-endif()
 
 if (PFUNIT_FOUND)
   add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/superstructure/generic/MAPL_Generic.F90
+++ b/superstructure/generic/MAPL_Generic.F90
@@ -540,11 +540,7 @@ contains
    subroutine gridcomp_add_child_by_spec(gridcomp, child_name, child_spec, rc)
       type(ESMF_GridComp), intent(inout) :: gridcomp
       character(len=*), intent(in) :: child_name
-#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
       type(ChildSpec), intent(inout) :: child_spec
-#else
-      type(ChildSpec), intent(in) :: child_spec
-#endif
       integer, optional, intent(out) :: rc
 
       integer :: status

--- a/superstructure/generic/OuterMetaComponent.F90
+++ b/superstructure/generic/OuterMetaComponent.F90
@@ -162,11 +162,7 @@ module mapl_OuterMetaComponent_mod
       module recursive subroutine add_child_by_spec(this, child_name, child_spec, rc)
          class(OuterMetaComponent), target, intent(inout) :: this
          character(*), intent(in) :: child_name
-#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
          type(ChildSpec), intent(inout) :: child_spec
-#else
-         type(ChildSpec), intent(in) :: child_spec
-#endif
          integer, optional, intent(out) :: rc
       end subroutine add_child_by_spec
 

--- a/superstructure/generic/OuterMetaComponent/add_child_by_spec.F90
+++ b/superstructure/generic/OuterMetaComponent/add_child_by_spec.F90
@@ -19,11 +19,7 @@ contains
    module recursive subroutine add_child_by_spec(this, child_name, child_spec, rc)
       class(OuterMetaComponent), target, intent(inout) :: this
       character(*), intent(in) :: child_name
-#if defined(ESMF_HCONFIGSET_HAS_INTENT_INOUT)
       type(ChildSpec), intent(inout) :: child_spec
-#else
-      type(ChildSpec), intent(in) :: child_spec
-#endif
       integer, optional, intent(out) :: rc
 
       integer :: status


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests` or `ctest`)

## Description

ESMF >= 9.0.0 is already required (enforced in `CMakeLists.txt`), which is >= 8.9.0 where `ESMF_HConfigSet` gained `intent(inout)`. The `#else` branches in the `ESMF_HCONFIGSET_HAS_INTENT_INOUT` ifdefs are permanently dead code.

This PR removes the entire ifdef scaffolding:
- CMake version check and `target_compile_definitions` blocks in the top-level and three target-level `CMakeLists.txt` files
- Unconditional `intent(inout)` in `HConfigUtilities.F90`, `OuterMetaComponent.F90`, `add_child_by_spec.F90`, `MAPL_Generic.F90`
- Updates `INSTALL.md` to reflect ESMF 9.0.0 as the minimum requirement

## Related Issue

Closes #3477