### PR TITLE
Add named default pfio server constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Named default pfio server constants (#5242): new module `mapl_DefaultServerNames_mod`
+  exports `MAPL_DEFAULT_INPUT_SERVER` and `MAPL_DEFAULT_OUTPUT_SERVER`; all hardcoded
+  `'i_client'`/`'o_client'`/`'i_server'`/`'o_server'` string literals replaced with these
+  constants throughout `MaplFramework`, `RestartHandler`, `GeomPFIO`, `GridPFIO`,
+  `FieldBundleRead`, `FieldBundleWrite`, `HistoryGridComp`, `ExtDataFileReader`, and
+  `PrimaryExport`; fixed `MAX_LEN_PORT_NAME` (16 → 64) to support longer port names
+
 - Added `MAPL_StateMerge` to combine two `ESMF_State` objects into one without allocating new field memory
 - MAPL3 initialization lifecycle (#5231): new 6-call application lifecycle
   (`MAPL_Initialize`, `MAPL_CreateServers`, `MAPL_CapCreate`, `MAPL_RunServers`,

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -1,10 +1,11 @@
 #include "MAPL.h"
 module mapl_ExtDataReader_mod
    use esmf
-   use gftl2_StringStringMap
-   use gftl2_StringIntegerMap
-   use MAPL
-   use pFlogger, only: logger
+    use gftl2_StringStringMap
+    use gftl2_StringIntegerMap
+    use MAPL
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER
+    use pFlogger, only: logger
    use, intrinsic :: iso_c_binding, only: c_ptr
    implicit none(type,external)
    private
@@ -95,7 +96,7 @@ module mapl_ExtDataReader_mod
          _RETURN(_SUCCESS)
       end if
 
-      i_client => mapl_get_client('i_client', _RC)
+      i_client => mapl_get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
 
       call MAPL_FieldBundleGet(this%accumulated_fields, fieldList=field_list, _RC)
       do i=1,size(field_list)

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -95,7 +95,7 @@ module mapl_ExtDataReader_mod
          _RETURN(_SUCCESS)
       end if
 
-      i_client => mapl_get_client_thread('i_client', _RC)
+      i_client => mapl_get_client('i_client', _RC)
 
       call MAPL_FieldBundleGet(this%accumulated_fields, fieldList=field_list, _RC)
       do i=1,size(field_list)

--- a/gridcomps/extdata/PrimaryExport.F90
+++ b/gridcomps/extdata/PrimaryExport.F90
@@ -94,7 +94,7 @@ module mapl_PrimaryExport_mod
          call primary_export%bracket%set_node(NODE_LEFT, left_node)
          call primary_export%bracket%set_node(NODE_RIGHT, right_node)
          call primary_export%file_selector%get_file_template(file_template)
-         i_client => mapl_get_client_thread('i_client', _RC)
+         i_client => mapl_get_client('i_client', _RC)
          primary_export%client_collection_id = i_client%add_data_collection(file_template, _RC)
          call primary_export%bracket%set_parameters(time_interpolation=sample%time_interpolation)
          allocate(primary_export%start_and_end, source=time_range)

--- a/gridcomps/extdata/PrimaryExport.F90
+++ b/gridcomps/extdata/PrimaryExport.F90
@@ -13,10 +13,11 @@ module mapl_PrimaryExport_mod
    use gftl2_StringVector
    use mapl_ExtDataRule_mod
    use mapl_ExtDataCollection_mod
-   use mapl_ExtDataSample_mod
-   use VerticalCoordinateMod
-   use pflogger, only: logger
-   implicit none(type,external)
+    use mapl_ExtDataSample_mod
+    use VerticalCoordinateMod
+    use pflogger, only: logger
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER
+    implicit none(type,external)
    private
 
    public PrimaryExport
@@ -94,7 +95,7 @@ module mapl_PrimaryExport_mod
          call primary_export%bracket%set_node(NODE_LEFT, left_node)
          call primary_export%bracket%set_node(NODE_RIGHT, right_node)
          call primary_export%file_selector%get_file_template(file_template)
-         i_client => mapl_get_client('i_client', _RC)
+          i_client => mapl_get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
          primary_export%client_collection_id = i_client%add_data_collection(file_template, _RC)
          call primary_export%bracket%set_parameters(time_interpolation=sample%time_interpolation)
          allocate(primary_export%start_and_end, source=time_range)

--- a/gridcomps/history/HistoryCollectionGridComp.F90
+++ b/gridcomps/history/HistoryCollectionGridComp.F90
@@ -65,7 +65,9 @@ contains
       type(HistoryCollectionGridComp), pointer :: collection_gridcomp
       type(ESMF_HConfig) :: hconfig
       type(ESMF_Geom) :: geom
+      logical :: has_server
       character(len=ESMF_MAXSTR) :: name
+      character(len=:), allocatable :: server_name
       type(mapl_FileMetadata) :: metadata
 
       call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
@@ -78,7 +80,10 @@ contains
       metadata = mapl_bundle_to_metadata(collection_gridcomp%output_bundle, geom, _RC)
       allocate(collection_gridcomp%writer, source=mapl_make_geom_pfio(metadata, rc=status))
       _VERIFY(STATUS)
-      call collection_gridcomp%writer%init_with_metadata(metadata, geom, _RC)
+      server_name = MAPL_DEFAULT_OUTPUT_SERVER
+      has_server = ESMF_HConfigIsDefined(hconfig, keyString='server', _RC)
+      if (has_server) server_name = ESMF_HConfigAsString(hconfig, keyString='server', _RC)
+      call collection_gridcomp%writer%init_with_metadata(metadata, geom, output_server_name=server_name, _RC)
 
       collection_gridcomp%start_stop_times = set_start_stop_time(clock, hconfig, _RC)
       collection_gridcomp%timeStep = get_frequency(hconfig, _RC)

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -151,7 +151,7 @@ contains
 
       call MAPL_GridCompRunChildren(gridcomp, phase_name='run', _RC)
 
-      o_client => mapl_get_client_thread('o_client', _RC)
+      o_client => mapl_get_client('o_client', _RC)
       call o_client%done_collective_stage()
       call o_client%post_wait_all()
 

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -152,6 +152,7 @@ contains
 
       logical :: is_default_server
       type(HistoryGridComp), pointer :: history
+      integer :: status
 
       _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryGridComp, PRIVATE_STATE, history)
       is_default_server = history%server_name == MAPL_DEFAULT_OUTPUT_SERVER

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -15,6 +15,12 @@ module mapl_HistoryGridComp_mod
 
    public :: setServices
 
+   type :: HistoryGridComp
+      character(:), allocatable :: server_name
+   end type HistoryGridComp
+
+   character(*), parameter :: PRIVATE_STATE = 'History'
+
 contains
 
    subroutine setServices(gridcomp, rc)
@@ -25,7 +31,9 @@ contains
       character(len=:), allocatable :: child_name, collection_name
       type(ESMF_HConfigIter) :: iter, iter_begin, iter_end
       logical :: has_active_collections
+      logical :: has_server
       class(logger), pointer :: lgr
+      type(HistoryGridComp), pointer :: history
       integer :: num_collections, status
       type(ESMF_TimeInterval), allocatable :: timeStep
 
@@ -33,8 +41,17 @@ contains
       call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_INITIALIZE, init, phase_name="GENERIC::INIT_USER", _RC)
       call MAPL_GridCompSetEntryPoint(gridcomp, ESMF_METHOD_RUN, run, phase_name='run', _RC)
 
+      _SET_NAMED_PRIVATE_STATE(gridcomp, HistoryGridComp, PRIVATE_STATE)
+      _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryGridComp, PRIVATE_STATE, history)
+
       ! Determine collections
       call MAPL_GridCompGet(gridcomp, hconfig=hconfig, _RC)
+
+      history%server_name = MAPL_DEFAULT_OUTPUT_SERVER
+      has_server = ESMF_HConfigIsDefined(hconfig, keyString='server', _RC)
+      if (has_server) then
+         history%server_name = ESMF_HConfigAsString(hconfig, keyString='server', _RC)
+      end if
 
       has_active_collections = ESMF_HConfigIsDefined(hconfig, keyString='active_collections', _RC)
       if (.not. has_active_collections) then
@@ -133,6 +150,15 @@ contains
       type(ESMF_Clock)      :: clock
       integer, intent(out)  :: rc
 
+      logical :: is_default_server
+      type(HistoryGridComp), pointer :: history
+
+      _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryGridComp, PRIVATE_STATE, history)
+      is_default_server = history%server_name == MAPL_DEFAULT_OUTPUT_SERVER
+      if (.not. is_default_server) then
+         call MAPL_ConnectToServer(history%server_name, _RC)
+      end if
+
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(gridcomp)
       _UNUSED_DUMMY(importState)
@@ -149,10 +175,13 @@ contains
 
       integer :: status
       class(ClientThread), pointer :: o_client
+      type(HistoryGridComp), pointer :: history
+
+      _GET_NAMED_PRIVATE_STATE(gridcomp, HistoryGridComp, PRIVATE_STATE, history)
 
       call MAPL_GridCompRunChildren(gridcomp, phase_name='run', _RC)
 
-       o_client => mapl_get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+      o_client => mapl_get_client(history%server_name, _RC)
       call o_client%done_collective_stage()
       call o_client%post_wait_all()
 

--- a/gridcomps/history/HistoryGridComp.F90
+++ b/gridcomps/history/HistoryGridComp.F90
@@ -2,12 +2,13 @@
 
 module mapl_HistoryGridComp_mod
 
-   use MAPL
-   use ESMF
-   use mapl_HistoryGridComp_private_mod
-   use mapl_HistoryCollectionGridComp_mod, only: collection_setServices => setServices
-   use mapl_StatisticsGridComp_mod, only: statistics_setServices => setServices
-   use pFlogger, only: logger
+    use MAPL
+    use ESMF
+    use mapl_HistoryGridComp_private_mod
+    use mapl_HistoryCollectionGridComp_mod, only: collection_setServices => setServices
+    use mapl_StatisticsGridComp_mod, only: statistics_setServices => setServices
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_OUTPUT_SERVER
+    use pFlogger, only: logger
 
    implicit none(type,external)
    private
@@ -151,7 +152,7 @@ contains
 
       call MAPL_GridCompRunChildren(gridcomp, phase_name='run', _RC)
 
-      o_client => mapl_get_client('o_client', _RC)
+       o_client => mapl_get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       call o_client%done_collective_stage()
       call o_client%post_wait_all()
 
@@ -176,4 +177,3 @@ subroutine setServices(gridcomp,rc)
 
    _RETURN(_SUCCESS)
 end subroutine
-

--- a/gridcomps/history/HistoryGridComp_private.F90
+++ b/gridcomps/history/HistoryGridComp_private.F90
@@ -48,6 +48,8 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
+      logical :: has_server
+      character(len=:), allocatable :: server_name
       type(ESMF_HConfig) :: collections_hconfig
 
       collections_hconfig = get_subconfig(hconfig, 'collections', _RC)
@@ -55,6 +57,12 @@ contains
       call ESMF_HConfigDestroy(collections_hconfig, _RC)
 
       call ESMF_HConfigAdd(child_hconfig, content=collection_name, addKeyString='collection_name', _RC)
+
+      has_server = ESMF_HConfigIsDefined(hconfig, keystring='server', _RC)
+      if (has_server) then
+         server_name = ESMF_HConfigAsString(hconfig, keystring='server', _RC)
+         call ESMF_HConfigAdd(child_hconfig, content=server_name, addKeyString='server', _RC)
+      end if
 
       _RETURN(_SUCCESS)
    end function make_child_hconfig

--- a/infrastructure/geom_io/FieldBundleRead.F90
+++ b/infrastructure/geom_io/FieldBundleRead.F90
@@ -13,14 +13,15 @@ module mapl_FieldBundleRead_mod
    use mapl_VerticalStaggerLoc_mod
    use mapl_vertical_grid_api
    ! Note: mapl_VerticalGridManager_mod used inside MAPL_read_bundle only
-   use mapl_RegridderManager_mod, only: get_regridder_manager, RegridderManager
-   use mapl_RegridderSpec_mod
-   use mapl_RegridderMethods_mod
-   use mapl_Regridder_mod, only: Regridder
-   use mapl_FileMetadataUtils_mod
-   use mapl_StringTemplate_mod, only: fill_grads_template
-   use pFIO
-   use gFTL2_StringVector
+    use mapl_RegridderManager_mod, only: get_regridder_manager, RegridderManager
+    use mapl_RegridderSpec_mod
+    use mapl_RegridderMethods_mod
+    use mapl_Regridder_mod, only: Regridder
+    use mapl_FileMetadataUtils_mod
+    use mapl_StringTemplate_mod, only: fill_grads_template
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER
+    use pFIO
+    use gFTL2_StringVector
 
    implicit none(type, external)
    private
@@ -365,7 +366,7 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(trim(file_name), file_geom, _RC)
       call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
-      i_client => get_client('i_client', _RC)
+       i_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
       call i_client%done_collective_prefetch()
       call i_client%wait_all()
 

--- a/infrastructure/geom_io/FieldBundleRead.F90
+++ b/infrastructure/geom_io/FieldBundleRead.F90
@@ -365,7 +365,7 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(trim(file_name), file_geom, _RC)
       call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
-      i_client => get_client_thread('i_client', _RC)
+      i_client => get_client('i_client', _RC)
       call i_client%done_collective_prefetch()
       call i_client%wait_all()
 

