### PR TITLE
Feature/wdboggs/#5165 acg remove pointers vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Add new `color_message` function
     - Add helper script for regression test work
 - For ACG, only declare pointer and get_pointer for MAPL_STATEITEM_FIELD
+- For ACG, add spec_filters to generalize testing specs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Better detect FMS/yaml support (needed for spack)
     - Add new `color_message` function
     - Add helper script for regression test work
+- For ACG, only declare pointer and get_pointer for MAPL_STATEITEM_FIELD
 
 ### Fixed
 

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -263,6 +263,8 @@ def get_options(args):
     return options
 
 def make_specfilter(key=None, default=False, func=bool):
+    """Make a filter (bool valued) for spec based on key and a default if key is not found."""
+    # key is optional. If it is not present, the function will be called on the entire spec.
     selector = (lambda s: s.get(key)) if key else (lambda s: s)
     def inner(spec):
         value = selector(spec)
@@ -270,41 +272,46 @@ def make_specfilter(key=None, default=False, func=bool):
     return inner
 
 def specfilter(key=None, default=False):
+    """ Decorator to build spec filters with optional parameters """
     f = partial(make_specfilter, key, default)
+    # wrap the decorated function
     def inner(func):
         return f(func)
     return inner
 
 def make_andfilter(other, func):
+    """ Make a spec filter from a logical AND of two filters """
     def inner(spec):
         return func(spec) and other(spec)
     return inner
 
 def andfilter(other):
+    """ Decorator to build an AND filter from an existing spec filter and the decorated function. """
     f = partial(make_andfilter, other)
+    # wrap the decorated function
     def inner(func):
         return f(func)
     return inner
 
 def make_orfilter(other, func):
-    def inner(func):
-        def f(spec):
-            return func(spec) or other(spec)
-        return f
+    """ Make a spec filter from a logical OR of two filters """
+    def inner(spec):
+        return func(spec) or other(spec)
     return inner
 
 def orfilter(other):
+    """ Decorator to build an OR filter from an existing spec filter and the decorated function. """
     f = partial(make_orfilter, other)
+    # wrap the decorated function
     def inner(func):
         return f(func)
     return inner
 
 def notfilter(func):
+    """ Decorator to build a NOT filter from an existing spec filter. """
     def inner(spec):
         return not func(spec)
     return inner
-
-#field_filter = SpecFilter([SpecFilter(lambda s: ITEMTYPE in s, invert=True), (ITEMTYPE, MAPL_STATEITEM_FIELD)], forall=False)
 
 @specfilter(key=ITEMTYPE, default=True)
 def field_filter(value):
@@ -374,17 +381,6 @@ def emit_declare_pointers(specs, states=None):
             linesep.join(f'spec {spec} => {str(ex)}' for spec, ex in error))
     return DECLARE, declarations
         
-#    declarations = []
-#    for spec in specs:
-#        if not f(spec):
-#            continue
-#        try:
-#            declaration = emit_declare_pointer(spec)
-#        except RuntimeError as ex:
-#            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)}')
-#        declarations.append(declaration)
-#    return DECLARE, declarations
-
 def emit_declare_pointer(spec):
     """Emit individual pointer declartion."""
     # get fortran type and kind of pointer

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -12,6 +12,61 @@ from enum import Enum
 import logging
 import io
 
+class SpecFilter:
+    """ Callable object to build a filter on a spec """
+    def __init__(self, conditions=None, forall=True, invert=False):
+        """ Create filter based on arguments. An invalid filter is indicated by self._condition is None """
+        match conditions:
+            # If there is no conditions argument, return invert (default False)
+            case None:
+                self._condition = lambda s: invert
+            # A str is not a valid condition, but it is a Sequence, so it needs to be explicitly added as a case
+            case str():
+                self._condition = None
+            # A simple pair (a condition on spec[key])
+            case [key, value]:
+                # value is a callable on spec[key]
+                if callable(value):
+                    def inner(s):
+                        return value(s.get(key))
+                # check if spec[key] is None
+                elif value is None:
+                    def inner(s):
+                        if key in s:
+                            return s[key] is None
+                        return False
+                # check equality
+                else:
+                    def inner(s):
+                        return s.get(key) == value
+                # negate function if invert
+                self._condition = negate(inner) if invert else inner
+            case Sequence() as seq:
+                # conditions is any other Sequence of sub filters
+                gen = (SpecFilter(condition) for condition in seq)
+                if forall:
+                    def inner(s):
+                        return all(gen(s))
+                else:
+                    def inner(s):
+                        return any(gen(s))
+                self._condition = negate(inner) if invert else inner
+            case _ as condition:
+                # Not Sequence
+                # default is None
+                inner = None
+                # condition is any other condition on the entire spec
+                if callable(condition):
+                    def inner(s):
+                        return condition(s)
+                # if inner and invert, negate it. Otherwise, leave it alone.
+                self._condition = negate(inner) if (invert and inner) else inner
+
+
+    def __call__(self, s):
+        """ apply condition to spec unless the condition is None (invalid) then return None """
+        return None if self._condition is None else self._condition(s)
+
 # ESMF_TYPEKIND enum
 class TYPEKIND_Type:
     __slots__=('type', 'kind', 'variable_type')
