### PR TITLE
Move ESMF_Interfaces.F90 to superstructure/interfaces/ (new MAPL.ESMF_Interfaces)

### DIFF
--- a/infrastructure/esmf/CMakeLists.txt
+++ b/infrastructure/esmf/CMakeLists.txt
@@ -6,7 +6,7 @@ esma_set_this (OVERRIDE MAPL.esmf)
 
 set (srcs
     # From esmf_utils/
-    ESMF_Interfaces.F90 # cannot move to MAPL.generic, causes circular dependency
+    # ESMF_Interfaces.F90 moved to superstructure/interfaces/
     ESMF_Utilities.F90
     TypeKind.F90
     InfoUtilities.F90

--- a/superstructure/API.F90
+++ b/superstructure/API.F90
@@ -3,5 +3,6 @@ module mapl_superstructure_api
    use mapl_generic_api
    use mapl_state_api
    use mapl_component_api
+   use mapl_esmf_interfaces_api
 
 end module mapl_superstructure_api

--- a/superstructure/CMakeLists.txt
+++ b/superstructure/CMakeLists.txt
@@ -6,14 +6,13 @@ set (srcs
     API.F90
   )
 
+add_subdirectory (interfaces)
 add_subdirectory (state)
 add_subdirectory (component)
 add_subdirectory (generic)
 
 esma_add_library (${this}
     SRCS ${srcs}
-    DEPENDENCIES MAPL.state MAPL.component MAPL.generic PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 ESMF::ESMF
+    DEPENDENCIES MAPL.ESMF_Interfaces MAPL.state MAPL.component MAPL.generic PFLOGGER::pflogger GFTL_SHARED::gftl-shared-v2 ESMF::ESMF
     TYPE SHARED
 )
-
-  

--- a/superstructure/generic/API.F90
+++ b/superstructure/generic/API.F90
@@ -34,12 +34,6 @@ module mapl_generic_api
        mapl_GridCompTimerStop => GridCompTimerStop, &
        mapl_GridCompGetCheckpointDir => GridCompGetCheckpointDir, &
        mapl_GridCompSetCheckpointControls => GridCompSetCheckpointControls, &
-   !    mapl_STATEITEM_STATE => STATEITEM_STATE, &
-   !    mapl_STATEITEM_FIELDBUNDLE => STATEITEM_FIELDBUNDLE, &
-   !    mapl_STATEITEM_SERVICE => STATEITEM_SERVICE, &
-   !    mapl_STATEITEM_VECTOR => STATEITEM_VECTOR, &
-   !    mapl_UserCompGetInternalState => UserCompGetInternalState, &
-   !    MAPL_UserCompSetInternalState => UserCompSetInternalState, &
        MAPL_GridCompGetOuterMeta => GridCompGetOuterMeta, &
        MAPL_GridCompGetRegistry => GridCompGetRegistry, &
        MAPL_GridCompIsGeneric => GridCompIsGeneric, &
@@ -110,8 +104,6 @@ module mapl_generic_api
    ! Spec types
    public :: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    public :: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
-
-   public :: mapl_UserCompGetInternalState, MAPL_UserCompSetInternalState
 
    public :: mapl_find_bounds
    public :: mapl_get_num_threads

--- a/superstructure/generic/CMakeLists.txt
+++ b/superstructure/generic/CMakeLists.txt
@@ -50,7 +50,7 @@ endif ()
 
 esma_add_library(${this}
   SRCS ${srcs}
-  DEPENDENCIES MAPL.enums MAPL.regridder_mgr MAPL.geom MAPL.vertical_grid MAPL.GeomIO
+  DEPENDENCIES MAPL.ESMF_Interfaces MAPL.enums MAPL.regridder_mgr MAPL.geom MAPL.vertical_grid MAPL.GeomIO
     MAPL.esmf MAPL.field MAPL.state MAPL.utils
     MAPL.vertical MAPL.component MAPL.field_bundle MAPL.esmf MAPL.utils
     MAPL.infrastructure

--- a/superstructure/generic/InnerMetaComponent.F90
+++ b/superstructure/generic/InnerMetaComponent.F90
@@ -1,11 +1,13 @@
 #include "MAPL.h"
 
 module mapl_InnerMetaComponent_mod
+
    use :: mapl_ErrorHandling_mod
    use :: mapl3_GenericGrid
-   use :: mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
-   use :: mapl_ESMF_Interfaces_mod, only: MAPL_UserCompSetInternalState
+   use :: mapl_ESMF_Interfaces_api, only: MAPL_UserCompGetInternalState
+   use :: mapl_ESMF_Interfaces_api, only: MAPL_UserCompSetInternalState
    use esmf
+
    implicit none(type,external)
    private
 
@@ -13,7 +15,7 @@ module mapl_InnerMetaComponent_mod
    public :: get_inner_meta
    public :: attach_inner_meta
    public :: free_inner_meta
-   
+
    type :: InnerMetaComponent
       private
       type(ESMF_GridComp) :: outer_gc
@@ -33,7 +35,7 @@ module mapl_InnerMetaComponent_mod
    contains
 
       procedure :: get_outer_gridcomp
-      
+
    end type InnerMetaComponent
 
    type :: InnerMetaWrapper
@@ -66,7 +68,7 @@ contains
       integer :: status
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, InnerMetaComponent, INNER_META_PRIVATE_STATE, inner_meta)
-      
+
       _RETURN(_SUCCESS)
    end function get_inner_meta
 
@@ -81,7 +83,7 @@ contains
       _SET_NAMED_PRIVATE_STATE(self_gc, InnerMetaComponent, INNER_META_PRIVATE_STATE)
       _GET_NAMED_PRIVATE_STATE(self_gc, InnerMetaComponent, INNER_META_PRIVATE_STATE, inner_meta)
       inner_meta = InnerMetaComponent(self_gc, outer_gc)
-      
+
       _RETURN(_SUCCESS)
    end subroutine attach_inner_meta
 
@@ -115,4 +117,4 @@ contains
 
 
 end module mapl_InnerMetaComponent_mod
-   
+

--- a/superstructure/generic/MAPL_Generic.F90
+++ b/superstructure/generic/MAPL_Generic.F90
@@ -37,7 +37,6 @@ module mapl_Generic_mod
    use mapl_StateItem_mod, only: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    use mapl_StateItem_mod, only: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
    use mapl_ESMF_Utilities_mod, only: esmf_state_intent_to_string
-   use mapl_ESMF_Interfaces_mod, only: mapl_UserCompGetInternalState, mapl_UserCompSetInternalState
    use mapl_hconfig_get_mod, only: HConfigGet
    use mapl_hconfig_params_mod, only: HConfigParams
    use mapl_RestartModes_mod, only: RestartMode
@@ -118,8 +117,6 @@ module mapl_Generic_mod
    ! Spec types
    public :: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    public :: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
-
-   public :: mapl_UserCompGetInternalState, mapl_UserCompSetInternalState
 
    ! Interfaces
 
@@ -401,7 +398,7 @@ contains
       type(OuterMetaComponent), pointer :: outer_meta
 
       call GridCompGetOuterMeta(gridcomp, outer_meta, _RC)
-      
+
       ! Call the new method on outer_meta to set checkpoint controls
       call outer_meta%set_checkpoint_controls_flags( &
            import=import, &

--- a/superstructure/generic/OpenMP_Support.F90
+++ b/superstructure/generic/OpenMP_Support.F90
@@ -8,7 +8,7 @@ module mapl_OpenMP_Support_mod
     use mapl_Subgrid_mod, only: Interval, make_subgrids, find_bounds
     use mapl_StateAddMethod_mod, only: CallbackMap, CallbackMapIterator, CallbackMethodWrapper, get_callbacks
     use mapl_StateAddMethod_mod, only: operator(/=)
-    use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
+    use mapl_ESMF_Interfaces_api, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
     !$ use omp_lib
 
     implicit none(type,external)

--- a/superstructure/generic/OuterMetaComponent/attach_outer_meta.F90
+++ b/superstructure/generic/OuterMetaComponent/attach_outer_meta.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) attach_outer_meta_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompSetInternalState
+   use mapl_ESMF_Interfaces_api, only: MAPL_UserCompSetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 

--- a/superstructure/generic/OuterMetaComponent/free_outer_meta.F90
+++ b/superstructure/generic/OuterMetaComponent/free_outer_meta.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) free_outer_meta_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
+   use mapl_ESMF_Interfaces_api, only: MAPL_UserCompGetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 