--- a/infrastructure/geom_io/FieldBundleRead.F90
+++ b/infrastructure/geom_io/FieldBundleRead.F90
@@ -230,16 +230,17 @@ contains
    !                   share the same schema (optional)
    !   rc            - Return code (optional)
    !---------------------------------------------------------------------------
-    subroutine read_bundle(bundle, file_tmpl, time, only_vars, regrid_method, &
-         noread, file_override, rc)
-      type(ESMF_FieldBundle), intent(inout) :: bundle
-      character(*),           intent(in)    :: file_tmpl
-      type(ESMF_Time),        intent(in)    :: time
-      character(*), optional, intent(in)    :: only_vars
-      integer, optional,      intent(in)    :: regrid_method
-      logical, optional,      intent(in)    :: noread
-       character(*), optional, intent(in)    :: file_override
-       integer, optional,      intent(out)   :: rc
+     subroutine read_bundle(bundle, file_tmpl, time, only_vars, regrid_method, &
+          noread, file_override, input_server_name, rc)
+       type(ESMF_FieldBundle), intent(inout) :: bundle
+       character(*),           intent(in)    :: file_tmpl
+       type(ESMF_Time),        intent(in)    :: time
+       character(*), optional, intent(in)    :: only_vars
+       integer, optional,      intent(in)    :: regrid_method
+       logical, optional,      intent(in)    :: noread
+        character(*), optional, intent(in)    :: file_override
+        character(*), optional, intent(in)    :: input_server_name
+        integer, optional,      intent(out)   :: rc
       integer :: status
       integer :: field_count, time_index, i, regrid_method_
 
@@ -363,10 +364,10 @@ contains
       end if
 
       !--- Read data into file_bundle via GeomIO ---
-      allocate(reader, source=make_geom_pfio(metadata), _STAT)
-      call reader%initialize(trim(file_name), file_geom, _RC)
-      call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
-       i_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
+       allocate(reader, source=make_geom_pfio(metadata), _STAT)
+       call reader%initialize(trim(file_name), file_geom, input_server_name=input_server_name, _RC)
+       call reader%request_data_from_file(trim(file_name), file_bundle, _RC)
+        i_client => get_client(reader%get_input_server_name(), _RC)
       call i_client%done_collective_prefetch()
       call i_client%wait_all()
 

--- a/infrastructure/geom_io/FieldBundleWrite.F90
+++ b/infrastructure/geom_io/FieldBundleWrite.F90
@@ -29,11 +29,12 @@ module mapl_FieldBundleWrite_mod
 
    contains
 
-      subroutine write_bundle_single_time(bundle,clock,output_file,rc)
-         type(ESMF_FieldBundle), intent(inout) :: bundle
-         type(ESMF_Clock), intent(inout) :: clock
-         character(len=*), intent(in) :: output_file
-         integer, optional, intent(out) :: rc
+      subroutine write_bundle_single_time(bundle,clock,output_file,output_server_name,rc)
+          type(ESMF_FieldBundle), intent(inout) :: bundle
+          type(ESMF_Clock), intent(inout) :: clock
+          character(len=*), intent(in) :: output_file
+          character(len=*), optional, intent(in) :: output_server_name
+          integer, optional, intent(out) :: rc
 
          integer :: status
 
@@ -41,33 +42,38 @@ module mapl_FieldBundleWrite_mod
          type(ESMF_Time) :: time
 
          call ESMF_ClockGet(clock, currTime=time, _RC)
-         call newWriter%start_new_file(output_File, time, _RC)
-         call newWriter%write_to_file(bundle, time, _RC)
+          if (present(output_server_name)) then
+             call newWriter%start_new_file(output_File, time, output_server_name=output_server_name, _RC)
+          else
+             call newWriter%start_new_file(output_File, time, _RC)
+          end if
+          call newWriter%write_to_file(bundle, time, _RC)
          _RETURN(_SUCCESS)
       end subroutine write_bundle_single_time
 
-      subroutine create_from_bundle(this,bundle,clock,rc)
-         class(FieldBundleWRiter), intent(inout) :: this
-         type(ESMF_FieldBundle), intent(inout) :: bundle
-         type(ESMF_Clock), intent(inout) :: clock
-         integer, optional, intent(out) :: rc
+      subroutine create_from_bundle(this,bundle,clock, output_server_name, rc)
+          class(FieldBundleWRiter), intent(inout) :: this
+          type(ESMF_FieldBundle), intent(inout) :: bundle
+          type(ESMF_Clock), intent(inout) :: clock
+          character(len=*), intent(in), optional :: output_server_name
+          integer, optional, intent(out) :: rc
 
          integer :: num_fields,i,file_steps,collection_id,status
          type(ESMF_Geom) :: geom
          type(FileMetadata) :: metadata
 
 
-         call ESMF_FieldBundleGet(bundle, geom=geom, _RC)
-         metadata = bundle_to_metadata(bundle, geom, _RC)
-         allocate(this%writer, source=make_geom_pfio(metadata,rc=status))
-         _VERIFY(status)
-         call this%writer%initialize(metadata, geom, _RC)
+          call ESMF_FieldBundleGet(bundle, geom=geom, _RC)
+          metadata = bundle_to_metadata(bundle, geom, _RC)
+          allocate(this%writer, source=make_geom_pfio(metadata,rc=status))
+          _VERIFY(status)
+          call this%writer%initialize(metadata, geom, output_server_name=output_server_name, _RC)
 
          _RETURN(_SUCCESS)
 
       end subroutine create_from_bundle
 
-      subroutine write_to_file(this,bundle, time, rc)
+       subroutine write_to_file(this,bundle, time, rc)
          class(FieldBundleWriter), intent(inout) :: this
          type(ESMF_FieldBundle), intent(inout) :: bundle
          type(ESMF_Time), intent(inout) :: time
@@ -77,7 +83,7 @@ module mapl_FieldBundleWrite_mod
          real, allocatable :: file_times(:)
          type(ESMF_TimeInterval) :: time_interval
          real(kind=ESMF_KIND_R8) :: real_time_interval
-         class(ClientThread), pointer :: o_client
+           class(ClientThread), pointer :: o_client
 
          old_size = size(this%file_times) 
          allocate(file_times, source=this%file_times, _STAT)
@@ -90,7 +96,7 @@ module mapl_FieldBundleWrite_mod
          this%file_times(time_index) = real_time_interval
 
          time_index = size(this%file_times)
-           o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+           o_client => get_client(this%writer%get_output_server_name(), _RC)
           call this%writer%stage_time_to_file(this%file_name, this%file_times, _RC)
           call this%writer%stage_data_to_file(bundle, this%file_name, time_index, _RC)
 
@@ -101,20 +107,21 @@ module mapl_FieldBundleWrite_mod
 
       end subroutine write_to_file
 
-      subroutine start_new_file(this, filename, time, rc)
-         class(fieldBundleWriter),intent(inout) :: this
-         character(len=*), intent(in) :: filename
-         type(ESMF_Time), intent(in) :: time
-         integer, optional, intent(out) :: rc
+      subroutine start_new_file(this, filename, time, output_server_name, rc)
+          class(fieldBundleWriter),intent(inout) :: this
+          character(len=*), intent(in) :: filename
+          type(ESMF_Time), intent(in) :: time
+           character(len=*), intent(in), optional :: output_server_name
+          integer, optional, intent(out) :: rc
 
          integer :: status
 
-         allocate(this%file_times(0), _STAT)
-         this%file_name=filename
-         this%initial_time=time
-         call this%writer%stage_coordinates_to_file(filename, _RC)
-         call this%writer%update_time_on_server(time, _RC)
-         _RETURN(_SUCCESS)
-      end subroutine start_new_file
+          allocate(this%file_times(0), _STAT)
+          this%file_name=filename
+          this%initial_time=time
+           call this%writer%stage_coordinates_to_file(filename, _RC)
+           call this%writer%update_time_on_server(time, _RC)
+          _RETURN(_SUCCESS)
+       end subroutine start_new_file
 
 end module mapl_FieldBundleWrite_mod

--- a/infrastructure/geom_io/FieldBundleWrite.F90
+++ b/infrastructure/geom_io/FieldBundleWrite.F90
@@ -1,12 +1,13 @@
 #include "MAPL.h"
 module mapl_FieldBundleWrite_mod
    use ESMF
-   use pFIO
-   use mapl_ErrorHandling_mod
-   use mapl_GeomPFIO_mod
-   use mapl_SharedIO_mod
-   use mapl_GeomCategorizer_mod
-   implicit none
+    use pFIO
+    use mapl_ErrorHandling_mod
+    use mapl_GeomPFIO_mod
+    use mapl_SharedIO_mod
+    use mapl_GeomCategorizer_mod
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_OUTPUT_SERVER
+    implicit none
    private
 
    public :: FieldBundleWriter
@@ -89,7 +90,7 @@ module mapl_FieldBundleWrite_mod
          this%file_times(time_index) = real_time_interval
 
          time_index = size(this%file_times)
-          o_client => get_client('o_client', _RC)
+           o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
           call this%writer%stage_time_to_file(this%file_name, this%file_times, _RC)
           call this%writer%stage_data_to_file(bundle, this%file_name, time_index, _RC)
 

--- a/infrastructure/geom_io/FieldBundleWrite.F90
+++ b/infrastructure/geom_io/FieldBundleWrite.F90
@@ -89,7 +89,7 @@ module mapl_FieldBundleWrite_mod
          this%file_times(time_index) = real_time_interval
 
          time_index = size(this%file_times)
-          o_client => get_client_thread('o_client', _RC)
+          o_client => get_client('o_client', _RC)
           call this%writer%stage_time_to_file(this%file_name, this%file_times, _RC)
           call this%writer%stage_data_to_file(bundle, this%file_name, time_index, _RC)
 

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -3,7 +3,7 @@
 module mapl_GeomPFIO_mod
    use mapl_ErrorHandling_mod
    use ESMF
-   use pfio, only: get_client_thread, ClientThread, StringVariableMap, ArrayReference, FileMetadata, Variable
+   use pfio, only: get_client, ClientThread, StringVariableMap, ArrayReference, FileMetadata, Variable
    use mapl_geom_api
    use mapl_SharedIO_mod
    implicit none
@@ -74,7 +74,7 @@ contains
 
       time_var = create_time_variable(time, _RC)
       call var_map%insert('time',time_var)
-      client => get_client_thread('o_client', _RC)
+      client => get_client('o_client', _RC)
       call client%modify_metadata(this%collection_id, var_map=var_map, _RC)
 
       _RETURN(_SUCCESS)
@@ -93,7 +93,7 @@ contains
       class(ClientThread), pointer :: client
 
       ref = ArrayReference(times)
-      client => get_client_thread('o_client', _RC)
+      client => get_client('o_client', _RC)
       request_id = client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
       _RETURN(_SUCCESS)
 
@@ -109,7 +109,7 @@ contains
       class(ClientThread), pointer :: client
 
       this%esmfgeom = esmfgeom
-      client => get_client_thread('o_client', _RC)
+      client => get_client('o_client', _RC)
       this%collection_id = client%add_data_collection(metadata, _RC)
       this%file_metadata = metadata
 
@@ -126,7 +126,7 @@ contains
       class(ClientThread), pointer :: client
 
       this%esmfgeom = esmfgeom
-      client => get_client_thread('i_client', _RC)
+      client => get_client('i_client', _RC)
       this%collection_id = client%add_data_collection(file_name, _RC)
 
       _RETURN(_SUCCESS)

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -1,12 +1,13 @@
 #include "MAPL.h"
 
 module mapl_GeomPFIO_mod
-   use mapl_ErrorHandling_mod
-   use ESMF
-   use pfio, only: get_client, ClientThread, StringVariableMap, ArrayReference, FileMetadata, Variable
-   use mapl_geom_api
-   use mapl_SharedIO_mod
-   implicit none
+    use mapl_ErrorHandling_mod
+    use ESMF
+    use pfio, only: get_client, ClientThread, StringVariableMap, ArrayReference, FileMetadata, Variable
+    use mapl_geom_api
+    use mapl_SharedIO_mod
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER
+    implicit none
    private
 
    public :: GeomPFIO
@@ -74,7 +75,7 @@ contains
 
       time_var = create_time_variable(time, _RC)
       call var_map%insert('time',time_var)
-      client => get_client('o_client', _RC)
+       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       call client%modify_metadata(this%collection_id, var_map=var_map, _RC)
 
       _RETURN(_SUCCESS)
@@ -93,7 +94,7 @@ contains
       class(ClientThread), pointer :: client
 
       ref = ArrayReference(times)
-      client => get_client('o_client', _RC)
+       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       request_id = client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
       _RETURN(_SUCCESS)
 
@@ -109,7 +110,7 @@ contains
       class(ClientThread), pointer :: client
 
       this%esmfgeom = esmfgeom
-      client => get_client('o_client', _RC)
+       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       this%collection_id = client%add_data_collection(metadata, _RC)
       this%file_metadata = metadata
 
@@ -126,7 +127,7 @@ contains
       class(ClientThread), pointer :: client
 
       this%esmfgeom = esmfgeom
-      client => get_client('i_client', _RC)
+       client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
       this%collection_id = client%add_data_collection(file_name, _RC)
 
       _RETURN(_SUCCESS)

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -17,6 +17,8 @@ module mapl_GeomPFIO_mod
       integer :: collection_id
       type(ESMF_Geom) :: esmfgeom
       type(FileMetadata) :: file_metadata
