### PR TITLE
v3: allow blank ACG vstagger for 2D fields; assorted improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-export `PackedDateCreate`, `PackedTimeCreate`, `PackedDateTimeCreate`, and
   `StrTemplate` through the top-level `MAPL` umbrella module.
 - `to_string` (`integer_to_string`) added to `mapl_StringUtilities`.
+- Added ACG option to leave vstagger entry blank for 2D fields
 
 ### Changed
 

--- a/apps/MAPL_GridCompSpecs_ACG.py
+++ b/apps/MAPL_GridCompSpecs_ACG.py
@@ -68,9 +68,13 @@ GC_ARGNAME = 'gridcomp'
 GET = 'get'
 MAKE_BLOCK = 'make_block'
 INTENT_PREFIX = 'ESMF_STATEINTENT_'
+INVALID_VALUES = 'invalid_values'
 KIND = 'kind'
 MAPL_STATEITEM_FIELD = 'MAPL_STATEITEM_FIELD'
 MAPL_STATEITEM_VECTOR = 'MAPL_STATEITEM_VECTOR'
+MAPL_VERTICAL_STAGGER_CENTER = 'MAPL_VERTICAL_STAGGER_CENTER'
+MAPL_VERTICAL_STAGGER_EDGE = 'MAPL_VERTICAL_STAGGER_EDGE'
+MAPL_VERTICAL_STAGGER_NONE = 'MAPL_VERTICAL_STAGGER_NONE'
 MAPPED = 'mapped' 
 MAPPING = 'mapping'
 MISSING_MANDATORY = 'missing_mandatory'
@@ -93,6 +97,9 @@ ALLOC = 'alloc'
 ARRAY = 'array'
 CONDITION = 'condition'
 DIMS = 'dims'
+DIMS_XY = "'xy'"
+DIMS_XYZ = "'xyz'"
+DIMS_Z = "'z'"
 EXPORT_NAME = 'export_name'
 FILL_VALUE = 'fill_value'
 INTENT_ARG = 'intent_arg'
@@ -113,6 +120,7 @@ TYPEKIND = 'typekind'
 UNGRIDDED_DIMS = 'ungridded_dim_array'
 USE_FIELD_DICTIONARY = 'use_field_dictionary'
 VSTAGGER = 'vertical_stagger'
+VSTAGGER_ARG = 'vertical_stagger_arg'
 RESTART = 'restart_mode'
 
 # command-line option constants
@@ -183,20 +191,20 @@ def get_options(args):
     # spec columns
     options[SPECIFICATIONS] = {
         DIMS: {FLAGS: {MANDATORY}, MAPPING: {
-            'z': "'z'",
-            'xy': "'xy'",
-            'xyz': "'xyz'",
-            'MAPL_DimsVertOnly': "'z'",
-            'MAPL_DimsHorzOnly': "'xy'",
-            'MAPL_DimsHorzVert': "'xyz'"}},
+            'z': DIMS_Z,
+            'xy': DIMS_XY,
+            'xyz': DIMS_XYZ,
+            'MAPL_DimsVertOnly': DIMS_Z,
+            'MAPL_DimsHorzOnly': DIMS_XY,
+            'MAPL_DimsHorzVert': DIMS_XYZ}},
         SHORT_NAME: {MAPPING: MANGLED, FLAGS: MANDATORY},
         STATE_INTENT: {FLAGS: {MANDATORY}},
         STANDARD_NAME: {FLAGS: MANDATORY},
         UNGRIDDED_DIMS: {MAPPING: ARRAY},
         VSTAGGER: {FLAGS: MANDATORY, MAPPING: {
-             'C': 'MAPL_VERTICAL_STAGGER_CENTER',
-             'E': 'MAPL_VERTICAL_STAGGER_EDGE',
-             'N': 'MAPL_VERTICAL_STAGGER_NONE'}},
+             'C': MAPL_VERTICAL_STAGGER_CENTER,
+             'E': MAPL_VERTICAL_STAGGER_EDGE,
+             'N': MAPL_VERTICAL_STAGGER_NONE}},
         ALIAS: {FLAGS: {STORE}},
         ALLOC: {FLAGS: {STORE}},
         ADD_TO_EXPORT: {MAPPING: STRLOGICAL},
