### PR TITLE
Bugfix/wdboggs/fix extdata dangling pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed documentation workflows so manual runs publish only from trusted branches and v2 and MAPL3 documentation deployments preserve each other's output
 - Removed deployment and build-cache credentials from pull request jobs and restricted PR workflow tokens to read-only access
-- Dangling pointer in ExtDataFileReader due to a missing target attribute
+- Dangling pointer in ExtDataFileReader due to a missing target attribute on ExtDataReader
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed documentation workflows so manual runs publish only from trusted branches and v2 and MAPL3 documentation deployments preserve each other's output
 - Removed deployment and build-cache credentials from pull request jobs and restricted PR workflow tokens to read-only access
+- Dangling pointer in ExtDataFileReader due to a missing target attribute
 
 ### Changed
 

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -150,9 +150,9 @@ module mapl_ExtDataReader_mod
 
       iter = this%filename_map%ftn_begin()
       do while (iter /= this%filename_map%ftn_end())
+         call iter%next()
          filename => iter%second()
          call fileset%insert(filename)
-         call iter%next()
       end do
 
       _RETURN(_SUCCESS)

--- a/gridcomps/extdata/ExtDataFileReader.F90
+++ b/gridcomps/extdata/ExtDataFileReader.F90
@@ -148,8 +148,8 @@ module mapl_ExtDataReader_mod
       character(len=:), pointer :: filename
       integer :: status
 
-      iter = this%filename_map%begin()
-      do while (iter /= this%filename_map%end())
+      iter = this%filename_map%ftn_begin()
+      do while (iter /= this%filename_map%ftn_end())
          filename => iter%second()
          call fileset%insert(filename)
          call iter%next()

--- a/gridcomps/extdata/ExtDataGridComp.F90
+++ b/gridcomps/extdata/ExtDataGridComp.F90
@@ -150,7 +150,7 @@ contains
       real, allocatable :: weights(:)
       character(len=:), allocatable :: export_name
       character(len=:), pointer :: base_name
-      type(ExtDataReader) :: reader
+      type(ExtDataReader), target :: reader
       class(logger), pointer :: lgr
       type(ESMF_FieldBundle) :: bundle
       integer :: idx


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests`)

## Description
When iterating on a StringStringMap, the NAG compiler produced a dangling pointer error. This PR adds a target attribute to the ExtDataReader object that is passed into the problem proceduere. Also, it changes the iterator to use ftn_begin() and ftn_end() instead of begin() and end(). This is consistent with most iterators in MAPL.