@@ -69,6 +124,8 @@ GET = 'get'
 MAKE_BLOCK = 'make_block'
 INTENT_PREFIX = 'ESMF_STATEINTENT_'
 KIND = 'kind'
+MAPL_STATEITEM_FIELD = 'MAPL_STATEITEM_FIELD'
+MAPL_STATEITEM_VECTOR = 'MAPL_STATEITEM_VECTOR'
 MAPPED = 'mapped' 
 MAPPING = 'mapping'
 MISSING_MANDATORY = 'missing_mandatory'
@@ -93,7 +150,6 @@ CONDITION = 'condition'
 DIMS = 'dims'
 EXPORT_NAME = 'export_name'
 FILL_VALUE = 'fill_value'
-HAS_POINTER = 'has_pointer'
 INTENT_ARG = 'intent_arg'
 INTERNAL_NAME = 'internal_name'
 ITEMTYPE = 'itemtype'
@@ -113,8 +169,6 @@ UNGRIDDED_DIMS = 'ungridded_dim_array'
 USE_FIELD_DICTIONARY = 'use_field_dictionary'
 VSTAGGER = 'vertical_stagger'
 RESTART = 'restart_mode'
-MAPL_STATEITEM_FIELD = 'mapl_stateitem_field'
-MAPL_STATEITEM_VECTOR = 'mapl_stateitem_vector'
 
 # command-line option constants
 GC_VARIABLE = 'gridcomp_variable'
@@ -255,8 +309,7 @@ def get_options(args):
         STANDARD_NAME_ARG: {MAPPING: STANDARD_NAME, FROM: (STANDARD_NAME, STANDARD_NAME_PREFIX), AS: STANDARD_NAME},
         INTENT_ARG: {FROM: (STATE_INTENT, STATE), MAPPING: (ID, dict(zip(states, intents))), FLAGS: AS},
         RANK: {MAPPING: RANK, FLAGS: {STORE, MANDATORY}, FROM: (DIMS, UNGRIDDED_DIMS)},
-        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS},
-        HAS_POINTER: {FROM: ITEMTYPE, MAPPING: HAS_POINTER}
+        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS}
     }
 
     # internal constants
@@ -265,7 +318,15 @@ def get_options(args):
     return options
 
 # Procedures for writing to files
+def negate(f):
+    def inner(*args, **kwargs):
+        return not f(*args, **kwargs)
+    return inner
 
+field_filter = SpecFilter([SpecFilter(lambda s: ITEMTYPE in s, invert=True), (ITEMTYPE, MAPL_STATEITEM_FIELD)], forall=False)
+
+def itemtype_filter(*itemtypes):
+    
 def state_filter(states=None):
     """Create a filter on state."""
     match states:
@@ -300,10 +361,10 @@ def emit_args(values, options):
 def emit_declare_pointers(specs, states=None):
     """Emit pointer declarations from Iterable of spec instances."""
     # filter on state
-    f = state_filter(states)
+    f = state_filter(states) and field_filter
     declarations = []
     for spec in specs:
-        if not (f(spec) and spec[HAS_POINTER]):
+        if not f(spec):
             continue
         try:
             declaration = emit_declare_pointer(spec)
@@ -326,8 +387,8 @@ def emit_declare_pointer(spec):
 def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
     # filter of state
-    f = state_filter(states)
-    return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec) and spec[HAS_POINTER]))
+    f = state_filter(states) and field_filter
+    return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec)))
 
 def emit_get_pointer(spec):
     """Emit individual pointer statement from a spec instance."""
