### PR TITLE
v2: Improve MAPL2 Spack library support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Only look for FMS via `find_package` when `FV_PRECISION` is defined, so projects like MAPL that don't use FMS no longer require it
     - Enforce a minimum ESMF version for Baselibs builds (previously only enforced for Spack/non-Baselibs builds)
     - Added an `ESMA_ESMF_MIN_VERSION` variable, settable before `include(esma)`, to control the minimum ESMF version enforced for both Baselibs and Spack builds (defaults to `8.6.1`)
+    - Suppress compiler `-save-temps` in Debug builds generated with Ninja to prevent parallel compile collisions for shared source basenames
+    - Keep ESMF wrapper link options in `INTERFACE_LINK_OPTIONS` rather than treating them as libraries in `FindESMF.cmake`
+    - Added `copy_restarts()` helper function to `esma_regression_run_helpers.cmake` for regression test restart handling
+    - Update GitHub Actions workflow dependencies (`actions/checkout`, `actions/upload-artifact`) to current major versions
   - ESMA_cmake v4.42.0
     - Fix CMake 4.0 `CMP0219` policy warning in `esma_generate_gocart_code` macro
     - Fix `f2py` and `f2py3` NetCDF-Fortran builds and post-build Python import tests when dependencies are supplied by Spack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the manual `find_package(MPI)`/`find_package(NetCDF)`/`find_package(HDF5)`/`find_package(ESMF)` block (and the Baselibs-only ESMF version guard) from the top-level `CMakeLists.txt`. As of ESMA_cmake v4.43.0, `esma.cmake` automatically `include()`s `ConfigureBaselibs.cmake` or `ConfigureExternalLibraries.cmake` based on `Baselibs_FOUND` right after `include(FindBaselibs)`, creating all of these dependency targets for us, including enforcing a minimum ESMF version of 8.6.1 for both Baselibs and Spack/non-Baselibs builds
+- Update `components.yaml`
+  - ESMA_cmake v4.43.0
+    - Split dependency-target creation (NetCDF, HDF5, ESMF, FMS, etc.) out of `FindBaselibs.cmake` into `ConfigureBaselibs.cmake` and `ConfigureExternalLibraries.cmake`; `esma.cmake` now `include()`s the appropriate one automatically based on `Baselibs_FOUND`
+    - Guard the historical `ZLIB::zlib` alias creation with `if(NOT TARGET ZLIB::zlib)`
+    - Only look for FMS via `find_package` when `FV_PRECISION` is defined, so projects like MAPL that don't use FMS no longer require it
+    - Enforce a minimum ESMF version for Baselibs builds (previously only enforced for Spack/non-Baselibs builds)
+    - Added an `ESMA_ESMF_MIN_VERSION` variable, settable before `include(esma)`, to control the minimum ESMF version enforced for both Baselibs and Spack builds (defaults to `8.6.1`)
+  - ESMA_cmake v4.42.0
+    - Fix CMake 4.0 `CMP0219` policy warning in `esma_generate_gocart_code` macro
+    - Fix `f2py` and `f2py3` NetCDF-Fortran builds and post-build Python import tests when dependencies are supplied by Spack
+  - ESMA_cmake v4.41.0
+    - Add new `esma_install_manifest.cmake` to create a manifest of installed files
+    - Added `esma_add_regression_tests()` macro to centralise the CMake boilerplate for registering GEOS component regression tests
+    - Added `esma_sync_aws_s3_data.cmake` and `esma_regression_run_helpers.cmake` to support S3-based regression test data
+    - Switch macOS RPATH in `osx_extras.cmake` from absolute to relative (`@loader_path/../lib`) so experiment-local install trees resolve GEOS/MAPL shared libraries correctly
+
 ### Removed
 
 ### Deprecated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,34 +141,6 @@ endif ()
 
 ecbuild_declare_project()
 
-if (NOT Baselibs_FOUND)
-  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-  find_package(MPI)
-
-  find_package(NetCDF REQUIRED C Fortran)
-  add_definitions(-DHAS_NETCDF4)
-  add_definitions(-DHAS_NETCDF3)
-  add_definitions(-DNETCDF_NEED_NF_MPIIO)
-  add_definitions(-DHAS_NETCDF3)
-
-  find_package(HDF5 REQUIRED)
-  if(HDF5_IS_PARALLEL)
-     add_definitions(-DH5_HAVE_PARALLEL)
-  endif()
-
-  if (NOT TARGET ESMF::ESMF)
-    find_package(ESMF 8.6.1 MODULE REQUIRED)
-    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
-  endif ()
-else ()
-  # This is an ESMF version test when using Baselibs which doesn't use the
-  # same find_package internally in ESMA_cmake as used above (with a version
-  # number) so this lets us at least trap use of old Baselibs here.
-  if (ESMF_VERSION VERSION_LESS 8.6.1)
-    message(FATAL_ERROR "ESMF must be at least 8.6.1")
-  endif ()
-endif ()
-
 # We wish to add extra flags when compiling as Debug. We should only
 # do this if we are using esma_cmake since the flags are defined
 # there. Note that some flags like STANDARD_F18 might be available on

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: v4.40.0
+  tag: feature/v4-external-libs
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ ESMA_env:
 ESMA_cmake:
   local: ./ESMA_cmake
   remote: ../ESMA_cmake.git
-  tag: feature/v4-external-libs
+  tag: v4.43.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [x] Refactor (no functional changes, no API changes)

## Checklist
- [x] Tested this change with a Spack-provided library stack
- [x] Ran the relevant build and test suite

## Description

Updates MAPL2 to use ESMA_cmake's centralized dependency configuration for MPI, NetCDF, HDF5, and ESMF. This removes duplicated top-level setup while enforcing the ESMF 8.6.1 minimum consistently for Baselibs and external/Spack builds.

Updates the ESMA_cmake component to v4.43.0 to include external-library support and related configuration fixes.

