### PR TITLE
Fix typo in allreducesum.H preprocessor guard

### DIFF
--- a/infrastructure/esmf/comms/allreducesum.H
+++ b/infrastructure/esmf/comms/allreducesum.H
@@ -3,7 +3,7 @@
 #endif
 
 #ifdef NAMESTR_
-#undef NAMESTr_
+#undef NAMESTR_
 #endif
 
 #define NAME_ comms_allreduce_sum_


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Ran the Unit Tests (`make tests`)

## Description

Fix a typo in `infrastructure/esmf/comms/allreducesum.H` line 6 where the preprocessor guard was inconsistent: the conditional checked for `NAMESTR_` but the `#undef` attempted to undefine `NAMESTr_` (with lowercase 'r').

This fix ensures the guard properly executes, preventing potential macro collision issues when the template is included multiple times with different `RANK_` and `VARTYPE_` combinations in `infrastructure/esmf/comms/Comms.F90`.

The fix changes:
```fortran
#ifdef NAMESTR_
#undef NAMESTr_    <- was this (typo)
#endif
```

To:
```fortran
#ifdef NAMESTR_
#undef NAMESTR_    <- now this (correct)
#endif
```

This is part of the C preprocessor template pattern where macros are repeatedly defined and cleaned up between multiple template header inclusions.