@@ -703,10 +764,8 @@ NAMED_MAPPINGS = {
         RANK: compute_rank,
         MAKE_BLOCK: lambda value: partial(make_block, value),
         BOOL: convert_to_bool,
-        STRLOGICAL: lambda s: convert_to_logical(convert_to_bool(s)),
-        HAS_POINTER: lambda value: value == MAPL_STATEITEM_FIELD
+        STRLOGICAL: lambda s: convert_to_logical(convert_to_bool(s))
         }
-
 
 def fetch_mapping_function(o, func_dict=NAMED_MAPPINGS):
     """Get the mapping function for option o."""
@@ -726,20 +785,18 @@ def make_mapping(m, func_sequence=None, func_dict=None, flags=UNIT):
     # Default case: identity map
     if m is None or m is UNIT:
         return ID
-    # If m is already callable, return it.
-    elif callable(m):
-        return m
+    f = m
     # Otherwise
-    match m:
+    match f:
         # Retrieve mapping by key if there is a func_dict.
         case str() if func_dict:
-            return func_dict.get(m)
+            f = func_dict.get(m)
         # Make a function from a dict.
         case dict():
-            return lambda k: m.get(k, k if k in m.values() else None)
+            f = lambda k: m.get(k, k if k in m.values() else None)
         # Fetch mapping based on index if there is a sequence of functions.
         case int() if valid_index(func_sequence, m):
-            return func_sequence[n]
+            f = func_sequence[n]
         # Return None if m is empty list or tuple.
         case list() | tuple() if len(m) == 0:
             return None
@@ -749,7 +806,7 @@ def make_mapping(m, func_sequence=None, func_dict=None, flags=UNIT):
             funcs = tuple(make_mapping(sm, func_sequence=func_sequence, func_dict=func_dict, flags=flags) for sm in m[::-1])
             def inner(*args):
                 return reduce(lambda a, c: c(a), funcs, *args)
-            return inner
+            f = inner
         # Return a mapping of multiple values with a sequence of functions. The number of args should match the number of mappings.
         case tuple() | list():
             funcs = tuple(make_mapping(sm, func_sequence=None, func_dict=None, flags=flags) for sm in m)
@@ -759,7 +816,8 @@ def make_mapping(m, func_sequence=None, func_dict=None, flags=UNIT):
                         continue
                     return f(arg)
                 return None
-            return inner
+            f = inner
+    return f
 
 # Main Procedure (Added to facilitate testing.)
 def main(logger):

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -262,39 +262,51 @@ def get_options(args):
 
     return options
 
-#def specfilter(predicate, key=None):
-def specfilter(other=None, **kwargs):
-    s = (lambda s: s.get(kwargs['key'])) if 'key' in kwargs else (lambda x: x)
-    op = kwargs.get('boolean_operator')
-    if other and op:
-        def g(func, spec):
-            return op(func(s(spec)), other(s(spec)))
-    elif other:
-        def g(func, spec):
-            return func(s(spec)), other(s(spec))
-    elif op:
-        def g(func, spec):
-            return op(func(s(spec)))
-    else:
-        def g(func, spec):
-            return func(s(spec))
-    def h(func):
-        def f(spec):
-            return g(func, spec)
-        return f
-    return h
+def make_specfilter(key=None, default=False, func=bool):
+    selector = (lambda s: s.get(key)) if key else (lambda s: s)
+    def inner(spec):
+        value = selector(spec)
+        return func(value) if value else default
+    return inner
 
-andfilter = lambda other: specfilter(other, boolean_operator=lambda a, b: a and b)
-orfilter = lambda other: specfilter(other, boolean_operator=lambda a, b: a or b)
-notfilter = specfilter(boolean_operator=lambda a: not a)
-def allfilter(*filters):
-    return reduce(andfilter, filters) if filters else None
-def anyfilter(*filters):
-    return reduce(orfilter, filters) if filters else None
+def specfilter(key=None, default=False):
+    f = partial(make_specfilter, key, default)
+    def inner(func):
+        return f(func)
+    return inner
+
+def make_andfilter(other, func):
+    def inner(spec):
+        return func(spec) and other(spec)
+    return inner
+
+def andfilter(other):
+    f = partial(make_andfilter, other)
+    def inner(func):
+        return f(func)
+    return inner
+
+def make_orfilter(other, func):
+    def inner(func):
+        def f(spec):
+            return func(spec) or other(spec)
+        return f
+    return inner
+
+def orfilter(other):
+    f = partial(make_orfilter, other)
+    def inner(func):
+        return f(func)
+    return inner
+
+def notfilter(func):
+    def inner(spec):
+        return not func(spec)
+    return inner
 
 #field_filter = SpecFilter([SpecFilter(lambda s: ITEMTYPE in s, invert=True), (ITEMTYPE, MAPL_STATEITEM_FIELD)], forall=False)
 
