### PR TITLE
v3: Fix omission of setting allocation_status when creating ServiceClassAspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed documentation workflows so manual runs publish only from trusted branches and v2 and MAPL3 documentation deployments preserve each other's output
 - Removed deployment and build-cache credentials from pull request jobs and restricted PR workflow tokens to read-only access
 - Dangling pointer in ExtDataFileReader due to a missing target attribute on ExtDataReader
+- Fixed omission of setting FieldBundle allocation status in create() for ServiceClassAspect
 
 ### Changed
 

--- a/superstructure/generic/specs/ServiceClassAspect.F90
+++ b/superstructure/generic/specs/ServiceClassAspect.F90
@@ -6,6 +6,7 @@ module mapl_ServiceClassAspect_mod
    use mapl_AspectId_mod
    use mapl_StateItemAspect_mod
    use mapl_enums_api, only: MAPL_STATEITEM_ALLOCATION_ACTIVE, MAPL_FIELDBUNDLETYPE_SERVICE
+   use mapl_enums_api, only: MAPL_STATEITEM_ALLOCATION_CREATED
    use mapl_ClassAspect_mod
    use mapl_FieldClassAspect_mod
    use mapl_StateRegistry_mod
@@ -103,8 +104,12 @@ contains
       integer, optional, intent(out) :: rc
 
       integer :: status
+      type(ESMF_Info) :: info
 
       this%payload = MAPL_FieldBundleCreate(fieldBundleType=MAPL_FIELDBUNDLETYPE_SERVICE, _RC)
+
+      call ESMF_InfoGetFromHost(this%payload, info, _RC)
+      call MAPL_FieldBundleInfoSetInternal(info, allocation_status=MAPL_STATEITEM_ALLOCATION_CREATED, _RC)
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(other_aspects)


### PR DESCRIPTION
## Types of change(s)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no api changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [ ] Ran the Unit Tests (`make tests`)
- [X] Tested with GCHP 

## Description

While testing a two-child case in GCHP using MAPL3 I ran into the following run issue:

```
pe=00001 FAIL at line=00125    InfoUtilities.F90                        <Key not found in info object: /MAPL/internal/allocation_status>
pe=00001 FAIL at line=00103    FieldBundleInfo.F90                      <status=1>
pe=00001 FAIL at line=00116    FieldBundleGet.F90                       <status=1>
pe=00001 FAIL at line=00707    StateItemSpec.F90                        <status=1>
pe=00001 FAIL at line=00177    StateItemSpec.F90                        <status=1>
```

Claude traced it to a problem in `ServiceClassAspect.F90` subroutine `create`, where a field bundle is created for type `MAPL_FIELDBUNDLETYPE_SERVICE`, but the `allocation_status=MAPL_STATEITEM_ALLOCATION_CREATED` is not set. This differs from all other `ClassAspect` types and is therefore deemed a bug, assuming they should all have this. I fixed it with the recommended fix, and that solved it.

The reason this was triggered was `AdvCore` declares bundle `TRADV` as a provider but I did not give it any subscribers. This is because I have not hooked up GEOS-Chem yet, which will be the subscriber. If the intention is for the model to not allow the case of declaring a provider without having a subscriber, then that would need to be a separate update in the error handling.

Note I am relying heavily on Claude (Sonnet 5) for this analysis. I am looking to @tclune for whether all of this makes sense. 

## Related Issue

none

