### PR TITLE
Mapl2esmf set get int state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced MAPL_UserComp[Set,Get]InternalState with ESMF_UserComp[Set,Get]InternalState
 - Added PythonBridge to MAPL interface
 - Moved configurable test from superstructure/generic
 - Consolidated MAPL ESMF_Info keys into mapl_esmf_info_keys_mod

--- a/MAPL_Public_API.md
+++ b/MAPL_Public_API.md
@@ -56,7 +56,7 @@ Notable source modules and their key exported entities:
 
 | Source module | Key public entities |
 |---|---|
-| `mapl_Generic_mod` | `MAPL_GridCompGet`, `MAPL_GridCompSet`, `MAPL_GridCompAddChild`, `MAPL_GridCompAddVarSpec`, `MAPL_GridCompIsGeneric`, `MAPL_GridCompIsUser`, `MAPL_GridCompSetEntryPoint`, `MAPL_GridCompRunChild`, `MAPL_GridCompRunChildren`, `MAPL_GridCompGetInternalState`, `MAPL_GridCompSetGeometry`, `MAPL_GridCompSetGeom`, `MAPL_GridCompSetVerticalGrid`, `MAPL_GridCompAddConnection`, `MAPL_GridCompReexport`, `MAPL_GridCompConnectAll`, `MAPL_GridCompTimerStart`, `MAPL_GridCompTimerStop`, `MAPL_ClockGet`, `MAPL_UserCompGetInternalState`, `MAPL_UserCompSetInternalState` |
+| `mapl_Generic_mod` | `MAPL_GridCompGet`, `MAPL_GridCompSet`, `MAPL_GridCompAddChild`, `MAPL_GridCompAddVarSpec`, `MAPL_GridCompIsGeneric`, `MAPL_GridCompIsUser`, `MAPL_GridCompSetEntryPoint`, `MAPL_GridCompRunChild`, `MAPL_GridCompRunChildren`, `MAPL_GridCompGetInternalState`, `MAPL_GridCompSetGeometry`, `MAPL_GridCompSetGeom`, `MAPL_GridCompSetVerticalGrid`, `MAPL_GridCompAddConnection`, `MAPL_GridCompReexport`, `MAPL_GridCompConnectAll`, `MAPL_GridCompTimerStart`, `MAPL_GridCompTimerStop`, `MAPL_ClockGet` |
 | `mapl_VariableSpec_mod` | `VariableSpec` (type) |
 | `mapl_GenericPhases_mod` | phase constants/types |
 | `mapl_OuterMetaComponent_mod` | `OuterMetaComponent` (type) |
@@ -927,8 +927,6 @@ No `private`; itself a package re-exporter of ~30 sub-modules. Two names are ren
 | `MAPL_STATEITEM_FIELDBUNDLE` | parameter |
 | `MAPL_STATEITEM_SERVICE` | parameter |
 | `MAPL_STATEITEM_VECTOR` | parameter |
-| `MAPL_UserCompGetInternalState` | subroutine |
-| `MAPL_UserCompSetInternalState` | subroutine |
 
 ---
 

--- a/include/MAPL_private_state.h
+++ b/include/MAPL_private_state.h
@@ -43,7 +43,7 @@
     _DECLARE_WRAPPER(T);                               \
     type(PrivateWrapper) :: w;                         \
     allocate(w%ptr);                                           \