-@specfilter(key=ITEMTYPE)
+@specfilter(key=ITEMTYPE, default=True)
 def field_filter(value):
     return value is None or value == MAPL_STATEITEM_FIELD
 
@@ -335,28 +347,43 @@ def emit_args(values, options):
     return [f"{CALL} {ADDSPEC}({GC_ARGNAME}={options[GC_VARIABLE]}, &",
             *lines, f"{INDENT}& {TERMINATOR}"]
 
+
+def make_field_state_filter(states):
+    @andfilter(other=field_filter)
+    @specfilter(key=STATE)
+    def inner(value):
+        return value.lower() in states
+    return inner
+
 def emit_declare_pointers(specs, states=None):
     """Emit pointer declarations from Iterable of spec instances."""
-#    @specfilter(key=ITEMTYPE)
-#    def field_filter(value):
-#        return value is None or value == MAPL_STATEITEM_FIELD
-
-    # filter on state
-#    f = state_filter(states) and field_filter
-    @andfilter(other=field_filter)
-    def f(value):
-        return value in states
-
-    declarations = []
-    for spec in specs:
-        if not f(spec):
-            continue
+    def declaration(spec):
+        declaration = None
         try:
-            declaration = emit_declare_pointer(spec)
+            return 0, emit_declare_pointer(spec)
         except RuntimeError as ex:
-            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)}')
-        declarations.append(declaration)
+            return ex, spec
+
+    f = make_field_state_filter(states)
+
+    pairs = [declaration(spec) for spec in specs if f(spec)]
+    declarations = [d for r, d in pairs if r == 0]
+    errors = [(spec, ex) for r, s in pairs if r != 0]
+    if errors:
+        raise RuntimeError(f'Error pointer claration for:{linesep}' +
+            linesep.join(f'spec {spec} => {str(ex)}' for spec, ex in error))
     return DECLARE, declarations
+        
+#    declarations = []
+#    for spec in specs:
+#        if not f(spec):
+#            continue
+#        try:
+#            declaration = emit_declare_pointer(spec)
+#        except RuntimeError as ex:
+#            raise RuntimeError(f'Error pointer declaration for spec {spec}: {str(ex)}')
+#        declarations.append(declaration)
+#    return DECLARE, declarations
 
 def emit_declare_pointer(spec):
     """Emit individual pointer declartion."""
@@ -371,11 +398,8 @@ def emit_declare_pointer(spec):
 
 def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
-    # filter of state
-#    f = state_filter(states) and field_filter
-    @andfilter(other=field_filter)
-    def f(value):
-        return value in states
+    f = make_field_state_filter(states)
+
     return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec)))
 
 def emit_get_pointer(spec):

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -93,8 +93,10 @@ CONDITION = 'condition'
 DIMS = 'dims'
 EXPORT_NAME = 'export_name'
 FILL_VALUE = 'fill_value'
+HAS_POINTER = 'has_pointer'
 INTENT_ARG = 'intent_arg'
 INTERNAL_NAME = 'internal_name'
+ITEMTYPE = 'itemtype'
 MANGLED = 'mangled'
 STANDARD_NAME_ARG = 'standard_name_arg'
 RANK = 'rank'
@@ -111,6 +113,8 @@ UNGRIDDED_DIMS = 'ungridded_dim_array'
 USE_FIELD_DICTIONARY = 'use_field_dictionary'
 VSTAGGER = 'vertical_stagger'
 RESTART = 'restart_mode'
+MAPL_STATEITEM_FIELD = 'mapl_stateitem_field'
+MAPL_STATEITEM_VECTOR = 'mapl_stateitem_vector'
 
 # command-line option constants
 GC_VARIABLE = 'gridcomp_variable'
