### PR TITLE
Fixes #5261

### DIFF
--- a/gridcomps/extdata/ExtDataConfig.F90
+++ b/gridcomps/extdata/ExtDataConfig.F90
@@ -464,12 +464,12 @@ contains
          collection => this%file_stream_map%at(export_rule%collection)
          _ASSERT(associated(collection), 'invalid collection key for '//trim(base_name))
       end if
-      if (export_rule%sample_key == SAMPLE_NOT_PROVDED) then
+      if (export_rule%sample_key == SAMPLE_NOT_PROVIDED) then
          call default_sample%set_defaults()
          sample => default_sample
       else
          sample => this%sample_map%at(export_rule%sample_key)
-         _ASSERT(associated(sample), 'invalid sample key for '//trim(base-name))
+         _ASSERT(associated(sample), 'invalid sample key for '//trim(base_name))
       end if
       call this%get_time_range(full_name, base_name, time_range, _RC)
       export = PrimaryExport(base_name, export_rule, collection, sample, time_range, time_step, _RC)

--- a/gridcomps/extdata/ExtDataConfig.F90
+++ b/gridcomps/extdata/ExtDataConfig.F90
@@ -460,13 +460,16 @@ contains
 
       export_rule => this%rule_map%at(full_name)
       collection => null()
-      sample => this%sample_map%at(export_rule%sample_key)
       if (export_rule%collection /= "/dev/null") then
          collection => this%file_stream_map%at(export_rule%collection)
+         _ASSERT(associated(collection), 'invalid collection key for '//trim(base_name))
       end if
-      if (.not. associated(sample)) then
+      if (export_rule%sample_key == SAMPLE_NOT_PROVDED) then
          call default_sample%set_defaults()
          sample => default_sample
+      else
+         sample => this%sample_map%at(export_rule%sample_key)
+         _ASSERT(associated(sample), 'invalid sample key for '//trim(base-name))
       end if
       call this%get_time_range(full_name, base_name, time_range, _RC)
       export = PrimaryExport(base_name, export_rule, collection, sample, time_range, time_step, _RC)

--- a/gridcomps/extdata/ExtDataConstants.F90
+++ b/gridcomps/extdata/ExtDataConstants.F90
@@ -8,5 +8,6 @@ private
   integer, parameter, public    :: PRIMARY_TYPE_VECTOR_COMP2 = 3
   integer, parameter, public    :: DERIVED_TYPE      = 4
   character(len=14), parameter, public :: FILE_NOT_FOUND = "file_not_found"
+  character(len=19), parameter, public :: SAMPLE_NOT_PROVIDED = "sample_not_provided"
 
 end module mapl_ExtDataConstants_mod

--- a/gridcomps/extdata/ExtDataRule.F90
+++ b/gridcomps/extdata/ExtDataRule.F90
@@ -14,7 +14,7 @@ module mapl_ExtDataRule_mod
       character(:), allocatable :: collection
       !character(:), allocatable :: file_var
       type(StringVector) :: file_vars
-      character(:), allocatable :: sample_key = SAMPLE_NOT_PROVIDED
+      character(:), allocatable :: sample_key
       real, allocatable :: linear_trans(:)
       character(:), allocatable :: regrid_method
       character(:), allocatable :: vector_partner
@@ -57,6 +57,7 @@ contains
          usable_multi_rule = .false.
       end if
 
+      rule%sample_key = SAMPLE_NOT_PROVIDED
       if (allocated(tempc)) deallocate(tempc)
       collection_present = ESMF_HConfigIsDefined(config,keyString="collection")
       _ASSERT(collection_present,"no collection present in ExtData export")

--- a/gridcomps/extdata/ExtDataRule.F90
+++ b/gridcomps/extdata/ExtDataRule.F90
@@ -4,6 +4,7 @@ module mapl_ExtDataRule_mod
    use MAPL
    use mapl_ExtDataSample_mod
    use mapl_ExtDataSampleMap_mod
+   use mapl_ExtDataConstants_mod
    use gFTL2_StringVector
    implicit none
    private
@@ -13,7 +14,7 @@ module mapl_ExtDataRule_mod
       character(:), allocatable :: collection
       !character(:), allocatable :: file_var
       type(StringVector) :: file_vars
-      character(:), allocatable :: sample_key
+      character(:), allocatable :: sample_key = SAMPLE_NOT_PROVIDED
       real, allocatable :: linear_trans(:)
       character(:), allocatable :: regrid_method
       character(:), allocatable :: vector_partner

--- a/gridcomps/extdata/ExtDataRule.F90
+++ b/gridcomps/extdata/ExtDataRule.F90
@@ -12,7 +12,6 @@ module mapl_ExtDataRule_mod
    type, public :: ExtDataRule
       type(ESMF_Time), allocatable :: start_time
       character(:), allocatable :: collection
-      !character(:), allocatable :: file_var
       type(StringVector) :: file_vars
       character(:), allocatable :: sample_key
       real, allocatable :: linear_trans(:)

--- a/gridcomps/extdata/ExtDataRule.F90
+++ b/gridcomps/extdata/ExtDataRule.F90
@@ -57,7 +57,6 @@ contains
          usable_multi_rule = .false.
       end if
 
-      rule%sample_key = SAMPLE_NOT_PROVIDED
       if (allocated(tempc)) deallocate(tempc)
       collection_present = ESMF_HConfigIsDefined(config,keyString="collection")
       _ASSERT(collection_present,"no collection present in ExtData export")
@@ -86,7 +85,7 @@ contains
             rule%sample_key=ESMF_HConfigAsString(config1,_RC)
          end if
       else
-         rule%sample_key = ""
+         rule%sample_key = SAMPLE_NOT_PROVIDED
       end if
 
       if (allocated(rule%linear_trans)) deallocate(rule%linear_trans)


### PR DESCRIPTION
Just a small PR to add a protection is a user specifies an non-existent sampling definition with a useful error rather than continuing on, same change was made in MAPL2
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

