### PR TITLE
Improve valid range handling: Part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update ExtData to not initialize primary items in multi rule case when the use this rule range does not overlap execution range
 - Update CI to use Baselibs 8.32.0 and circleci-tools orb v5
 - Update `components.yaml`
   - ESMA_env v5.22.0

--- a/Tests/ExtDataDriverGridComp.F90
+++ b/Tests/ExtDataDriverGridComp.F90
@@ -846,7 +846,7 @@ contains
     integer                  :: status
     integer        :: datetime(2)
     type(ESMF_Calendar) :: cal
-    type(ESMF_Time)          :: CurrTime
+    type(ESMF_Time)          :: CurrTime, StopTime
     type(ESMF_TimeInterval) :: timeInterval, duration
 
 
@@ -909,6 +909,9 @@ contains
          rc = STATUS  )
     _VERIFY(STATUS)
     nsteps = duration/timeInterval
+    StopTime = currTime+duration
+    call ESMF_ClockSet(clock, stopTime=stopTime, _RC)
+  
     _RETURN(ESMF_SUCCESS)
 
   end subroutine MAPL_ClockInit

--- a/gridcomps/ExtData2G/ExtDataAbstractFileHandler.F90
+++ b/gridcomps/ExtData2G/ExtDataAbstractFileHandler.F90
@@ -181,16 +181,15 @@ contains
      character(len=ESMF_MAXPATHLEN) :: trial_file
      logical :: file_found
 
-     useable_time = current_time
-     if (allocated(this%valid_range)) then
-        useable_time = this%valid_range(1)
-     end if
-     call fill_grads_template(trial_file, this%file_template, time=useable_time, _RC)
+     call fill_grads_template(trial_file, this%file_template, time=current_time, _RC)
      inquire(file=trim(trial_file),exist=file_found)
 
      if (file_found) then
         filename = trial_file
         _RETURN(_SUCCESS)
+     end if
+     if (allocated(this%valid_range)) then
+        useable_time = this%valid_range(1)
      end if
      do i=1, MAX_TRIALS
         useable_time = useable_time + this%frequency

--- a/gridcomps/ExtData2G/ExtDataAbstractFileHandler.F90
+++ b/gridcomps/ExtData2G/ExtDataAbstractFileHandler.F90
@@ -181,7 +181,8 @@ contains
      character(len=ESMF_MAXPATHLEN) :: trial_file
      logical :: file_found
 
-     call fill_grads_template(trial_file, this%file_template, time=current_time, _RC)
+     useable_time = current_time
+     call fill_grads_template(trial_file, this%file_template, time=useable_time, _RC)
      inquire(file=trim(trial_file),exist=file_found)
 
      if (file_found) then

--- a/gridcomps/ExtData2G/ExtDataGridCompNG.F90
+++ b/gridcomps/ExtData2G/ExtDataGridCompNG.F90
@@ -262,8 +262,10 @@ CONTAINS
    integer, pointer :: i_start
    integer :: new_size
    logical, allocatable :: rules_with_ps(:), rules_with_q(:)
+   type(ESMF_Time) :: run_range(2)
    !class(logger), pointer :: lgr
 
+   call ESMF_ClockGet(clock, starttime=run_range(1), stoptime=run_range(2), _RC)
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
    call ESMF_GridCompGet( GC, name=comp_name, config=CF_master, vm=vm, _RC )
@@ -405,7 +407,9 @@ CONTAINS
       do j=1,self%primary%number_of_rules%at(i)
          item => self%primary%item_vec%at(i_start+j-1)
          item%pfioCOllection_id = MAPL_DataAddCollection(item%file_template)
-         call GetLevs(item, time, _RC)
+         if (range_overlaps_item(run_range, item)) then
+            call GetLevs(item, time, _RC)
+         end if
       enddo
 
    enddo
@@ -1805,9 +1809,26 @@ CONTAINS
      end if
      _ASSERT(item_index/=-1,"ExtData did not find item index for basename "//TRIM(base_name))
      _RETURN(_SUCCESS)
-  end function get_item_index
+   end function get_item_index
 
-  subroutine get_global_options(yaml_file,am_running,use_file_weights,rc)
+   function range_overlaps_item(range, item) result(overlaps)
+      logical :: overlaps
+      type(ESMF_Time), intent(in) :: range(2)
+      type(PrimaryExport), intent(in) :: item
+
+      ! Single-rule items carry no start_end_time constraint
+      if (.not. allocated(item%start_end_time)) then
+         overlaps = .true.
+         return
+      end if
+
+      ! Half-open overlap: [A,B) and [C,D) overlap iff A<D and C<B
+      overlaps = (item%start_end_time(1) < range(2)) .and. &
+                 (range(1) < item%start_end_time(2))
+
+   end function range_overlaps_item
+
+   subroutine get_global_options(yaml_file,am_running,use_file_weights,rc)
      character(len=*), intent(in) :: yaml_file
      logical,intent(out) :: am_running
      logical,intent(out) :: use_file_weights

--- a/gridcomps/ExtData2G/ExtDataGridCompNG.F90
+++ b/gridcomps/ExtData2G/ExtDataGridCompNG.F90
@@ -265,7 +265,6 @@ CONTAINS
    type(ESMF_Time) :: run_range(2)
    !class(logger), pointer :: lgr
 
-   call ESMF_ClockGet(clock, starttime=run_range(1), stoptime=run_range(2), _RC)
 !  Get my name and set-up traceback handle
 !  ---------------------------------------
    call ESMF_GridCompGet( GC, name=comp_name, config=CF_master, vm=vm, _RC )
@@ -400,6 +399,7 @@ CONTAINS
       end if
    enddo
 
+   call ESMF_ClockGet(clock, currtime=run_range(1), stoptime=run_range(2), _RC)
 !  now lets establish the horizonal and vertical grid for each component, replaces getlevs
    do i=1,self%primary%import_names%size()
 


### PR DESCRIPTION
This is the first of multiple parts to deal with handling cases in ExtData when you are on a system that does not have all the data that is implied by the valid range. @mathomp4 hit this with his tiny BC's on bucy.

This is a few common sense fixes as follows
1. In the multi-rule case I was checking the collection metadata for each item in the rule. This is what was causing the issue with small BC's. But if the actual job execution does not even overlap the range of for one of the rules in an item this is just not necessary. So I get the range of the run from the clock and only do this introspection if the run range overlaps the use this rule range.
2. When I do go to try to find a file to get the metadata, rather than starting at the first valid range, I changed the code to use the current time. Only if a file is not found do I use the valid range to try to find any file. This also was causing a problem with tiny BC's on bucy.

Note that I will make a similar change in ExtData in MAPL3 as it has the same issue.

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