@@ -202,9 +206,9 @@ def get_options(args):
         'dependencies': {MAPPING: STRINGVECTOR},
         EXPORT_NAME: {MAPPING: STRING},
         FILL_VALUE: {},
-        'itemtype': {MAPPING: {
-            'F': 'MAPL_STATEITEM_FIELD',
-            'V': 'MAPL_STATEITEM_VECTOR'}},
+        ITEMTYPE: {MAPPING: {
+            'F': MAPL_STATEITEM_FIELD,
+            'V': MAPL_STATEITEM_VECTOR}},
         'orientation': {},
         'regrid_method': {},
         'restart_mode': {MAPPING: {
@@ -251,7 +255,8 @@ def get_options(args):
         STANDARD_NAME_ARG: {MAPPING: STANDARD_NAME, FROM: (STANDARD_NAME, STANDARD_NAME_PREFIX), AS: STANDARD_NAME},
         INTENT_ARG: {FROM: (STATE_INTENT, STATE), MAPPING: (ID, dict(zip(states, intents))), FLAGS: AS},
         RANK: {MAPPING: RANK, FLAGS: {STORE, MANDATORY}, FROM: (DIMS, UNGRIDDED_DIMS)},
-        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS}
+        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS},
+        HAS_POINTER: {FROM: ITEMTYPE, MAPPING: HAS_POINTER}
     }
 
     # internal constants
@@ -298,7 +303,7 @@ def emit_declare_pointers(specs, states=None):
     f = state_filter(states)
     declarations = []
     for spec in specs:
-        if not f(spec):
+        if not (f(spec) and spec[HAS_POINTER]):
             continue
         try:
             declaration = emit_declare_pointer(spec)
@@ -322,7 +327,7 @@ def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
     # filter of state
     f = state_filter(states)
-    return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec)))
+    return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec) and spec[HAS_POINTER]))
 
 def emit_get_pointer(spec):
     """Emit individual pointer statement from a spec instance."""
@@ -698,7 +703,8 @@ NAMED_MAPPINGS = {
         RANK: compute_rank,
         MAKE_BLOCK: lambda value: partial(make_block, value),
         BOOL: convert_to_bool,
-        STRLOGICAL: lambda s: convert_to_logical(convert_to_bool(s))
+        STRLOGICAL: lambda s: convert_to_logical(convert_to_bool(s)),
+        HAS_POINTER: lambda value: value == MAPL_STATEITEM_FIELD
         }
 
 

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -12,61 +12,6 @@ from enum import Enum
 import logging
 import io
 
-class SpecFilter:
-    """ Callable object to build a filter on a spec """
-    def __init__(self, conditions=None, forall=True, invert=False):
-        """ Create filter based on arguments. An invalid filter is indicated by self._condition is None """
-        match conditions:
-            # If there is no conditions argument, return invert (default False)
-            case None:
-                self._condition = lambda s: invert
-            # A str is not a valid condition, but it is a Sequence, so it needs to be explicitly added as a case
-            case str():
-                self._condition = None
-            # A simple pair (a condition on spec[key])
-            case [key, value]:
-                # value is a callable on spec[key]
-                if callable(value):
-                    def inner(s):
-                        return value(s.get(key))
-                # check if spec[key] is None
-                elif value is None:
-                    def inner(s):
-                        if key in s:
-                            return s[key] is None
-                        return False
-                # check equality
-                else:
-                    def inner(s):
-                        return s.get(key) == value
-                # negate function if invert
-                self._condition = negate(inner) if invert else inner
-            case Sequence() as seq:
-                # conditions is any other Sequence of sub filters
-                gen = (SpecFilter(condition) for condition in seq)
-                if forall:
-                    def inner(s):
-                        return all(gen(s))
-                else:
-                    def inner(s):
-                        return any(gen(s))
-                self._condition = negate(inner) if invert else inner
-            case _ as condition:
-                # Not Sequence
-                # default is None
-                inner = None
-                # condition is any other condition on the entire spec
-                if callable(condition):
-                    def inner(s):
-                        return condition(s)
-                # if inner and invert, negate it. Otherwise, leave it alone.
-                self._condition = negate(inner) if (invert and inner) else inner
-
-
-    def __call__(self, s):
-        """ apply condition to spec unless the condition is None (invalid) then return None """
-        return None if self._condition is None else self._condition(s)
-
 # ESMF_TYPEKIND enum
 class TYPEKIND_Type:
     __slots__=('type', 'kind', 'variable_type')
