### PR TITLE
Add dso/setServices info to yaml files of child GridComps

### DIFF
--- a/gridcomps/cap/tests/parent_child_captest/AGCM.yaml
+++ b/gridcomps/cap/tests/parent_child_captest/AGCM.yaml
@@ -25,3 +25,7 @@ mapl:
     vertical_grid:
       class: basic
       num_levels: 4
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/gridcomps/cap/tests/write_restart/AGCM.yaml
+++ b/gridcomps/cap/tests/write_restart/AGCM.yaml
@@ -45,3 +45,7 @@ mapl:
     vertical_grid:
       class: basic
       num_levels: 4
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/gridcomps/configurable/tests/scenarios/scenario_1/child_A.yaml
+++ b/gridcomps/configurable/tests/scenarios/scenario_1/child_A.yaml
@@ -27,3 +27,7 @@ mapl:
       dst_name: Z_A1
       dst_comp: <self>
       dst_intent: export
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/gridcomps/configurable/tests/scenarios/scenario_1/child_B.yaml
+++ b/gridcomps/configurable/tests/scenarios/scenario_1/child_B.yaml
@@ -18,3 +18,7 @@ mapl:
         standard_name: 'Z_B1 standard name'
         units: 'm'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/3d_specs/A.yaml
+++ b/superstructure/generic/tests/scenarios/3d_specs/A.yaml
@@ -20,3 +20,7 @@ mapl:
         typekind: R4
         fill_value: 3.
         vertical_dim_spec: 'vertical_dim_center'
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/3d_specs/B.yaml
+++ b/superstructure/generic/tests/scenarios/3d_specs/B.yaml
@@ -21,3 +21,7 @@ mapl:
         typekind: R4
         fill_value: 2. # expected to change
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/export_dependency/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/export_dependency/child_A.yaml
@@ -13,3 +13,7 @@ mapl:
         units: 'km'
         fill_value: 1
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/export_dependency/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/export_dependency/child_B.yaml
@@ -5,3 +5,7 @@ mapl:
         standard_name: 'I1'
         units: 'm'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/expression/A.yaml
+++ b/superstructure/generic/tests/scenarios/expression/A.yaml
@@ -24,3 +24,7 @@ mapl:
 
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/expression/B.yaml
+++ b/superstructure/generic/tests/scenarios/expression/B.yaml
@@ -9,3 +9,7 @@ mapl:
     export: {}
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/expression_defer_geom/A.yaml
+++ b/superstructure/generic/tests/scenarios/expression_defer_geom/A.yaml
@@ -45,3 +45,7 @@ mapl:
         geometry: *file_geom
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/expression_defer_geom/B.yaml
+++ b/superstructure/generic/tests/scenarios/expression_defer_geom/B.yaml
@@ -22,3 +22,7 @@ mapl:
     export: {}
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/expression_defer_geom/C.yaml
+++ b/superstructure/generic/tests/scenarios/expression_defer_geom/C.yaml
@@ -21,3 +21,7 @@ mapl:
     export: {}
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/extdata_1/collection_1.yaml
+++ b/superstructure/generic/tests/scenarios/extdata_1/collection_1.yaml
@@ -13,3 +13,7 @@ mapl:
         typekind: R4
         fill_value: 1
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/extdata_1/extdata.yaml
+++ b/superstructure/generic/tests/scenarios/extdata_1/extdata.yaml
@@ -30,3 +30,7 @@ mapl:
     collection_1:
       dso: libconfigurable_gridcomp
       config_file: scenarios/extdata_1/collection_1.yaml
+
+  setServices:
+    sharedObj: libproto_extdata_gc
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/extdata_1/root.yaml
+++ b/superstructure/generic/tests/scenarios/extdata_1/root.yaml
@@ -23,3 +23,7 @@ mapl:
         units: 'none'
         typekind: R4
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/A.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/A.yaml
@@ -12,3 +12,7 @@ mapl:
         units: ''
         fill_value: 1.
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/B.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/B.yaml
@@ -17,3 +17,7 @@ mapl:
         units: 'm'
         fill_value: 17.
         vertical_dim_spec: CENTER
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/collection_1.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/collection_1.yaml
@@ -23,3 +23,7 @@ mapl:
       B/E_B3:
         typekind: mirror
         vertical_dim_spec: MIRROR
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/history.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/history.yaml
@@ -8,3 +8,7 @@ mapl:
       config_file: scenarios/history_1/mirror_geom_collection.yaml
 
   states: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/mirror_geom_collection.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/mirror_geom_collection.yaml
