### PR TITLE
Improve connection assertion messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved `SimpleConnection` assertion messages for unknown virtual connection points
 - Fixed bug in FieldBundleRead when file grid and output bundle grid are different grid classes
 - Buggy logic in server initialization (#5214)
 - Missing call to initialize error handling in MPI context

--- a/superstructure/generic/connection/SimpleConnection.F90
+++ b/superstructure/generic/connection/SimpleConnection.F90
@@ -77,6 +77,7 @@ contains
       type(StateItemSpecPtr), target, allocatable :: src_extensions(:), dst_extensions(:)
       type(StateItemSpec), pointer :: src_extension, dst_extension
       type(StateItemSpec), pointer :: spec
+      character(:), allocatable :: error_message
       integer :: i
       integer :: status
 
@@ -89,9 +90,13 @@ contains
       _ASSERT(associated(src_registry), 'Unknown source registry')
       _ASSERT(associated(dst_registry), 'Unknown destination registry')
 
-      _ASSERT(dst_registry%has_virtual_pt(dst_pt%v_pt), "connection to unknown src_pt")
+      error_message = "Unknown destination v_pt '" // dst_pt%v_pt%get_full_name() // &
+           "' for component '" // dst_pt%component_name // "'"
+      _ASSERT(dst_registry%has_virtual_pt(dst_pt%v_pt), error_message)
       dst_extensions = dst_registry%get_specs(dst_pt%v_pt, _RC)
-      _ASSERT(src_registry%has_virtual_pt(src_pt%v_pt), "connection to unknown src_pt")
+      error_message = "Unknown source v_pt '" // src_pt%v_pt%get_full_name() // &
+           "' for component '" // src_pt%component_name // "'"
+      _ASSERT(src_registry%has_virtual_pt(src_pt%v_pt), error_message)
       src_extensions = src_registry%get_specs(src_pt%v_pt, _RC)
 
       do i = 1, size(dst_extensions)
@@ -220,4 +225,3 @@ contains
    end subroutine activate_dependencies
 
 end module mapl_SimpleConnection_mod
-


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests` or `ctest`)

## Description
Report source or destination, component name, and virtual point full name when `SimpleConnection` activation cannot find a virtual connection point. Keep `_ASSERT` invocations on one physical line for gfortran preprocessing compatibility.

Static checks: `git diff --check`; Fortran line-length check. No configured build tree was available.

## Related Issue

Fixes #5291