+      character(:), allocatable :: output_server_name
+      character(:), allocatable :: input_server_name
    contains
       procedure(I_stage_data_to_file), deferred :: stage_data_to_file
       procedure(I_stage_coordinates_to_file), deferred :: stage_coordinates_to_file
@@ -29,6 +31,8 @@ module mapl_GeomPFIO_mod
       procedure, non_overridable :: get_collection_id
       procedure, non_overridable :: get_file_metadata
       procedure, non_overridable :: get_esmf_geom
+      procedure, non_overridable :: get_output_server_name
+      procedure, non_overridable :: get_input_server_name
    end type GeomPFIO
 
    abstract interface
@@ -71,12 +75,12 @@ contains
       integer :: status
       type(StringVariableMap) :: var_map
       type(Variable) :: time_var
-      class(ClientThread), pointer :: client
+       class(ClientThread), pointer :: client
 
-      time_var = create_time_variable(time, _RC)
-      call var_map%insert('time',time_var)
-       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-      call client%modify_metadata(this%collection_id, var_map=var_map, _RC)
+       time_var = create_time_variable(time, _RC)
+       call var_map%insert('time',time_var)
+       client => get_client(this%output_server_name, _RC)
+       call client%modify_metadata(this%collection_id, var_map=var_map, _RC)
 
       _RETURN(_SUCCESS)
 
@@ -93,42 +97,52 @@ contains
       integer :: request_id
       class(ClientThread), pointer :: client
 
-      ref = ArrayReference(times)
-       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-      request_id = client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
+       ref = ArrayReference(times)
+       client => get_client(this%output_server_name, _RC)
+       request_id = client%stage_nondistributed_data(this%collection_id, filename, 'time', ref, _RC)
       _RETURN(_SUCCESS)
 
    end subroutine
 
-   subroutine init_with_metadata(this, metadata, esmfgeom,  rc)
-      class(GeomPFIO), intent(inout) :: this
-      type(FileMetadata), intent(in) :: metadata
-      type(ESMF_Geom), intent(in) :: esmfgeom
-      integer, optional, intent(out) :: rc
+   subroutine init_with_metadata(this, metadata, esmfgeom, output_server_name, rc)
+       class(GeomPFIO), intent(inout) :: this
+       type(FileMetadata), intent(in) :: metadata
+       type(ESMF_Geom), intent(in) :: esmfgeom
+       character(len=*), intent(in), optional :: output_server_name
+       integer, optional, intent(out) :: rc
 
-      integer :: status
-      class(ClientThread), pointer :: client
+       integer :: status
+       class(ClientThread), pointer :: client
+       character(len=:), allocatable :: server_name
 
-      this%esmfgeom = esmfgeom
-       client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-      this%collection_id = client%add_data_collection(metadata, _RC)
-      this%file_metadata = metadata
+       server_name = MAPL_DEFAULT_OUTPUT_SERVER
+       if (present(output_server_name)) server_name = output_server_name
+       this%esmfgeom = esmfgeom
+       this%output_server_name = server_name
+       client => get_client(this%output_server_name, _RC)
+       this%collection_id = client%add_data_collection(metadata, _RC)
+       this%file_metadata = metadata
 
       _RETURN(_SUCCESS)
    end subroutine init_with_metadata
 
-   subroutine init_with_filename(this, file_name, esmfgeom,  rc)
-      class(GeomPFIO), intent(inout) :: this
-      character(len=*), intent(in) :: file_name
-      type(ESMF_Geom), intent(in) :: esmfgeom
-      integer, optional, intent(out) :: rc
+   subroutine init_with_filename(this, file_name, esmfgeom, input_server_name, rc)
+       class(GeomPFIO), intent(inout) :: this
+       character(len=*), intent(in) :: file_name
+       type(ESMF_Geom), intent(in) :: esmfgeom
+       character(len=*), intent(in), optional :: input_server_name
+       integer, optional, intent(out) :: rc
 
-      integer :: status
-      class(ClientThread), pointer :: client
+       integer :: status
+       class(ClientThread), pointer :: client
+       character(len=:), allocatable :: server_name
 
-      this%esmfgeom = esmfgeom
-       client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
-      this%collection_id = client%add_data_collection(file_name, _RC)
+       server_name = MAPL_DEFAULT_INPUT_SERVER
+       if (present(input_server_name)) server_name = input_server_name
+       this%esmfgeom = esmfgeom
+       this%input_server_name = server_name
+       client => get_client(this%input_server_name, _RC)
+       this%collection_id = client%add_data_collection(file_name, _RC)
 
       _RETURN(_SUCCESS)
    end subroutine init_with_filename
@@ -152,5 +166,21 @@ contains
 
       esmfgeom=this%esmfgeom
    end function get_esmf_geom
+
+   function get_output_server_name(this) result(server_name)
+      class(GeomPFIO), intent(in) :: this
+      character(:), allocatable :: server_name
+
+      server_name = this%output_server_name
+
+   end function get_output_server_name
+
+   function get_input_server_name(this) result(server_name)
+      class(GeomPFIO), intent(in) :: this
+      character(:), allocatable :: server_name
+
+      server_name = this%input_server_name
+
+   end function get_input_server_name
 
 end module mapl_GeomPFIO_mod

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -48,7 +48,7 @@ contains
       integer :: request_id
       class(ClientThread), pointer :: o_client
 
-      o_client => get_client_thread('o_client', _RC)
+      o_client => get_client('o_client', _RC)
       file_metadata = this%get_file_metadata()
       has_ll = file_metadata%has_variable('lons') .and. file_metadata%has_variable('lats')
       if (has_ll) then
@@ -138,7 +138,7 @@ contains
       type(ESMF_Grid) :: grid
       type(pFIOServerBounds) :: server_bounds
 
-      o_client => get_client_thread('o_client', _RC)
+      o_client => get_client('o_client', _RC)
       collection_id = this%get_collection_id()
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)
       allocate(field_names(num_fields))
@@ -187,7 +187,7 @@ contains
       integer :: collection_id, num_fields, idx, pfio_typekind, status, request_id
       class(ClientThread), pointer :: i_client
 
-      i_client => get_client_thread('i_client', _RC)
+      i_client => get_client('i_client', _RC)
       collection_id = this%get_collection_id()
 
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -47,9 +47,9 @@ contains
       type(ArrayReference) :: ref
       real(ESMF_Kind_R8), pointer :: coords(:,:)
       integer :: request_id
-      class(ClientThread), pointer :: o_client
+       class(ClientThread), pointer :: o_client
 
-       o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+       o_client => get_client(this%get_output_server_name(), _RC)
       file_metadata = this%get_file_metadata()
       has_ll = file_metadata%has_variable('lons') .and. file_metadata%has_variable('lats')
       if (has_ll) then
@@ -134,12 +134,12 @@ contains
       type(ESMF_TypeKind_Flag) :: tk
       integer, allocatable :: element_count(:), new_element_count(:)
       integer :: request_id
-      class(ClientThread), pointer :: o_client
+       class(ClientThread), pointer :: o_client
 
       type(ESMF_Grid) :: grid
       type(pFIOServerBounds) :: server_bounds
 
-       o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+       o_client => get_client(this%get_output_server_name(), _RC)
       collection_id = this%get_collection_id()
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)
       allocate(field_names(num_fields))
@@ -186,9 +186,9 @@ contains
       type(c_ptr) :: address
       type(ArrayReference) :: ref
       integer :: collection_id, num_fields, idx, pfio_typekind, status, request_id
-      class(ClientThread), pointer :: i_client
+       class(ClientThread), pointer :: i_client
 
-       i_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
+       i_client => get_client(this%get_input_server_name(), _RC)
       collection_id = this%get_collection_id()
 
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -6,12 +6,13 @@ module mapl_GridPFIO_mod
 
    use mapl_ErrorHandling_mod
    use mapl_GeomPFIO_mod
-   use mapl_SharedIO_mod
-   use ESMF
-   use PFIO
-   use MAPL_Constants,  only: MAPL_RADIANS_TO_DEGREES
-   use mapl_FieldPointerUtilities_mod
-   use mapl_pFIOServerBounds_mod, only: pFIOServerBounds, PFIO_BOUNDS_WRITE, PFIO_BOUNDS_READ
+    use mapl_SharedIO_mod
+    use ESMF
+    use PFIO
+    use MAPL_Constants,  only: MAPL_RADIANS_TO_DEGREES
+    use mapl_FieldPointerUtilities_mod
+    use mapl_pFIOServerBounds_mod, only: pFIOServerBounds, PFIO_BOUNDS_WRITE, PFIO_BOUNDS_READ
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER
 
    implicit none
    private
@@ -48,7 +49,7 @@ contains
       integer :: request_id
       class(ClientThread), pointer :: o_client
 
-      o_client => get_client('o_client', _RC)
+       o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       file_metadata = this%get_file_metadata()
       has_ll = file_metadata%has_variable('lons') .and. file_metadata%has_variable('lats')
       if (has_ll) then
@@ -138,7 +139,7 @@ contains
       type(ESMF_Grid) :: grid
       type(pFIOServerBounds) :: server_bounds
 
-      o_client => get_client('o_client', _RC)
+       o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       collection_id = this%get_collection_id()
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)
       allocate(field_names(num_fields))
@@ -187,7 +188,7 @@ contains
       integer :: collection_id, num_fields, idx, pfio_typekind, status, request_id
       class(ClientThread), pointer :: i_client
 
-      i_client => get_client('i_client', _RC)
+       i_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
       collection_id = this%get_collection_id()
 
       call ESMF_FieldBundleGet(bundle, fieldCount=num_fields, _RC)

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -385,7 +385,7 @@ contains
 
       ! Always initialize local servers on model PETs.
       if (this%is_model_pet) then
-         this%directory_service = DirectoryService(this%model_comm)
+         this%directory_service = DirectoryService(world_comm)
          call this%initialize_local_servers(_RC)
       end if
 

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -45,6 +45,7 @@ module mapl_MaplFramework_mod
    public :: MAPL_Get
    public :: MAPL_CreateServers
    public :: MAPL_RunServers
+   public :: MAPL_ConnectToServer
 
    type :: MaplFramework
       private
@@ -105,6 +106,10 @@ module mapl_MaplFramework_mod
    interface MAPL_RunServers
       procedure :: mapl_run_servers
    end interface MAPL_RunServers
+
+   interface MAPL_ConnectToServer
+      procedure :: mapl_connect_to_server
+   end interface MAPL_ConnectToServer
 
 contains
 
@@ -729,6 +734,29 @@ contains
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
    end subroutine run_servers
+
+   subroutine mapl_connect_to_server(server_name, unusable, client_name, rc)
+      character(*), intent(in) :: server_name
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      character(*), optional, intent(in) :: client_name
+      integer, optional, intent(out) :: rc
+
+      character(:), allocatable :: client_name_
+      class(ClientThread), allocatable :: client
+      class(ClientThread), pointer :: p_client
+      integer :: status
+
+      client_name_ = server_name
+      if (present(client_name)) client_name_ = client_name
+
+      allocate(FastClientThread :: client)
+      call add_client(client_name_, client, _RC)
+      p_client => get_client(client_name_, _RC)
+      call the_mapl_object%directory_service%connect_to_server(server_name, p_client)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine mapl_connect_to_server
 
    subroutine get(this, unusable, directory_service, is_model_pet, hconfig, rc)
       class(MaplFramework), target, intent(in) :: this

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -68,6 +68,7 @@ module mapl_MaplFramework_mod
       procedure :: get_vm_topology
       procedure :: validate_resources
       procedure :: create_servers
+      procedure :: initialize_clients
       procedure :: initialize_local_servers
       procedure :: add_local_server
       procedure :: initialize_complex_servers
@@ -388,12 +389,12 @@ contains
          call this%initialize_local_servers(_RC)
       end if
 
