### PR TITLE
Simplify ClientManager to single ClientThread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactored `pFIO_ClientManagerMod`: replaced `ClientThreadVector` pool with a
+  single `class(ClientThread), allocatable` member; removed multi-client cycling
+  logic (`next`, `set_current`, `size`, `set_optimal_server`, `split_server_pools`,
+  `set_server_size`) and server-pool fields; renamed module-level singletons
+  `i_Clients`/`o_Clients` to `i_Client`/`o_Client` and the corresponding
+  `mapl_pfio_api` aliases to `mapl_i_client`/`mapl_o_client`.
 - Changed "use esmf" to "import <specifi ESMF objects>" in GeomPFI abstract interfaces
 - Added PythonBridge to MAPL interface
 - Moved configurable test from superstructure/generic

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -116,7 +116,7 @@ module mapl_ExtDataReader_mod
          pfio_typekind = mapl_esmf_to_pfio_type(esmf_typekind, _RC)
          new_element_count = server_bounds%get_file_shape()
          ref = mapl_ArrayReference(address, pfio_typekind, new_element_count)
-         call mapl_i_Clients%collective_prefetch_data( &
+          call mapl_i_Client%collective_prefetch_data( &
               client_id, &
               filename, &
               alias, &
@@ -127,8 +127,8 @@ module mapl_ExtDataReader_mod
          deallocate(global_start, global_count, local_start, element_count, new_element_count)
          call lgr%info('reading %a from file %a at time index %i0.5', alias, filename, time_index)
       enddo
-      call mapl_i_Clients%done_collective_prefetch()
-      call mapl_i_Clients%wait()
+       call mapl_i_Client%done_collective_prefetch()
+       call mapl_i_Client%wait()
 
       _RETURN(_SUCCESS)
    end subroutine

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -79,7 +79,7 @@ module mapl_ExtDataReader_mod
       character(len=ESMF_MAXSTR) :: field_name
       integer, pointer :: client_id, time_index
       character(len=:), pointer :: alias, filename
-      integer :: status, i, pfio_typekind, num_fields
+      integer :: status, i, pfio_typekind, num_fields, request_id
       type(ESMF_Field), allocatable :: field_list(:)
       type(ESMF_Grid) :: grid
       type(ESMF_TypeKind_Flag) :: esmf_typekind
@@ -116,19 +116,19 @@ module mapl_ExtDataReader_mod
          pfio_typekind = mapl_esmf_to_pfio_type(esmf_typekind, _RC)
          new_element_count = server_bounds%get_file_shape()
          ref = mapl_ArrayReference(address, pfio_typekind, new_element_count)
-          call mapl_i_Client%collective_prefetch_data( &
-              client_id, &
-              filename, &
-              alias, &
-              ref, &
-              start=local_start, &
-              global_start=global_start, &
-              global_count=global_count)
+          request_id = mapl_i_Client%collective_prefetch_data( &
+               client_id, &
+               filename, &
+               alias, &
+               ref, &
+               start=local_start, &
+               global_start=global_start, &
+               global_count=global_count)
          deallocate(global_start, global_count, local_start, element_count, new_element_count)
          call lgr%info('reading %a from file %a at time index %i0.5', alias, filename, time_index)
       enddo
        call mapl_i_Client%done_collective_prefetch()
-       call mapl_i_Client%wait()
+       call mapl_i_Client%wait_all()
 
       _RETURN(_SUCCESS)
    end subroutine

--- a/gridcomps/extdata/PrimaryExport.F90
+++ b/gridcomps/extdata/PrimaryExport.F90
@@ -93,7 +93,7 @@ module mapl_PrimaryExport_mod
          call primary_export%bracket%set_node(NODE_LEFT, left_node)
          call primary_export%bracket%set_node(NODE_RIGHT, right_node)
          call primary_export%file_selector%get_file_template(file_template)
-         primary_export%client_collection_id = mapl_i_clients%add_data_collection(file_template, _RC)
+          primary_export%client_collection_id = mapl_i_client%add_data_collection(file_template, _RC)
          call primary_export%bracket%set_parameters(time_interpolation=sample%time_interpolation)
          allocate(primary_export%start_and_end, source=time_range)
       end if

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -150,8 +150,8 @@ contains
 
       call MAPL_GridCompRunChildren(gridcomp, phase_name='run', _RC)
 
-      call mapl_o_Clients%done_collective_stage()
-      call mapl_o_Clients%post_wait()
+       call mapl_o_Client%done_collective_stage()
+       call mapl_o_Client%post_wait()
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(importState)

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -151,7 +151,7 @@ contains
       call MAPL_GridCompRunChildren(gridcomp, phase_name='run', _RC)
 
        call mapl_o_Client%done_collective_stage()
-       call mapl_o_Client%post_wait()
+       call mapl_o_Client%post_wait_all()
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(importState)

--- a/infrastructure/geom_io/FieldBundleRead.F90
+++ b/infrastructure/geom_io/FieldBundleRead.F90
@@ -364,8 +364,8 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(trim(file_name), file_geom, _RC)
       call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
-      call i_Clients%done_collective_prefetch()
-      call i_Clients%wait()
+      call i_Client%done_collective_prefetch()
+      call i_Client%wait()
 
       !--- Regrid if grids differ ---
       if (.not. same_grid) then

--- a/infrastructure/geom_io/FieldBundleRead.F90
+++ b/infrastructure/geom_io/FieldBundleRead.F90
@@ -365,7 +365,7 @@ contains
       call reader%initialize(trim(file_name), file_geom, _RC)
       call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
       call i_Client%done_collective_prefetch()
-      call i_Client%wait()
+      call i_Client%wait_all()
 
       !--- Regrid if grids differ ---
       if (.not. same_grid) then

--- a/infrastructure/geom_io/FieldBundleWrite.F90
+++ b/infrastructure/geom_io/FieldBundleWrite.F90
@@ -2,7 +2,7 @@
 module mapl_FieldBundleWrite_mod
    use ESMF
    use pFIO
-   use pFIO_ClientManagerMod, only: o_Clients
+   use pFIO_ClientManagerMod, only: o_Client
    use mapl_ErrorHandling_mod
    use mapl_GeomPFIO_mod
    use mapl_SharedIO_mod
@@ -92,8 +92,8 @@ module mapl_FieldBundleWrite_mod
          call this%writer%stage_time_to_file(this%file_name, this%file_times, _RC)
          call this%writer%stage_data_to_file(bundle, this%file_name, time_index, _RC)
 
-         call o_Clients%done_collective_stage()
-         call o_Clients%post_wait()
+          call o_Client%done_collective_stage()
+          call o_Client%post_wait()
          _VERIFY(status)
          _RETURN(_SUCCESS)
 

--- a/infrastructure/geom_io/FieldBundleWrite.F90
+++ b/infrastructure/geom_io/FieldBundleWrite.F90
@@ -93,7 +93,7 @@ module mapl_FieldBundleWrite_mod
          call this%writer%stage_data_to_file(bundle, this%file_name, time_index, _RC)
 
           call o_Client%done_collective_stage()
-          call o_Client%post_wait()
+          call o_Client%post_wait_all()
          _VERIFY(status)
          _RETURN(_SUCCESS)
 

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -87,9 +87,10 @@ contains
 
       integer :: status
       type(ArrayReference) :: ref
+      integer :: request_id
 
       ref = ArrayReference(times)
-      call o_Client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
+      request_id = o_Client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
       _RETURN(_SUCCESS)
 
    end subroutine

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -3,7 +3,7 @@
 module mapl_GeomPFIO_mod
    use mapl_ErrorHandling_mod
    use ESMF
-   use pfio, only: i_Clients, o_Clients, StringVariableMap, ArrayReference, FileMetadata, Variable
+   use pfio, only: i_Client, o_Client, StringVariableMap, ArrayReference, FileMetadata, Variable
    use mapl_geom_api
    use mapl_SharedIO_mod
    implicit none
@@ -73,7 +73,7 @@ contains
 
       time_var = create_time_variable(time, _RC)
       call var_map%insert('time',time_var)
-      call o_Clients%modify_metadata(this%collection_id, var_map=var_map, _RC)
+      call o_Client%modify_metadata(this%collection_id, var_map=var_map, _RC)
 
       _RETURN(_SUCCESS)
 
@@ -89,7 +89,7 @@ contains
       type(ArrayReference) :: ref
 
       ref = ArrayReference(times)
-      call o_Clients%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
+      call o_Client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
       _RETURN(_SUCCESS)
 
    end subroutine
@@ -103,7 +103,7 @@ contains
       integer :: status
 
       this%esmfgeom = esmfgeom
-      this%collection_id = o_Clients%add_data_collection(metadata, _RC)
+      this%collection_id = o_Client%add_data_collection(metadata, _RC)
       this%file_metadata = metadata
 
       _RETURN(_SUCCESS)
@@ -118,7 +118,7 @@ contains
       integer :: status
 
       this%esmfgeom = esmfgeom
-      this%collection_id = i_Clients%add_data_collection(file_name, _RC)
+      this%collection_id = i_Client%add_data_collection(file_name, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine init_with_filename

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -65,7 +65,7 @@ contains
          allocate(this%lons(size(coords,1), size(coords,2)), _STAT)
          this%lons = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%lons)
-         call o_clients%collective_stage_data(collection_id,filename, 'lons', &
+         call o_Client%collective_stage_data(collection_id,filename, 'lons', &
               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, _RC)
@@ -73,7 +73,7 @@ contains
          allocate(this%lats(size(coords,1), size(coords,2)), _STAT)
          this%lats = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%lats)
-         call o_clients%collective_stage_data(collection_id,filename, 'lats', &
+         call o_Client%collective_stage_data(collection_id,filename, 'lats', &
               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_FieldDestroy(field, noGarbage=.true., _RC)
@@ -97,7 +97,7 @@ contains
          allocate(this%corner_lons(size(coords,1), size(coords,2)), _STAT)
          this%corner_lons = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%corner_lons)
-         call o_clients%collective_stage_data(collection_id,filename, 'corner_lons', &
+          call o_Client%collective_stage_data(collection_id,filename, 'corner_lons', &
               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
@@ -105,7 +105,7 @@ contains
          allocate(this%corner_lats(size(coords,1), size(coords,2)), _STAT)
          this%corner_lats = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%corner_lats)
-         call o_clients%collective_stage_data(collection_id,filename, 'corner_lats', &
+          call o_Client%collective_stage_data(collection_id,filename, 'corner_lats', &
               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_FieldDestroy(field, noGarbage=.true., _RC)
@@ -154,7 +154,7 @@ contains
          new_element_count = server_bounds%get_file_shape()
          ref = ArrayReference(address, type_kind, new_element_count)
 
-         call o_clients%collective_stage_data(collection_id,filename, trim(field_names(i)), &
+          call o_Client%collective_stage_data(collection_id,filename, trim(field_names(i)), &
               ref, start=local_start, global_start=global_start, global_count=global_count)
       enddo
 
@@ -198,7 +198,7 @@ contains
          pfio_typekind = esmf_to_pfio_type(esmf_typekind, _RC)
          new_element_count = server_bounds%get_file_shape()
          ref = ArrayReference(address, pfio_typekind, new_element_count)
-         call i_Clients%collective_prefetch_data( &
+          call i_Client%collective_prefetch_data( &
               collection_id, &
               filename, &
               field_names(idx), &

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -45,6 +45,7 @@ contains
       type(ESMF_TypeKind_Flag) :: tk
       type(ArrayReference) :: ref
       real(ESMF_Kind_R8), pointer :: coords(:,:)
+      integer :: request_id
 
       file_metadata = this%get_file_metadata()
       has_ll = file_metadata%has_variable('lons') .and. file_metadata%has_variable('lats')
@@ -65,16 +66,16 @@ contains
          allocate(this%lons(size(coords,1), size(coords,2)), _STAT)
          this%lons = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%lons)
-         call o_Client%collective_stage_data(collection_id,filename, 'lons', &
-              ref, start=local_start, global_start=global_start, global_count=global_count)
+         request_id = o_Client%collective_stage_data(collection_id,filename, 'lons', &
+               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, _RC)
          if (allocated(this%lats)) deallocate(this%lats)
          allocate(this%lats(size(coords,1), size(coords,2)), _STAT)
          this%lats = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%lats)
-         call o_Client%collective_stage_data(collection_id,filename, 'lats', &
-              ref, start=local_start, global_start=global_start, global_count=global_count)
+         request_id = o_Client%collective_stage_data(collection_id,filename, 'lats', &
+               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_FieldDestroy(field, noGarbage=.true., _RC)
       end if
@@ -97,16 +98,16 @@ contains
          allocate(this%corner_lons(size(coords,1), size(coords,2)), _STAT)
          this%corner_lons = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%corner_lons)
-          call o_Client%collective_stage_data(collection_id,filename, 'corner_lons', &
-              ref, start=local_start, global_start=global_start, global_count=global_count)
+          request_id = o_Client%collective_stage_data(collection_id,filename, 'corner_lons', &
+               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
          if (allocated(this%corner_lats)) deallocate(this%corner_lats)
          allocate(this%corner_lats(size(coords,1), size(coords,2)), _STAT)
          this%corner_lats = coords*MAPL_RADIANS_TO_DEGREES
          ref = ArrayReference(this%corner_lats)
-          call o_Client%collective_stage_data(collection_id,filename, 'corner_lats', &
-              ref, start=local_start, global_start=global_start, global_count=global_count)
+          request_id = o_Client%collective_stage_data(collection_id,filename, 'corner_lats', &
+               ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_FieldDestroy(field, noGarbage=.true., _RC)
       end if
@@ -129,6 +130,7 @@ contains
       integer :: type_kind
       type(ESMF_TypeKind_Flag) :: tk
       integer, allocatable :: element_count(:), new_element_count(:)
+      integer :: request_id
 
       type(ESMF_Grid) :: grid
       type(pFIOServerBounds) :: server_bounds
@@ -154,8 +156,8 @@ contains
          new_element_count = server_bounds%get_file_shape()
          ref = ArrayReference(address, type_kind, new_element_count)
 
-          call o_Client%collective_stage_data(collection_id,filename, trim(field_names(i)), &
-              ref, start=local_start, global_start=global_start, global_count=global_count)
+          request_id = o_Client%collective_stage_data(collection_id,filename, trim(field_names(i)), &
+               ref, start=local_start, global_start=global_start, global_count=global_count)
       enddo
 
       _RETURN(_SUCCESS)
@@ -178,7 +180,7 @@ contains
       integer, allocatable :: local_start(:), global_start(:), global_count(:)
       type(c_ptr) :: address
       type(ArrayReference) :: ref
-      integer :: collection_id, num_fields, idx, pfio_typekind, status
+      integer :: collection_id, num_fields, idx, pfio_typekind, status, request_id
 
       collection_id = this%get_collection_id()
 
@@ -198,7 +200,7 @@ contains
          pfio_typekind = esmf_to_pfio_type(esmf_typekind, _RC)
          new_element_count = server_bounds%get_file_shape()
          ref = ArrayReference(address, pfio_typekind, new_element_count)
-          call i_Client%collective_prefetch_data( &
+          request_id = i_Client%collective_prefetch_data( &
               collection_id, &
               filename, &
               field_names(idx), &

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -21,7 +21,6 @@ module mapl_MaplFramework_mod
    use pfio_DirectoryServiceMod, only: DirectoryService
    use pfio_ClientManagerMod
    use pfio_MpiServerMod, only: MpiServer
-   use pfio_ClientThreadMod, only: ClientThread
    use pfio_AbstractDirectoryServiceMod, only: PortInfo
    use udunits2f, only: UDUNITS_Initialize => Initialize
    use pflogger, only: logging
@@ -445,7 +444,6 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status, stat_alloc
-      type(ClientThread), pointer :: clientPtr
 
       call init_IO_ClientManager(this%model_comm, _RC)
 
@@ -454,16 +452,14 @@ contains
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('o_server', this%o_server), this%o_server)
-       clientPtr => o_Client%get_client_thread()
-      call this%directory_service%connect_to_server('o_server', clientPtr, this%model_comm)
+      call this%directory_service%connect_to_server('o_server', o_Client)
 
       ! i server
       allocate(this%i_server, source=MpiServer(this%model_comm, 'i_server', rc=status), stat=stat_alloc)
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('i_server', this%i_server), this%i_server)
-       clientPtr => i_Client%get_client_thread()
-      call this%directory_service%connect_to_server('i_server', clientPtr, this%model_comm)
+      call this%directory_service%connect_to_server('i_server', i_Client)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -454,7 +454,7 @@ contains
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('o_server', this%o_server), this%o_server)
-      clientPtr => o_Clients%current()
+       clientPtr => o_Client%current()
       call this%directory_service%connect_to_server('o_server', clientPtr, this%model_comm)
 
       ! i server
@@ -462,7 +462,7 @@ contains
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('i_server', this%i_server), this%i_server)
-      clientPtr => i_Clients%current()
+       clientPtr => i_Client%current()
       call this%directory_service%connect_to_server('i_server', clientPtr, this%model_comm)
 
       _RETURN(_SUCCESS)

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -454,7 +454,7 @@ contains
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('o_server', this%o_server), this%o_server)
-      clientPtr => o_Clients%current()
+       clientPtr => o_Client%get_client_thread()
       call this%directory_service%connect_to_server('o_server', clientPtr, this%model_comm)
 
       ! i server
@@ -462,7 +462,7 @@ contains
       _VERIFY(status)
       _VERIFY(stat_alloc)
       call this%directory_service%publish(PortInfo('i_server', this%i_server), this%i_server)
-      clientPtr => i_Clients%current()
+       clientPtr => i_Client%get_client_thread()
       call this%directory_service%connect_to_server('i_server', clientPtr, this%model_comm)
 
       _RETURN(_SUCCESS)

--- a/pfio/API.F90
+++ b/pfio/API.F90
@@ -7,8 +7,8 @@ module mapl_pfio_api
   use pfio, only: mapl_ArrayReference => ArrayReference
   use pfio, only: operator(==), operator(/=)
 
-  use pfio, only: mapl_i_clients => i_clients
-  use pfio, only: mapl_o_clients => o_clients
+  use pfio, only: mapl_i_client => i_client
+  use pfio, only: mapl_o_client => o_client
   use pfio, only: mapl_pfio_read => pfio_read
   use pfio, only: mapl_string_in_stringvector => string_in_stringvector
 
@@ -21,8 +21,8 @@ module mapl_pfio_api
   public :: mapl_StringVariableMapIterator
   public :: mapl_NetCDF4_FileFormatter
 
-  public :: mapl_i_clients
-  public :: mapl_o_clients
+  public :: mapl_i_client
+  public :: mapl_o_client
   public :: mapl_pfio_read
   public :: mapl_ArrayReference
   public :: mapl_string_in_stringvector

--- a/pfio/AbstractDirectoryService.F90
+++ b/pfio/AbstractDirectoryService.F90
@@ -31,7 +31,7 @@ module pFIO_AbstractDirectoryServiceMod
 
    abstract interface
 
-      subroutine connect_to_server(this, port_name, client, client_comm, unusable, server_size, rc)
+      subroutine connect_to_server(this, port_name, client, unusable, server_size, rc)
          use pFIO_ClientThreadMod
          import AbstractDirectoryService
          import PortInfo
@@ -40,7 +40,6 @@ module pFIO_AbstractDirectoryServiceMod
          class (AbstractDirectoryService), target, intent(inout) :: this
          character(len=*), intent(in) :: port_name
          class (ClientThread), target, intent(inout) :: client
-         integer, intent(in) :: client_comm
          class (KeywordEnforcer), optional, intent(in) :: unusable
          integer, optional, intent(out) :: server_size
          integer, optional, intent(out) :: rc

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -5,384 +5,24 @@ module pFIO_ClientManagerMod
 
    use mapl_ErrorHandling_mod
    use mapl_KeywordEnforcer_mod
-   use pFIO_AbstractDataReferenceMod
-   use pFIO_FileMetadataMod
    use pFIO_ClientThreadMod
    use pFIO_FastClientThreadMod
-   use pFIO_StringVariableMapMod
 
    implicit none
    private
 
-   public :: ClientManager
    public :: init_IO_ClientManager
    public :: i_Client
    public :: o_Client
-
-   type :: ClientManager
-     private
-     integer :: client_comm, rank
-     class(ClientThread), allocatable :: client
-   contains
-      procedure, private :: add_read_data_collection
-      procedure, private :: add_write_data_collection
-      generic :: add_data_collection => add_read_data_collection, add_write_data_collection
-      procedure :: modify_metadata
-      procedure :: replace_metadata
-      procedure :: modify_metadata_all
-      procedure :: replace_metadata_all
-      procedure :: prefetch_data
-      procedure :: stage_data
-      procedure :: collective_prefetch_data
-      procedure :: collective_stage_data
-      procedure :: stage_nondistributed_data
-      procedure :: shake_hand
-
-      procedure :: done_prefetch
-      procedure :: done_collective_prefetch
-      procedure :: done_stage
-      procedure :: done_collective_stage
-      procedure :: wait
-      procedure :: post_wait
-      procedure :: terminate
-
-      procedure :: get_client_thread
-   end type
-
-   interface ClientManager
-      module procedure new_ClientManager
-   end interface
 
    interface init_IO_ClientManager
       module procedure init_ClientManager
    end interface
 
-   type (ClientManager), target :: i_Client
-   type (ClientManager), target :: o_Client
+   class(ClientThread), allocatable, target :: i_Client
+   class(ClientThread), allocatable, target :: o_Client
 
 contains
-
-   function new_ClientManager(client_comm, unusable, fast_oclient, rc) result(c_manager)
-      integer, intent(in) :: client_comm
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      logical, optional, intent(in) :: fast_oclient
-      integer, optional, intent(out) :: rc
-      type (ClientManager) :: c_manager
-
-      logical :: fast_
-
-      fast_ = .false.
-      if (present(fast_oclient)) fast_ = fast_oclient
-
-      if (fast_) then
-         allocate(c_manager%client, source=FastClientThread())
-      else
-         allocate(c_manager%client, source=ClientThread())
-      end if
-
-      c_manager%client_comm = client_comm
-      call MPI_Comm_rank(client_comm, c_manager%rank, rc)
-      _VERIFY(rc)
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end function new_ClientManager
-
-   function add_read_data_collection(this, file_template, unusable, rc) result(collection_id)
-      integer :: collection_id
-      class (ClientManager), intent(inout) :: this
-      character(len=*), intent(in) :: file_template
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-
-      collection_id = this%client%add_data_collection(file_template)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end function add_read_data_collection
-
-   function add_write_data_collection(this, file_metadata, unusable, mode, rc) result(collection_id)
-      integer :: collection_id
-      class (ClientManager), intent(inout) :: this
-      type(FileMetadata), intent(in) :: file_metadata
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: mode
-      integer, optional, intent(out) :: rc
-
-      collection_id = this%client%add_data_collection(file_metadata, mode=mode)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end function add_write_data_collection
-
-   subroutine prefetch_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      character(len=*), intent(in) :: file_name
-      character(len=*), intent(in) :: var_name
-      class (AbstractDataReference), intent(in) :: data_reference
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in)  :: start(:)
-      integer, optional, intent(out) :: rc
-
-      integer :: request_id, status
-
-      request_id = this%client%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, _RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-      _UNUSED_DUMMY(request_id)
-   end subroutine prefetch_data
-
-   subroutine modify_metadata(this, collection_id, unusable, var_map, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional, intent(in) :: var_map
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
-      _VERIFY(status)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine modify_metadata
-
-   subroutine replace_metadata(this, collection_id, fmd, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      type (FileMetadata), intent(in) :: fmd
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%replace_metadata(collection_id, fmd, rc=status)
-      _VERIFY(status)
-
-      _RETURN(_SUCCESS)
-   end subroutine replace_metadata
-
-   subroutine modify_metadata_all(this, collection_id, unusable, var_map, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional, intent(in) :: var_map
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
-      _VERIFY(status)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine modify_metadata_all
-
-   subroutine replace_metadata_all(this, collection_id, fmd, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      type (FileMetadata), intent(in) :: fmd
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%replace_metadata(collection_id, fmd, rc=status)
-      _VERIFY(status)
-
-      _RETURN(_SUCCESS)
-   end subroutine replace_metadata_all
-
-   subroutine collective_prefetch_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start, global_start, global_count, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      character(len=*), intent(in) :: file_name
-      character(len=*), intent(in) :: var_name
-      class (AbstractDataReference), intent(in) :: data_reference
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: start(:)
-      integer, optional, intent(in) :: global_start(:)
-      integer, optional, intent(in) :: global_count(:)
-      integer, optional, intent(out) :: rc
-
-      integer :: request_id, status
-
-      request_id = this%client%collective_prefetch_data(collection_id, file_name, var_name, data_reference, &
-                   start=start, global_start=global_start, global_count=global_count, rc=status)
-      _VERIFY(status)
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-      _UNUSED_DUMMY(request_id)
-   end subroutine collective_prefetch_data
-
-   subroutine stage_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      character(len=*), intent(in) :: file_name
-      character(len=*), intent(in) :: var_name
-      class (AbstractDataReference), intent(in) :: data_reference
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in)  :: start(:)
-      integer, optional, intent(out) :: rc
-
-      integer :: request_id, status
-
-      request_id = this%client%stage_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)
-      _VERIFY(status)
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-      _UNUSED_DUMMY(request_id)
-   end subroutine stage_data
-
-   subroutine collective_stage_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start, global_start, global_count, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      character(len=*), intent(in) :: file_name
-      character(len=*), intent(in) :: var_name
-      class (AbstractDataReference), intent(in) :: data_reference
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: start(:)
-      integer, optional, intent(in) :: global_start(:)
-      integer, optional, intent(in) :: global_count(:)
-      integer, optional, intent(out) :: rc
-
-      integer :: request_id, status
-
-      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, &
-                   start=start, global_start=global_start, global_count=global_count, rc=status)
-      _VERIFY(status)
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-      _UNUSED_DUMMY(request_id)
-   end subroutine collective_stage_data
-
-   subroutine stage_nondistributed_data(this, collection_id, file_name, var_name, data_reference, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: collection_id
-      character(len=*), intent(in) :: file_name
-      character(len=*), intent(in) :: var_name
-      class (AbstractDataReference), intent(in) :: data_reference
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-
-      integer :: request_id, status
-
-      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, _RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-      _UNUSED_DUMMY(request_id)
-   end subroutine stage_nondistributed_data
-
-   subroutine shake_hand(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      call this%client%shake_hand(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine shake_hand
-
-   subroutine done_prefetch(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      call this%client%done_prefetch(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine done_prefetch
-
-   subroutine done_collective_prefetch(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      call this%client%done_collective_prefetch(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine done_collective_prefetch
-
-   subroutine done_stage(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      call this%client%done_stage(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine done_stage
-
-   subroutine done_collective_stage(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%done_collective_stage(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine done_collective_stage
-
-   subroutine wait(this, unusable, rc)
-      class (ClientManager), target, intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-      integer :: status
-
-      call this%client%wait_all(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine wait
-
-   subroutine post_wait(this, unusable, rc)
-      class (ClientManager), target, intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%post_wait_all(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine post_wait
-
-   subroutine terminate(this, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(out) :: rc
-
-      integer :: status
-
-      call this%client%wait_all(_RC)
-      call this%client%terminate()
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine terminate
-
-   function get_client_thread(this) result(clientPtr)
-      class (ClientManager), target, intent(in) :: this
-      class (ClientThread), pointer :: clientPtr
-      clientPtr => this%client
-   end function get_client_thread
 
    subroutine init_ClientManager(client_comm, unusable, fast_oclient, rc)
       integer, intent(in) :: client_comm
@@ -391,10 +31,23 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
 
-      i_Client = ClientManager(client_comm, rc=status)
+      logical :: fast_
+
+      fast_ = .false.
+      if (present(fast_oclient)) fast_ = fast_oclient
+
+      if (allocated(i_Client)) deallocate(i_Client)
+      allocate(i_Client, source=ClientThread(client_comm=client_comm, rc=status))
       _VERIFY(status)
-      o_Client = ClientManager(client_comm, fast_oclient=fast_oclient, rc=status)
+
+      if (allocated(o_Client)) deallocate(o_Client)
+      if (fast_) then
+         allocate(o_Client, source=FastClientThread(client_comm=client_comm, rc=status))
+      else
+         allocate(o_Client, source=ClientThread(client_comm=client_comm, rc=status))
+      end if
       _VERIFY(status)
+
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine init_ClientManager

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -4,37 +4,25 @@
 module pFIO_ClientManagerMod
 
    use mapl_ErrorHandling_mod
-   use mapl_Sort_mod
    use mapl_KeywordEnforcer_mod
    use pFIO_AbstractDataReferenceMod
    use pFIO_FileMetadataMod
    use pFIO_ClientThreadMod
    use pFIO_FastClientThreadMod
-   use pFIO_ClientThreadVectorMod
    use pFIO_StringVariableMapMod
-   use gFTL_IntegerVector
 
    implicit none
    private
 
    public :: ClientManager
    public :: init_IO_ClientManager
-   public :: i_Clients
-   public :: o_Clients
+   public :: i_Client
+   public :: o_Client
 
    type :: ClientManager
      private
      integer :: client_comm, rank
-     integer :: current_client = 1
-     type(ClientThreadVector) :: clients
-     type(IntegerVector) :: server_sizes
-     type(IntegerVector) :: large_server_pool
-     type(IntegerVector) :: small_server_pool
-     integer :: smallCurrent=1
-     integer :: largeCurrent=1
-     integer :: writeCutoff
-     integer :: large_total = 0
-     integer :: small_total = 0
+     class(ClientThread), allocatable :: client
    contains
       procedure, private :: add_read_data_collection
       procedure, private :: add_write_data_collection
@@ -58,13 +46,7 @@ module pFIO_ClientManagerMod
       procedure :: post_wait
       procedure :: terminate
 
-      procedure :: size
-      procedure :: next => next_
-      procedure :: current
-      procedure :: set_current
-      procedure :: set_optimal_server
-      procedure :: split_server_pools
-      procedure :: set_server_size
+      procedure :: get_client_thread
    end type
 
    interface ClientManager
@@ -75,38 +57,28 @@ module pFIO_ClientManagerMod
       module procedure init_ClientManager
    end interface
 
-   type (ClientManager), target :: i_Clients
-   type (ClientManager), target :: o_Clients
+   type (ClientManager), target :: i_Client
+   type (ClientManager), target :: o_Client
 
 contains
 
-   function new_ClientManager(client_comm, unusable, n_client, fast_oclient, rc) result (c_manager)
+   function new_ClientManager(client_comm, unusable, fast_oclient, rc) result(c_manager)
       integer, intent(in) :: client_comm
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: n_client
       logical, optional, intent(in) :: fast_oclient
       integer, optional, intent(out) :: rc
       type (ClientManager) :: c_manager
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, n
       logical :: fast_
 
-      n = 1
-      if (present(n_client)) n = n_client
       fast_ = .false.
       if (present(fast_oclient)) fast_ = fast_oclient
-      c_manager%clients = ClientThreadVector()
-      do i = 1, n
-        if (fast_) then
-           allocate(clientPtr, source = FastClientThread())
-        else
-           allocate(clientPtr, source = ClientThread())
-        endif
-        call c_manager%clients%push_back(clientPtr)
 
-        clientPtr=>null()
-      enddo
+      if (fast_) then
+         allocate(c_manager%client, source=FastClientThread())
+      else
+         allocate(c_manager%client, source=ClientThread())
+      end if
 
       c_manager%client_comm = client_comm
       call MPI_Comm_rank(client_comm, c_manager%rank, rc)
@@ -121,33 +93,22 @@ contains
       character(len=*), intent(in) :: file_template
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
-      class (ClientThread), pointer :: clientPtr
 
-      integer :: i
-
-      do i = 1, this%size()
-         ClientPtr => this%clients%at(i)
-         collection_id = clientPtr%add_data_collection(file_template)
-      enddo
+      collection_id = this%client%add_data_collection(file_template)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end function add_read_data_collection
 
-   function add_write_data_collection(this, file_metadata, unusable,mode, rc) result(collection_id)
+   function add_write_data_collection(this, file_metadata, unusable, mode, rc) result(collection_id)
       integer :: collection_id
       class (ClientManager), intent(inout) :: this
-      type(FileMetadata),intent(in) :: file_metadata
+      type(FileMetadata), intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(in) :: mode
       integer, optional, intent(out) :: rc
-      class (ClientThread), pointer :: clientPtr
-      integer :: i
 
-      do i = 1, this%size()
-         ClientPtr => this%clients%at(i)
-         collection_id = clientPtr%add_data_collection(file_metadata, mode=mode)
-      enddo
+      collection_id = this%client%add_data_collection(file_metadata, mode=mode)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -164,29 +125,25 @@ contains
       integer, optional, intent(in)  :: start(:)
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr => this%current()
-      request_id = clientPtr%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, _RC)
+      request_id = this%client%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
       _UNUSED_DUMMY(request_id)
    end subroutine prefetch_data
 
-   subroutine modify_metadata(this, collection_id, unusable,var_map, rc)
+   subroutine modify_metadata(this, collection_id, unusable, var_map, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional,intent(in) :: var_map
+      type (StringVariableMap), optional, intent(in) :: var_map
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      ClientPtr => this%current()
-      call clientPtr%modify_metadata(collection_id, var_map = var_map, rc=status)
+      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
@@ -199,31 +156,25 @@ contains
       type (FileMetadata), intent(in) :: fmd
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      ClientPtr => this%current()
-      call clientPtr%replace_metadata(collection_id, fmd, rc=status)
+      call this%client%replace_metadata(collection_id, fmd, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
    end subroutine replace_metadata
 
-   subroutine modify_metadata_all(this, collection_id, unusable,var_map,rc)
+   subroutine modify_metadata_all(this, collection_id, unusable, var_map, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional,intent(in) :: var_map
+      type (StringVariableMap), optional, intent(in) :: var_map
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, status
+      integer :: status
 
-      do i = 1, this%clients%size()
-         ClientPtr => this%clients%at(i)
-         call clientPtr%modify_metadata(collection_id, var_map = var_map, rc=status)
-         _VERIFY(status)
-      enddo
+      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
+      _VERIFY(status)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -235,20 +186,16 @@ contains
       type (FileMetadata), intent(in) :: fmd
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, status
+      integer :: status
 
-      do i = 1, this%clients%size()
-         ClientPtr => this%clients%at(i)
-         call clientPtr%replace_metadata(collection_id, fmd, rc=status)
-         _VERIFY(status)
-      enddo
+      call this%client%replace_metadata(collection_id, fmd, rc=status)
+      _VERIFY(status)
 
       _RETURN(_SUCCESS)
    end subroutine replace_metadata_all
 
    subroutine collective_prefetch_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start,global_start,global_count, rc)
+        & unusable, start, global_start, global_count, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       character(len=*), intent(in) :: file_name
@@ -258,14 +205,12 @@ contains
       integer, optional, intent(in) :: start(:)
       integer, optional, intent(in) :: global_start(:)
       integer, optional, intent(in) :: global_count(:)
-      integer, optional, intent(out):: rc
+      integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%collective_prefetch_data(collection_id, file_name, var_name, data_reference, start=start, &
-                   global_start = global_start, global_count=global_count, rc=status)
+      request_id = this%client%collective_prefetch_data(collection_id, file_name, var_name, data_reference, &
+                   start=start, global_start=global_start, global_count=global_count, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -283,11 +228,9 @@ contains
       integer, optional, intent(in)  :: start(:)
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%stage_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)
+      request_id = this%client%stage_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -295,7 +238,7 @@ contains
    end subroutine stage_data
 
    subroutine collective_stage_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start,global_start,global_count, rc)
+        & unusable, start, global_start, global_count, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       character(len=*), intent(in) :: file_name
@@ -307,12 +250,10 @@ contains
       integer, optional, intent(in) :: global_count(:)
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%collective_stage_data(collection_id, file_name, var_name, data_reference, start=start, global_start=global_start, &
-                   global_count=global_count, rc=status)
+      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, &
+                   start=start, global_start=global_start, global_count=global_count, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -328,11 +269,9 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr => this%current()
-      request_id = clientPtr%collective_stage_data(collection_id, file_name, var_name, data_reference, _RC)
+      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -344,10 +283,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%shake_hand(_RC)
+      call this%client%shake_hand(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -359,10 +296,7 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
 
-      class (ClientThread), pointer :: clientPtr
-
-      clientPtr =>this%current()
-      call clientPtr%done_prefetch(_RC)
+      call this%client%done_prefetch(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -373,10 +307,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%done_collective_prefetch(_RC)
+      call this%client%done_collective_prefetch(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -387,10 +319,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%done_stage(_RC)
+      call this%client%done_stage(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -401,11 +331,9 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      clientPtr =>this%current()
-      call clientPtr%done_collective_stage(_RC)
+      call this%client%done_collective_stage(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -416,10 +344,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%wait_all(_RC)
+      call this%client%wait_all(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -431,10 +357,8 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%post_wait_all(_RC)
+      call this%client%post_wait_all(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -446,220 +370,31 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      class (ClientThread), pointer :: clientPtr
-      integer :: i
 
-      do i = 1, this%size()
-         clientPtr =>this%clients%at(i)
-         call clientPtr%wait_all(_RC)
-         call clientPtr%terminate()
-      enddo
+      call this%client%wait_all(_RC)
+      call this%client%terminate()
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine terminate
 
-   subroutine next_(this)
-      class (ClientManager), target,intent(inout) :: this
-      this%current_client = this%current_client + 1
-      if (this%current_client > this%clients%size()) this%current_client = 1
-   end subroutine next_
-
-   subroutine set_current(this, ith, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, optional, intent(in) :: ith
-      integer, optional, intent(out) :: rc
-      integer :: ith_
-      ith_ = 1
-      if (present(ith)) ith_ = ith
-      _ASSERT( ith_>=1, 'needs at least one client number')
-      _ASSERT( ith_<=this%size(), "exceeding the clients number")
-      this%current_client = ith_
-      _RETURN(_SUCCESS)
-   end subroutine set_current
-
-   function current(this) result(clientPtr)
+   function get_client_thread(this) result(clientPtr)
       class (ClientManager), target, intent(in) :: this
       class (ClientThread), pointer :: clientPtr
-      clientPtr => this%clients%at(this%current_client)
-   end function current
+      clientPtr => this%client
+   end function get_client_thread
 
-   subroutine set_optimal_server(this,nwriting,unusable,rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: nwriting
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-      integer, save, allocatable :: nwritings(:) ! saved the past nwritings
-      integer, save, allocatable :: nwritings_large(:) ! saved the past large nwritings
-      integer, save, allocatable :: nwritings_small(:) ! saved the past small nwritings
-      integer :: Cuttoff, ssize, lsize, tsize, ith
-      integer, allocatable :: nwritings_order(:)
-      real :: l_ratio, s_ratio
-      integer :: status
-
-      ! if there is no "small" pool, then there is no "large" pool either, just get next
-      ssize = this%small_server_pool%size()
-      lsize = this%large_server_pool%size()
-      tsize = this%server_sizes%size()
-
-      if (ssize == 0) then
-         call this%next()
-         call this%wait(_RC)
-         _RETURN(_SUCCESS)
-      endif
-
-      _ASSERT(lsize > 0,'large server pool must be great than zero')
-
-      if (.not. allocated (nwritings)) allocate (nwritings(tsize), source = 0)
-      if (.not. allocated (nwritings_large)) allocate (nwritings_large(lsize), source = 0)
-      if (.not. allocated (nwritings_small)) allocate (nwritings_small(ssize), source = 0)
-
-      Cuttoff = this%writeCutoff
-      ! if writeCutoff is not set, then pick one from the past experience
-      ! the whole pool size is used to determine how many past nwrting are saved
-      if (this%writeCutoff == 0) then
-         nwritings(2:tsize) = nwritings(1:tsize-1)
-         nwritings(1)       = nwriting
-         allocate(nwritings_order(tsize), source = nwritings(:))
-
-         call MAPL_sort(nwritings_order)
-         Cuttoff = nwritings_order(tsize/2)
-         deallocate(nwritings_order)
-      endif
-
-      if (nwriting == Cuttoff) then ! after this block, nwrting /= Cuttoff
-         l_ratio = sum(nwritings_large)/ (this%large_total*1.0)
-         s_ratio = sum(nwritings_small)/ (this%small_total*1.0)
-
-         if (s_ratio >= l_ratio ) then! .true. means small pool is busier
-            Cuttoff = Cuttoff - 1 ! artificially decrease Cuttoff, so the next will go to large pool
-         else
-            Cuttoff = Cuttoff + 1 ! artificially increase Cuttoff, so the next will go to small pool
-         endif
-      endif
-
-      if (nwriting > Cuttoff) then
-         this%largeCurrent=this%largeCurrent+1
-         if (this%largeCurrent .gt. lsize) this%largeCurrent=1
-         ith = this%large_server_pool%at(this%largeCurrent)
-         call this%set_current( ith = ith)
-         if (this%rank ==0) print*, "Large pool oserver is chosen, nwriting and server size :", nwriting, this%server_sizes%at(ith)
-         nwritings_large(1:lsize-1) = nwritings_large(2:lsize)
-         nwritings_large(lsize) = nwriting
-      endif
-
-      if (nwriting < Cuttoff) then
-         this%smallCurrent=this%smallCurrent+1
-         if (this%smallCurrent .gt. ssize) this%smallCurrent=1
-         ith = this%small_server_pool%at(this%smallCurrent)
-         call this%set_current( ith = ith )
-         if (this%rank ==0) print*, "Small pool oserver is chosen, nwriting and server size :", nwriting, this%server_sizes%at(ith)
-         nwritings_small(1:ssize-1) = nwritings_small(2:ssize)
-         nwritings_small(ssize) = nwriting
-      end if
-      call this%wait(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine set_optimal_server
-
-   subroutine split_server_pools(this, unusable, n_server_split, n_hist_split, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(in) :: n_server_split
-      integer, optional, intent(in) :: n_hist_split
-      integer, optional, intent(out) :: rc
-
-      integer :: i, nsplit, tsize
-      integer, allocatable :: server_sizes(:), tmp_position(:)
-      integer :: pos
-
-      tsize = this%server_sizes%size()
-      if (tsize == 1) then
-         if (this%rank == 0) print*, " oserver is not split"
-        _RETURN(_SUCCESS)
-      endif
-
-      nsplit = 0
-      if (present(n_server_split)) nsplit = n_server_split
-
-      allocate(server_sizes(tsize))
-      allocate(tmp_position(tsize))
-      do i=1,tsize
-         server_sizes(i) = this%server_sizes%at(i)
-         tmp_position(i) = i
-      enddo
-      call MAPL_Sort(server_sizes, tmp_position)
-      ! if nsplit is out of scope, pick the mid point
-      if (nsplit < server_sizes(1) .or. nsplit > server_sizes(tsize)) then
-         pos = tsize/2
-      else
-         pos = 0
-         do i = 1, tsize
-            if ( nsplit < server_sizes(i) ) then
-               pos = i-1
-               exit
-            endif
-         enddo
-         if (pos == 0) pos = tsize/2
-      endif
-
-      this%large_total = 0
-      this%small_total = 0
-
-      do i = 1, pos
-         call this%small_server_pool%push_back(tmp_position(i))
-         this%small_total = this%small_total + this%server_sizes%at(tmp_position(i))
-      enddo
-
-      do i = pos + 1, tsize
-         call this%large_server_pool%push_back(tmp_position(i))
-         this%large_total = this%large_total + this%server_sizes%at(tmp_position(i))
-      enddo
-
-      this%writeCutoff = 0
-      if (present(n_hist_split)) this%writeCutoff = n_hist_split
-
-      if (this%rank == 0) then
-         print*, "Oservers are split: ", server_sizes
-         print*, "Small pool oserver npes: ", server_sizes(1:pos)
-         print*, "Large pool oserver npes: ", server_sizes(pos+1:tsize)
-      endif
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-
-   end subroutine split_server_pools
-
-   subroutine set_server_size(this, server_size, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: server_size
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-
-      _UNUSED_DUMMY(unusable)
-      call this%server_sizes%push_back(server_size)
-
-      _RETURN(_SUCCESS)
-   end subroutine set_server_size
-
-   function size(this) result(n_client)
-      class (ClientManager), intent(in) :: this
-      integer :: n_client
-      n_client = this%clients%size()
-   end function size
-
-   subroutine init_ClientManager(client_comm, unusable, n_i, n_o, fast_oclient, rc)
+   subroutine init_ClientManager(client_comm, unusable, fast_oclient, rc)
       integer, intent(in) :: client_comm
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: n_i
-      integer, optional, intent(in) :: n_o
       logical, optional, intent(in) :: fast_oclient
-      integer, optional, intent(out):: rc
+      integer, optional, intent(out) :: rc
       integer :: status
 
-      i_Clients = ClientManager(client_comm, n_client = n_i, rc=status)
-      o_Clients = ClientManager(client_comm, n_client = n_o, fast_oclient = fast_oclient, rc=status)
+      i_Client = ClientManager(client_comm, rc=status)
+      _VERIFY(status)
+      o_Client = ClientManager(client_comm, fast_oclient=fast_oclient, rc=status)
+      _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine init_ClientManager

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -4,37 +4,25 @@
 module pFIO_ClientManagerMod
 
    use mapl_ErrorHandling_mod
-   use mapl_Sort_mod
    use mapl_KeywordEnforcer_mod
    use pFIO_AbstractDataReferenceMod
    use pFIO_FileMetadataMod
    use pFIO_ClientThreadMod
    use pFIO_FastClientThreadMod
-   use pFIO_ClientThreadVectorMod
    use pFIO_StringVariableMapMod
-   use gFTL_IntegerVector
 
    implicit none
    private
 
    public :: ClientManager
    public :: init_IO_ClientManager
-   public :: i_Clients
-   public :: o_Clients
+   public :: i_Client
+   public :: o_Client
 
    type :: ClientManager
      private
      integer :: client_comm, rank
-     integer :: current_client = 1
-     type(ClientThreadVector) :: clients
-     type(IntegerVector) :: server_sizes
-     type(IntegerVector) :: large_server_pool
-     type(IntegerVector) :: small_server_pool
-     integer :: smallCurrent=1
-     integer :: largeCurrent=1
-     integer :: writeCutoff
-     integer :: large_total = 0
-     integer :: small_total = 0
+     class(ClientThread), allocatable :: client
    contains
       procedure, private :: add_read_data_collection
       procedure, private :: add_write_data_collection
@@ -58,13 +46,7 @@ module pFIO_ClientManagerMod
       procedure :: post_wait
       procedure :: terminate
 
-      procedure :: size
-      procedure :: next => next_
       procedure :: current
-      procedure :: set_current
-      procedure :: set_optimal_server
-      procedure :: split_server_pools
-      procedure :: set_server_size
    end type
 
    interface ClientManager
@@ -75,38 +57,28 @@ module pFIO_ClientManagerMod
       module procedure init_ClientManager
    end interface
 
-   type (ClientManager), target :: i_Clients
-   type (ClientManager), target :: o_Clients
+   type (ClientManager), target :: i_Client
+   type (ClientManager), target :: o_Client
 
 contains
 
-   function new_ClientManager(client_comm, unusable, n_client, fast_oclient, rc) result (c_manager)
+   function new_ClientManager(client_comm, unusable, fast_oclient, rc) result(c_manager)
       integer, intent(in) :: client_comm
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: n_client
       logical, optional, intent(in) :: fast_oclient
       integer, optional, intent(out) :: rc
       type (ClientManager) :: c_manager
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, n
       logical :: fast_
 
-      n = 1
-      if (present(n_client)) n = n_client
       fast_ = .false.
       if (present(fast_oclient)) fast_ = fast_oclient
-      c_manager%clients = ClientThreadVector()
-      do i = 1, n
-        if (fast_) then
-           allocate(clientPtr, source = FastClientThread())
-        else
-           allocate(clientPtr, source = ClientThread())
-        endif
-        call c_manager%clients%push_back(clientPtr)
 
-        clientPtr=>null()
-      enddo
+      if (fast_) then
+         allocate(c_manager%client, source=FastClientThread())
+      else
+         allocate(c_manager%client, source=ClientThread())
+      end if
 
       c_manager%client_comm = client_comm
       call MPI_Comm_rank(client_comm, c_manager%rank, rc)
@@ -121,33 +93,22 @@ contains
       character(len=*), intent(in) :: file_template
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
-      class (ClientThread), pointer :: clientPtr
 
-      integer :: i
-
-      do i = 1, this%size()
-         ClientPtr => this%clients%at(i)
-         collection_id = clientPtr%add_data_collection(file_template)
-      enddo
+      collection_id = this%client%add_data_collection(file_template)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end function add_read_data_collection
 
-   function add_write_data_collection(this, file_metadata, unusable,mode, rc) result(collection_id)
+   function add_write_data_collection(this, file_metadata, unusable, mode, rc) result(collection_id)
       integer :: collection_id
       class (ClientManager), intent(inout) :: this
-      type(FileMetadata),intent(in) :: file_metadata
+      type(FileMetadata), intent(in) :: file_metadata
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(in) :: mode
       integer, optional, intent(out) :: rc
-      class (ClientThread), pointer :: clientPtr
-      integer :: i
 
-      do i = 1, this%size()
-         ClientPtr => this%clients%at(i)
-         collection_id = clientPtr%add_data_collection(file_metadata, mode=mode)
-      enddo
+      collection_id = this%client%add_data_collection(file_metadata, mode=mode)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -164,29 +125,25 @@ contains
       integer, optional, intent(in)  :: start(:)
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr => this%current()
-      request_id = clientPtr%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, _RC)
+      request_id = this%client%prefetch_data(collection_id, file_name, var_name, data_reference, start=start, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
       _UNUSED_DUMMY(request_id)
    end subroutine prefetch_data
 
-   subroutine modify_metadata(this, collection_id, unusable,var_map, rc)
+   subroutine modify_metadata(this, collection_id, unusable, var_map, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional,intent(in) :: var_map
+      type (StringVariableMap), optional, intent(in) :: var_map
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      ClientPtr => this%current()
-      call clientPtr%modify_metadata(collection_id, var_map = var_map, rc=status)
+      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
@@ -199,31 +156,25 @@ contains
       type (FileMetadata), intent(in) :: fmd
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      ClientPtr => this%current()
-      call clientPtr%replace_metadata(collection_id, fmd, rc=status)
+      call this%client%replace_metadata(collection_id, fmd, rc=status)
       _VERIFY(status)
 
       _RETURN(_SUCCESS)
    end subroutine replace_metadata
 
-   subroutine modify_metadata_all(this, collection_id, unusable,var_map,rc)
+   subroutine modify_metadata_all(this, collection_id, unusable, var_map, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      type (StringVariableMap), optional,intent(in) :: var_map
+      type (StringVariableMap), optional, intent(in) :: var_map
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, status
+      integer :: status
 
-      do i = 1, this%clients%size()
-         ClientPtr => this%clients%at(i)
-         call clientPtr%modify_metadata(collection_id, var_map = var_map, rc=status)
-         _VERIFY(status)
-      enddo
+      call this%client%modify_metadata(collection_id, var_map=var_map, rc=status)
+      _VERIFY(status)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -235,20 +186,16 @@ contains
       type (FileMetadata), intent(in) :: fmd
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
-      integer :: i, status
+      integer :: status
 
-      do i = 1, this%clients%size()
-         ClientPtr => this%clients%at(i)
-         call clientPtr%replace_metadata(collection_id, fmd, rc=status)
-         _VERIFY(status)
-      enddo
+      call this%client%replace_metadata(collection_id, fmd, rc=status)
+      _VERIFY(status)
 
       _RETURN(_SUCCESS)
    end subroutine replace_metadata_all
 
    subroutine collective_prefetch_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start,global_start,global_count, rc)
+        & unusable, start, global_start, global_count, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       character(len=*), intent(in) :: file_name
@@ -258,14 +205,12 @@ contains
       integer, optional, intent(in) :: start(:)
       integer, optional, intent(in) :: global_start(:)
       integer, optional, intent(in) :: global_count(:)
-      integer, optional, intent(out):: rc
+      integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%collective_prefetch_data(collection_id, file_name, var_name, data_reference, start=start, &
-                   global_start = global_start, global_count=global_count, rc=status)
+      request_id = this%client%collective_prefetch_data(collection_id, file_name, var_name, data_reference, &
+                   start=start, global_start=global_start, global_count=global_count, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -283,11 +228,9 @@ contains
       integer, optional, intent(in)  :: start(:)
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%stage_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)
+      request_id = this%client%stage_data(collection_id, file_name, var_name, data_reference, start=start, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -295,7 +238,7 @@ contains
    end subroutine stage_data
 
    subroutine collective_stage_data(this, collection_id, file_name, var_name, data_reference, &
-        & unusable, start,global_start,global_count, rc)
+        & unusable, start, global_start, global_count, rc)
       class (ClientManager), intent(inout) :: this
       integer, intent(in) :: collection_id
       character(len=*), intent(in) :: file_name
@@ -307,12 +250,10 @@ contains
       integer, optional, intent(in) :: global_count(:)
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr =>this%current()
-      request_id = clientPtr%collective_stage_data(collection_id, file_name, var_name, data_reference, start=start, global_start=global_start, &
-                   global_count=global_count, rc=status)
+      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, &
+                   start=start, global_start=global_start, global_count=global_count, rc=status)
       _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -328,11 +269,9 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
 
-      class (clientThread), pointer :: clientPtr
       integer :: request_id, status
 
-      clientPtr => this%current()
-      request_id = clientPtr%collective_stage_data(collection_id, file_name, var_name, data_reference, _RC)
+      request_id = this%client%collective_stage_data(collection_id, file_name, var_name, data_reference, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -344,10 +283,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%shake_hand(_RC)
+      call this%client%shake_hand(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -359,10 +296,7 @@ contains
       integer, optional, intent(out) :: rc
       integer :: status
 
-      class (ClientThread), pointer :: clientPtr
-
-      clientPtr =>this%current()
-      call clientPtr%done_prefetch(_RC)
+      call this%client%done_prefetch(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -373,10 +307,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%done_collective_prefetch(_RC)
+      call this%client%done_collective_prefetch(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -387,10 +319,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%done_stage(_RC)
+      call this%client%done_stage(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -401,11 +331,9 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
 
-      class (ClientThread), pointer :: clientPtr
       integer :: status
 
-      clientPtr =>this%current()
-      call clientPtr%done_collective_stage(_RC)
+      call this%client%done_collective_stage(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -416,10 +344,8 @@ contains
       class (KeywordEnforcer), optional, intent(out) :: unusable
       integer, optional, intent(out) :: rc
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%wait_all(_RC)
+      call this%client%wait_all(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -431,10 +357,8 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      class (ClientThread), pointer :: clientPtr
 
-      clientPtr =>this%current()
-      call clientPtr%post_wait_all(_RC)
+      call this%client%post_wait_all(_RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -446,220 +370,31 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
-      class (ClientThread), pointer :: clientPtr
-      integer :: i
 
-      do i = 1, this%size()
-         clientPtr =>this%clients%at(i)
-         call clientPtr%wait_all(_RC)
-         call clientPtr%terminate()
-      enddo
+      call this%client%wait_all(_RC)
+      call this%client%terminate()
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine terminate
 
-   subroutine next_(this)
-      class (ClientManager), target,intent(inout) :: this
-      this%current_client = this%current_client + 1
-      if (this%current_client > this%clients%size()) this%current_client = 1
-   end subroutine next_
-
-   subroutine set_current(this, ith, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, optional, intent(in) :: ith
-      integer, optional, intent(out) :: rc
-      integer :: ith_
-      ith_ = 1
-      if (present(ith)) ith_ = ith
-      _ASSERT( ith_>=1, 'needs at least one client number')
-      _ASSERT( ith_<=this%size(), "exceeding the clients number")
-      this%current_client = ith_
-      _RETURN(_SUCCESS)
-   end subroutine set_current
-
    function current(this) result(clientPtr)
       class (ClientManager), target, intent(in) :: this
       class (ClientThread), pointer :: clientPtr
-      clientPtr => this%clients%at(this%current_client)
+      clientPtr => this%client
    end function current
 
-   subroutine set_optimal_server(this,nwriting,unusable,rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: nwriting
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-      integer, save, allocatable :: nwritings(:) ! saved the past nwritings
-      integer, save, allocatable :: nwritings_large(:) ! saved the past large nwritings
-      integer, save, allocatable :: nwritings_small(:) ! saved the past small nwritings
-      integer :: Cuttoff, ssize, lsize, tsize, ith
-      integer, allocatable :: nwritings_order(:)
-      real :: l_ratio, s_ratio
-      integer :: status
-
-      ! if there is no "small" pool, then there is no "large" pool either, just get next
-      ssize = this%small_server_pool%size()
-      lsize = this%large_server_pool%size()
-      tsize = this%server_sizes%size()
-
-      if (ssize == 0) then
-         call this%next()
-         call this%wait(_RC)
-         _RETURN(_SUCCESS)
-      endif
-
-      _ASSERT(lsize > 0,'large server pool must be great than zero')
-
-      if (.not. allocated (nwritings)) allocate (nwritings(tsize), source = 0)
-      if (.not. allocated (nwritings_large)) allocate (nwritings_large(lsize), source = 0)
-      if (.not. allocated (nwritings_small)) allocate (nwritings_small(ssize), source = 0)
-
-      Cuttoff = this%writeCutoff
-      ! if writeCutoff is not set, then pick one from the past experience
-      ! the whole pool size is used to determine how many past nwrting are saved
-      if (this%writeCutoff == 0) then
-         nwritings(2:tsize) = nwritings(1:tsize-1)
-         nwritings(1)       = nwriting
-         allocate(nwritings_order(tsize), source = nwritings(:))
-
-         call MAPL_sort(nwritings_order)
-         Cuttoff = nwritings_order(tsize/2)
-         deallocate(nwritings_order)
-      endif
-
-      if (nwriting == Cuttoff) then ! after this block, nwrting /= Cuttoff
-         l_ratio = sum(nwritings_large)/ (this%large_total*1.0)
-         s_ratio = sum(nwritings_small)/ (this%small_total*1.0)
-
-         if (s_ratio >= l_ratio ) then! .true. means small pool is busier
-            Cuttoff = Cuttoff - 1 ! artificially decrease Cuttoff, so the next will go to large pool
-         else
-            Cuttoff = Cuttoff + 1 ! artificially increase Cuttoff, so the next will go to small pool
-         endif
-      endif
-
-      if (nwriting > Cuttoff) then
-         this%largeCurrent=this%largeCurrent+1
-         if (this%largeCurrent .gt. lsize) this%largeCurrent=1
-         ith = this%large_server_pool%at(this%largeCurrent)
-         call this%set_current( ith = ith)
-         if (this%rank ==0) print*, "Large pool oserver is chosen, nwriting and server size :", nwriting, this%server_sizes%at(ith)
-         nwritings_large(1:lsize-1) = nwritings_large(2:lsize)
-         nwritings_large(lsize) = nwriting
-      endif
-
-      if (nwriting < Cuttoff) then
-         this%smallCurrent=this%smallCurrent+1
-         if (this%smallCurrent .gt. ssize) this%smallCurrent=1
-         ith = this%small_server_pool%at(this%smallCurrent)
-         call this%set_current( ith = ith )
-         if (this%rank ==0) print*, "Small pool oserver is chosen, nwriting and server size :", nwriting, this%server_sizes%at(ith)
-         nwritings_small(1:ssize-1) = nwritings_small(2:ssize)
-         nwritings_small(ssize) = nwriting
-      end if
-      call this%wait(_RC)
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine set_optimal_server
-
-   subroutine split_server_pools(this, unusable, n_server_split, n_hist_split, rc)
-      class (ClientManager), intent(inout) :: this
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(in) :: n_server_split
-      integer, optional, intent(in) :: n_hist_split
-      integer, optional, intent(out) :: rc
-
-      integer :: i, nsplit, tsize
-      integer, allocatable :: server_sizes(:), tmp_position(:)
-      integer :: pos
-
-      tsize = this%server_sizes%size()
-      if (tsize == 1) then
-         if (this%rank == 0) print*, " oserver is not split"
-        _RETURN(_SUCCESS)
-      endif
-
-      nsplit = 0
-      if (present(n_server_split)) nsplit = n_server_split
-
-      allocate(server_sizes(tsize))
-      allocate(tmp_position(tsize))
-      do i=1,tsize
-         server_sizes(i) = this%server_sizes%at(i)
-         tmp_position(i) = i
-      enddo
-      call MAPL_Sort(server_sizes, tmp_position)
-      ! if nsplit is out of scope, pick the mid point
-      if (nsplit < server_sizes(1) .or. nsplit > server_sizes(tsize)) then
-         pos = tsize/2
-      else
-         pos = 0
-         do i = 1, tsize
-            if ( nsplit < server_sizes(i) ) then
-               pos = i-1
-               exit
-            endif
-         enddo
-         if (pos == 0) pos = tsize/2
-      endif
-
-      this%large_total = 0
-      this%small_total = 0
-
-      do i = 1, pos
-         call this%small_server_pool%push_back(tmp_position(i))
-         this%small_total = this%small_total + this%server_sizes%at(tmp_position(i))
-      enddo
-
-      do i = pos + 1, tsize
-         call this%large_server_pool%push_back(tmp_position(i))
-         this%large_total = this%large_total + this%server_sizes%at(tmp_position(i))
-      enddo
-
-      this%writeCutoff = 0
-      if (present(n_hist_split)) this%writeCutoff = n_hist_split
-
-      if (this%rank == 0) then
-         print*, "Oservers are split: ", server_sizes
-         print*, "Small pool oserver npes: ", server_sizes(1:pos)
-         print*, "Large pool oserver npes: ", server_sizes(pos+1:tsize)
-      endif
-
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-
-   end subroutine split_server_pools
-
-   subroutine set_server_size(this, server_size, unusable, rc)
-      class (ClientManager), intent(inout) :: this
-      integer, intent(in) :: server_size
-      class (KeywordEnforcer),  optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
-
-      _UNUSED_DUMMY(unusable)
-      call this%server_sizes%push_back(server_size)
-
-      _RETURN(_SUCCESS)
-   end subroutine set_server_size
-
-   function size(this) result(n_client)
-      class (ClientManager), intent(in) :: this
-      integer :: n_client
-      n_client = this%clients%size()
-   end function size
-
-   subroutine init_ClientManager(client_comm, unusable, n_i, n_o, fast_oclient, rc)
+   subroutine init_ClientManager(client_comm, unusable, fast_oclient, rc)
       integer, intent(in) :: client_comm
       class (KeywordEnforcer), optional, intent(out) :: unusable
-      integer, optional, intent(in) :: n_i
-      integer, optional, intent(in) :: n_o
       logical, optional, intent(in) :: fast_oclient
-      integer, optional, intent(out):: rc
+      integer, optional, intent(out) :: rc
       integer :: status
 
-      i_Clients = ClientManager(client_comm, n_client = n_i, rc=status)
-      o_Clients = ClientManager(client_comm, n_client = n_o, fast_oclient = fast_oclient, rc=status)
+      i_Client = ClientManager(client_comm, rc=status)
+      _VERIFY(status)
+      o_Client = ClientManager(client_comm, fast_oclient=fast_oclient, rc=status)
+      _VERIFY(status)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine init_ClientManager

--- a/pfio/ClientThread.F90
+++ b/pfio/ClientThread.F90
@@ -14,6 +14,7 @@ module pFIO_ClientThreadMod
    use mapl_KeywordEnforcer_mod
    use pFIO_SimpleSocketMod
    use pFIO_FileMetadataMod
+   use mpi
 
    use pFIO_TerminateMessageMod
    use pFIO_DoneMessageMod
@@ -49,6 +50,9 @@ module pFIO_ClientThreadMod
    type, extends(BaseThread) :: ClientThread
       private
 
+      integer :: client_comm = MPI_COMM_NULL
+      integer :: rank = -1
+
       ! scratch pad for return values from application level interfaces
       integer :: collection_id      = -1
       integer :: request_counter    = MIN_ID
@@ -81,6 +85,9 @@ module pFIO_ClientThreadMod
 
       procedure :: get_unique_request_id
       procedure :: get_unique_collective_request_id
+      procedure :: get_client_comm
+      procedure :: get_rank
+      procedure :: set_client_comm
    end type ClientThread
 
 
@@ -90,11 +97,21 @@ module pFIO_ClientThreadMod
 
 contains
 
-   function new_ClientThread(sckt) result(c)
+   function new_ClientThread(sckt, client_comm, rc) result(c)
       type (ClientThread),target :: c
       class(AbstractSocket),optional,intent(in) :: sckt
+      integer, optional, intent(in) :: client_comm
+      integer, optional, intent(out) :: rc
+
+      integer :: ierror
 
       if(present(sckt)) call c%set_connection(sckt)
+      if (present(client_comm)) then
+         call c%set_client_comm(client_comm, rc=ierror)
+         if (present(rc)) rc = ierror
+      else
+         if (present(rc)) rc = 0
+      end if
 
    end function new_ClientThread
 
@@ -526,5 +543,25 @@ contains
       call connection%send(TerminateMessage(),_RC)
       _RETURN(_SUCCESS)
    end subroutine terminate
+
+   integer function get_client_comm(this) result(client_comm)
+      class (ClientThread), intent(in) :: this
+      client_comm = this%client_comm
+   end function get_client_comm
+
+   integer function get_rank(this) result(rank)
+      class (ClientThread), intent(in) :: this
+      rank = this%rank
+   end function get_rank
+
+   subroutine set_client_comm(this, client_comm, rc)
+      class (ClientThread), intent(inout) :: this
+      integer, intent(in) :: client_comm
+      integer, optional, intent(out) :: rc
+      integer :: ierror
+      this%client_comm = client_comm
+      call MPI_Comm_rank(client_comm, this%rank, ierror)
+      if (present(rc)) rc = ierror
+   end subroutine set_client_comm
 
 end module pFIO_ClientThreadMod

--- a/pfio/DirectoryService.F90
+++ b/pfio/DirectoryService.F90
@@ -156,17 +156,17 @@ contains
 
    end function make_directory_window
 
-   subroutine connect_to_server(this, port_name, client, client_comm, unusable, server_size, rc)
+   subroutine connect_to_server(this, port_name, client, unusable, server_size, rc)
       use pFIO_ClientThreadMod
       class (DirectoryService), target, intent(inout) :: this
       character(*), intent(in) :: port_name
       class (ClientThread), target, intent(inout) :: client
-      integer, intent(in) :: client_comm
       class (KeywordEnforcer), optional, intent(in) :: unusable
       integer, optional, intent(out) :: server_size
       integer, optional, intent(out) :: rc
 
       class (AbstractSocket), pointer :: sckt
+      integer :: client_comm
       integer :: rank_in_client
       integer :: ierror
       integer :: status(MPI_STATUS_SIZE)
@@ -190,6 +190,8 @@ contains
       ! First, check ports to see if server is local, in which case
       ! a SimpleSocket is used for the connection.
       ! Note: In this scenario, the server _must_ always publish prior to this.
+
+      client_comm = client%get_client_comm()
 
       do n = 1, this%n_local_ports
          if (trim(this%local_ports(n)%port_name) == port_name) then

--- a/pfio/FastClientThread.F90
+++ b/pfio/FastClientThread.F90
@@ -32,10 +32,19 @@ module pFIO_FastClientThreadMod
 
 contains
 
-   function new_FastClientThread(sckt) result(c)
+   function new_FastClientThread(sckt, client_comm, rc) result(c)
       class(AbstractSocket),optional,intent(in) :: sckt
+      integer, optional, intent(in) :: client_comm
+      integer, optional, intent(out) :: rc
       type (FastClientThread),target :: c
+      integer :: ierror
       if (present(sckt)) call c%set_connection(sckt)
+      if (present(client_comm)) then
+         call c%set_client_comm(client_comm, rc=ierror)
+         if (present(rc)) rc = ierror
+      else
+         if (present(rc)) rc = 0
+      end if
    end function new_FastClientThread
 
    function stage_data(this, collection_id, file_name, var_name, data_reference, &

--- a/pfio/programs/pfio_collective_demo.F90
+++ b/pfio/programs/pfio_collective_demo.F90
@@ -172,8 +172,8 @@ contains
       type (NetCDF4_FileFormatter) :: formatter
       type (StringIntegerMap) :: dims
 
-      this%c = ClientThread()
-      call d_s%connect_to_server(port_name, this%c, comm)
+      this%c = ClientThread(client_comm=comm)
+      call d_s%connect_to_server(port_name, this%c)
 
       this%file_1 = options%file_1
       this%file_2 = options%file_2

--- a/pfio/programs/pfio_server_demo.F90
+++ b/pfio/programs/pfio_server_demo.F90
@@ -173,8 +173,8 @@ contains
       type (NetCDF4_FileFormatter) :: formatter
       type (StringIntegerMap) :: dims
 
-      this%c = ClientThread()
-      call d_s%connect_to_server('i_server', this%c, comm)
+      this%c = ClientThread(client_comm=comm)
+      call d_s%connect_to_server('i_server', this%c)
 
       this%file_1 = options%file_1
       this%file_2 = options%file_2

--- a/pfio/tests/Test_DirectoryService.pf
+++ b/pfio/tests/Test_DirectoryService.pf
@@ -83,8 +83,8 @@ contains
          call ds%publish(PortInfo('input', mock_server), mock_server)
          call ds%connect_to_client('input', mock_server)
       case (1) ! client
-         mock_client = MockClient()
-         call ds%connect_to_server('input', mock_client, comm)
+         mock_client = MockClient(); call mock_client%set_client_comm(comm)
+         call ds%connect_to_server('input', mock_client)
       end select
 
 !C$      select type (s)
@@ -122,8 +122,8 @@ contains
          call ds%publish(PortInfo('input', mock_server), mock_server)
          call ds%connect_to_client('input', mock_server)
       case (0) ! client
-         mock_client = MockClient()
-         call ds%connect_to_server('input', mock_client, comm)
+         mock_client = MockClient(); call mock_client%set_client_comm(comm)
+         call ds%connect_to_server('input', mock_client)
       end select
 
 !C$      select type (s)
@@ -168,8 +168,8 @@ contains
             call ds%connect_to_client('input', mock_server)
          end select
       case (0) ! client
-         mock_client = MockClient()
-         call ds%connect_to_server('input', mock_client, comm)
+         mock_client = MockClient(); call mock_client%set_client_comm(comm)
+         call ds%connect_to_server('input', mock_client)
       end select
 
       call ds%free_directory_resources()
@@ -215,8 +215,8 @@ contains
             call ds%connect_to_client('input', mock_server)
          end select
       case (0) ! client
-         mock_client = MockClient()
-         call ds%connect_to_server('input', mock_client, comm)
+         mock_client = MockClient(); call mock_client%set_client_comm(comm)
+         call ds%connect_to_server('input', mock_client)
       end select
 
       call ds%free_directory_resources()
@@ -258,8 +258,8 @@ contains
          call ds%publish(portInfo('input', mock_server), mock_server)
          call ds%connect_to_client('input', mock_server)
       case (0) ! client
-         mock_client = MockClient()
-         call ds%connect_to_server('input', mock_client, comm)
+         mock_client = MockClient(); call mock_client%set_client_comm(comm)
+         call ds%connect_to_server('input', mock_client)
       end select
 
       call ds%free_directory_resources()

--- a/pfio/tests/pfio_ctest_io.F90
+++ b/pfio/tests/pfio_ctest_io.F90
@@ -216,8 +216,9 @@ contains
       this%oc_vec = ClientThreadVector()
 
       do i = 1, N_iclient_g
-         allocate(threadPtr, source = ClientThread())
-         call app_ds%connect_to_server('iserver',threadPtr, comms(i), rc=status)
+         allocate(threadPtr, source = ClientThread(client_comm=comms(i), rc=status))
+         _VERIFY(status)
+         call app_ds%connect_to_server('iserver',threadPtr, rc=status)
          _VERIFY(status)
          !call threadPtr%init_connection(app_ds(i)%dsPtr, comms(i),'i_server')
          call this%ic_vec%push_back(threadPtr)
@@ -225,8 +226,9 @@ contains
       enddo
 
       do i = 1 + N_iclient_g, N_iclient_g + N_oclient_g
-         allocate(threadPtr, source = ClientThread())
-         call app_ds%connect_to_server('oserver',threadPtr, comms(i), rc=status)
+         allocate(threadPtr, source = ClientThread(client_comm=comms(i), rc=status))
+         _VERIFY(status)
+         call app_ds%connect_to_server('oserver',threadPtr, rc=status)
          _VERIFY(status)
          !call threadPtr%init_connection(app_ds(i)%dsPtr, comms(i),'o_server')
          call this%oc_vec%push_back(threadPtr)

--- a/superstructure/generic/RestartHandler.F90
+++ b/superstructure/generic/RestartHandler.F90
@@ -114,7 +114,7 @@ contains
       ! TODO: no-op if bundle is empty, or should we skip empty bundles?
       call writer%stage_data_to_file(bundle, filename, 1, _RC)
        call o_Client%done_collective_stage()
-       call o_Client%post_wait()
+       call o_Client%post_wait_all()
 
       _RETURN(_SUCCESS)
    end subroutine write_bundle_
@@ -137,7 +137,7 @@ contains
       call reader%initialize(filename, this%gridcomp_geom, _RC)
       call reader%request_data_from_file(filename, bundle, _RC)
        call i_Client%done_collective_prefetch()
-       call i_Client%wait()
+       call i_Client%wait_all()
 
       _RETURN(_SUCCESS)
    end subroutine read_bundle_

--- a/superstructure/generic/RestartHandler.F90
+++ b/superstructure/generic/RestartHandler.F90
@@ -12,7 +12,7 @@ module mapl_RestartHandler_mod
    use mapl_state_api, only: MAPL_StateGet
    use mapl_field_bundle_api, only: MAPL_FieldBundleFilter
    use pFIO, only: PFIO_READ, FileMetaData, NetCDF4_FileFormatter
-   use pFIO, only: i_Clients, o_Clients
+   use pFIO, only: i_Client, o_Client
    use pFlogger, only: logging, logger
 
    implicit none(type,external)
@@ -113,8 +113,8 @@ contains
       call writer%update_time_on_server(this%current_time, _RC)
       ! TODO: no-op if bundle is empty, or should we skip empty bundles?
       call writer%stage_data_to_file(bundle, filename, 1, _RC)
-      call o_Clients%done_collective_stage()
-      call o_Clients%post_wait()
+       call o_Client%done_collective_stage()
+       call o_Client%post_wait()
 
       _RETURN(_SUCCESS)
    end subroutine write_bundle_
@@ -136,8 +136,8 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(filename, this%gridcomp_geom, _RC)
       call reader%request_data_from_file(filename, bundle, _RC)
-      call i_Clients%done_collective_prefetch()
-      call i_Clients%wait()
+       call i_Client%done_collective_prefetch()
+       call i_Client%wait()
 
       _RETURN(_SUCCESS)
    end subroutine read_bundle_


### PR DESCRIPTION
Replace ClientThreadVector pool with one allocatable class(ClientThread) member; remove multi-client cycling (next, set_current, size, set_optimal_server,
split_server_pools, set_server_size) and all server-pool fields. Rename i_Clients/o_Clients -> i_Client/o_Client and mapl_pfio_api aliases accordingly.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

