### PR TITLE
v2: Fix documentation workflows and CI credentials

### DIFF
--- a/.github/actions/deploy-ford-docs/action.yml
+++ b/.github/actions/deploy-ford-docs/action.yml
@@ -15,7 +15,20 @@ inputs:
     default: ""
   deploy-token:
     description: "GitHub token for deployment"
-    required: true
+    required: false
+    default: ""
+  clean:
+    description: "Remove files no longer present in the generated documentation"
+    required: false
+    default: "true"
+  clean-exclude:
+    description: "Files or folders to preserve when cleaning the deployment destination"
+    required: false
+    default: ""
+  publish:
+    description: "Publish the generated documentation to GitHub Pages"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -50,6 +63,7 @@ runs:
         path: gFTL
         fetch-depth: 1
         ref: v1.17.0
+        persist-credentials: false
 
     - name: Build gFTL
       run: |
@@ -68,10 +82,13 @@ runs:
 
     - name: Deploy Pages
       uses: JamesIves/github-pages-deploy-action@v4
-      if: github.event_name == 'push' && github.repository == 'GEOS-ESM/MAPL' && ( startsWith( github.ref, 'refs/tags/v' ) || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' )
+      if: inputs.publish == 'true' && ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) && github.repository == 'GEOS-ESM/MAPL'
       with:
         folder: ${{ inputs.doc-folder }}
         target-folder: ${{ inputs.target-folder }}
         branch: gh-pages
         repository-name: GEOS-ESM/MAPL-docs
         token: ${{ inputs.deploy-token }}
+        clean: ${{ inputs.clean }}
+        clean-exclude: ${{ inputs.clean-exclude }}
+        force: false

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,44 @@
+name: "Build Documentation for PR"
+
+on:
+  pull_request:
+    branches:
+      - release/v2
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-v2-documentation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Build Docs
+        uses: ./.github/actions/deploy-ford-docs
+        with:
+          ford-input: docs-with-remote-esmf.md
+          doc-folder: docs/Ford/doc
+
+  build-dev-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Build Dev Docs
+        uses: ./.github/actions/deploy-ford-docs
+        with:
+          ford-input: docs-with-remote-esmf.public_private_protected.md
+          doc-folder: docs/Ford/dev-doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,15 +4,18 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: mapl-v2-documentation-deployment-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-docs:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,9 +33,16 @@ jobs:
           # relative path to the ford input file.
           ford-input: docs-with-remote-esmf.md
           doc-folder: docs/Ford/doc
+          clean-exclude: |
+            dev-doc
+            mapl3-doc
+            mapl3-dev-doc
+          publish: ${{ github.ref == 'refs/heads/main' }}
           deploy-token: ${{ secrets.DOCS_DEPLOY_PAT }}
 
   build-and-deploy-dev-docs:
+    if: github.ref == 'refs/heads/main'
+    needs: build-and-deploy-docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -51,4 +61,5 @@ jobs:
           ford-input: docs-with-remote-esmf.public_private_protected.md
           doc-folder: docs/Ford/dev-doc
           target-folder: dev-doc
+          publish: ${{ github.ref == 'refs/heads/main' }}
           deploy-token: ${{ secrets.DOCS_DEPLOY_PAT }}

--- a/.github/workflows/mapl3docs.yml
+++ b/.github/workflows/mapl3docs.yml
@@ -9,8 +9,13 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: mapl3-documentation-deployment-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-mapl3-docs:
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +34,7 @@ jobs:
           ford-input: mapl3docs-with-remote-esmf.md
           doc-folder: docs/Ford/mapl3-doc
           target-folder: mapl3-doc
+          publish: ${{ github.ref == 'refs/heads/develop' }}
           deploy-token: ${{ secrets.DOCS_DEPLOY_PAT }}
 
   ##############################################################################

--- a/.github/workflows/spack-ci.yml
+++ b/.github/workflows/spack-ci.yml
@@ -12,6 +12,9 @@ on:
       - ".github/CODEOWNERS"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # For PRs: one slot per PR number.
   # For non-PR events (schedule, workflow_dispatch): one slot per ref.
