### PR TITLE
Issue 5167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed "use esmf" to "import <specifi ESMF objects>" in GeomPFI abstract interfaces
 - Added PythonBridge to MAPL interface
 - Moved configurable test from superstructure/generic
 - Consolidated MAPL ESMF_Info keys into mapl_esmf_info_keys_mod

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -33,8 +33,8 @@ module mapl_GeomPFIO_mod
    abstract interface
 
      subroutine I_stage_data_to_file(this, bundle, filename, time_index, rc)
-        use esmf
         import GeomPFIO
+        import ESMF_FieldBundle
         class(GeomPFIO), intent(inout) :: this
         type(ESMF_FieldBundle), intent(in) :: bundle
         character(len=*), intent(in) :: filename
@@ -43,7 +43,6 @@ module mapl_GeomPFIO_mod
      end subroutine I_stage_data_to_file
 
      subroutine I_stage_coordinates_to_file(this, filename, rc)
-        use esmf
         import GeomPFIO
         class(GeomPFIO), intent(inout) :: this
         character(len=*), intent(in) :: filename
@@ -51,8 +50,8 @@ module mapl_GeomPFIO_mod
      end subroutine I_stage_coordinates_to_file
 
      subroutine I_request_data_from_file(this, filename, bundle, rc)
-        use esmf
         import GeomPFIO
+        import ESMF_FieldBundle
         class(GeomPFIO), intent(inout) :: this
         character(len=*), intent(in) :: filename
         type(ESMF_FieldBundle), intent(inout) :: bundle


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [X] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description
 Changed "use esmf" to "import <specific ESMF objects>" in GeomPFIO abstract interfaces to get rid of the warning message `MAPL_Initialize.i90: warning #7925: An interface-block in a subprogram that contains an interface-body for a procedure defined by that subprogram is non-standard.   [MAPL_GEOMPFIO_MOD^I_STAGE_DATA_TO_FILE]`

## Related Issue
[5167](https://github.com/GEOS-ESM/MAPL/issues/5167)