@@ -14,3 +14,7 @@ mapl:
       B/E_B3:
         typekind: mirror
         vertical_dim_spec: MIRROR
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_1/root.yaml
+++ b/superstructure/generic/tests/scenarios/history_1/root.yaml
@@ -22,3 +22,7 @@ mapl:
 
   states:
     import: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_wildcard/A.yaml
+++ b/superstructure/generic/tests/scenarios/history_wildcard/A.yaml
@@ -17,3 +17,7 @@ mapl:
         units: 'm'
         fill_value: 1
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_wildcard/B.yaml
+++ b/superstructure/generic/tests/scenarios/history_wildcard/B.yaml
@@ -12,3 +12,7 @@ mapl:
         units: 'm'
         fill_value: 1
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_wildcard/collection_1.yaml
+++ b/superstructure/generic/tests/scenarios/history_wildcard/collection_1.yaml
@@ -8,3 +8,7 @@ mapl:
         standard_name: 'huh1'
         units: 'm'
         vertical_dim_spec: MIRROR
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_wildcard/history.yaml
+++ b/superstructure/generic/tests/scenarios/history_wildcard/history.yaml
@@ -5,3 +5,7 @@ mapl:
       config_file: scenarios/history_wildcard/collection_1.yaml
 
   states: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/history_wildcard/root.yaml
+++ b/superstructure/generic/tests/scenarios/history_wildcard/root.yaml
@@ -10,3 +10,7 @@ mapl:
 
   states:
     import: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/invalidate/A.yaml
+++ b/superstructure/generic/tests/scenarios/invalidate/A.yaml
@@ -23,3 +23,7 @@ mapl:
         units: 'km'
         vertical_dim_spec: NONE
         typekind: R4
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/invalidate/B.yaml
+++ b/superstructure/generic/tests/scenarios/invalidate/B.yaml
@@ -20,3 +20,7 @@ mapl:
         units: 'm'
         vertical_dim_spec: NONE
         typekind: R8
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/precision_extension/A.yaml
+++ b/superstructure/generic/tests/scenarios/precision_extension/A.yaml
@@ -20,3 +20,7 @@ mapl:
         typekind: R8
         fill_value: 3.
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/precision_extension/B.yaml
+++ b/superstructure/generic/tests/scenarios/precision_extension/B.yaml
@@ -22,3 +22,7 @@ mapl:
         typekind: R4
         fill_value: 2. # expected to change
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/precision_extension_3d/A.yaml
+++ b/superstructure/generic/tests/scenarios/precision_extension_3d/A.yaml
@@ -20,3 +20,7 @@ mapl:
         typekind: R8
         fill_value: 3.
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/precision_extension_3d/B.yaml
+++ b/superstructure/generic/tests/scenarios/precision_extension_3d/B.yaml
@@ -21,3 +21,7 @@ mapl:
         typekind: R8
         fill_value: 2. # expected to change
         vertical_dim_spec: none
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/propagate_geom/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/propagate_geom/child_A.yaml
@@ -39,3 +39,7 @@ mapl:
       dst_name: Z_A1
       dst_comp: <self>
       dst_intent: export
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/propagate_geom/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/propagate_geom/child_B.yaml
@@ -20,3 +20,7 @@ mapl:
         standard_name: 'Z_B1 standard name'
         units: 'm'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/regrid/A.yaml
+++ b/superstructure/generic/tests/scenarios/regrid/A.yaml
@@ -20,3 +20,7 @@ mapl:
         standard_name: 'name'
         units: 'barn'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/regrid/B.yaml
+++ b/superstructure/generic/tests/scenarios/regrid/B.yaml
@@ -19,3 +19,7 @@ mapl:
         standard_name: 'name'
         units: 'barn'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/regrid_r8/A.yaml
+++ b/superstructure/generic/tests/scenarios/regrid_r8/A.yaml
@@ -21,3 +21,7 @@ mapl:
         units: 'barn'
         typekind: R8
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/regrid_r8/B.yaml
+++ b/superstructure/generic/tests/scenarios/regrid_r8/B.yaml
@@ -20,3 +20,7 @@ mapl:
         units: 'barn'
         typekind: R4
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_1/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_1/child_A.yaml
@@ -27,3 +27,7 @@ mapl:
       dst_name: Z_A1
       dst_comp: <self>
       dst_intent: export
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_1/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_1/child_B.yaml
@@ -18,3 +18,7 @@ mapl:
         standard_name: 'Z_B1 standard name'
         units: 'm'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_2/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_2/child_A.yaml