@@ -317,16 +262,48 @@ def get_options(args):
 
     return options
 
-# Procedures for writing to files
-def negate(f):
-    def inner(*args, **kwargs):
-        return not f(*args, **kwargs)
+#def specfilter(predicate, key=None):
+def specfilter(other=None, **kwargs):
+    s = (lambda s: s.get(kwargs['key'])) if 'key' in kwargs else (lambda x: x)
+    op = kwargs.get('boolean_operator')
+    if other and op:
+        def g(func, spec):
+            return op(func(s(spec)), other(s(spec)))
+    elif other:
+        def g(func, spec):
+            return func(s(spec)), other(s(spec))
+    elif op:
+        def g(func, spec):
+            return op(func(s(spec)))
+    else:
+        def g(func, spec):
+            return func(s(spec))
+    def h(func):
+        def f(spec):
+            return g(func, spec)
+        return f
+    return h
+
+andfilter = lambda other: specfilter(other, boolean_operator=lambda a, b: a and b)
+orfilter = lambda other: specfilter(other, boolean_operator=lambda a, b: a or b)
+notfilter = specfilter(boolean_operator=lambda a: not a)
+def allfilter(*filters):
+    return reduce(andfilter, filters) if filters else None
+def anyfilter(*filters):
+    return reduce(orfilter, filters) if filters else None
+
+#field_filter = SpecFilter([SpecFilter(lambda s: ITEMTYPE in s, invert=True), (ITEMTYPE, MAPL_STATEITEM_FIELD)], forall=False)
+
+@specfilter(key=ITEMTYPE)
+def field_filter(value):
+    return value is None or value == MAPL_STATEITEM_FIELD
+
+def make_state_filter(*states):
+    @specfilter(key=STATE)
+    def inner(value):
+        return value in states
     return inner
 
-field_filter = SpecFilter([SpecFilter(lambda s: ITEMTYPE in s, invert=True), (ITEMTYPE, MAPL_STATEITEM_FIELD)], forall=False)
-
-def itemtype_filter(*itemtypes):
-    
 def state_filter(states=None):
     """Create a filter on state."""
     match states:
@@ -360,8 +337,16 @@ def emit_args(values, options):
 
 def emit_declare_pointers(specs, states=None):
     """Emit pointer declarations from Iterable of spec instances."""
+#    @specfilter(key=ITEMTYPE)
+#    def field_filter(value):
+#        return value is None or value == MAPL_STATEITEM_FIELD
+
     # filter on state
-    f = state_filter(states) and field_filter
+#    f = state_filter(states) and field_filter
+    @andfilter(other=field_filter)
+    def f(value):
+        return value in states
+
     declarations = []
     for spec in specs:
         if not f(spec):
@@ -387,7 +372,10 @@ def emit_declare_pointer(spec):
 def emit_get_pointers(specs, states=None):
     """Emit pointer get statements from an Iterable of spec instances."""
     # filter of state
-    f = state_filter(states) and field_filter
+#    f = state_filter(states) and field_filter
+    @andfilter(other=field_filter)
+    def f(value):
+        return value in states
     return GET, reduce(concat, (emit_get_pointer(spec) for spec in specs if f(spec)))
 
 def emit_get_pointer(spec):

--- a/apps/tests/acg3/acg3_unittests.py
+++ b/apps/tests/acg3/acg3_unittests.py
@@ -623,14 +623,74 @@ class TestHelpers(unittest.TestCase):
         self.assertIsNone(result_neither, 
                          'Lambda should return None for invalid input')
 
-    def test_make_specfilter(self):
+    def test_specfilter(self):
+        specfilter = acg3.specfilter
         spec_keys = 'name age height'.split()
         spec_values = [('Alice', 32, 67), ('Bob', 31, 70), ('Connie', 25, 60)]
