### PR TITLE
fixes #5270

### DIFF
--- a/gridcomps/extdata/tests/CMakeLists.txt
+++ b/gridcomps/extdata/tests/CMakeLists.txt
@@ -1,10 +1,21 @@
 set(MODULE_DIRECTORY "${esma_include}/MAPL.extdata.tests")
 
+# For known sites, set LOCAL_REGRESSION_DATA_DIR automatically if not already set
+if (${GEOS_SITE} MATCHES "NCCS")
+  if (NOT DEFINED ENV{LOCAL_REGRESSION_DATA_DIR})
+    set(ENV{LOCAL_REGRESSION_DATA_DIR} "/discover/nobackup/bmauer/test-data")
+  endif ()
+elseif (${GEOS_SITE} MATCHES "GMAO.desktop")
+  if (NOT DEFINED ENV{LOCAL_REGRESSION_DATA_DIR})
+    set(ENV{LOCAL_REGRESSION_DATA_DIR} "/home/bmauer/test-data")
+  endif ()
+endif ()
+
 set (test_srcs
   Test_ExtDataNodeBracket.pf
   )
 
-if (${GEOS_SITE} MATCHES "NCCS" OR ${GEOS_SITE} MATCHES "GMAO.desktop") 
+if (DEFINED ENV{LOCAL_REGRESSION_DATA_DIR} AND IS_DIRECTORY "$ENV{LOCAL_REGRESSION_DATA_DIR}")
   list(APPEND test_srcs Test_NonClimDataSetFileSelector.pf)
   list(APPEND test_srcs Test_DataSetNode.pf)
 endif ()


### PR DESCRIPTION
This fits is #5270 
This way people won't have to set the environment variable themselves
Seems to trivial to bother with changelog
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

