### PR TITLE
Fix truncated length for 'SetServices' key in parse_child

### DIFF
--- a/superstructure/generic/ComponentSpecParser/parse_child.F90
+++ b/superstructure/generic/ComponentSpecParser/parse_child.F90
@@ -14,7 +14,7 @@ contains
       class(AbstractUserSetServices), allocatable :: setservices
 
       character(*), parameter :: dso_keys(*) = [character(len=9) :: 'dso', 'DSO', 'sharedObj', 'sharedobj']
-      character(*), parameter :: userProcedure_keys(*) = [character(len=10) :: 'SetServices', 'setServices', 'setservices']
+      character(*), parameter :: userProcedure_keys(*) = [character(len=11) :: 'SetServices', 'setServices', 'setservices']
       integer :: i
       character(:), allocatable :: dso_key, userProcedure_key, try_key
       logical :: dso_found, userProcedure_found
@@ -48,7 +48,7 @@ contains
             userProcedure_key = try_key
          end if
       end do
-      userProcedure = 'setservices_'         
+      userProcedure = 'setservices_'
       if (userProcedure_found) then
          userProcedure = ESMF_HconfigAsString(hconfig, keyString=userProcedure_key,_RC)
       end if


### PR DESCRIPTION
## Summary
- `userProcedure_keys` in `parse_child.F90` was declared with `len=10`, one character short of `SetServices` (11 chars), silently truncating it to `SetService` and breaking the key match.
- Also drops trailing whitespace on an unrelated line.

## Test plan
- [ ] CI checks pass

Fixes #5298 