### PR TITLE
v2: Prepare for 2.70.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [2.70.0] - 2026-07-06
+
+### Fixed
+
 - Fix typo in `allreducesum.H`
 - Fixed bug that prevented R8 exports being written as R4 output in History
 
@@ -30,10 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Better detect FMS/yaml support (needed for spack)
     - Add new `color_message` function
     - Add helper script for regression test work
-
-### Removed
-
-### Deprecated
 
 ## [2.69.1] - 2026-05-19
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 project (
   MAPL
-  VERSION 2.69.1
+  VERSION 2.70.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 # Set the possible values of build type for cmake-gui


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description

Both `main` and `release/v2` have some good changes on them that are worth a release:

* (some) Fixes for ExtData (that @mathomp4 and @lizziel have it)
* Fixes for R8 exports (for @lizziel and @yuanjianz, see #3747 )

 So, we prepare for a release.

## Related Issue