-      has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
-      if (.not. has_server_section) then
-         ! Simple path: local servers only, no ESMF GridComp servers.
-         allocate(servers(0))
-         _RETURN(_SUCCESS)
-      end if
+       has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
+       if (.not. has_server_section) then
+          ! Simple path: local default servers only, no ESMF GridComp servers.
+          allocate(servers(0))
+          _RETURN(_SUCCESS)
+       end if
 
       ! Complex path: remote servers are additive on top of local servers.
       call this%initialize_complex_servers(servers, world_comm, model_petCount, ssiCount, ssiMap, &
@@ -480,54 +481,52 @@ contains
        class(KeywordEnforcer), optional, intent(in) :: unusable
        integer, optional, intent(out) :: rc
 
-       integer :: status
-       logical :: has_server_section
-       type(ESMF_HConfig) :: servers_hconfig
-       type(ESMF_HConfig), allocatable :: server_hconfigs(:)
-       integer :: i_server
-       character(:), allocatable :: server_name
-       logical :: is_local
-       type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
-       class(ClientThread), allocatable :: i_client, o_client
+        integer :: status
+        logical :: has_server_section
+        type(ESMF_HConfig) :: servers_hconfig
+        type(ESMF_HConfig), allocatable :: server_hconfigs(:)
+        integer :: i_server
+        character(:), allocatable :: server_name
+        logical :: is_local
+        type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
 
-       allocate(i_client, source=ClientThread(client_comm=this%model_comm, rc=status))
-       allocate(o_client, source=FastClientThread(client_comm=this%model_comm, rc=status))
-       call add_client('i_client', i_client, _RC)
-       call add_client('o_client', o_client, _RC)
+        ! Initialize default or configured clients.
+        call this%initialize_clients(_RC)
 
-       ! Check if servers: section exists
-       has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
+        ! Check if servers: section exists
+        has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
 
-       if (has_server_section) then
-          ! Read servers: section and iterate to find local: true entries
-          servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
-          iter_begin = ESMF_HConfigIterBegin(servers_hconfig, _RC)
-          iter_end = ESMF_HConfigIterEnd(servers_hconfig, _RC)
-          iter = iter_begin
+        if (has_server_section) then
+           ! Read servers: section and iterate to find local: true entries
+           servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
+           iter_begin = ESMF_HConfigIterBegin(servers_hconfig, _RC)
+           iter_end = ESMF_HConfigIterEnd(servers_hconfig, _RC)
+           iter = iter_begin
 
-          do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
-             ! Get server name from the key
-             server_name = ESMF_HConfigAsStringMapKey(iter, _RC)
-             ! Check if this entry has local: true
-             is_local = ESMF_HConfigIsDefined(iter, keystring='local', _RC)
-             if (is_local) then
-                is_local = ESMF_HConfigAsLogical(iter, keystring='local', _RC)
-             end if
+           do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
+              ! Get server name from the key
+              server_name = ESMF_HConfigAsStringMapKey(iter, _RC)
+              ! Check if this entry has local: true
+              is_local = ESMF_HConfigIsDefined(iter, keystring='local', _RC)
+              if (is_local) then
+                 is_local = ESMF_HConfigAsLogical(iter, keystring='local', _RC)
+              end if
 
-             if (is_local) then
-                ! Create local server from hconfig
-                call this%add_local_server(server_name, &
-                     make_client_name(server_name), &
-                     hconfig=iter, _RC)
-             end if
-          end do
+              if (is_local) then
+                 ! Create local server from hconfig
+                 call this%add_local_server(server_name, &
+                      make_client_name(server_name), &
+                      hconfig=iter, _RC)
+              end if
+           end do
 
-          call ESMF_HConfigDestroy(servers_hconfig, _RC)
-       else
-          ! Backward compatibility: no servers: section, use hardcoded defaults
-          call this%add_local_server('i_server', 'i_client', _RC)
-          call this%add_local_server('o_server', 'o_client', _RC)
-       end if
+           call ESMF_HConfigDestroy(servers_hconfig, _RC)
+        else
+           ! Backward compatibility: no servers: section, use hardcoded defaults.
+           ! These connect default clients created above.
+           call this%add_local_server('i_server', 'i_client', _RC)
+           call this%add_local_server('o_server', 'o_client', _RC)
+        end if
 
        _RETURN(_SUCCESS)
        _UNUSED_DUMMY(unusable)
@@ -587,7 +586,83 @@ contains
        _RETURN(_SUCCESS)
     end subroutine add_local_server
 
-   ! Run servers on server PETs; model PETs return immediately.
+     ! Initialize configured clients from pfio_clients: section.
+     ! Each client entry specifies:
+     !   - server: the name of the server to connect to
+     !   - subclass: 'default' (ClientThread) or 'fast' (FastClientThread); defaults to 'default'
+     subroutine initialize_clients(this, unusable, rc)
+        class(MaplFramework), target, intent(inout) :: this
+        class(KeywordEnforcer), optional, intent(in) :: unusable
+        integer, optional, intent(out) :: rc
+
+        integer :: status
+        logical :: has_client_section
+        type(ESMF_HConfig) :: clients_hconfig
+        type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
+        character(:), allocatable :: client_name, server_name, subclass_name
+        logical :: has_server, has_subclass
+        class(ClientThread), allocatable :: client
+
+        has_client_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='pfio_clients', _RC)
+        if (.not. has_client_section) then
+           allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
+           _VERIFY(status)
+           call add_client('i_client', client, _RC)
+
+           deallocate(client)
+           allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
+           _VERIFY(status)
+           call add_client('o_client', client, _RC)
+
+           _RETURN(_SUCCESS)
+        end if
+
+        clients_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='pfio_clients', _RC)
+        iter_begin = ESMF_HConfigIterBegin(clients_hconfig, _RC)
+        iter_end = ESMF_HConfigIterEnd(clients_hconfig, _RC)
+        iter = iter_begin
+
+        do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
+           ! Get client name from the key
+           client_name = ESMF_HConfigAsStringMapKey(iter, _RC)
+
+           ! server: is required
+           has_server = ESMF_HConfigIsDefined(iter, keystring='server', _RC)
+           _ASSERT(has_server, "pfio_clients entry '"//client_name//"' missing required 'server' field")
+           server_name = ESMF_HConfigAsString(iter, keystring='server', _RC)
+
+           ! subclass: is optional; defaults to 'default'
+           subclass_name = 'default'
+           has_subclass = ESMF_HConfigIsDefined(iter, keystring='subclass', _RC)
+           if (has_subclass) then
+              subclass_name = ESMF_HConfigAsString(iter, keystring='subclass', _RC)
+           end if
+
+           ! Create appropriate client subclass
+           select case (trim(subclass_name))
+           case ('default')
+              allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
+           case ('fast')
+              allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
+           case default
+              _ASSERT(.false., "Unknown client subclass: '"//trim(subclass_name)//"' (must be 'default' or 'fast')")
+           end select
+
+           ! Register client in the client manager
+           call add_client(client_name, client, _RC)
+
+           ! Connect client to its server
+           call this%directory_service%connect_to_server(server_name, client)
+
+        end do
+
+        call ESMF_HConfigDestroy(clients_hconfig, _RC)
+
+        _RETURN(_SUCCESS)
+        _UNUSED_DUMMY(unusable)
+     end subroutine initialize_clients
+
+    ! Run servers on server PETs; model PETs return immediately.
    ! ESMF_GridCompInitialize/Run/Finalize only require the petList PETs —
    ! no global collective needed.
    subroutine run_servers(this, servers, unusable, rc)

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -71,7 +71,6 @@ module mapl_MaplFramework_mod
       procedure :: validate_resources
       procedure :: initialize_default_servers
       procedure :: create_servers
-      procedure :: initialize_clients
       procedure :: initialize_configured_local_servers
       procedure :: add_local_server
       procedure :: initialize_non_default_servers
@@ -390,9 +389,9 @@ contains
       this%directory_service = DirectoryService(world_comm)
 
       ! Create the two default local servers and their clients.
+      ! Input uses a standard ClientThread; output uses a FastClientThread.
       call this%add_local_server(MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_INPUT_SERVER, _RC)
-      call this%add_local_server(MAPL_DEFAULT_OUTPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-      call this%initialize_clients(_RC)
+      call this%add_local_server(MAPL_DEFAULT_OUTPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER, fast_client=.true., _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
@@ -563,32 +562,34 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_configured_local_servers
 
-    ! Register one local server and connect its client.
-    ! server_name: key used in local_server_map and DirectoryService port registry.
-    ! client_name: key used in the pfio client_map (via get_client_thread).
-    ! hconfig: optional hconfig for the server entry; if provided, reads subclass: to dispatch.
-    !   If not provided, defaults to MpiServer (backward compatibility).
-    subroutine add_local_server(this, server_name, client_name, hconfig, rc)
-       class(MaplFramework), target, intent(inout) :: this
-       character(*), intent(in) :: server_name
-       character(*), intent(in) :: client_name  ! reserved for future use (client registration)
-       type(ESMF_HConfigIter), optional, intent(in) :: hconfig
-       integer, optional, intent(out) :: rc
+   ! Register one local server and connect its client in a single atomic step.
+   ! server_name: key used in local_server_map and DirectoryService port registry.
+   ! client_name: key used in the pfio ClientManager.
+   ! hconfig: optional — if provided, reads subclass: to dispatch server type.
+   !          If not provided, defaults to MpiServer.
+   ! fast_client: if .true., use FastClientThread for the client; default is ClientThread.
+   subroutine add_local_server(this, server_name, client_name, hconfig, fast_client, rc)
+      class(MaplFramework), target, intent(inout) :: this
+      character(*), intent(in) :: server_name
+      character(*), intent(in) :: client_name
+      type(ESMF_HConfigIter), optional, intent(in) :: hconfig
+      logical, optional, intent(in) :: fast_client
+      integer, optional, intent(out) :: rc
 
-       integer :: status, alloc_stat
-       class(BaseServer), allocatable :: tmp
-       class(BaseServer), pointer :: srv
-       logical :: has_subclass
-       character(:), allocatable :: subclass_name
+      integer :: status, alloc_stat
+      class(BaseServer), allocatable :: tmp
+      class(BaseServer), pointer :: srv
+      class(ClientThread), allocatable :: new_client
+      class(ClientThread), pointer :: p_client
+      logical :: has_subclass, use_fast
+      character(:), allocatable :: subclass_name
 
-       ! Determine server subclass
-       subclass_name = 'MpiServer'  ! default
-       if (present(hconfig)) then
-          has_subclass = ESMF_HConfigIsDefined(hconfig, keystring='subclass', _RC)
-          if (has_subclass) then
-             subclass_name = ESMF_HConfigAsString(hconfig, keystring='subclass', _RC)
-          end if
-       end if
+      ! Determine server subclass.
+      subclass_name = 'MpiServer'  ! default
+      if (present(hconfig)) then
+         has_subclass = ESMF_HConfigIsDefined(hconfig, keystring='subclass', _RC)
+         if (has_subclass) subclass_name = ESMF_HConfigAsString(hconfig, keystring='subclass', _RC)
+      end if
 
       ! Allocate appropriate server subclass.
       select case (trim(subclass_name))
@@ -597,8 +598,6 @@ contains
          _VERIFY(status)
          _VERIFY(alloc_stat)
       case ('MultiGroupServer')
-         ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
-         ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
          allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
               stat=alloc_stat)
          _VERIFY(status)
@@ -607,94 +606,31 @@ contains
          _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
       end select
 
+      ! Publish the server so connect_to_server can find it by name.
       call this%local_server_map%insert(server_name, tmp)
       srv => this%local_server_map%at(server_name)
       call this%directory_service%publish(PortInfo(server_name, srv), srv)
 
+      ! Create the client, store it in the ClientManager, then connect the
+      ! map-resident copy to the server.  connect_to_server stores a pointer to
+      ! the client internally (SimpleSocket), so the client must be stored in
+      ! stable long-lived storage (the ClientManager map) before connecting.
+      use_fast = .false.
+      if (present(fast_client)) use_fast = fast_client
+
+      if (use_fast) then
+         allocate(new_client, source=FastClientThread(client_comm=this%model_comm, rc=status))
+      else
+         allocate(new_client, source=ClientThread(client_comm=this%model_comm, rc=status))
+      end if
+      _VERIFY(status)
+
+      call add_client(client_name, new_client, _RC)
+      p_client => get_client(client_name, _RC)
+      call this%directory_service%connect_to_server(server_name, p_client)
+
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(client_name)
    end subroutine add_local_server
-
-     ! Initialize configured clients from pfio_clients: section.
-     ! Each client entry specifies:
-     !   - server: the name of the server to connect to
-     !   - subclass: 'default' (ClientThread) or 'fast' (FastClientThread); defaults to 'default'
-     subroutine initialize_clients(this, unusable, rc)
-        class(MaplFramework), target, intent(inout) :: this
-        class(KeywordEnforcer), optional, intent(in) :: unusable
-        integer, optional, intent(out) :: rc
-
-        integer :: status
-        logical :: has_client_section
-        type(ESMF_HConfig) :: clients_hconfig
-        type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
-        character(:), allocatable :: client_name, server_name, subclass_name
-        logical :: has_server, has_subclass
-        class(ClientThread), allocatable :: client
-        class(ClientThread), pointer :: p_client
-
-        has_client_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='pfio_clients', _RC)
-         if (.not. has_client_section) then
-            allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
-            _VERIFY(status)
-            call add_client(MAPL_DEFAULT_INPUT_SERVER, client, _RC)
-            p_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
-            call this%directory_service%connect_to_server(MAPL_DEFAULT_INPUT_SERVER, p_client)
-
-            deallocate(client)
-            allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
-            _VERIFY(status)
-            call add_client(MAPL_DEFAULT_OUTPUT_SERVER, client, _RC)
-            p_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-            call this%directory_service%connect_to_server(MAPL_DEFAULT_OUTPUT_SERVER, p_client)
-
-            _RETURN(_SUCCESS)
-         end if
-
-        clients_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='pfio_clients', _RC)
-        iter_begin = ESMF_HConfigIterBegin(clients_hconfig, _RC)
-        iter_end = ESMF_HConfigIterEnd(clients_hconfig, _RC)
-        iter = iter_begin
-
-        do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
-           ! Get client name from the key
-           client_name = ESMF_HConfigAsStringMapKey(iter, _RC)
-
-           ! server: is required
-           has_server = ESMF_HConfigIsDefined(iter, keystring='server', _RC)
-           _ASSERT(has_server, "pfio_clients entry '"//client_name//"' missing required 'server' field")
-           server_name = ESMF_HConfigAsString(iter, keystring='server', _RC)
-
-           ! subclass: is optional; defaults to 'default'
-           subclass_name = 'default'
-           has_subclass = ESMF_HConfigIsDefined(iter, keystring='subclass', _RC)
-           if (has_subclass) then
-              subclass_name = ESMF_HConfigAsString(iter, keystring='subclass', _RC)
-           end if
-
-           ! Create appropriate client subclass
-           select case (trim(subclass_name))
-           case ('default')
-              allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
-           case ('fast')
-              allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
-           case default
-              _ASSERT(.false., "Unknown client subclass: '"//trim(subclass_name)//"' (must be 'default' or 'fast')")
-           end select
-
-           ! Register client in the client manager
-           call add_client(client_name, client, _RC)
-
-           ! Connect client to its server
-           call this%directory_service%connect_to_server(server_name, client)
-
-        end do
-
-        call ESMF_HConfigDestroy(clients_hconfig, _RC)
-
-        _RETURN(_SUCCESS)
-        _UNUSED_DUMMY(unusable)
-     end subroutine initialize_clients
 
     ! Run servers on server PETs; model PETs return immediately.
    ! ESMF_GridCompInitialize/Run/Finalize only require the petList PETs —

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -20,13 +20,15 @@ module mapl_MaplFramework_mod
    use mapl_ModelVerticalGrid_mod
    use mapl_FieldDictionary_mod, only: load_field_dictionary
    use mapl_Profiler_mod, only: profiler_initialize => initialize, profiler_finalize => finalize
-   use pfio_DirectoryServiceMod, only: DirectoryService
-   use pfio_ClientManagerMod, only: init_IO_ClientManager, get_client_thread
-   use pfio_MpiServerMod, only: MpiServer
-   use pfio_BaseServerMod, only: BaseServer
-   use pfio_StringServerMapMod, only: StringServerMap
-   use pfio_ClientThreadMod, only: ClientThread
-   use pfio_AbstractDirectoryServiceMod, only: PortInfo
+    use pfio_DirectoryServiceMod, only: DirectoryService
+    use pfio_ClientManagerMod, only: get_client, add_client
+    use pfio_MpiServerMod, only: MpiServer
+    use pfio_MultiGroupServerMod, only: MultiGroupServer
+    use pfio_BaseServerMod, only: BaseServer
+    use pfio_StringServerMapMod, only: StringServerMap
+    use pfio_ClientThreadMod, only: ClientThread
+    use pfio_FastClientThreadMod, only: FastClientThread
+    use pfio_AbstractDirectoryServiceMod, only: PortInfo
    use udunits2f, only: UDUNITS_Initialize => Initialize
    use pflogger, only: logging
    use pflogger, only: Logger
@@ -414,13 +416,15 @@ contains
       logical, optional, intent(out) :: is_model_pet
       integer, optional, intent(out) :: rc
 
-      integer :: status
-      type(ESMF_HConfig) :: servers_hconfig
-      integer :: world_group, model_group
-      integer :: server_comm, model_server_comm
-      integer :: num_model_ssis
-      integer :: ssi_0, ssi_1, i_server
-      integer, allocatable :: ssis_per_server(:)
+       integer :: status
+       type(ESMF_HConfig) :: servers_hconfig
+       integer :: world_group, model_group
+       integer :: server_comm, model_server_comm
+       integer :: num_model_ssis
+       integer :: n_servers
+       logical :: is_local
+       integer :: ssi_0, ssi_1, i_server, i_all
+       integer, allocatable :: ssis_per_server(:)
       integer, allocatable :: model_pets(:), server_pets(:), model_server_pets(:)
       type(ESMF_HConfig), allocatable :: server_hconfigs(:)
       class(Logger), pointer :: lgr
@@ -441,13 +445,24 @@ contains
       if (present(is_model_pet)) is_model_pet = (this%model_comm /= MPI_COMM_NULL)
 
       ssi_0 = num_model_ssis
-      allocate(servers(size(server_hconfigs)))
-      do i_server = 1, size(server_hconfigs)
-         ssi_1 = ssi_0 + ssis_per_server(i_server)
+      n_servers = count_remote_servers(server_hconfigs, _RC)
+      allocate(servers(n_servers))
+
+      ! Populate only remote (non-local) servers
+      i_server = 0
+      do i_all = 1, size(server_hconfigs)
+         ! Skip local servers (already handled in initialize_local_servers)
+         is_local = is_local_server(server_hconfigs(i_all), _RC)
+         if (is_local) then
+            cycle
+         end if
+         
+         i_server = i_server + 1
+         ssi_1 = ssi_0 + ssis_per_server(i_all)
          server_pets = pets_on_ssis(ssiMap, ssi_0, ssi_1)
          call create_server_comms(world_comm, world_group, model_group, server_pets, server_comm, model_server_comm, _RC)
          model_server_pets = [model_pets, server_pets]
-         servers(i_server) = make_server_gridcomp(server_hconfigs(i_server), &
+         servers(i_server) = make_server_gridcomp(server_hconfigs(i_all), &
               model_server_pets, [model_server_comm, this%model_comm, server_comm], _RC)
          ssi_0 = ssi_1
       end do
@@ -460,46 +475,117 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine initialize_complex_servers
 
-   subroutine initialize_local_servers(this, unusable, rc)
-      class(MaplFramework), target, intent(inout) :: this
-      class(KeywordEnforcer), optional, intent(in) :: unusable
-      integer, optional, intent(out) :: rc
+    subroutine initialize_local_servers(this, unusable, rc)
+       class(MaplFramework), target, intent(inout) :: this
+       class(KeywordEnforcer), optional, intent(in) :: unusable
+       integer, optional, intent(out) :: rc
 
-      integer :: status
+       integer :: status
+       logical :: has_server_section
+       type(ESMF_HConfig) :: servers_hconfig
+       type(ESMF_HConfig), allocatable :: server_hconfigs(:)
+       integer :: i_server
+       character(:), allocatable :: server_name
+       logical :: is_local
+       type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
+       class(ClientThread), allocatable :: i_client, o_client
 
-      call init_IO_ClientManager(this%model_comm, _RC)
-      call this%add_local_server('i_server', 'i_client', _RC)
-      call this%add_local_server('o_server', 'o_client', _RC)
+       allocate(i_client, source=ClientThread(client_comm=this%model_comm, rc=status))
+       allocate(o_client, source=FastClientThread(client_comm=this%model_comm, rc=status))
+       call add_client('i_client', i_client, _RC)
+       call add_client('o_client', o_client, _RC)
 
-      _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine initialize_local_servers
+       ! Check if servers: section exists
+       has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
 
-   ! Register one local MpiServer and connect its client.
-   ! server_name: key used in local_server_map and DirectoryService port registry.
-   ! client_name: key used in the pfio client_map (via get_client_thread).
-   subroutine add_local_server(this, server_name, client_name, rc)
-      class(MaplFramework), target, intent(inout) :: this
-      character(*), intent(in) :: server_name
-      character(*), intent(in) :: client_name
-      integer, optional, intent(out) :: rc
+       if (has_server_section) then
+          ! Read servers: section and iterate to find local: true entries
+          servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
+          iter_begin = ESMF_HConfigIterBegin(servers_hconfig, _RC)
+          iter_end = ESMF_HConfigIterEnd(servers_hconfig, _RC)
+          iter = iter_begin
 
-      integer :: status, alloc_stat
-      class(BaseServer), allocatable :: tmp
-      class(BaseServer), pointer :: srv
-      class(ClientThread), pointer :: client
+          do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
+             ! Get server name from the key
+             server_name = ESMF_HConfigAsStringMapKey(iter, _RC)
+             ! Check if this entry has local: true
+             is_local = ESMF_HConfigIsDefined(iter, keystring='local', _RC)
+             if (is_local) then
+                is_local = ESMF_HConfigAsLogical(iter, keystring='local', _RC)
+             end if
 
-      allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
-      _VERIFY(status)
-      _VERIFY(alloc_stat)
-      call this%local_server_map%insert(server_name, tmp)
-      srv => this%local_server_map%at(server_name)
-      call this%directory_service%publish(PortInfo(server_name, srv), srv)
-      client => get_client_thread(client_name, _RC)
-      call this%directory_service%connect_to_server(server_name, client)
+             if (is_local) then
+                ! Create local server from hconfig
+                call this%add_local_server(server_name, &
+                     make_client_name(server_name), &
+                     hconfig=iter, _RC)
+             end if
+          end do
 
-      _RETURN(_SUCCESS)
-   end subroutine add_local_server
+          call ESMF_HConfigDestroy(servers_hconfig, _RC)
+       else
+          ! Backward compatibility: no servers: section, use hardcoded defaults
+          call this%add_local_server('i_server', 'i_client', _RC)
+          call this%add_local_server('o_server', 'o_client', _RC)
+       end if
+
+       _RETURN(_SUCCESS)
+       _UNUSED_DUMMY(unusable)
+    end subroutine initialize_local_servers
+
+    ! Register one local server and connect its client.
+    ! server_name: key used in local_server_map and DirectoryService port registry.
+    ! client_name: key used in the pfio client_map (via get_client_thread).
+    ! hconfig: optional hconfig for the server entry; if provided, reads subclass: to dispatch.
+    !   If not provided, defaults to MpiServer (backward compatibility).
+    subroutine add_local_server(this, server_name, client_name, hconfig, rc)
+       class(MaplFramework), target, intent(inout) :: this
+       character(*), intent(in) :: server_name
+       character(*), intent(in) :: client_name
+       type(ESMF_HConfigIter), optional, intent(in) :: hconfig
+       integer, optional, intent(out) :: rc
+
+       integer :: status, alloc_stat
+       class(BaseServer), allocatable :: tmp
+       class(BaseServer), pointer :: srv
+       class(ClientThread), pointer :: client
+       logical :: has_subclass
+       character(:), allocatable :: subclass_name
+
+       ! Determine server subclass
+       subclass_name = 'MpiServer'  ! default
+       if (present(hconfig)) then
+          has_subclass = ESMF_HConfigIsDefined(hconfig, keystring='subclass', _RC)
+          if (has_subclass) then
+             subclass_name = ESMF_HConfigAsString(hconfig, keystring='subclass', _RC)
+          end if
+       end if
+
+       ! Allocate appropriate server subclass
+       select case (trim(subclass_name))
+       case ('MpiServer')
+          allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
+          _VERIFY(status)
+          _VERIFY(alloc_stat)
+       case ('MultiGroupServer')
+          ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
+          ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
+          allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
+               stat=alloc_stat)
+          _VERIFY(status)
+          _VERIFY(alloc_stat)
+       case default
+          _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
+       end select
+
+       call this%local_server_map%insert(server_name, tmp)
+       srv => this%local_server_map%at(server_name)
+       call this%directory_service%publish(PortInfo(server_name, srv), srv)
+       client => get_client(client_name, _RC)
+       call this%directory_service%connect_to_server(server_name, client)
+
+       _RETURN(_SUCCESS)
+    end subroutine add_local_server
 
    ! Run servers on server PETs; model PETs return immediately.
    ! ESMF_GridCompInitialize/Run/Finalize only require the petList PETs —
@@ -635,8 +721,65 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine finalize_esmf
 
-   ! Public interfaces that rely on the singleton object
-   subroutine mapl_get(unusable, directory_service, is_model_pet, hconfig, rc)
+    ! Helper function to derive client name from server name.
+    ! Convention: 'foo_server' -> 'foo_client', 'foo' -> 'foo_client'.
+    function make_client_name(server_name) result(client_name)
+       character(*), intent(in) :: server_name
+       character(:), allocatable :: client_name
+       integer :: pos
+
+       ! Look for '_server' suffix
+       pos = index(server_name, '_server', back=.true.)
+       if (pos > 0) then
+          ! Replace _server with _client
+          allocate(character(len=pos-1+7) :: client_name)
+          client_name = server_name(1:pos-1) // '_client'
+       else
+          ! Append _client
+          allocate(character(len=len_trim(server_name)+7) :: client_name)
+          client_name = trim(server_name) // '_client'
+       end if
+    end function make_client_name
+
+    ! Helper function to check if a server hconfig has local: true.
+    function is_local_server(server_hconfig, rc) result(is_local)
+       type(ESMF_HConfig), intent(in) :: server_hconfig
+       integer, optional, intent(out) :: rc
+       logical :: is_local
+
+       integer :: status
+
+       is_local = ESMF_HConfigIsDefined(server_hconfig, keystring='local', _RC)
+       if (is_local) then
+          is_local = ESMF_HConfigAsLogical(server_hconfig, keystring='local', _RC)
+       end if
+
+       _RETURN(_SUCCESS)
+    end function is_local_server
+
+    ! Helper function to count the number of remote (non-local) server entries.
+    function count_remote_servers(server_hconfigs, rc) result(count)
+       type(ESMF_HConfig), intent(in) :: server_hconfigs(:)
+       integer, optional, intent(out) :: rc
+       integer :: count
+
+       integer :: status
+       logical :: is_local
+       integer :: i_server
+
+       count = 0
+       do i_server = 1, size(server_hconfigs)
+          is_local = is_local_server(server_hconfigs(i_server), _RC) 
+          if (.not. is_local) then
+             count = count + 1
+          end if
+       end do
+
+       _RETURN(_SUCCESS)
+    end function count_remote_servers
+
+    ! Public interfaces that rely on the singleton object
+    subroutine mapl_get(unusable, directory_service, is_model_pet, hconfig, rc)
       class(KeywordEnforcer), optional, intent(in) :: unusable
       type(DirectoryService), pointer, optional, intent(out) :: directory_service
       logical, optional, intent(out) :: is_model_pet

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -18,10 +18,11 @@ module mapl_MaplFramework_mod
    ! Note: mapl_VerticalGridManager_mod used inside initialize() only
    use mapl_FixedLevelsVerticalGrid_mod
    use mapl_ModelVerticalGrid_mod
-   use mapl_FieldDictionary_mod, only: load_field_dictionary
-   use mapl_Profiler_mod, only: profiler_initialize => initialize, profiler_finalize => finalize
-    use pfio_DirectoryServiceMod, only: DirectoryService
-    use pfio_ClientManagerMod, only: get_client, add_client
+    use mapl_FieldDictionary_mod, only: load_field_dictionary
+    use mapl_Profiler_mod, only: profiler_initialize => initialize, profiler_finalize => finalize
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER
+     use pfio_DirectoryServiceMod, only: DirectoryService
+     use pfio_ClientManagerMod, only: get_client, add_client
     use pfio_MpiServerMod, only: MpiServer
     use pfio_MultiGroupServerMod, only: MultiGroupServer
     use pfio_BaseServerMod, only: BaseServer
@@ -519,15 +520,25 @@ contains
            end do
 
            call ESMF_HConfigDestroy(servers_hconfig, _RC)
-        else
-           ! Backward compatibility: no servers: section, use hardcoded defaults.
-           ! These connect default clients created above.
-           call this%add_local_server('i_server', 'i_client', _RC)
-           call this%add_local_server('o_server', 'o_client', _RC)
-        end if
+         else
+            ! Backward compatibility: no servers: section, use hardcoded defaults.
+            ! These connect default clients created above.
+             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: default path, calling add_local_server for INPUT'
+             flush(6)
+             call this%add_local_server(MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_INPUT_SERVER, _RC)
+             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: add_local_server INPUT returned'
+             flush(6)
+             call this%add_local_server(MAPL_DEFAULT_OUTPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: add_local_server OUTPUT returned'
+             flush(6)
+         end if
 
         ! Initialize default or configured clients.
+        write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: calling initialize_clients'
+        flush(6)
         call this%initialize_clients(_RC)
+        write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: initialize_clients returned'
+        flush(6)
 
        _RETURN(_SUCCESS)
        _UNUSED_DUMMY(unusable)
@@ -561,26 +572,36 @@ contains
           end if
        end if
 
-       ! Allocate appropriate server subclass
-       select case (trim(subclass_name))
-       case ('MpiServer')
-          allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
-          _VERIFY(status)
-          _VERIFY(alloc_stat)
-       case ('MultiGroupServer')
-          ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
-          ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
-          allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
-               stat=alloc_stat)
-          _VERIFY(status)
-          _VERIFY(alloc_stat)
-       case default
-          _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
-       end select
+        ! Allocate appropriate server subclass
+        select case (trim(subclass_name))
+        case ('MpiServer')
+            write(*,'(A)') '[MAPL_DEBUG] add_local_server: constructing MpiServer for "'//trim(server_name)//'"'
+           flush(6)
+           allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
+           write(*,'(A)') '[MAPL_DEBUG] add_local_server: MpiServer constructed for "'//trim(server_name)//'"'
+           flush(6)
+           _VERIFY(status)
+           _VERIFY(alloc_stat)
+        case ('MultiGroupServer')
+           ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
+           ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
+           allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
+                stat=alloc_stat)
+           _VERIFY(status)
+           _VERIFY(alloc_stat)
+        case default
+           _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
+        end select
 
-       call this%local_server_map%insert(server_name, tmp)
-       srv => this%local_server_map%at(server_name)
-       call this%directory_service%publish(PortInfo(server_name, srv), srv)
+         write(*,'(A)') '[MAPL_DEBUG] add_local_server: inserting "'//trim(server_name)//'" into local_server_map'
+         flush(6)
+         call this%local_server_map%insert(server_name, tmp)
+         srv => this%local_server_map%at(server_name)
+         write(*,'(A)') '[MAPL_DEBUG] add_local_server: calling directory_service%publish for "'//trim(server_name)//'"'
+         flush(6)
+         call this%directory_service%publish(PortInfo(server_name, srv), srv)
+         write(*,'(A)') '[MAPL_DEBUG] add_local_server: publish returned for "'//trim(server_name)//'"'
+         flush(6)
 !#       client => get_client(client_name, _RC)
 !#       call this%directory_service%connect_to_server(server_name, client)
 
@@ -606,22 +627,36 @@ contains
         class(ClientThread), pointer :: p_client
 
         has_client_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='pfio_clients', _RC)
-        if (.not. has_client_section) then
-           allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
-           _VERIFY(status)
-           call add_client('i_client', client, _RC)
-           p_client => get_client('i_client', _RC)
-           call this%directory_service%connect_to_server('i_server', p_client)
+         if (.not. has_client_section) then
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: default path (no pfio_clients section)'
+            flush(6)
+            allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
+            _VERIFY(status)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling add_client for "'//MAPL_DEFAULT_INPUT_SERVER//'"'
+            flush(6)
+            call add_client(MAPL_DEFAULT_INPUT_SERVER, client, _RC)
+            p_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling connect_to_server for "'//MAPL_DEFAULT_INPUT_SERVER//'"'
+            flush(6)
+            call this%directory_service%connect_to_server(MAPL_DEFAULT_INPUT_SERVER, p_client)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: connect_to_server INPUT returned'
+            flush(6)
 
-           deallocate(client)
-           allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
-           _VERIFY(status)
-           call add_client('o_client', client, _RC)
-           p_client => get_client('o_client', _RC)
-           call this%directory_service%connect_to_server('o_server', p_client)
+            deallocate(client)
+            allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
+            _VERIFY(status)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling add_client for "'//MAPL_DEFAULT_OUTPUT_SERVER//'"'
+            flush(6)
+            call add_client(MAPL_DEFAULT_OUTPUT_SERVER, client, _RC)
+            p_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling connect_to_server for "'//MAPL_DEFAULT_OUTPUT_SERVER//'"'
+            flush(6)
+            call this%directory_service%connect_to_server(MAPL_DEFAULT_OUTPUT_SERVER, p_client)
+            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: connect_to_server OUTPUT returned'
+            flush(6)
 
-           _RETURN(_SUCCESS)
-        end if
+            _RETURN(_SUCCESS)
+         end if
 
         clients_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='pfio_clients', _RC)
         iter_begin = ESMF_HConfigIterBegin(clients_hconfig, _RC)

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -69,11 +69,12 @@ module mapl_MaplFramework_mod
       procedure :: initialize_udunits
       procedure :: get_vm_topology
       procedure :: validate_resources
