### PR TITLE
Skip NAG CI for fork pull requests

### DIFF
--- a/.github/workflows/nag_build_discover.yml
+++ b/.github/workflows/nag_build_discover.yml
@@ -28,5 +28,16 @@ defaults:
 
 jobs:
   run-nag-build-discover:
-    if: github.event.pull_request.draft == false
+    # Fork PRs cannot normally use the NCCS runner. A maintainer can opt in by
+    # re-running the workflow; the reusable workflow then authorizes the
+    # maintainer through github.triggering_actor.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (
+        github.event.pull_request.draft == false &&
+        (
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          github.run_attempt > 1
+        )
+      )
     uses: GEOS-ESM/CI-workflows/.github/workflows/nag-build.yml@project/mapl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the Discover NAG CI workflow to skip fork pull requests by default,
+  while allowing an authorized maintainer to run it by rerunning the workflow.
+
 - `Regrid_Util.x` now uses the fargparse library for command line argument parsing instead
   of raw Fortran intrinsics. Multi-character options that previously used a single-dash prefix
   (e.g. `-ogrid`, `-nx`, `-ny`, `-method`, `-tp_in`, `-tp_out`, `-lon_range`, `-lat_range`,


### PR DESCRIPTION
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Description

The Discover NAG CI workflow now skips fork pull requests by default, avoiding failures when fork contributors do not have NCCS Discover access. An authorized maintainer can opt in by rerunning the workflow; manual and scheduled runs remain enabled.

The Unreleased changelog has been updated accordingly.

## Testing

- YAML parsed successfully locally.
- `git diff --check` passed.