@@ -34,8 +37,10 @@ jobs:
     uses: GEOS-ESM/CI-workflows/.github/workflows/spack_gcc_build.yml@project/geosgcm
     name: Spack Build with ESMF (${{ matrix.name }})
     secrets:
-      BUILDCACHE_USERNAME: ${{ secrets.BUILDCACHE_USERNAME }}
-      BUILDCACHE_TOKEN: ${{ secrets.BUILDCACHE_TOKEN }}
+      # The public build cache supports anonymous reads. These empty values
+      # satisfy the reusable workflow's currently required secret interface.
+      BUILDCACHE_USERNAME: ""
+      BUILDCACHE_TOKEN: ""
     with:
       use-esmf-develop: ${{ matrix.use-esmf-develop }}
       run-tests: ${{ matrix.run-tests }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,6 +12,9 @@ on:
       - ".github/PULL_REQUEST_TEMPLATE.md"
       - ".editorconfig"
 
+permissions:
+  contents: read
+
 concurrency:
   # For PRs: one slot per PR number.
   # For non-PR events (schedule, workflow_dispatch): one slot per ref.
@@ -19,28 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-ford-docs:
-    name: Build Ford Docs
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          filter: blob:none
-
-      - name: Build and Deploy Docs
-        uses: ./.github/actions/deploy-ford-docs
-        with:
-          # Due to a bug in ford, for now we do *not* want to use
-          # the full path to the ford input file. Rather, the
-          # action will cd into docs/Ford and then run ford
-          # relative path to the ford input file.
-          ford-input: ford-ci.md
-          doc-folder: docs/Ford/ci-doc
-          deploy-token: ${{ secrets.DOCS_DEPLOY_PAT }}
-
   build_test_mapl_gnu14:
     name: gfortran / ${{ matrix.cmake-build-type }} / ${{ matrix.cmake-generator }}
     if: github.event.pull_request.draft == false
@@ -62,6 +43,7 @@ jobs:
         with:
           fetch-depth: 1
           filter: blob:none
+          persist-credentials: false
 
       - name: Build and Test MAPL
         uses: ./.github/actions/ci-build-and-test-mapl
@@ -92,6 +74,7 @@ jobs:
         with:
           fetch-depth: 1
           filter: blob:none
+          persist-credentials: false
 
       - name: Build and Test MAPL
         uses: ./.github/actions/ci-build-and-test-mapl
@@ -118,6 +101,7 @@ jobs:
         with:
           fetch-depth: 1
           filter: blob:none
+          persist-credentials: false
 
       - name: Build and Test MAPL
         uses: ./.github/actions/ci-build-and-test-mapl
@@ -143,6 +127,7 @@ jobs:
         with:
           fetch-depth: 1
           filter: blob:none
+          persist-credentials: false
 
       - name: Build and Test MAPL
         uses: ./.github/actions/ci-build-and-test-mapl
@@ -163,6 +148,7 @@ jobs:
         with:
           fetch-depth: 1
           filter: blob:none
+          persist-credentials: false
 
       - name: Build MAPL without optional packages
         uses: ./.github/actions/ci-build-and-test-mapl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed documentation workflows so manual runs publish only from trusted branches and v2 and MAPL3 documentation deployments preserve each other's output
+- Removed deployment and build-cache credentials from pull request jobs and restricted PR workflow tokens to read-only access
 - Added `log_files_read` option to ExtData2G to easily log all files read during a run
 
 ### Added


### PR DESCRIPTION
## Summary
- make documentation publishing explicit and restrict it to trusted branch runs
- preserve v2, developer, and MAPL3 documentation during Pages deployments
- add secret-free documentation builds for pull requests
- restrict PR workflow tokens and remove build-cache credentials from Spack CI

## Validation
- actionlint
- YAML parsing and yamllint
- git diff --check