### PR TITLE
prepare_v2.35.3+R21C_v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [v2.35.3+R21C_v1.6.0] - 2026-08-18
+
+### Fixed
+
+- Fixed bug so that MAPL_GridGet will return 0 for the level size if the grid has no level, instead of 1
+
 ## [v2.35.3+R21C_v1.5.0] - 2026-08-06
 
 ### Fixed

--- a/base/MaplGrid.F90
+++ b/base/MaplGrid.F90
@@ -287,7 +287,7 @@ subroutine GridCoordGet(GRID, coord, name, Location, Units, rc)
 
       if (pglobal) then
 
-         globalCellCountPerDim = 1
+         globalCellCountPerDim = 0
          call ESMF_GridGet(grid, tileCount=tileCount,_RC)
 
          call ESMF_GridGet(grid, tile=1, staggerLoc=ESMF_STAGGERLOC_CENTER, &
@@ -311,7 +311,7 @@ subroutine GridCoordGet(GRID, coord, name, Location, Units, rc)
       end if
 
       if (plocal) then
-         localCellCountPerDim = 1
+         localCellCountPerDim = 0
 
          HasDE = MAPL_GridHasDE(grid,_RC)
          if (HasDE) then


### PR DESCRIPTION
Fixes another bug exposed in time_ave_util.x

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