@@ -254,7 +262,8 @@ def get_options(args):
         STANDARD_NAME_ARG: {MAPPING: STANDARD_NAME, FROM: (STANDARD_NAME, STANDARD_NAME_PREFIX), AS: STANDARD_NAME},
         INTENT_ARG: {FROM: (STATE_INTENT, STATE), MAPPING: (ID, dict(zip(states, intents))), FLAGS: AS},
         RANK: {MAPPING: RANK, FLAGS: {STORE, MANDATORY}, FROM: (DIMS, UNGRIDDED_DIMS)},
-        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS}
+        STATE_ARG: {FROM: (STATE, STATE_INTENT), MAPPING: (ID, dict(zip(intents, states))), FLAGS: AS},
+        VSTAGGER_ARG: {MAPPING: VSTAGGER, FROM: (VSTAGGER, DIMS), AS: VSTAGGER},
     }
 
     # internal constants
@@ -595,6 +604,7 @@ def get_values(specs, options):
                   SPECS_NOT_FOUND: specs_not_found,
                   VALUES_NOT_FOUND: values_not_found,
                   MISSING_MANDATORY: missing_mandatory,
+                  INVALID_VALUES: validate_values(values),
                   NONES: nones}
         results.append(result)
     return all_values, results
@@ -694,6 +704,30 @@ def compute_rank(dims, ungridded):
         extra_rank = r0
     return base_rank + extra_rank
 
