### PR TITLE
fix(configurable): guard against missing states section in init

### DIFF
--- a/gridcomps/configurable/ConfigurableGridComp.F90
+++ b/gridcomps/configurable/ConfigurableGridComp.F90
@@ -40,7 +40,7 @@ contains
 
       character(:), allocatable :: field_name
       type(ESMF_HConfig) :: hconfig, mapl_cfg, states_cfg, export_cfg, field_cfg
-      logical :: has_export_section, has_default_vert_profile
+      logical :: has_states_section, has_export_section, has_default_vert_profile
       real(kind=ESMF_KIND_R4), allocatable :: default_vert_profile(:)
       real(kind=ESMF_KIND_R4), pointer :: ptr3d(:, :, :)
       integer :: ii, jj, shape_(3), status
@@ -48,8 +48,10 @@ contains
       type(ESMF_HConfigIter) :: iter, e, b
 
       call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
-      ! ASSUME: mapl and states sections always exist
+      ! ASSUME: mapl section always exists
       mapl_cfg = ESMF_HConfigCreateAt(hconfig, keyString=MAPL_SECTION, _RC)
+      has_states_section = ESMF_HConfigIsDefined(mapl_cfg, keyString=COMPONENT_STATES_SECTION, _RC)
+      _RETURN_UNLESS(has_states_section)
       states_cfg = ESMF_HConfigCreateAt(mapl_cfg, keyString=COMPONENT_STATES_SECTION, _RC)
       has_export_section = ESMF_HConfigIsDefined(states_cfg, keyString=COMPONENT_EXPORT_STATE_SECTION, _RC)
       _RETURN_UNLESS(has_export_section)


### PR DESCRIPTION
## Problem

`ESMF_HConfigCreateAt` returns a null/undefined HConfig (without signaling an error) when the requested key does not exist in the parent map. Passing that null object to `ESMF_HConfigIsDefined` with a `keyString` then fails internally with:

```
HConfig object MUST be map when key specified
```

This was triggered for any component whose YAML has a `mapl:` section but no `states:` subsection (e.g. `root.yaml` in the `gocart+seasalt+dust` regression test), causing spurious ESMF ERROR entries in every PET log file on every rank.

## Fix

Check for the `states:` key via `ESMF_HConfigIsDefined` before navigating into it, and return early (`_RETURN_UNLESS`) if it is absent.

Also promotes the `has_export_section` rc check from the silent `rc=status` form to `_RC`, since `states_cfg` is now guaranteed to be a valid map at that point.

## Testing

Verified against the `gocart+seasalt+dust` regression test — PET log files no longer contain ESMF HConfig ERROR entries.