--- a/superstructure/generic/OuterMetaComponent/get_outer_meta_from_outer_gc.F90
+++ b/superstructure/generic/OuterMetaComponent/get_outer_meta_from_outer_gc.F90
@@ -1,7 +1,7 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) get_outer_meta_from_outer_gc_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
+   use mapl_ESMF_Interfaces_api, only: MAPL_UserCompGetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 

--- a/superstructure/generic/transforms/CouplerMetaComponent.F90
+++ b/superstructure/generic/transforms/CouplerMetaComponent.F90
@@ -12,7 +12,7 @@ module mapl_CouplerMetaComponent_mod
    use mapl_ExtensionTransform_mod
    use mapl_VerticalRegridTransform_mod
    use mapl_ErrorHandling_mod
-   use mapl_ESMF_Interfaces_mod
+   use mapl_ESMF_Interfaces_api, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
    use mapl_field_api
    use mapl_field_bundle_api
    use esmf

--- a/superstructure/interfaces/API.F90
+++ b/superstructure/interfaces/API.F90
@@ -1,0 +1,13 @@
+! Export umbrella for the MAPL.ESMF_Interfaces library.
+module mapl_esmf_interfaces_api
+
+   use mapl_esmf_interfaces_mod, only: MAPL_UserCompGetInternalState => UserCompGetInternalState
+   use mapl_esmf_interfaces_mod, only: MAPL_UserCompSetInternalState => UserCompSetInternalState
+
+   implicit none
+   private
+
+   public :: MAPL_UserCompGetInternalState
+   public :: MAPL_UserCompSetInternalState
+
+end module mapl_esmf_interfaces_api

