### PR TITLE
Make updating cap_restart optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `update_restart` in `Cap.F90` now supports a `skip_restart_write` boolean flag in the
+  `ESMF_HConfig`. When present and `true`, the routine returns immediately without writing
+  the restart file. Default behavior (key absent or `false`) is unchanged.
+
 - `Regrid_Util.x` now has the option to be drive via a yaml file passed on the command line rather than
    a whole list of command line arguments.
 - Modified ExtData tests to get path to test data from environment variable `LOCAL_REGRESSION_DATA_DIR`

--- a/mapl/Cap.F90
+++ b/mapl/Cap.F90
@@ -684,7 +684,7 @@ contains
       skip_key_exists = ESMF_HConfigIsDefined(hconfig, keyString='skip_restart_write', _RC)
       if (skip_key_exists) then
          skip_restart_write = ESMF_HConfigAsLogical(hconfig, keyString='skip_restart_write', _RC)
-         if (skip_restart_write) _RETURN(_SUCCESS)
+         _RETURN_IF(skip_restart_write)
       end if
 
       call ESMF_ClockGet(clock, currTime=currTime, repeatCount=repeatCount, _RC)

--- a/mapl/Cap.F90
+++ b/mapl/Cap.F90
@@ -674,10 +674,18 @@ contains
       type(ESMF_Time) :: currTime
       integer(kind=ESMF_KIND_I8) :: repeatCount
       logical :: restart_is_defined
+      logical :: skip_key_exists
+      logical :: skip_restart_write
       character(:), allocatable :: cap_restart_file
       type(ESMF_HConfig) :: restart_cfg
       integer, parameter :: ISOSTRING_LENGTH = 20
       character(len=ISOSTRING_LENGTH) :: timeString
+
+      skip_key_exists = ESMF_HConfigIsDefined(hconfig, keyString='skip_restart_write', _RC)
+      if (skip_key_exists) then
+         skip_restart_write = ESMF_HConfigAsLogical(hconfig, keyString='skip_restart_write', _RC)
+         if (skip_restart_write) _RETURN(_SUCCESS)
+      end if
 
       call ESMF_ClockGet(clock, currTime=currTime, repeatCount=repeatCount, _RC)
       call ESMF_TimeGet(currTime, timeString=timeString, _RC)


### PR DESCRIPTION
Fixes #5293 

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