+      procedure :: initialize_default_servers
       procedure :: create_servers
       procedure :: initialize_clients
-      procedure :: initialize_local_servers
+      procedure :: initialize_configured_local_servers
       procedure :: add_local_server
-      procedure :: initialize_complex_servers
+      procedure :: initialize_non_default_servers
       procedure :: run_servers
       procedure :: initialize_field_dictionary
       procedure :: initialize_field_fill_defaults
@@ -152,6 +153,11 @@ contains
            field_default_fill_value_r4=field_default_fill_value_r4, &
            field_default_fill_value_r8=field_default_fill_value_r8, &
            _RC)
+
+      ! Always create the default input/output servers and clients so that
+      ! simple utilities (e.g. Regrid_Util.x) that never call MAPL_CreateServers
+      ! can use pfio I/O without extra setup.
+      call this%initialize_default_servers(_RC)
 
       vgrid_manager => mapl_get_vertical_grid_manager(_RC)
       call vgrid_manager%initialize(_RC)
@@ -359,11 +365,45 @@ contains
       _UNUSED_DUMMY(unusable)
    end subroutine validate_resources
 
-   ! Create server communicators and ESMF GridComps for any explicit servers:
-   ! section, or set up in-process simple servers if no servers: section exists.
-   ! Local servers are always created for model PETs.  Remote servers (complex
-   ! path) are additive on top of local servers.
-   ! Sets this%is_model_pet and returns server GridComps via servers(:).
+   ! Initialize the default input/output servers and clients unconditionally.
+   ! Called from initialize() so that simple utilities (e.g. Regrid_Util.x) that
+   ! never call MAPL_CreateServers can still perform pfio I/O.
+   ! Uses the full world communicator as the model communicator (all PETs are
+   ! model PETs).  MAPL_CreateServers will re-partition if a servers: section
+   ! is present in the configuration.
+   subroutine initialize_default_servers(this, unusable, rc)
+      class(MaplFramework), target, intent(inout) :: this
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
+
+      integer :: status
+      integer :: world_comm
+
+      call ESMF_VMGet(this%mapl_vm, mpiCommunicator=world_comm, _RC)
+
+      ! Duplicate the world communicator so model_comm can be safely freed in finalize()
+      ! or replaced by create_servers() if a servers: section partitions it.
+      call MPI_Comm_dup(world_comm, this%model_comm, _IERROR)
+      this%is_model_pet = .true.
+
+      ! DirectoryService needs the full world communicator so all PETs can discover ports.
+      this%directory_service = DirectoryService(world_comm)
+
+      ! Create the two default local servers and their clients.
+      call this%add_local_server(MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_INPUT_SERVER, _RC)
+      call this%add_local_server(MAPL_DEFAULT_OUTPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER, _RC)
+      call this%initialize_clients(_RC)
+
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine initialize_default_servers
+
+   ! Create non-default server communicators and ESMF GridComps when an explicit
+   ! servers: section is present.  The default input/output servers created in
+   ! initialize() remain available.  This routine re-partitions model_comm to
+   ! exclude server PETs, then adds any local: true servers from the config and
+   ! builds ESMF GridComps for the remote servers.
+   ! Returns server GridComps via servers(:); an empty array if no servers: section.
    subroutine create_servers(this, servers, unusable, rc)
       class(MaplFramework), target, intent(inout) :: this
       type(ESMF_GridComp), allocatable, intent(out) :: servers(:)
