### PR TITLE
Add skip restart to history/extdata tests

### DIFF
--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case01/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case01/cap1.yaml
@@ -15,6 +15,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case01/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case01/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case02/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case02/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case02/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case02/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case03/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case03/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case03/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case03/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case04/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case04/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case04/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case04/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case05/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case05/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case05/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case05/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case06/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case06/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case06/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case06/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case07/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case07/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case07/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case07/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case08/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case08/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case08/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case08/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case09/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case09/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case09/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case09/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case10/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case10/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case10/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case10/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case11/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case11/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case11/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case11/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case13/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case13/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case13/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case13/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case14/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case14/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case14/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case14/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case15/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case15/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case15/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case15/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case16/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case16/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case16/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case16/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case17/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case17/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case17/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case17/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case18/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case18/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case18/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case18/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case19/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case19/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case21/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case21/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case21/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case21/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap3.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case22/cap3.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart3.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap3.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case23/cap3.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart3.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case24/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case24/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 6
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case24/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case24/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 6
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case30/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case30/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case30/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case30/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case39/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case39/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case39/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case39/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case40/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case40/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 6
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case40/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case40/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 6
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case41/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case41/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   checkpointing:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case41/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case41/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   checkpointing:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   checkpointing:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap3.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap3.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart3.yaml
 
   checkpointing:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap4.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case42/cap4.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case43/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case43/cap1.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   checkpointing:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case43/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case43/cap2.yaml
@@ -6,7 +6,6 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-#
 #  servers:
 #    pfio:
 #       nodes: 1
@@ -15,6 +14,7 @@ mapl:
 
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case44/cap1.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case44/cap1.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart1.yaml
 
   clock:

--- a/tests/MAPL3G_Component_Testing_Framework/test_cases/case44/cap2.yaml
+++ b/tests/MAPL3G_Component_Testing_Framework/test_cases/case44/cap2.yaml
@@ -6,9 +6,9 @@ esmf:
 mapl:
   model_petcount: 1
   pflogger_cfg_file: logging.yaml
-
 cap:
   name: cap
+  skip_restart_write: true
   restart: cap_restart2.yaml
 
   clock:


### PR DESCRIPTION
This just adds the flag so the cap_restart.yaml won't get overwritten when you run the history/extdata tests by hand. I added the flag to cap, now adding to my test files, just annoying without this if you are running a test by hand...
I am making this skip changelog as this doesn't affect anyone other than me and no one other than me will probably ever run these tests by hand anyway...
Figured I would get this in before the cap.yaml is changed

## Types of change(s)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)

## Description

## Related Issue