@@ -27,3 +27,7 @@ mapl:
       dst_name: ZZ_A1
       dst_comp: <self>
       dst_intent: export
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_2/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_2/child_B.yaml
@@ -18,3 +18,7 @@ mapl:
         standard_name: 'Z_B1 standard name'
         units: '1'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_reexport_twice/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_reexport_twice/child_A.yaml
@@ -30,3 +30,7 @@ mapl:
         standard_name: 'Z_A1 standard name'
         units: '1'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_reexport_twice/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_reexport_twice/child_B.yaml
@@ -29,3 +29,7 @@ mapl:
         standard_name: 'Z_B1 standard name'
         units: '1'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/scenario_reexport_twice/parent.yaml
+++ b/superstructure/generic/tests/scenarios/scenario_reexport_twice/parent.yaml
@@ -17,3 +17,7 @@ mapl:
       src_comp: child_B
       dst_comp: <self>
       dst_intent: export
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_service/provider.yaml
+++ b/superstructure/generic/tests/scenarios/service_service/provider.yaml
@@ -7,3 +7,7 @@ mapl:
         class: service
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_service/subscriber_A.yaml
+++ b/superstructure/generic/tests/scenarios/service_service/subscriber_A.yaml
@@ -16,3 +16,7 @@ mapl:
         items: [Z_A1, Z_A2]
 
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_service/subscriber_B.yaml
+++ b/superstructure/generic/tests/scenarios/service_service/subscriber_B.yaml
@@ -12,3 +12,7 @@ mapl:
         items: [W]
 
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_geom/provider.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_geom/provider.yaml
@@ -21,3 +21,7 @@ mapl:
 
     internal: {}
 
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_geom/subscriber_A.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_geom/subscriber_A.yaml
@@ -17,3 +17,7 @@ mapl:
 
     export: {}
 
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_geom/subscriber_B.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_geom/subscriber_B.yaml
@@ -25,3 +25,7 @@ mapl:
 
     export: {}
 
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_options/provider_a.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_options/provider_a.yaml
@@ -7,3 +7,7 @@ mapl:
         class: service
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_options/provider_b.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_options/provider_b.yaml
@@ -7,3 +7,7 @@ mapl:
         class: service
 
     internal: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_options/subscriber_A.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_options/subscriber_A.yaml
@@ -16,3 +16,7 @@ mapl:
         items: [Z_A1, Z_A2]
 
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/service_with_options/subscriber_B.yaml
+++ b/superstructure/generic/tests/scenarios/service_with_options/subscriber_B.yaml
@@ -12,3 +12,7 @@ mapl:
         items: [W]
 
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics/A.yaml
+++ b/superstructure/generic/tests/scenarios/statistics/A.yaml
@@ -6,3 +6,7 @@ mapl:
         standard_name: 'Temperature'
         units: 'K'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics/collection_1.yaml
+++ b/superstructure/generic/tests/scenarios/statistics/collection_1.yaml
@@ -5,3 +5,7 @@ mapl:
         vertical_dim_spec: MIRROR
       avg_T:
         vertical_dim_spec: MIRROR
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics/history.yaml
+++ b/superstructure/generic/tests/scenarios/statistics/history.yaml
@@ -18,3 +18,7 @@ mapl:
       src_comp: STAT
       dst_name: avg_T
       dst_comp: collection_1
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics/root.yaml
+++ b/superstructure/generic/tests/scenarios/statistics/root.yaml
@@ -8,3 +8,7 @@ mapl:
   states:
     import: {}
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics_real/A.yaml
+++ b/superstructure/generic/tests/scenarios/statistics_real/A.yaml
@@ -14,3 +14,7 @@ mapl:
         standard_name: 'Surface Pressure'
         units: 'hPa'
         vertical_dim_spec: NONE
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics_real/collection_1.yaml
+++ b/superstructure/generic/tests/scenarios/statistics_real/collection_1.yaml
@@ -5,3 +5,7 @@ mapl:
         vertical_dim_spec: MIRROR
       PS_min:
         vertical_dim_spec: MIRROR
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/statistics_real/history.yaml
+++ b/superstructure/generic/tests/scenarios/statistics_real/history.yaml
@@ -11,6 +11,9 @@ mapl:
   states: {}
 
   import: {}
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_
 #    A/TS:
 #      vertical_dim_spec: MIRROR
 

