### PR TITLE
fixes #3747

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug that prevented R8 exports being written as R4 output in History
+
 ### Added
 
 ### Changed

--- a/Tests/ExtDataRoot_GridComp.F90
+++ b/Tests/ExtDataRoot_GridComp.F90
@@ -754,13 +754,16 @@ MODULE ExtDataUtRoot_GridCompMod
 
       integer :: status
       integer                             :: i
-      real, pointer                       :: ptr1(:)
-      real, pointer                       :: ptr2(:)
+      real(ESMF_KIND_R4), pointer         :: ptr1_r4(:)
+      real(ESMF_KIND_R4), pointer         :: ptr2_r4(:)
+      real(ESMF_KIND_R8), pointer         :: ptr1_r8(:)
+      real(ESMF_KIND_R8), pointer         :: ptr2_r8(:)
       integer :: itemcount,rank1,rank2
       character(len=ESMF_MAXSTR), allocatable :: NameList(:)
       logical, allocatable :: foundDiff(:)
       type(ESMF_Field) :: Field1,Field2
       logical :: all_undef1, all_undef2
+      type(ESMF_TypeKind_Flag) :: typekind1, typekind2
 
       call ESMF_StateGet(State1,itemcount=itemCount,_RC)
          allocate(NameList(itemCount),stat=status)
@@ -770,25 +773,57 @@ MODULE ExtDataUtRoot_GridCompMod
          call ESMF_StateGet(State1,itemNameList=NameList,_RC)
          do i=1,itemCount
             if (trim(nameList(i)) == 'PLE') cycle
+            
+            ! Get fields from both states
             call ESMF_StateGet(State1,trim(nameList(i)),field1,_RC)
             call ESMF_StateGet(State2,trim(nameList(i)),field2,_RC)
+            
+            ! Get ranks and verify they match
             call ESMF_FieldGet(field1,rank=rank1,_RC)
             call ESMF_FieldGet(field2,rank=rank2,_RC)