@@ -378,10 +418,23 @@ contains
       integer :: ssiCount
       integer, allocatable :: ssiMap(:)
 
+      has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
+      if (.not. has_server_section) then
+         ! Simple path: default servers already created in initialize(); nothing to do.
+         allocate(servers(0))
+         _RETURN(_SUCCESS)
+      end if
+
+      ! Complex path: re-partition model_comm to the model-only PETs, add any
+      ! local: true servers from config, and build remote server GridComps.
       call this%get_vm_topology(ssiMap=ssiMap, ssiCount=ssiCount, world_comm=world_comm, _RC)
       model_petCount = get_model_petcount(this%mapl_vm, this%mapl_hconfig, _RC)
 
-      ! Always create the model communicator (both simple and complex paths).
+      ! Free the world-spanning model_comm set in initialize_default_servers and
+      ! replace it with the model-only partition.
+      if (this%model_comm /= MPI_COMM_NULL) then
+         call MPI_Comm_free(this%model_comm, _IERROR)
+      end if
       call MPI_Comm_group(world_comm, world_group, _IERROR)
       call MPI_Group_range_incl(world_group, 1, reshape([0, model_petCount-1, 1], [3,1]), model_group, _IERROR)
       call MPI_Comm_create_group(world_comm, model_group, 0, this%model_comm, _IERROR)
@@ -389,21 +442,13 @@ contains
       call MPI_Group_free(world_group, _IERROR)
       this%is_model_pet = (this%model_comm /= MPI_COMM_NULL)
 
-      ! Always initialize local servers on model PETs.
+      ! Add any local: true servers declared in the servers: section.
       if (this%is_model_pet) then
-         this%directory_service = DirectoryService(world_comm)
-         call this%initialize_local_servers(_RC)
+         call this%initialize_configured_local_servers(_RC)
       end if
 
