### PR TITLE
v2: Fix typo in allreducesum.H

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix typo in `allreducesum.H`
+
 ### Added
 
 - Add release guide (`docs/releasing.md`) documenting the MAPL release process

--- a/base/allreducesum.H
+++ b/base/allreducesum.H
@@ -4,7 +4,7 @@
 #endif
 
 #ifdef NAMESTR_
-#undef NAMESTr_
+#undef NAMESTR_
 #endif
 
 #define NAME_ MAPL_CommsAllReduceSum_


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

This is the v2 equivalent of #5185. I looked and the typo was there too.

## Related Issue