+def default_vstagger(vstagger, dims):
+    """Default the vertical stagger for horizontal-only (2D) variables to NONE."""
+    if vstagger:
+        return vstagger
+    return MAPL_VERTICAL_STAGGER_NONE if dims == DIMS_XY else None
+
+def validate_vstagger(values):
+    """Check the vertical stagger against dims. Return an error message or None."""
+    dims = values.get(DIMS)
+    vstagger = values.get(VSTAGGER)
+    if dims == DIMS_XY and vstagger != MAPL_VERTICAL_STAGGER_NONE:
+        return f"{VSTAGGER} must be N or blank when {DIMS} is xy, not {vstagger}"
+    if dims == DIMS_XYZ and vstagger == MAPL_VERTICAL_STAGGER_NONE:
+        return f"{VSTAGGER} must be C or E when {DIMS} is xyz"
+    return None
+
+# Validators check a spec for consistency between columns. Each is called with
+# the values digested from one spec and returns an error message or None.
+VALIDATORS = (validate_vstagger,)
+
+def validate_values(values):
+    """Run the validators against a spec's values and return the error messages."""
+    return [message for message in (v(values) for v in VALIDATORS) if message]
+
 def header():
     """
     Returns a standard warning that can be placed at the top of each
@@ -770,6 +804,7 @@ NAMED_MAPPINGS = {
         MANGLED: lambda name: f''' '{rm_quotes(name).replace("*", "'//trim(comp_name)//'")}' ''' if name else None,
         STANDARD_NAME: mangle_standard_name,
         RANK: compute_rank,
+        VSTAGGER: default_vstagger,
         MAKE_BLOCK: lambda value: partial(make_block, value),
         BOOL: convert_to_bool,
         STRLOGICAL: lambda s: convert_to_logical(convert_to_bool(s))
@@ -847,16 +882,26 @@ def main(logger):
     parsed_specs = read_specs(args['input'])
 
     values, results = get_values(parsed_specs, options)
+    exit_code = SUCCESS
     # Make sure mandatory keys are present in specs.
     missing = [(r[SPEC], r[MISSING_MANDATORY]) for r in results if r[MISSING_MANDATORY]]
     if missing:
         for s, n in missing:
             print(f"value for {n} is missing in spec {s}")
         exit_code = ERROR
+    # Make sure the values within each spec are mutually consistent.
+    invalid = [(r[SPEC], r[INVALID_VALUES]) for r in results if r[INVALID_VALUES]]
+    if invalid:
+        for s, messages in invalid:
+            for message in messages:
+                print(f"{message} in spec {s}")
+        exit_code = ERROR
+    # Do not emit anything if any spec is bad.
+    if exit_code != SUCCESS:
+        sys.exit(exit_code)
 
 # Emit values
-    exit_code = emit_values(values, options)
-    sys.exit(exit_code)
+    sys.exit(emit_values(values, options))
 
 #############################################
 # MAIN program begins here

--- a/apps/tests/acg3/acg3_unittests.py
+++ b/apps/tests/acg3/acg3_unittests.py
@@ -718,7 +718,118 @@ class TestTypes(unittest.TestCase):
             with self.subTest(value=value, test=test, msg=msg):
                 test(value, msg)
 
-test_cases = (TestMappings, TestHelpers, TestColumns, TestTypes)
+class TestVerticalStagger(unittest.TestCase):
+    """Tests for defaulting and validating VLOC (vertical_stagger) against DIMS."""
+
+    def make_spec(self, dims, vstagger=None):
+        """Build a minimal valid spec. Omit vstagger entirely when it is None."""
+        spec = {
+            acg3.SHORT_NAME: 'TEST_FIELD',
+            acg3.STATE: 'import',
+            acg3.STATE_INTENT: 'ESMF_STATEINTENT_IMPORT',
+            acg3.STANDARD_NAME: 'test_standard_name',
+            acg3.DIMS: dims,
+        }
+        if vstagger is not None:
+            spec[acg3.VSTAGGER] = vstagger
+        return [spec]
+
+    def test_default_vstagger_defaults_xy_only(self):
+        """A blank vertical stagger defaults to NONE only for 2D (xy) variables."""
+        # default_vstagger operates on mapped values, hence DIMS_XY rather than 'xy'.
+        test_cases = (
+            (acg3.DIMS_XY, acg3.MAPL_VERTICAL_STAGGER_NONE,
+             'blank vstagger should default to NONE for xy'),
+            (acg3.DIMS_XYZ, None, 'blank vstagger should not be defaulted for xyz'),
+            (acg3.DIMS_Z, None, 'blank vstagger should not be defaulted for z'),
+        )
+
+        for dims, expected, msg in test_cases:
+            with self.subTest(dims=dims):
+                self.assertEqual(expected, acg3.default_vstagger(None, dims), msg)
+
+    def test_default_vstagger_preserves_explicit_value(self):
+        """An explicit vertical stagger is never overridden by the default."""
+        staggers = (acg3.MAPL_VERTICAL_STAGGER_CENTER,
+                    acg3.MAPL_VERTICAL_STAGGER_EDGE,
+                    acg3.MAPL_VERTICAL_STAGGER_NONE)
+        dims = (acg3.DIMS_Z, acg3.DIMS_XY, acg3.DIMS_XYZ)
+
+        for d, vstagger in product(dims, staggers):
+            with self.subTest(dims=d, vstagger=vstagger):
+                self.assertEqual(vstagger, acg3.default_vstagger(vstagger, d),
+                                 general_msg('vertical_stagger', vstagger))
+
+    def test_blank_vstagger_defaulted_in_values(self):
+        """A blank VLOC on an xy spec yields an explicit NONE and is not reported missing."""
+        # Absent, empty and whitespace-only all reach default_vstagger as None.
+        for vstagger in (None, '', '   '):
+            with self.subTest(vstagger=repr(vstagger)):
+                values, results = acg3.get_values(self.make_spec('xy', vstagger),
+                                                  acg3.get_options({}))
+                self.assertEqual(acg3.MAPL_VERTICAL_STAGGER_NONE,
+                                 values[0].get(acg3.VSTAGGER),
+                                 'blank VLOC on an xy spec should default to NONE')
+                self.assertNotIn(acg3.VSTAGGER, results[0][acg3.MISSING_MANDATORY],
+                                 'defaulted vertical_stagger should not be reported missing')
+
+    def test_blank_vstagger_still_mandatory_for_xyz(self):
+        """A blank VLOC is still reported missing for 3D variables."""
+        values, results = acg3.get_values(self.make_spec('xyz'), acg3.get_options({}))
+
+        self.assertNotIn(acg3.VSTAGGER, values[0],
+                         'blank VLOC on an xyz spec should not be defaulted')
+        self.assertIn(acg3.VSTAGGER, results[0][acg3.MISSING_MANDATORY],
+                      'vertical_stagger should be mandatory for xyz')
+
+    def test_validate_vstagger_rejects_inconsistent_dims(self):
+        """A layered stagger on a 2D variable, or NONE on a 3D variable, is an error."""
+        test_cases = (
+            (acg3.DIMS_XY, acg3.MAPL_VERTICAL_STAGGER_CENTER, 'C should be rejected for xy'),
+            (acg3.DIMS_XY, acg3.MAPL_VERTICAL_STAGGER_EDGE, 'E should be rejected for xy'),
+            (acg3.DIMS_XYZ, acg3.MAPL_VERTICAL_STAGGER_NONE, 'N should be rejected for xyz'),
+        )
+
+        for dims, vstagger, msg in test_cases:
+            with self.subTest(dims=dims, vstagger=vstagger):
+                values = {acg3.DIMS: dims, acg3.VSTAGGER: vstagger}
+                self.assertIsNotNone(acg3.validate_vstagger(values), msg)
+
+    def test_validate_vstagger_accepts_consistent_dims(self):
+        """Consistent dims/stagger combinations produce no error."""
+        valid = (
+            (acg3.DIMS_XY, acg3.MAPL_VERTICAL_STAGGER_NONE),
+            (acg3.DIMS_XYZ, acg3.MAPL_VERTICAL_STAGGER_CENTER),
+            (acg3.DIMS_XYZ, acg3.MAPL_VERTICAL_STAGGER_EDGE),
+            (acg3.DIMS_Z, acg3.MAPL_VERTICAL_STAGGER_CENTER),
+            (acg3.DIMS_Z, acg3.MAPL_VERTICAL_STAGGER_EDGE),
+        )
+
+        for dims, vstagger in valid:
+            with self.subTest(dims=dims, vstagger=vstagger):
+                values = {acg3.DIMS: dims, acg3.VSTAGGER: vstagger}
+                self.assertIsNone(acg3.validate_vstagger(values),
+                                  f'{vstagger} should be valid for {dims}')
+
+    def test_invalid_values_reported_in_results(self):
+        """An inconsistent spec is reported through INVALID_VALUES."""
+        for dims, vstagger in (('xy', 'C'), ('xy', 'E'), ('xyz', 'N')):
+            with self.subTest(dims=dims, vstagger=vstagger):
+                _, results = acg3.get_values(self.make_spec(dims, vstagger),
+                                             acg3.get_options({}))
+                self.assertTrue(results[0][acg3.INVALID_VALUES],
+                                f'{dims} with VLOC={vstagger} should be reported invalid')
+
+    def test_no_invalid_values_for_consistent_spec(self):
+        """A consistent spec reports no validation errors."""
+        for dims, vstagger in (('xy', 'N'), ('xy', None), ('xyz', 'C'), ('xyz', 'E')):
+            with self.subTest(dims=dims, vstagger=vstagger):
+                _, results = acg3.get_values(self.make_spec(dims, vstagger),
+                                             acg3.get_options({}))
+                self.assertFalse(results[0][acg3.INVALID_VALUES],
+                                 f'{dims} with VLOC={vstagger} should be valid')
+
+test_cases = (TestMappings, TestHelpers, TestColumns, TestTypes, TestVerticalStagger)
 
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()

--- a/superstructure/generic/specs/VerticalGridAspect.F90
+++ b/superstructure/generic/specs/VerticalGridAspect.F90
@@ -152,6 +152,8 @@ contains
       select type (dst)
       class is (VerticalGridAspect)
 
+         if (.not. allocated(src%vertical_grid)) return
+         if (.not. allocated(dst%vertical_grid)) return
          vec_in = src%vertical_grid%get_supported_physical_dimensions()
          vec_out = dst%vertical_grid%get_supported_physical_dimensions()
 


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [X] Ran the Unit Tests (`make tests`) **(NOTE: I only ran the acg3 unit tests)**

## Description

This PR addresses an error I ran into while testing GCHP MAPL3, where an incorrect entry for `VLOC` in an ACG3 file was not caught and ultimately triggered a seg fault in `VerticalGridAspect.F90`. The issue was that two of the 2D imports had entry `E` in the ACG file.

I corrected this and also made changes to improve ACG3 in general. Changes include:
1. Adding the option of leaving `VLOC` in the ACG3 file blank for 2D fields
2. Fixing the handling of `mandatory` fields in ACG by enforcing their presence
3. Adding general error checks for vstagger, forcing the model to error during build if `DIMS=xyz` entries in ACG do not have `E` or `C` for `VLOC`, and if `DIMS=xy` entries are not blank or `N`.
4. Adding checks that pointers are associated before use in `VerticalGridAspect.F90`

Regarding the last change, more pointer association checks are needed throughout MAPL3. For this PR I only updated the location where I ran into a seg fault. 

## Related Issue

None