+            _ASSERT(rank1==rank2,'Field ranks must match: '//trim(nameList(i)))
+            
+            ! Check for UNDEF fields
             all_undef1 = FieldIsConstant(field1,MAPL_UNDEF,_RC)
             all_undef2 = FieldIsConstant(field2,MAPL_UNDEF,_RC)
             if (all_undef1 .or. all_undef2) then
                exit
             end if
-            _ASSERT(rank1==rank2,'needs informative message')
-            call assign_fptr(field1, ptr1, _RC)
-            call assign_fptr(field2, ptr2, _RC)
-            _ASSERT(size(ptr1)==size(ptr2),'needs informative message')
-            foundDiff(i)=.false.
-            if (any(abs(ptr1-ptr2) > tol)) then
-                foundDiff(i) = .true.
+            
+            ! Get typekind for both fields
+            call ESMF_FieldGet(field1, typekind=typekind1, _RC)
+            call ESMF_FieldGet(field2, typekind=typekind2, _RC)
+            
+            ! Require same precision
+            if (typekind1 /= typekind2) then
+               _FAIL('Fields must have same precision for comparison: '//trim(nameList(i)))
             end if
+            
+            ! Handle based on precision
+            foundDiff(i) = .false.
+            
+            if (typekind1 == ESMF_TYPEKIND_R4) then
+               ! R4 comparison
+               call assign_fptr(field1, ptr1_r4, _RC)
+               call assign_fptr(field2, ptr2_r4, _RC)
+               _ASSERT(size(ptr1_r4)==size(ptr2_r4),'Field sizes must match: '//trim(nameList(i)))
+               if (any(abs(ptr1_r4 - ptr2_r4) > tol)) then
+                  foundDiff(i) = .true.
+               end if
+            else if (typekind1 == ESMF_TYPEKIND_R8) then
+               ! R8 comparison
+               call assign_fptr(field1, ptr1_r8, _RC)
+               call assign_fptr(field2, ptr2_r8, _RC)
+               _ASSERT(size(ptr1_r8)==size(ptr2_r8),'Field sizes must match: '//trim(nameList(i)))
+               if (any(abs(ptr1_r8 - ptr2_r8) > real(tol,ESMF_KIND_R8))) then
+                  foundDiff(i) = .true.
+               end if
+            else
+               _FAIL('Unsupported field precision: '//trim(nameList(i)))
+            end if
+            
             if (foundDiff(i)) then
-               _FAIL('found difference when compare state')
+               _FAIL('found difference when compare state: '//trim(nameList(i)))
             end if
          enddo
 

--- a/Tests/ExtData_Testing_Framework/test_cases/case01/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case01/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R8 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case01/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case01/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case02/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case02/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case02/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case02/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case03/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case03/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case03/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case03/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case04/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case04/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case04/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case04/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case05/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case05/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case05/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case05/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case06/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case06/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case06/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case06/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case07/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case07/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case07/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case07/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case08/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case08/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case08/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case08/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case09/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case09/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case09/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case09/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case10/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case10/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case10/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case10/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case11/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case11/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case11/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case11/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case12/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case12/AGCM1.rc
@@ -10,8 +10,8 @@ Root.IM_WORLD: 24
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case12/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case12/AGCM2.rc
@@ -10,13 +10,13 @@ Root.IM_WORLD: 24
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case13/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case13/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case13/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case13/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case14/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case14/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case14/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case14/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case15/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case15/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case15/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case15/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case16/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case16/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case16/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case16/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case17/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case17/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case17/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case17/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case18/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case18/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-U2D , time , days , xy , c
-V2D , time , days , xy , c
+U2D  , R4 , time , days , xy , c
+V2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case18/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case18/AGCM2.rc
@@ -12,16 +12,16 @@ Root.DATELINE: 'DC'
 RUN_MODE: FillExportsFromImports
 
 IMPORT_STATE::
-U2D , time , days , xy , c
+U2D  , R4 , time , days , xy , c
 #U3D , time , days , xyz , c
-V2D , time , days , xy , c
+V2D  , R4 , time , days , xy , c
 #V3D , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-U2D , time , days , xy , c
+U2D  , R4 , time , days , xy , c
 #U3D , time , days , xyz , c
-V2D , time , days , xy , c
+V2D  , R4 , time , days , xy , c
 #V3D , time , days , xyz , c
 ::
 

--- a/Tests/ExtData_Testing_Framework/test_cases/case19/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case19/AGCM1.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case20/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case20/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case20/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case20/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case21/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case21/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR1 , time , days , xy , c
-VAR2 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
+VAR2  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case21/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case21/AGCM2.rc
@@ -12,15 +12,15 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR1 , time , days , xy , c
-VAR2 , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
+VAR2  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR1 , time , days , xy , c
-VAR2 , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
+VAR2  , R4 , time , days , xy , c
 ::
 
 

--- a/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM2.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM3.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case22/AGCM3.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM2.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM3.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case23/AGCM3.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: FillImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case24/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case24/AGCM1.rc
@@ -10,8 +10,8 @@ Root.NF: 6
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case24/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case24/AGCM2.rc
@@ -10,13 +10,13 @@ Root.NF: 6
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case25/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case25/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR3D , time , days , xyz , e
+VAR3D  , R4 , time , days , xyz , e
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case25/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case25/AGCM2.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR3D , time , days , xyz , e
+VAR3D  , R4 , time , days , xyz , e
 ::
 
 EXPORT_STATE::
-VAR3D , time , days , xyz , e
+VAR3D  , R4 , time , days , xyz , e
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case26/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case26/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR3Dc , time , days , xyz , c
-VAR3De , time , days , xyz , e
+VAR3Dc  , R4 , time , days , xyz , c
+VAR3De  , R4 , time , days , xyz , e
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case26/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case26/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR3Dc , time , days , xyz , c
-VAR3De , time , days , xyz , e
+VAR3Dc  , R4 , time , days , xyz , c
+VAR3De  , R4 , time , days , xyz , e
 ::
 
 EXPORT_STATE::
-VAR3Dc , time , days , xyz , c
-VAR3De , time , days , xyz , e
+VAR3Dc  , R4 , time , days , xyz , c
+VAR3De  , R4 , time , days , xyz , e
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM2.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM3.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM3.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: FillImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM4.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case27/AGCM4.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: FillImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case28/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case28/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case28/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case28/AGCM2.rc
@@ -13,11 +13,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case29/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case29/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case29/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case29/AGCM2.rc
@@ -13,11 +13,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case30/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case30/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case30/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case30/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case31/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case31/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case31/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case31/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case32/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case32/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case32/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case32/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case33/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case33/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case33/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case33/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case34/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case34/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case34/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case34/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case35/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case35/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case35/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case35/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case36/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case36/AGCM1.rc
@@ -12,8 +12,8 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case36/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case36/AGCM2.rc
@@ -12,13 +12,13 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
-VAR3D , time , days , xyz , c
+VAR2D  , R4 , time , days , xy , c
+VAR3D  , R4 , time , days , xyz , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM1.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR1 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM2.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM2.rc
@@ -12,7 +12,7 @@ Root.DATELINE: 'DC'
 RUN_MODE: GenerateExports
 
 EXPORT_STATE::
-VAR1 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM3.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case37/AGCM3.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR1 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR1 , time , days , xy , c
+VAR1  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/ExtData_Testing_Framework/test_cases/case38/AGCM1.rc
+++ b/Tests/ExtData_Testing_Framework/test_cases/case38/AGCM1.rc
@@ -12,11 +12,11 @@ Root.DATELINE: 'DC'
 RUN_MODE: CompareImports
 
 IMPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 EXPORT_STATE::
-VAR2D , time , days , xy , c
+VAR2D  , R4 , time , days , xy , c
 ::
 
 FILL_DEF::

--- a/Tests/VarspecDescription.F90
+++ b/Tests/VarspecDescription.F90
@@ -1,8 +1,4 @@
-#define _SUCCESS      0
-#define _FAILURE     1
-#define _VERIFY(A)   if(  A/=0) then; if(present(rc)) rc=A; PRINT *, Iam, __LINE__; return; endif
-#define _ASSERT(A)   if(.not.A) then; if(present(rc)) rc=_FAILURE; PRINT *, Iam, __LINE__; return; endif
-#define _RETURN(A)   if(present(rc)) rc=A; return
+#include "MAPL_Generic.h"
 
 module VarspecDescriptionMod
    use MAPL
@@ -34,7 +30,6 @@ contains
       logical :: lcomp
       integer, optional, intent(out) :: rc
 
-      character(len=*), parameter :: Iam = 'new_VarspecDescriptionFromConfig'
       integer :: status
 
       type(StringVector) :: svec
@@ -50,7 +45,7 @@ contains
       enddo
 
       lcomp = (svec%size()==6 .or. svec%size()==7)
-      _ASSERT(lcomp)
+      _ASSERT(lcomp, 'Wrong number of columns in state descriptor')
       VarspecDescr%short_name = svec%at(1)
       
       ! Parse and validate precision (column 2)
@@ -99,7 +94,6 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      character(len=*), parameter :: Iam = "addNewSpec"
 
       if (specType == "IMPORT") then
          call MAPL_AddImportSpec(GC, &
@@ -112,7 +106,7 @@ contains
               !STAGGERING = this%staggering, &
               !ROTATION = this%rotation, &
               UNGRIDDED_DIMS = this%ungridded_dims, &
-              RC = status)
+              _RC)
       else if (specType == "EXPORT") then
          call MAPL_AddExportSpec(GC, &
               SHORT_NAME = this%short_name, &
@@ -124,11 +118,10 @@ contains
               !STAGGERING = this%staggering, &
               !ROTATION = this%rotation, &
               UNGRIDDED_DIMS = this%ungridded_dims, &
-              RC = status)
+              _RC)
       else
          _RETURN(_FAILURE)
       end if
-      _VERIFY(status)
 
    end subroutine AddNewSpec
 

--- a/Tests/VarspecDescription.F90
+++ b/Tests/VarspecDescription.F90
@@ -8,6 +8,7 @@ module VarspecDescriptionMod
    use MAPL
    use ESMF
    use gFTL_StringVector
+   use MAPL_Constants, only: MAPL_R4, MAPL_R8
    implicit none
    private
 
@@ -48,12 +49,25 @@ contains
          call svec%push_back(trim(tmpstring))
       enddo
 
-      lcomp = (svec%size()==5 .or. svec%size()==6)
+      lcomp = (svec%size()==6 .or. svec%size()==7)
       _ASSERT(lcomp)
       VarspecDescr%short_name = svec%at(1)
-      VarspecDescr%long_name = svec%at(2)
-      VarspecDescr%units = svec%at(3)
-      tmpstring = svec%at(4)
+      
+      ! Parse and validate precision (column 2)
+      tmpstring = svec%at(2)
+      if (trim(tmpstring) == 'R4') then
+         VarspecDescr%precision = MAPL_R4
+      else if (trim(tmpstring) == 'R8') then
+         VarspecDescr%precision = MAPL_R8
+      else
+         PRINT *, Iam, ': Invalid precision "', trim(tmpstring), '"'
+         PRINT *, Iam, ': Must be either R4 or R8'
+         _ASSERT(.false.)
+      end if
+      
+      VarspecDescr%long_name = svec%at(3)
+      VarspecDescr%units = svec%at(4)
+      tmpstring = svec%at(5)
       if (trim(tmpstring) == 'xy') then
          VarspecDescr%dims = MAPL_DimsHorzOnly
       else if (trim(tmpstring) == 'xyz') then
@@ -61,7 +75,7 @@ contains
       else if (trim(tmpstring) == 'tileonly') then
          VarspecDescr%dims = MAPL_DimsTileOnly
       end if
-      tmpstring = svec%at(5)
+      tmpstring = svec%at(6)
       if (trim(tmpstring) == 'none') then
          VarspecDescr%location = MAPL_VLocationNone
       else if (trim(tmpstring) == 'c') then
@@ -69,8 +83,8 @@ contains
       else if (trim(tmpstring) == 'e') then
          VarspecDescr%location = MAPL_VLocationEdge
       end if
-      if (svec%size() == 6) then
-         tmpstring = svec%at(6)
+      if (svec%size() == 7) then
+         tmpstring = svec%at(7)
          allocate(ungrid_ptr(1))
          read(tmpstring,*)ungrid_ptr(1)
          if (ungrid_ptr(1) > 0) VarspecDescr%ungridded_dims => ungrid_ptr
@@ -95,6 +109,7 @@ contains
               UNITS = this%units, &
               DIMS = this%dims, &
               VLOCATION = this%location, &
+              PRECISION = this%precision, &
               !STAGGERING = this%staggering, &
               !ROTATION = this%rotation, &
               UNGRIDDED_DIMS = this%ungridded_dims, &
@@ -106,6 +121,7 @@ contains
               UNITS = this%units, &
               DIMS = this%dims, &
               VLOCATION = this%location, &
+              PRECISION = this%precision, &
               !STAGGERING = this%staggering, &
               !ROTATION = this%rotation, &
               UNGRIDDED_DIMS = this%ungridded_dims, &

--- a/Tests/VarspecDescription.F90
+++ b/Tests/VarspecDescription.F90
@@ -60,9 +60,8 @@ contains
       else if (trim(tmpstring) == 'R8') then
          VarspecDescr%precision = MAPL_R8
       else
-         PRINT *, Iam, ': Invalid precision "', trim(tmpstring), '"'
-         PRINT *, Iam, ': Must be either R4 or R8'
-         _ASSERT(.false.)
+        _FAIL('Invalid precision "'// trim(tmpstring) // '": Must be either R4 or R8')
+
       end if
       
       VarspecDescr%long_name = svec%at(3)

--- a/base/Base/Base_Base_implementation.F90
+++ b/base/Base/Base_Base_implementation.F90
@@ -1412,7 +1412,8 @@ contains
        allocate(var_1d(lbound(vr8_1d,1):ubound(vr8_1d,1)), _STAT)
        var_1d=vr8_1d
        f = MAPL_FieldCreateEmpty(name=fieldNAME, grid=grid, _RC)
-       call ESMF_FieldEmptyComplete(F, farrayPtr=VAR_1D,    &
+       call ESMF_FieldEmptyComplete(F, farray=VAR_1D,    &
+                  indexflag=ESMF_INDEX_DELOCAL, &
             gridToFieldMap=gridToFieldMap,                      &
             datacopyFlag = datacopy,             &
             _RC)
@@ -1423,7 +1424,8 @@ contains
             _STAT)
        var_2d=vr8_2d
        f = MAPL_FieldCreateEmpty(name=fieldNAME, grid=grid, _RC)
-       call ESMF_FieldEmptyComplete(F, farrayPtr=VAR_2D,    &
+       call ESMF_FieldEmptyComplete(F, farray=VAR_2D,    &
+                  indexflag=ESMF_INDEX_DELOCAL, &
             gridToFieldMap=gridToFieldMap,                      &
             datacopyFlag = datacopy,             &
             _RC)
@@ -1435,7 +1437,8 @@ contains
             _STAT)
        var_3d=vr8_3d
        f = MAPL_FieldCreateEmpty(name=fieldNAME, grid=grid, _RC)
-       call ESMF_FieldEmptyComplete(F, farrayPtr=VAR_3D,    &
+       call ESMF_FieldEmptyComplete(F, farray=VAR_3D,    &
+                  indexflag=ESMF_INDEX_DELOCAL, &
             gridToFieldMap=gridToFieldMap,                      &
             datacopyFlag = datacopy,             &
             _RC)


### PR DESCRIPTION
This fixes a long standing bug that History could not write R8 exports downgraded to R4 in files as it used to do. I think I found the issue and fixed. 

I've also update by ExtDataDriver.x application so I can create R8 fields when populating the states to test this. That is why lots of RC files changed. I had to add new column to my dynamic state description.

The issue was that when the fields are downgraded to R4 they were done in a way that had a different index space that we usually create fields with which caused problems later on. The import item was the change in Base

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