-       has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
-       if (.not. has_server_section) then
-          ! Simple path: local default servers only, no ESMF GridComp servers.
-          allocate(servers(0))
-          _RETURN(_SUCCESS)
-       end if
-
-      ! Complex path: remote servers are additive on top of local servers.
-      call this%initialize_complex_servers(servers, world_comm, model_petCount, ssiCount, ssiMap, &
+      ! Build ESMF GridComps for remote (non-local) servers.
+      call this%initialize_non_default_servers(servers, world_comm, model_petCount, ssiCount, ssiMap, &
            is_model_pet=this%is_model_pet, _RC)
 
       _RETURN(_SUCCESS)
@@ -411,7 +456,7 @@ contains
    end subroutine create_servers
 
    ! Build MPI communicators and ESMF GridComps for an explicit servers: topology.
-   subroutine initialize_complex_servers(this, servers, world_comm, model_petCount, ssiCount, ssiMap, &
+   subroutine initialize_non_default_servers(this, servers, world_comm, model_petCount, ssiCount, ssiMap, &
         unusable, is_model_pet, rc)
       class(MaplFramework), target, intent(inout) :: this
       type(ESMF_GridComp), allocatable, intent(out) :: servers(:)
@@ -458,7 +503,7 @@ contains
       ! Populate only remote (non-local) servers
       i_server = 0
       do i_all = 1, size(server_hconfigs)
-         ! Skip local servers (already handled in initialize_local_servers)
+         ! Skip local servers (already handled in initialize_configured_local_servers)
          is_local = is_local_server(server_hconfigs(i_all), _RC)
          if (is_local) then
             cycle
@@ -480,74 +525,43 @@ contains
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)
-   end subroutine initialize_complex_servers
+   end subroutine initialize_non_default_servers
 
-    subroutine initialize_local_servers(this, unusable, rc)
-       class(MaplFramework), target, intent(inout) :: this
-       class(KeywordEnforcer), optional, intent(in) :: unusable
-       integer, optional, intent(out) :: rc
+   ! Initialize servers declared with local: true in the servers: config section.
+   ! Called from create_servers() when a servers: section is present.
+   ! The two default servers (MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER)
+   ! are NOT created here — they were already created in initialize_default_servers().
+   subroutine initialize_configured_local_servers(this, unusable, rc)
+      class(MaplFramework), target, intent(inout) :: this
+      class(KeywordEnforcer), optional, intent(in) :: unusable
+      integer, optional, intent(out) :: rc
 
-        integer :: status
-        logical :: has_server_section
-        type(ESMF_HConfig) :: servers_hconfig
-        type(ESMF_HConfig), allocatable :: server_hconfigs(:)
-        integer :: i_server
-        character(:), allocatable :: server_name
-        logical :: is_local
-        type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
+      integer :: status
+      type(ESMF_HConfig) :: servers_hconfig
+      character(:), allocatable :: server_name
+      logical :: is_local
+      type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
 
+      ! Iterate the servers: section and register any local: true entries.
+      servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
+      iter_begin = ESMF_HConfigIterBegin(servers_hconfig, _RC)
+      iter_end   = ESMF_HConfigIterEnd(servers_hconfig, _RC)
+      iter       = iter_begin
 
-        ! Check if servers: section exists
-        has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
-
-        if (has_server_section) then
-           ! Read servers: section and iterate to find local: true entries
-           servers_hconfig = ESMF_HConfigCreateAt(this%mapl_hconfig, keystring='servers', _RC)
-           iter_begin = ESMF_HConfigIterBegin(servers_hconfig, _RC)
-           iter_end = ESMF_HConfigIterEnd(servers_hconfig, _RC)
-           iter = iter_begin
-
-           do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
-              ! Get server name from the key
-              server_name = ESMF_HConfigAsStringMapKey(iter, _RC)
-              ! Check if this entry has local: true
-              is_local = ESMF_HConfigIsDefined(iter, keystring='local', _RC)
-              if (is_local) then
-                 is_local = ESMF_HConfigAsLogical(iter, keystring='local', _RC)
-              end if
-
-              if (is_local) then
-                 ! Create local server from hconfig
-                 call this%add_local_server(server_name, &
-                      make_client_name(server_name), &
-                      hconfig=iter, _RC)
-              end if
-           end do
-
-           call ESMF_HConfigDestroy(servers_hconfig, _RC)
-         else
-            ! Backward compatibility: no servers: section, use hardcoded defaults.
-            ! These connect default clients created above.
-             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: default path, calling add_local_server for INPUT'
-             flush(6)
-             call this%add_local_server(MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_INPUT_SERVER, _RC)
-             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: add_local_server INPUT returned'
-             flush(6)
-             call this%add_local_server(MAPL_DEFAULT_OUTPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-             write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: add_local_server OUTPUT returned'
-             flush(6)
+      do while (ESMF_HConfigIterLoop(iter, iter_begin, iter_end, rc=status))
+         server_name = ESMF_HConfigAsStringMapKey(iter, _RC)
+         is_local = ESMF_HConfigIsDefined(iter, keystring='local', _RC)
+         if (is_local) is_local = ESMF_HConfigAsLogical(iter, keystring='local', _RC)
+         if (is_local) then
+            call this%add_local_server(server_name, make_client_name(server_name), hconfig=iter, _RC)
          end if
+      end do
 
-        ! Initialize default or configured clients.
-        write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: calling initialize_clients'
-        flush(6)
-        call this%initialize_clients(_RC)
-        write(*,'(A)') '[MAPL_DEBUG] initialize_local_servers: initialize_clients returned'
-        flush(6)
+      call ESMF_HConfigDestroy(servers_hconfig, _RC)
 
-       _RETURN(_SUCCESS)
-       _UNUSED_DUMMY(unusable)
-    end subroutine initialize_local_servers
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(unusable)
+   end subroutine initialize_configured_local_servers
 
     ! Register one local server and connect its client.
     ! server_name: key used in local_server_map and DirectoryService port registry.
@@ -557,14 +571,13 @@ contains
     subroutine add_local_server(this, server_name, client_name, hconfig, rc)
        class(MaplFramework), target, intent(inout) :: this
        character(*), intent(in) :: server_name
-       character(*), intent(in) :: client_name
+       character(*), intent(in) :: client_name  ! reserved for future use (client registration)
        type(ESMF_HConfigIter), optional, intent(in) :: hconfig
        integer, optional, intent(out) :: rc
 
        integer :: status, alloc_stat
        class(BaseServer), allocatable :: tmp
        class(BaseServer), pointer :: srv
-       class(ClientThread), pointer :: client
        logical :: has_subclass
        character(:), allocatable :: subclass_name
 
@@ -577,41 +590,30 @@ contains
           end if
        end if
 
-        ! Allocate appropriate server subclass
-        select case (trim(subclass_name))
-        case ('MpiServer')
-            write(*,'(A)') '[MAPL_DEBUG] add_local_server: constructing MpiServer for "'//trim(server_name)//'"'
-           flush(6)
-           allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
-           write(*,'(A)') '[MAPL_DEBUG] add_local_server: MpiServer constructed for "'//trim(server_name)//'"'
-           flush(6)
-           _VERIFY(status)
-           _VERIFY(alloc_stat)
-        case ('MultiGroupServer')
-           ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
-           ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
-           allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
-                stat=alloc_stat)
-           _VERIFY(status)
-           _VERIFY(alloc_stat)
-        case default
-           _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
-        end select
+      ! Allocate appropriate server subclass.
+      select case (trim(subclass_name))
+      case ('MpiServer')
+         allocate(tmp, source=MpiServer(this%model_comm, server_name, rc=status), stat=alloc_stat)
+         _VERIFY(status)
+         _VERIFY(alloc_stat)
+      case ('MultiGroupServer')
+         ! MultiGroupServer needs model_comm but also needs nwriter_per_node from hconfig.
+         ! For now, default to 1 writer per node.  In the future, read from hconfig if provided.
+         allocate(tmp, source=MultiGroupServer(this%model_comm, server_name, nwriter_per_node=1, rc=status), &
+              stat=alloc_stat)
+         _VERIFY(status)
+         _VERIFY(alloc_stat)
+      case default
+         _ASSERT(.false., "Unknown server subclass: '"//trim(subclass_name)//"'")
+      end select
 
-         write(*,'(A)') '[MAPL_DEBUG] add_local_server: inserting "'//trim(server_name)//'" into local_server_map'
-         flush(6)
-         call this%local_server_map%insert(server_name, tmp)
-         srv => this%local_server_map%at(server_name)
-         write(*,'(A)') '[MAPL_DEBUG] add_local_server: calling directory_service%publish for "'//trim(server_name)//'"'
-         flush(6)
-         call this%directory_service%publish(PortInfo(server_name, srv), srv)
-         write(*,'(A)') '[MAPL_DEBUG] add_local_server: publish returned for "'//trim(server_name)//'"'
-         flush(6)
-!#       client => get_client(client_name, _RC)
-!#       call this%directory_service%connect_to_server(server_name, client)
+      call this%local_server_map%insert(server_name, tmp)
+      srv => this%local_server_map%at(server_name)
+      call this%directory_service%publish(PortInfo(server_name, srv), srv)
 
-       _RETURN(_SUCCESS)
-    end subroutine add_local_server
+      _RETURN(_SUCCESS)
+      _UNUSED_DUMMY(client_name)
+   end subroutine add_local_server
 
      ! Initialize configured clients from pfio_clients: section.
      ! Each client entry specifies:
@@ -633,32 +635,18 @@ contains
 
         has_client_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='pfio_clients', _RC)
          if (.not. has_client_section) then
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: default path (no pfio_clients section)'
-            flush(6)
             allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
             _VERIFY(status)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling add_client for "'//MAPL_DEFAULT_INPUT_SERVER//'"'
-            flush(6)
             call add_client(MAPL_DEFAULT_INPUT_SERVER, client, _RC)
             p_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling connect_to_server for "'//MAPL_DEFAULT_INPUT_SERVER//'"'
-            flush(6)
             call this%directory_service%connect_to_server(MAPL_DEFAULT_INPUT_SERVER, p_client)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: connect_to_server INPUT returned'
-            flush(6)
 
             deallocate(client)
             allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
             _VERIFY(status)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling add_client for "'//MAPL_DEFAULT_OUTPUT_SERVER//'"'
-            flush(6)
             call add_client(MAPL_DEFAULT_OUTPUT_SERVER, client, _RC)
             p_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: calling connect_to_server for "'//MAPL_DEFAULT_OUTPUT_SERVER//'"'
-            flush(6)
             call this%directory_service%connect_to_server(MAPL_DEFAULT_OUTPUT_SERVER, p_client)
-            write(*,'(A)') '[MAPL_DEBUG] initialize_clients: connect_to_server OUTPUT returned'
-            flush(6)
 
             _RETURN(_SUCCESS)
          end if

--- a/mapl/MaplFramework.F90
+++ b/mapl/MaplFramework.F90
@@ -490,8 +490,6 @@ contains
         logical :: is_local
         type(ESMF_HConfigIter) :: iter_begin, iter_end, iter
 
-        ! Initialize default or configured clients.
-        call this%initialize_clients(_RC)
 
         ! Check if servers: section exists
         has_server_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='servers', _RC)
@@ -527,6 +525,9 @@ contains
            call this%add_local_server('i_server', 'i_client', _RC)
            call this%add_local_server('o_server', 'o_client', _RC)
         end if
+
+        ! Initialize default or configured clients.
+        call this%initialize_clients(_RC)
 
        _RETURN(_SUCCESS)
        _UNUSED_DUMMY(unusable)
@@ -580,8 +581,8 @@ contains
        call this%local_server_map%insert(server_name, tmp)
        srv => this%local_server_map%at(server_name)
        call this%directory_service%publish(PortInfo(server_name, srv), srv)
-       client => get_client(client_name, _RC)
-       call this%directory_service%connect_to_server(server_name, client)
+!#       client => get_client(client_name, _RC)
+!#       call this%directory_service%connect_to_server(server_name, client)
 
        _RETURN(_SUCCESS)
     end subroutine add_local_server
@@ -602,17 +603,22 @@ contains
         character(:), allocatable :: client_name, server_name, subclass_name
         logical :: has_server, has_subclass
         class(ClientThread), allocatable :: client
+        class(ClientThread), pointer :: p_client
 
         has_client_section = ESMF_HConfigIsDefined(this%mapl_hconfig, keystring='pfio_clients', _RC)
         if (.not. has_client_section) then
            allocate(client, source=ClientThread(client_comm=this%model_comm, rc=status))
            _VERIFY(status)
            call add_client('i_client', client, _RC)
+           p_client => get_client('i_client', _RC)
+           call this%directory_service%connect_to_server('i_server', p_client)
 
            deallocate(client)
            allocate(client, source=FastClientThread(client_comm=this%model_comm, rc=status))
            _VERIFY(status)
            call add_client('o_client', client, _RC)
+           p_client => get_client('o_client', _RC)
+           call this%directory_service%connect_to_server('o_server', p_client)
 
            _RETURN(_SUCCESS)
         end if

--- a/mapl/MaplServerUtilities.F90
+++ b/mapl/MaplServerUtilities.F90
@@ -103,46 +103,71 @@ contains
       _RETURN(_SUCCESS)
    end function get_server_hconfigs
 
-   ! Resolve num_nodes for each server entry.  The last server may use the
-   ! wildcard value '*' to claim all remaining SSIs after model + prior servers.
-   ! ssiCount and num_model_ssis are required to resolve the wildcard.
-   !
-   ! Detection strategy: ESMF_HConfigAsString casts integer YAML nodes to string
-   ! without error, so reading as string first lets us check for '*' before
-   ! attempting an integer read — no spurious ESMF log warnings.
-   function get_ssis_per_server(server_hconfigs, ssiCount, num_model_ssis, rc) result(ssis_per_server)
-      integer, allocatable :: ssis_per_server(:)
-      type(ESMF_HConfig), intent(in) :: server_hconfigs(:)
-      integer, intent(in) :: ssiCount
-      integer, intent(in) :: num_model_ssis
-      integer, optional, intent(out) :: rc
+    ! Resolve num_nodes for each server entry.  The last server may use the
+    ! wildcard value '*' to claim all remaining SSIs after model + prior servers.
+    ! ssiCount and num_model_ssis are required to resolve the wildcard.
+    !
+    ! Local servers (local: true) consume zero SSIs and are skipped.
+    ! Remote servers must have num_nodes (either integer or '*' wildcard).
+    !
+    ! Detection strategy: ESMF_HConfigAsString casts integer YAML nodes to string
+    ! without error, so reading as string first lets us check for '*' before
+    ! attempting an integer read — no spurious ESMF log warnings.
+    function get_ssis_per_server(server_hconfigs, ssiCount, num_model_ssis, rc) result(ssis_per_server)
+       integer, allocatable :: ssis_per_server(:)
+       type(ESMF_HConfig), intent(in) :: server_hconfigs(:)
+       integer, intent(in) :: ssiCount
+       integer, intent(in) :: num_model_ssis
+       integer, optional, intent(out) :: rc
 
-      integer :: status
-      integer :: i_server
-      integer :: used_ssis
-      character(:), allocatable :: num_nodes_str
+       integer :: status
+       integer :: i_server
+       integer :: used_ssis
+       logical :: is_local, has_local
+       logical :: has_num_nodes
+       character(:), allocatable :: num_nodes_str
 