-        specs = dict(name: zip(spec_keys, (name, age, height)) for name, age, height in spec_values)
-        test_params = (
+        specs = dict((name, dict(zip(spec_keys, (name, age, height)))) for name, age, height in spec_values) 
+        @specfilter(key='age')
+        def sf(a):
+            return a > 30
+        expected = set(('Alice', 'Bob'))
+        filtered = set(key for key, spec in specs.items() if sf(spec))
+        self.assertEqual(filtered, expected)
 
-            [(key, default, func), spec, expected],
-        )
+        specs['Dave'] = {'name': 'Dave', 'height': 72}
+        @specfilter(key='age', default=True)
+        def sfd(a):
+            return a > 30
+        expected = set(('Alice', 'Bob', 'Dave'))
+        filtered = set(key for key, spec in specs.items() if sfd(spec))
+        self.assertEqual(filtered, expected)
+
+    def test_andfilter(self):
+        specfilter = acg3.specfilter
+        andfilter = acg3.andfilter
+        spec_keys = 'name age height'.split()
+        spec_values = [('Alice', 32, 67), ('Bob', 31, 70), ('Connie', 25, 60)]
+        specs = dict((name, dict(zip(spec_keys, (name, age, height)))) for name, age, height in spec_values) 
+        @specfilter(key='age')
+        def sf(a):
+            return a > 30
+        @andfilter(sf)
+        @specfilter(key='height')
+        def hf(height):
+            return height >= 70
+        expected = set(('Bob',))
+        filtered = set(key for key, spec in specs.items() if hf(spec))
+        self.assertEqual(filtered, expected)
+
+    def test_orfilter(self):
+        specfilter = acg3.specfilter
+        orfilter = acg3.orfilter
+        spec_keys = 'name age height'.split()
+        spec_values = [('Alice', 32, 67), ('Bob', 31, 70), ('Connie', 25, 60)]
+        specs = dict((name, dict(zip(spec_keys, (name, age, height)))) for name, age, height in spec_values) 
+        @specfilter(key='age')
+        def sf(a):
+            return a < 30
+        @orfilter(sf)
+        @specfilter(key='height')
+        def hf(height):
+            return height < 70
+        expected = set(('Alice','Connie'))
+        filtered = set(key for key, spec in specs.items() if hf(spec))
+        self.assertEqual(filtered, expected)
+
+    def test_notfilter(self):
+        specfilter = acg3.specfilter
+        notfilter = acg3.notfilter
+        spec_keys = 'name age height'.split()
+        spec_values = [('Alice', 32, 67), ('Bob', 31, 70), ('Connie', 25, 60)]
+        specs = dict((name, dict(zip(spec_keys, (name, age, height)))) for name, age, height in spec_values) 
+        @specfilter(key='age')
+        def sf(a):
+            return a > 30
+        yf = notfilter(sf)
+        expected = set(('Connie',))
+        filtered = set(key for key, spec in specs.items() if yf(spec))
+        self.assertEqual(filtered, expected)
+        
 
 class TestTypes(unittest.TestCase):
 

--- a/apps/tests/acg3/acg3_unittests.py
+++ b/apps/tests/acg3/acg3_unittests.py
@@ -623,6 +623,15 @@ class TestHelpers(unittest.TestCase):
         self.assertIsNone(result_neither, 
                          'Lambda should return None for invalid input')
 
+    def test_make_specfilter(self):
+        spec_keys = 'name age height'.split()
+        spec_values = [('Alice', 32, 67), ('Bob', 31, 70), ('Connie', 25, 60)]
+        specs = dict(name: zip(spec_keys, (name, age, height)) for name, age, height in spec_values)
+        test_params = (
+
+            [(key, default, func), spec, expected],
+        )
+
 class TestTypes(unittest.TestCase):
 
     def test_ESMF_Typekind(self):

--- a/apps/tests/acg3/acg3_unittests.py
+++ b/apps/tests/acg3/acg3_unittests.py
@@ -18,6 +18,8 @@ def general_msg(variable='EXPECTED VARIABLE', value=None):
 make_equal_test = lambda self, expected: partial(self.assertEqual, expected)
 
 SPECIFICATIONS = acg3.SPECIFICATIONS
+MAPL_STATEITEM_FIELD = acg3.MAPL_STATEITEM_FIELD
+MAPL_STATEITEM_VECTOR = acg3.MAPL_STATEITEM_VECTOR
 
 class TestMappings(unittest.TestCase):
 
