### PR TITLE
change default of MAPL_GridGet from 1 to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- MAPL_GridGet will now return 0 instead of 1 if the grid was never set with the "LM" attribute for the vertical grid size
 - Removed the manual `find_package(MPI)`/`find_package(NetCDF)`/`find_package(HDF5)`/`find_package(ESMF)` block (and the Baselibs-only ESMF version guard) from the top-level `CMakeLists.txt`. As of ESMA_cmake v4.43.0, `esma.cmake` automatically `include()`s `ConfigureBaselibs.cmake` or `ConfigureExternalLibraries.cmake` based on `Baselibs_FOUND` right after `include(FindBaselibs)`, creating all of these dependency targets for us, including enforcing a minimum ESMF version of 8.6.1 for both Baselibs and Spack/non-Baselibs builds
 - Update `components.yaml`
   - ESMA_cmake v4.44.0

--- a/base/MaplGrid.F90
+++ b/base/MaplGrid.F90
@@ -304,7 +304,7 @@ subroutine GridCoordGet(GRID, coord, name, Location, Units, rc)
 
       if (pglobal) then
 
-         globalCellCountPerDim = 1
+         globalCellCountPerDim = 0
          call ESMF_GridGet(grid, tileCount=tileCount,_RC)
 
          call ESMF_GridGet(grid, tile=1, staggerLoc=ESMF_STAGGERLOC_CENTER, &
@@ -328,7 +328,7 @@ subroutine GridCoordGet(GRID, coord, name, Location, Units, rc)
       end if
 
       if (plocal) then
-         localCellCountPerDim = 1
+         localCellCountPerDim = 0
 
          HasDE = MAPL_GridHasDE(grid,_RC)
          if (HasDE) then


### PR DESCRIPTION
This changes the default return values of MAPL_GridGet from 1 to 0, this was found in the context of a code that was using the 3 element of the array to get the vertical grid size. But the code always sets this to 1, even when the required attribute is not in the grid, so really if that attribute is not present it should be 0 as we have pathological files that have a level of size 1
## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