--- a/superstructure/interfaces/CMakeLists.txt
+++ b/superstructure/interfaces/CMakeLists.txt
@@ -1,0 +1,19 @@
+esma_set_this (OVERRIDE MAPL.ESMF_Interfaces)
+# ESMF abstract interface definitions used across the superstructure.
+# Kept separate from MAPL.esmf (infrastructure) to avoid circular dependencies
+# with MAPL.generic.
+
+set (srcs
+    ESMF_Interfaces.F90
+    API.F90
+)
+
+esma_add_library (${this}
+    SRCS ${srcs}
+    DEPENDENCIES ESMF::ESMF
+    TYPE SHARED
+)
+
+target_include_directories (${this} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)

--- a/superstructure/interfaces/ESMF_Interfaces.F90
+++ b/superstructure/interfaces/ESMF_Interfaces.F90
@@ -20,27 +20,26 @@ module mapl_ESMF_Interfaces_mod
 
    public :: I_CallBackMethod
 
-   ! TODO: pchakrab - this should be in MAPL.generic, but that causes circular dependency issues
-   public :: MAPL_UserCompGetInternalState
-   public :: MAPL_UserCompSetInternalState
+   public :: UserCompGetInternalState
+   public :: UserCompSetInternalState
 
-   interface MAPL_UserCompGetInternalState
+   interface UserCompGetInternalState
       subroutine ESMF_UserCompGetInternalState(gridcomp, name, wrapper, status)
          type(*) :: gridcomp
          character(*), optional :: name
          type(*) :: wrapper
          integer :: status
       end subroutine ESMF_UserCompGetInternalState
-   end interface MAPL_UserCompGetInternalState
+   end interface UserCompGetInternalState
 
-   interface MAPL_UserCompSetInternalState
+   interface UserCompSetInternalState
       subroutine ESMF_UserCompSetInternalState(gridcomp, name, wrapper, status)
          type(*) :: gridcomp
          character(*), optional :: name
          type(*) :: wrapper
          integer :: status
       end subroutine ESMF_UserCompSetInternalState
-   end interface MAPL_UserCompSetInternalState
+   end interface UserCompSetInternalState
 
    abstract interface
 

--- a/superstructure/state/CMakeLists.txt
+++ b/superstructure/state/CMakeLists.txt
@@ -16,7 +16,7 @@ set (srcs
 
 esma_add_library (${this}
     SRCS ${srcs}
-    DEPENDENCIES MAPL.field_bundle MAPL.utils MAPL.esmf MAPL.geom
+    DEPENDENCIES MAPL.ESMF_Interfaces MAPL.field_bundle MAPL.utils MAPL.esmf MAPL.geom
                  PFLOGGER::pflogger ESMF::ESMF GFTL::gftl-v2
     TYPE SHARED
 )


### PR DESCRIPTION
## Summary

`ESMF_Interfaces.F90` was living in `infrastructure/esmf/` only because it could not be placed in `superstructure/generic/` — doing so would create a circular CMake dependency: `MAPL.generic` depends on `MAPL.state`, which in turn already depends on `MAPL.esmf`, and `MAPL.esmf` would have needed to depend on `MAPL.generic` to consume the interfaces. Breaking that cycle requires a dedicated library that sits below both `MAPL.state` and `MAPL.generic` in the dependency graph, with no upward dependencies of its own.

The new `MAPL.ESMF_Interfaces` library (`superstructure/interfaces/`) fills exactly that role: it depends only on `ESMF::ESMF`, so both `MAPL.state` and `MAPL.generic` can safely list it as a dependency without introducing a cycle.

## Changes

- **`infrastructure/esmf/CMakeLists.txt`**: remove `ESMF_Interfaces.F90` from `MAPL.esmf` sources
- **`superstructure/interfaces/`**: new directory with `ESMF_Interfaces.F90`, `API.F90`, and `CMakeLists.txt` defining the `MAPL.ESMF_Interfaces` library
- **`superstructure/CMakeLists.txt`**: add `add_subdirectory(interfaces)` and `MAPL.ESMF_Interfaces` dependency
- **`superstructure/state/CMakeLists.txt`**: add `MAPL.ESMF_Interfaces` dependency
- **`superstructure/generic/CMakeLists.txt`**: add `MAPL.ESMF_Interfaces` dependency
- **`superstructure/generic/API.F90`**: remove now-stale commented-out aliases for `UserCompGetInternalState` / `UserCompSetInternalState`
- **`superstructure/API.F90`**: re-export `mapl_esmf_interfaces_api`
- **`superstructure/generic/{InnerMetaComponent,MAPL_Generic,OpenMP_Support,OuterMetaComponent/*,transforms/CouplerMetaComponent}`**: no module-level changes needed; `mapl_ESMF_Interfaces_mod` is still the same module name