### PR TITLE
M21C: Fix for time_ave_util when levels=1

### DIFF
--- a/Apps/time_ave_util.F90
+++ b/Apps/time_ave_util.F90
@@ -566,7 +566,7 @@ program  time_ave
          endif
 
          if( trim(quadratics(3,nv)).ne.'XXX' ) vname2(mv) = trim(quadratics(3,nv))
- 
+
          nstar = 0
          if (allow_zonal_means) nstar = index( trim(quadratics(1,nv)),'star',back=.true. )
          if( nstar.ne.0 ) then
@@ -1167,12 +1167,14 @@ contains
       basic_metadata=formatter%read(_RC)
       call metadata%create(basic_metadata,trim(filename))
       lev_name = metadata%get_level_name(_RC)
-      call metadata%get_coordinate_info(lev_name,coords=levs,coordUnits=lev_units,long_name=long_name,&
-            standard_name=standard_name,coordinate_attr=vcoord,_RC)
-      plevs => levs
-      vertical_data = VerticalData(levels=plevs,vunit=lev_units,vcoord=vcoord,standard_name=standard_name,long_name=long_name, &
-            force_no_regrid=.true.,_RC)
-      nullify(plevs)
+      if (lev_name /= '') then
+         call metadata%get_coordinate_info(lev_name,coords=levs,coordUnits=lev_units,long_name=long_name,&
+               standard_name=standard_name,coordinate_attr=vcoord,_RC)
+         plevs => levs
+         vertical_data = VerticalData(levels=plevs,vunit=lev_units,vcoord=vcoord,standard_name=standard_name,long_name=long_name, &
+               force_no_regrid=.true.,_RC)
+         nullify(plevs)
+      end if
 
       if (present(rc)) then
          rc=_SUCCESS
@@ -1186,7 +1188,7 @@ contains
       integer, intent(out), optional :: rc
       integer :: status, global_dims(3)
       call MAPL_GridGet(grid,globalCellCountPerDim=global_dims,_RC)
-      grid_has_level = (global_dims(3)/=1)
+      grid_has_level = (global_dims(3)>0)
       if (present(rc)) then
          RC=_SUCCESS
       end if
@@ -1529,8 +1531,9 @@ contains
    end subroutine get_esmf_grid_layout
 
    subroutine check_quad ( quad,vname,nvars,aliases,nalias,qloc )
+      integer  nvars, nalias
       character(len=ESMF_MAXSTR)  quad(2), aliases(2,nalias), vname(nvars)
-      integer  nvars, nalias, qloc(2)
+      integer  qloc(2)
       integer  m,n
 
 ! Initialize Location of Quadratics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [v2.35.3+R21C_v1.5.0] - 2026-08-06
+
+### Fixed
+
+- Fixed bug in `time_ave_util.x` when the input files have a level size of 1
+
 ## [v2.35.3+R21C_v1.4.0] - 2024-11-29
 
 ### Changed


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

This PR backports (some) changes from #2234 and #2675 for `time_ave_util.x` for handling files with a single level in them.

## Related Issue