-      associate (n_servers => size(server_hconfigs))
-         allocate(ssis_per_server(n_servers))
-         used_ssis = num_model_ssis
-         do i_server = 1, n_servers
-            ! Read as string: ESMF casts integer YAML nodes to string without
-            ! complaint, so "2" and "*" both arrive cleanly.
-            num_nodes_str = ESMF_HConfigAsString(server_hconfigs(i_server), keystring='num_nodes', _RC)
-            if (num_nodes_str == '*') then
-               ! Wildcard: takes all remaining SSIs; only valid on the last server.
-               _ASSERT(i_server == n_servers, "'*' for num_nodes is only valid for the last server")
-               ssis_per_server(i_server) = ssiCount - used_ssis
-               _ASSERT(ssis_per_server(i_server) > 0, "PET resources oversubscribed: no SSIs remain for wildcard server")
-            else
-               ! Integer value — re-read as I4 (ESMF casts without complaint).
-               ssis_per_server(i_server) = ESMF_HConfigAsI4(server_hconfigs(i_server), keystring='num_nodes', _RC)
-               used_ssis = used_ssis + ssis_per_server(i_server)
-            end if
-         end do
-      end associate
-      _RETURN(_SUCCESS)
-   end function get_ssis_per_server
+       associate (n_servers => size(server_hconfigs))
+          allocate(ssis_per_server(n_servers))
+          used_ssis = num_model_ssis
+          do i_server = 1, n_servers
+             ! Check if this is a local server.
+             has_local = ESMF_HConfigIsDefined(server_hconfigs(i_server), keystring='local', _RC)
+
+             is_local = .false. ! unless
+             if (has_local) then
+                is_local = ESMF_HConfigAsLogical(server_hconfigs(i_server), keystring='local', _RC)
+             end if
+
+             if (is_local) then
+                ! Local servers consume zero extra SSIs.
+                ! Validation: local: true and num_nodes are mutually exclusive.
+                has_num_nodes = ESMF_HConfigIsDefined(server_hconfigs(i_server), keystring='num_nodes', _RC)
+                _ASSERT(.not. has_num_nodes, "Server entry cannot have both 'local: true' and 'num_nodes'")
+                ssis_per_server(i_server) = 0
+                cycle
+             end if
+
+             ! Remote server: must have num_nodes.
+             ! Read as string: ESMF casts integer YAML nodes to string without
+             ! complaint, so "2" and "*" both arrive cleanly.
+             num_nodes_str = ESMF_HConfigAsString(server_hconfigs(i_server), keystring='num_nodes', _RC)
+             if (num_nodes_str == '*') then
+                ! Wildcard: takes all remaining SSIs; only valid on the last server.
+                _ASSERT(i_server == n_servers, "'*' for num_nodes is only valid for the last server")
+                ssis_per_server(i_server) = ssiCount - used_ssis
+                _ASSERT(ssis_per_server(i_server) > 0, "PET resources oversubscribed: no SSIs remain for wildcard server")
+                cycle
+             end if
+
+             ! Integer value — re-read as I4 (ESMF casts without complaint).
+             ssis_per_server(i_server) = ESMF_HConfigAsI4(server_hconfigs(i_server), keystring='num_nodes', _RC)
+             used_ssis = used_ssis + ssis_per_server(i_server)
+
+          end do
+       end associate
+       _RETURN(_SUCCESS)
+    end function get_ssis_per_server
 
    ! Create the server and model+server MPI communicators for one server entry.
    ! Allocates and immediately frees the intermediate MPI groups.

--- a/pfio/API.F90
+++ b/pfio/API.F90
@@ -7,7 +7,8 @@ module mapl_pfio_api
   use pfio, only: mapl_ArrayReference => ArrayReference
   use pfio, only: operator(==), operator(/=)
 
-  use pfio, only: mapl_get_client_thread => get_client_thread
+  use pfio, only: mapl_get_client => get_client
+  use pfio, only: mapl_add_client => add_client
   use pfio, only: ClientThread
   use pfio, only: mapl_pfio_read => pfio_read
   use pfio, only: mapl_string_in_stringvector => string_in_stringvector
@@ -21,7 +22,7 @@ module mapl_pfio_api
   public :: mapl_StringVariableMapIterator
   public :: mapl_NetCDF4_FileFormatter
 
-  public :: mapl_get_client_thread
+  public :: mapl_get_client
   public :: ClientThread
   public :: mapl_pfio_read
   public :: mapl_ArrayReference

--- a/pfio/API.F90
+++ b/pfio/API.F90
@@ -5,6 +5,7 @@ module mapl_pfio_api
   use pfio, only: mapl_StringVariableMapIterator => StringVariableMapIterator
   use pfio, only: mapl_NetCDF4_FileFormatter => NetCDF4_FileFormatter
   use pfio, only: mapl_ArrayReference => ArrayReference
+  use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER
   use pfio, only: operator(==), operator(/=)
 
   use pfio, only: mapl_get_client => get_client
@@ -21,6 +22,8 @@ module mapl_pfio_api
   public :: mapl_StringVariableMap
   public :: mapl_StringVariableMapIterator
   public :: mapl_NetCDF4_FileFormatter
+  public :: MAPL_DEFAULT_INPUT_SERVER
+  public :: MAPL_DEFAULT_OUTPUT_SERVER
 
   public :: mapl_get_client
   public :: ClientThread

--- a/pfio/AbstractDirectoryService.F90
+++ b/pfio/AbstractDirectoryService.F90
@@ -13,7 +13,7 @@ module pFIO_AbstractDirectoryServiceMod
    public :: PortInfo
 
    integer,parameter :: MAX_NUM_PORTS = 16
-   integer,parameter :: MAX_LEN_PORT_NAME= 16
+   integer,parameter :: MAX_LEN_PORT_NAME= 64
 
    type :: PortInfo
      character(len=MAX_LEN_PORT_NAME) :: port_name

--- a/pfio/CMakeLists.txt
+++ b/pfio/CMakeLists.txt
@@ -27,6 +27,7 @@ set (srcs
   pFIO_Utilities.F90
   pFIO.F90
   API.F90
+  ServerNames.F90
 
   AbstractMessage.F90
   MessageVisitor.F90

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -10,51 +10,23 @@ module pFIO_ClientManagerMod
    implicit none
    private
 
-   public :: init_IO_ClientManager
-   public :: get_client_thread
-   public :: client_map
+   public :: add_client
+   public :: get_client
 
-   interface init_IO_ClientManager
-      module procedure init_ClientManager
-   end interface
-
-   type(StringClientThreadMap), target, protected :: client_map
+   type(StringClientThreadMap), target, private :: client_map
 
 contains
 
-   subroutine init_ClientManager(client_comm, unusable, fast_oclient, rc)
-      integer, intent(in) :: client_comm
-      class (KeywordEnforcer), optional, intent(out) :: unusable
-      logical, optional, intent(in) :: fast_oclient
+   subroutine add_client(name, client, rc)
+      character(*), intent(in) :: name
+      class(ClientThread), intent(in) :: client
       integer, optional, intent(out) :: rc
-      integer :: status
 
-      logical :: fast_
-      type(ClientThread) :: i_client
-      class(ClientThread), allocatable :: o_client
-
-      fast_ = .false.
-      if (present(fast_oclient)) fast_ = fast_oclient
-
-      client_map = StringClientThreadMap()
-
-      i_client = ClientThread(client_comm=client_comm, rc=status)
-      _VERIFY(status)
-      call client_map%insert('i_client', i_client)
-
-      if (fast_) then
-         allocate(o_client, source=FastClientThread(client_comm=client_comm, rc=status))
-      else
-         allocate(o_client, source=ClientThread(client_comm=client_comm, rc=status))
-      end if
-      _VERIFY(status)
-      call client_map%insert('o_client', o_client)
-
+      call client_map%insert(name, client)
       _RETURN(_SUCCESS)
-      _UNUSED_DUMMY(unusable)
-   end subroutine init_ClientManager
+   end subroutine add_client
 
-   function get_client_thread(name, rc) result(client)
+   function get_client(name, rc) result(client)
       character(len=*), intent(in) :: name
       integer, optional, intent(out) :: rc
       class(ClientThread), pointer :: client
@@ -62,6 +34,6 @@ contains
       client => client_map%at(name)
       _ASSERT(associated(client), "Client '"//name//"' not found in client manager")
       _RETURN(_SUCCESS)
-   end function get_client_thread
+   end function get_client
 
 end module pFIO_ClientManagerMod

--- a/pfio/ServerNames.F90
+++ b/pfio/ServerNames.F90
@@ -1,0 +1,7 @@
+module mapl_DefaultServerNames_mod
+   implicit none
+
+   character(*), parameter :: MAPL_DEFAULT_INPUT_SERVER  = 'mapl_default_input_server'
+   character(*), parameter :: MAPL_DEFAULT_OUTPUT_SERVER = 'mapl_default_output_server'
+
+end module mapl_DefaultServerNames_mod

--- a/superstructure/generic/RestartHandler.F90
+++ b/superstructure/generic/RestartHandler.F90
@@ -8,11 +8,12 @@ module mapl_RestartHandler_mod
    use mapl_GeomPFIO_mod, only: GeomPFIO
    use mapl_GeomCategorizer_mod, only: make_geom_pfio
    use mapl_FieldInfo_mod, only: FieldInfoGetInternal
-   use mapl_RestartModes_mod, only: RestartMode, operator(==), RESTART_SKIP
-   use mapl_state_api, only: MAPL_StateGet
-   use mapl_field_bundle_api, only: MAPL_FieldBundleFilter
-   use pFIO, only: PFIO_READ, FileMetaData, NetCDF4_FileFormatter
-   use pFIO, only: get_client, ClientThread
+    use mapl_RestartModes_mod, only: RestartMode, operator(==), RESTART_SKIP
+    use mapl_state_api, only: MAPL_StateGet
+    use mapl_field_bundle_api, only: MAPL_FieldBundleFilter
+    use mapl_DefaultServerNames_mod, only: MAPL_DEFAULT_INPUT_SERVER, MAPL_DEFAULT_OUTPUT_SERVER
+    use pFIO, only: PFIO_READ, FileMetaData, NetCDF4_FileFormatter
+    use pFIO, only: get_client, ClientThread
    use pFlogger, only: logging, logger
 
    implicit none(type,external)
@@ -114,7 +115,7 @@ contains
       call writer%update_time_on_server(this%current_time, _RC)
       ! TODO: no-op if bundle is empty, or should we skip empty bundles?
       call writer%stage_data_to_file(bundle, filename, 1, _RC)
-      o_client => get_client('o_client', _RC)
+       o_client => get_client(MAPL_DEFAULT_OUTPUT_SERVER, _RC)
       call o_client%done_collective_stage()
       call o_client%post_wait_all()
 
@@ -139,7 +140,7 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(filename, this%gridcomp_geom, _RC)
       call reader%request_data_from_file(filename, bundle, _RC)
-      i_client => get_client('i_client', _RC)
+       i_client => get_client(MAPL_DEFAULT_INPUT_SERVER, _RC)
       call i_client%done_collective_prefetch()
       call i_client%wait_all()
 

--- a/superstructure/generic/RestartHandler.F90
+++ b/superstructure/generic/RestartHandler.F90
@@ -12,7 +12,7 @@ module mapl_RestartHandler_mod
    use mapl_state_api, only: MAPL_StateGet
    use mapl_field_bundle_api, only: MAPL_FieldBundleFilter
    use pFIO, only: PFIO_READ, FileMetaData, NetCDF4_FileFormatter
-   use pFIO, only: get_client_thread, ClientThread
+   use pFIO, only: get_client, ClientThread
    use pFlogger, only: logging, logger
 
    implicit none(type,external)
@@ -114,7 +114,7 @@ contains
       call writer%update_time_on_server(this%current_time, _RC)
       ! TODO: no-op if bundle is empty, or should we skip empty bundles?
       call writer%stage_data_to_file(bundle, filename, 1, _RC)
-      o_client => get_client_thread('o_client', _RC)
+      o_client => get_client('o_client', _RC)
       call o_client%done_collective_stage()
       call o_client%post_wait_all()
 
@@ -139,7 +139,7 @@ contains
       allocate(reader, source=make_geom_pfio(metadata), _STAT)
       call reader%initialize(filename, this%gridcomp_geom, _RC)
       call reader%request_data_from_file(filename, bundle, _RC)
-      i_client => get_client_thread('i_client', _RC)
+      i_client => get_client('i_client', _RC)
       call i_client%done_collective_prefetch()
       call i_client%wait_all()
 


### PR DESCRIPTION
## Types of change(s)
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`ctest`)

## Description

Introduces named constants `MAPL_DEFAULT_INPUT_SERVER` and `MAPL_DEFAULT_OUTPUT_SERVER`
in a new module `mapl_DefaultServerNames_mod` (exported via `pfio/API.F90`).
All hardcoded `'i_client'`/`'o_client'`/`'i_server'`/`'o_server'` string literals
are replaced with these constants throughout the codebase.

Also fixes a latent bug: `MAX_LEN_PORT_NAME` was 16, causing silent truncation of port
names longer than 16 characters, which caused `connect_to_server` to miss the local-port
fast path and deadlock in MPI remote discovery. Increased to 64.

## Related Issue

Fixes #5242