-    call MAPL_UserCompSetInternalState(gc, name, w, status);         \
+    call ESMF_UserCompSetInternalState(gc, name, w, status);         \
     _ASSERT(status==ESMF_SUCCESS, "Private state with name <" //name// "> already created for this gridcomp?"); \
   end block
 
@@ -53,7 +53,7 @@
   block;                                                      \
     _DECLARE_WRAPPER(T);                                        \
     type(PrivateWrapper) :: w;                                  \
-    call MAPL_UserCompGetInternalState(gc, name, w, status);         \
+    call ESMF_UserCompGetInternalState(gc, name, w, status);         \
     _ASSERT(status==ESMF_SUCCESS, "Private state with name <" //name// "> not found for this gridcomp."); \
     private_state => w%ptr;                         \
   end block
@@ -64,7 +64,7 @@
   block;                                                       \
     _DECLARE_WRAPPER(T);                                         \
     type(PrivateWrapper) :: w;                                   \
-    call MAPL_UserCompGetInternalState(gc, name, w, rc=status);         \
+    call ESMF_UserCompGetInternalState(gc, name, w, rc=status);         \
     _ASSERT(status==ESMF_SUCCESS, "Private state with name <" //name// "> not found for this gridcomp."); \
     private_state => w%ptr; \
   end block

--- a/infrastructure/esmf/ESMF_Interfaces.F90
+++ b/infrastructure/esmf/ESMF_Interfaces.F90
@@ -20,28 +20,6 @@ module mapl_ESMF_Interfaces_mod
 
    public :: I_CallBackMethod
 
-   ! TODO: pchakrab - this should be in MAPL.generic, but that causes circular dependency issues
-   public :: MAPL_UserCompGetInternalState
-   public :: MAPL_UserCompSetInternalState
-
-   interface MAPL_UserCompGetInternalState
-      subroutine ESMF_UserCompGetInternalState(gridcomp, name, wrapper, status)
-         type(*) :: gridcomp
-         character(*), optional :: name
-         type(*) :: wrapper
-         integer :: status
-      end subroutine ESMF_UserCompGetInternalState
-   end interface MAPL_UserCompGetInternalState
-
-   interface MAPL_UserCompSetInternalState
-      subroutine ESMF_UserCompSetInternalState(gridcomp, name, wrapper, status)
-         type(*) :: gridcomp
-         character(*), optional :: name
-         type(*) :: wrapper
-         integer :: status
-      end subroutine ESMF_UserCompSetInternalState
-   end interface MAPL_UserCompSetInternalState
-
    abstract interface
 
       subroutine I_CallBackMethod(state, rc)

--- a/superstructure/generic/API.F90
+++ b/superstructure/generic/API.F90
@@ -38,8 +38,6 @@ module mapl_generic_api
    !    mapl_STATEITEM_FIELDBUNDLE => STATEITEM_FIELDBUNDLE, &
    !    mapl_STATEITEM_SERVICE => STATEITEM_SERVICE, &
    !    mapl_STATEITEM_VECTOR => STATEITEM_VECTOR, &
-   !    mapl_UserCompGetInternalState => UserCompGetInternalState, &
-   !    MAPL_UserCompSetInternalState => UserCompSetInternalState, &
        MAPL_GridCompGetOuterMeta => GridCompGetOuterMeta, &
        MAPL_GridCompGetRegistry => GridCompGetRegistry, &
        MAPL_GridCompIsGeneric => GridCompIsGeneric, &
@@ -110,8 +108,6 @@ module mapl_generic_api
    ! Spec types
    public :: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    public :: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
-
-   public :: mapl_UserCompGetInternalState, MAPL_UserCompSetInternalState
 
    public :: mapl_find_bounds
    public :: mapl_get_num_threads

--- a/superstructure/generic/InnerMetaComponent.F90
+++ b/superstructure/generic/InnerMetaComponent.F90
@@ -3,8 +3,6 @@
 module mapl_InnerMetaComponent_mod
    use :: mapl_ErrorHandling_mod
    use :: mapl3_GenericGrid
-   use :: mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
-   use :: mapl_ESMF_Interfaces_mod, only: MAPL_UserCompSetInternalState
    use esmf
    implicit none(type,external)
    private
@@ -92,7 +90,7 @@ contains
       integer :: status
       type(InnerMetaWrapper) :: wrapper
 
-      call MAPL_UserCompGetInternalState(gridcomp, INNER_META_PRIVATE_STATE, wrapper, status)
+      call ESMF_UserCompGetInternalState(gridcomp, INNER_META_PRIVATE_STATE, wrapper, status)
       _ASSERT(status==ESMF_SUCCESS, "OuterMetaComponent not created for this gridcomp")
       deallocate(wrapper%inner_meta)
 

--- a/superstructure/generic/MAPL_Generic.F90
+++ b/superstructure/generic/MAPL_Generic.F90
@@ -37,7 +37,6 @@ module mapl_Generic_mod
    use mapl_StateItem_mod, only: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    use mapl_StateItem_mod, only: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
    use mapl_ESMF_Utilities_mod, only: esmf_state_intent_to_string
-   use mapl_ESMF_Interfaces_mod, only: mapl_UserCompGetInternalState, mapl_UserCompSetInternalState
    use mapl_hconfig_get_mod, only: HConfigGet
    use mapl_hconfig_params_mod, only: HConfigParams
    use mapl_RestartModes_mod, only: RestartMode
@@ -118,8 +117,6 @@ module mapl_Generic_mod
    ! Spec types
    public :: mapl_STATEITEM_STATE, mapl_STATEITEM_FIELDBUNDLE
    public :: mapl_STATEITEM_SERVICE, mapl_STATEITEM_VECTOR
-
-   public :: mapl_UserCompGetInternalState, mapl_UserCompSetInternalState
 
    ! Interfaces
 

--- a/superstructure/generic/OpenMP_Support.F90
+++ b/superstructure/generic/OpenMP_Support.F90
@@ -8,7 +8,6 @@ module mapl_OpenMP_Support_mod
     use mapl_Subgrid_mod, only: Interval, make_subgrids, find_bounds
     use mapl_StateAddMethod_mod, only: CallbackMap, CallbackMapIterator, CallbackMethodWrapper, get_callbacks
     use mapl_StateAddMethod_mod, only: operator(/=)
-    use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState, MAPL_UserCompSetInternalState
     !$ use omp_lib
 
     implicit none(type,external)
@@ -391,12 +390,12 @@ module mapl_OpenMP_Support_mod
         end do
 
         do ilabel = 1, size(labels)
-           call MAPL_UserCompGetInternalState(GridComp, trim(labels(ilabel)), wrap, status)
+           call ESMF_UserCompGetInternalState(GridComp, trim(labels(ilabel)), wrap, status)
            has_private_state = (status == ESMF_SUCCESS)
            do i = 1, num_grids
               associate (gc => subgridcomps(i) )
                 if (has_private_state) then
-                   call MAPL_UserCompSetInternalState(gc, trim(labels(ilabel)), wrap, status)
+                   call ESMF_UserCompSetInternalState(gc, trim(labels(ilabel)), wrap, status)
                    _VERIFY(status)
                 end if
               end associate

--- a/superstructure/generic/OuterMetaComponent/attach_outer_meta.F90
+++ b/superstructure/generic/OuterMetaComponent/attach_outer_meta.F90
@@ -1,7 +1,6 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) attach_outer_meta_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompSetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 

--- a/superstructure/generic/OuterMetaComponent/free_outer_meta.F90
+++ b/superstructure/generic/OuterMetaComponent/free_outer_meta.F90
@@ -1,7 +1,6 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) free_outer_meta_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 
@@ -15,7 +14,7 @@ contains
       type(OuterMetaWrapper) :: wrapper
       type(ESMF_GridComp) :: user_gridcomp
 
-      call MAPL_UserCompGetInternalState(gridcomp, OUTER_META_PRIVATE_STATE, wrapper, status)
+      call ESMF_UserCompGetInternalState(gridcomp, OUTER_META_PRIVATE_STATE, wrapper, status)
       _ASSERT(status==ESMF_SUCCESS, "OuterMetaComponent not created for this gridcomp")
 
       user_gridcomp = wrapper%outer_meta%user_gc_driver%get_gridcomp()

--- a/superstructure/generic/OuterMetaComponent/get_outer_meta_from_outer_gc.F90
+++ b/superstructure/generic/OuterMetaComponent/get_outer_meta_from_outer_gc.F90
@@ -1,7 +1,6 @@
 #include "MAPL.h"
 
 submodule (mapl_OuterMetaComponent_mod) get_outer_meta_from_outer_gc_smod
-   use mapl_ESMF_Interfaces_mod, only: MAPL_UserCompGetInternalState
    use mapl_ErrorHandling_mod
    implicit none(type,external)
 

--- a/superstructure/generic/transforms/CouplerMetaComponent.F90
+++ b/superstructure/generic/transforms/CouplerMetaComponent.F90
@@ -493,7 +493,7 @@ contains
       integer :: status
       type(CouplerMetaWrapper) :: wrapper
 
-      call MAPL_UserCompGetInternalState(gridcomp, COUPLER_META_PRIVATE_STATE, wrapper, status)
+      call ESMF_UserCompGetInternalState(gridcomp, COUPLER_META_PRIVATE_STATE, wrapper, status)
       _ASSERT(status==ESMF_SUCCESS, "CouplerMetaComponent not created for this gridcomp")
 
       deallocate(wrapper%coupler_meta)


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [X] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`)

## Description
Replaced MAPL_UserComp[Set,Get]InternalState with ESMF_UserComp[Set,Get]InternalState

## Related Issue
[5195](https://github.com/GEOS-ESM/MAPL/issues/5195)
