### PR TITLE
[v2 | PythonBridge] Fix the stack print from error/raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the unreliable feedback from Python bridge failures
 - Fixed bug that allowed ExtData2G to proceed if an invalid sampling key was provided
 
 ### Added

--- a/Python/MAPL_PythonBridge/fortran2python/fortran_python_bridge.py
+++ b/Python/MAPL_PythonBridge/fortran2python/fortran_python_bridge.py
@@ -11,15 +11,34 @@ from {} import ffi
 from datetime import datetime
 import MAPL_PythonBridge
 import traceback
+import sys
+
+try:
+    from mpi4py import MPI
+except ModuleNotFoundError as err:
+    MPI = None
+
+
+def _print_stack_and_return() -> int:
+    if MPI:
+        r = MPI.COMM_WORLD.Get_rank()
+    else:
+        r = ""
+    print(
+        f"\\n == == (Rank {{r}}) Error in Python: == == \\n"
+        f"{{traceback.format_exc()}}",
+        file=sys.stderr,
+        flush=True,
+    )
+    return -1
+
 
 @ffi.def_extern()
 def mapl_fortran_python_bridge_global_initialize_PyHook(IM, JM, LM) -> int:
     try:
         MAPL_PythonBridge.global_initialize(IM, JM, LM)
     except Exception as err:
-        print("Error in Python:")
-        print(traceback.format_exc())
-        return -1
+        return _print_stack_and_return()
     return 0
 
 @ffi.def_extern()
@@ -27,9 +46,7 @@ def mapl_fortran_python_bridge_user_init_PyHook(name, mapl_state, import_state, 
     try:
         MAPL_PythonBridge.named_init(name, mapl_state, import_state, export_state)
     except Exception as err:
-        print("Error in Python:")
-        print(traceback.format_exc())
-        return -1
+        return _print_stack_and_return()
     return 0
 
 @ffi.def_extern()
@@ -37,9 +54,7 @@ def mapl_fortran_python_bridge_user_run_PyHook(name, mapl_state, import_state, e
     try:
         MAPL_PythonBridge.named_run(name, mapl_state, import_state, export_state)
     except Exception as err:
-        print("Error in Python:")
-        print(traceback.format_exc())
-        return -1
+        return _print_stack_and_return()
     return 0
 
 @ffi.def_extern()
@@ -47,9 +62,7 @@ def mapl_fortran_python_bridge_user_run_with_internal_PyHook(name, mapl_state, i
     try:
         MAPL_PythonBridge.named_run_with_internal(name, mapl_state, import_state, export_state, internal_state)
     except Exception as err:
-        print("Error in Python:")
-        print(traceback.format_exc())
-        return -1
+        return _print_stack_and_return()
     return 0
 
 @ffi.def_extern()


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [x] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

Recent changes has made the previous strategy to surface error and stack from python raise/crash unreliable. This fix brings a more aggressive approach by using `stderr` directly and flushing the File IO before exiting with a `-1` status.