--- a/superstructure/generic/tests/scenarios/statistics_real/root.yaml
+++ b/superstructure/generic/tests/scenarios/statistics_real/root.yaml
@@ -20,3 +20,7 @@ mapl:
   states:
     import: {}
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/ungridded_dims/A.yaml
+++ b/superstructure/generic/tests/scenarios/ungridded_dims/A.yaml
@@ -19,3 +19,7 @@ mapl:
         ungridded_dims:
           - {dim_name: foo1, extent: 3}
           - {dim_name: foo2, extent: 2}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/ungridded_dims/B.yaml
+++ b/superstructure/generic/tests/scenarios/ungridded_dims/B.yaml
@@ -21,3 +21,7 @@ mapl:
         vertical_dim_spec: NONE
         ungridded_dims:
           - {dim_name: foo1, extent: 3}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vector_1/child_A.yaml
+++ b/superstructure/generic/tests/scenarios/vector_1/child_A.yaml
@@ -22,3 +22,7 @@ mapl:
         units: 'm s-1'
         fill_value: 1
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vector_1/child_B.yaml
+++ b/superstructure/generic/tests/scenarios/vector_1/child_B.yaml
@@ -20,3 +20,7 @@ mapl:
         units: 'm s-1'
         fill_value: 1
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_regrid/A.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_regrid/A.yaml
@@ -23,3 +23,7 @@ mapl:
         fill_value: 15.
         vertical_dim_spec: center
         vertical_alignment: downward
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_regrid/B.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_regrid/B.yaml
@@ -22,3 +22,7 @@ mapl:
         vertical_dim_spec: center
         vertical_alignment: upward
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_same_grid/A.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_same_grid/A.yaml
@@ -23,3 +23,7 @@ mapl:
         fill_value: 15.
         vertical_dim_spec: center
         vertical_alignment: downward
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_same_grid/B.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_same_grid/B.yaml
@@ -22,3 +22,7 @@ mapl:
         vertical_dim_spec: center
         vertical_alignment: upward
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_with_grid/A.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_with_grid/A.yaml
@@ -23,3 +23,7 @@ mapl:
         fill_value: 15.
         vertical_dim_spec: center
         vertical_alignment: with_grid
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_alignment_with_grid/B.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_alignment_with_grid/B.yaml
@@ -22,3 +22,7 @@ mapl:
         vertical_dim_spec: center
         vertical_alignment: with_grid
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding/A.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding/A.yaml
@@ -21,3 +21,7 @@ mapl:
         units: m
         fill_value: 15.
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding/B.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding/B.yaml
@@ -20,3 +20,7 @@ mapl:
         units: m
         vertical_dim_spec: center
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_2/A.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_2/A.yaml
@@ -25,3 +25,7 @@ mapl:
         units: hPa
         fill_value: 13.
         vertical_dim_spec: edge
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_2/B.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_2/B.yaml
@@ -20,3 +20,7 @@ mapl:
         units: hPa
         vertical_dim_spec: center
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_2/C.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_2/C.yaml
@@ -20,3 +20,7 @@ mapl:
         units: m
         fill_value: 23.
         vertical_dim_spec: edge
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_2/D.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_2/D.yaml
@@ -20,3 +20,7 @@ mapl:
         units: m
         vertical_dim_spec: center
     export: {}
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_3/C.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_3/C.yaml
@@ -19,3 +19,7 @@ mapl:
         standard_name: air_pressure_c_center
         units: hPa
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_3/DYN.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_3/DYN.yaml
@@ -25,3 +25,7 @@ mapl:
         units: K
         default_vertical_profile: [40., 20., 10., 5.]
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_

--- a/superstructure/generic/tests/scenarios/vertical_regridding_3/PHYS.yaml
+++ b/superstructure/generic/tests/scenarios/vertical_regridding_3/PHYS.yaml
@@ -19,3 +19,7 @@ mapl:
         standard_name: temperature_phys_center
         units: K
         vertical_dim_spec: center
+
+  setServices:
+    sharedObj: libconfigurable_gridcomp
+    userRoutine: setservices_


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
In order to prepare for the implementation of the new child GridComp procedure in MAPL, this PR adds the information from the parent GridComp yaml file to the child GridComp yaml file. The information from the parent has not been removed, and the added information in the child GridComp yaml is not utilized yet.

## Related Issue
#5288