@@ -336,14 +338,14 @@ class TestColumns(unittest.TestCase):
         
         # Test alias mappings
         test_cases = (
-            ('F', 'MAPL_STATEITEM_FIELD', 'F should map to MAPL_STATEITEM_FIELD'),
-            ('V', 'MAPL_STATEITEM_VECTOR', 'V should map to MAPL_STATEITEM_VECTOR'),
+            ('F', MAPL_STATEITEM_FIELD, f'F should map to "{MAPL_STATEITEM_FIELD.upper()}"'),
+            ('V', MAPL_STATEITEM_VECTOR, f'V should map to "{MAPL_STATEITEM_VECTOR.upper()}"'),
         )
         
         for alias, expected, msg in test_cases:
             with self.subTest(alias=alias, expected=expected):
-                actual = get_value(alias)
-                self.assertEqual(expected, actual, msg)
+                actual = get_value(alias).lower()
+                self.assertEqual(expected.lower(), actual, msg)
 
     def test_itemtype_full_values(self):
         """Test that full MAPL constant values are valid for itemtype."""
@@ -364,14 +366,14 @@ class TestColumns(unittest.TestCase):
         
         # Test full constant values (both dict keys and dict values should work)
         full_values = (
-            ('MAPL_STATEITEM_FIELD', 'MAPL_STATEITEM_FIELD', 'Full value MAPL_STATEITEM_FIELD should be valid'),
-            ('MAPL_STATEITEM_VECTOR', 'MAPL_STATEITEM_VECTOR', 'Full value MAPL_STATEITEM_VECTOR should be valid'),
+            (MAPL_STATEITEM_FIELD, MAPL_STATEITEM_FIELD, f'Full value "{MAPL_STATEITEM_FIELD.upper()}" should be valid'),
+            (MAPL_STATEITEM_VECTOR, MAPL_STATEITEM_VECTOR, f'Full value "{MAPL_STATEITEM_VECTOR.upper()}" should be valid'),
         )
         
         for full_value, expected, msg in full_values:
             with self.subTest(value=full_value, expected=expected):
-                actual = get_value(full_value)
-                self.assertEqual(expected, actual, msg)
+                actual = get_value(full_value).lower()
+                self.assertEqual(expected.lower(), actual, msg)
 
     def test_itemtype_absent(self):
         """Test that itemtype is optional and absence is handled correctly."""
@@ -574,6 +576,22 @@ class TestHelpers(unittest.TestCase):
     def test_emit_declare_pointer_unsupported_type(self):
         spec = {acg3.TYPEKIND: 'X4', acg3.INTERNAL_NAME: 'GX', acg3.RANK: 4}
         self.assertRaises(RuntimeError, acg3.emit_declare_pointer, spec)
+
+    def test_emit_declare_pointers(self):
+        ITEMTYPE = acg3.ITEMTYPE
+        options = acg3.get_options({})
+        states = options[acg3.CONSTANTS][acg3.STATES]
+        STATE = acg3.STATE
+        STATE_, *_ = states
+        BASE_SPEC = {acg3.INTERNAL_NAME: 'GX', acg3.RANK: 3}
+        DEFAULT_SPEC = BASE_SPEC | {STATE: STATE_}
+        FIELD_SPEC = DEFAULT_SPEC | {ITEMTYPE: MAPL_STATEITEM_FIELD}
+        VECTOR_SPEC = BASE_SPEC | {ITEMTYPE: MAPL_STATEITEM_VECTOR}
+        specs = FIELD_SPEC, VECTOR_SPEC, DEFAULT_SPEC
+        _, declarations = acg3.emit_declare_pointers(specs, states)
+        expected = len(specs)-1
+        actual = len(declarations)
+        self.assertEqual(expected, len(declarations), f'There should be {expected} declarations. There are {actual} declarations.')
 
     def test_dict_mapping_lambda(self):
         """Test lambda function behavior for dict mappings.


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
This PR adds a new behavior. Previously, ACG generated declaration and get pointer declaration files according to the command line options for all specs. Now, the ACG generates the files only for MAPL_STATEITEM_FIELD. Existing ACG spec files do not specify ITEMTYPE, but MAPL_STATEITEM_FIELD is the default ITEMTYPE. So ACG filters for ITEMTYPE is MAPL_STATEITEM_FIELD or unspecified. It uses a new general spec filter function to do this. The spec filter function decorates a simple function on a value and creates a function that filters a spec. The spec filter function has two optional arguments: key and default, which become parameters in the decorator. If the key parameter is present, the simple function acts on the value in the key value pair. Otherwise the simple function acts on the entire spec. When the key parameter is present, but it is not found in the spec, the value of the default parameter is returned.

## Related Issue
#5165