### PR TITLE
Fix NAG coordinate corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed corrupted cubed-sphere coordinate endpoints in NAG-generated output
 - Fixed documentation workflows so manual runs publish only from trusted branches and v2 and MAPL3 documentation deployments preserve each other's output
 - Removed deployment and build-cache credentials from pull request jobs and restricted PR workflow tokens to read-only access
 - Dangling pointer in ExtDataFileReader due to a missing target attribute on ExtDataReader

--- a/infrastructure/geom_io/GeomPFIO.F90
+++ b/infrastructure/geom_io/GeomPFIO.F90
@@ -49,7 +49,7 @@ module mapl_GeomPFIO_mod
 
      subroutine I_stage_coordinates_to_file(this, filename, rc)
         import GeomPFIO
-        class(GeomPFIO), intent(inout) :: this
+        class(GeomPFIO), target, intent(inout) :: this
         character(len=*), intent(in) :: filename
         integer, intent(out), optional :: rc
      end subroutine I_stage_coordinates_to_file

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -2,7 +2,7 @@
 
 module mapl_GridPFIO_mod
 
-   use, intrinsic :: iso_c_binding, only: c_ptr, c_loc
+   use, intrinsic :: iso_c_binding, only: c_ptr
 
    use mapl_ErrorHandling_mod
    use mapl_GeomPFIO_mod
@@ -20,8 +20,7 @@ module mapl_GridPFIO_mod
    public :: GridPFIO
    type, extends (GeomPFIO) :: GridPFIO
       private
-      real(ESMF_KIND_R8), pointer :: lons(:,:) => null(), lats(:,:) => null()
-      real(ESMF_KIND_R8), pointer :: corner_lons(:,:) => null(), corner_lats(:,:) => null()
+      real(ESMF_KIND_R8), allocatable :: lons(:,:), lats(:,:), corner_lons(:,:), corner_lats(:,:)
    contains
       procedure :: stage_data_to_file
       procedure :: request_data_from_file
@@ -31,7 +30,7 @@ module mapl_GridPFIO_mod
 contains
 
    subroutine stage_coordinates_to_file(this, filename, rc)
-      class(GridPFIO), intent(inout) :: this
+      class(GridPFIO), target, intent(inout) :: this
       character(len=*), intent(in) :: filename
       integer, intent(out), optional :: rc
 
@@ -66,18 +65,18 @@ contains
          local_start = server_bounds%get_local_start()
 
          call ESMF_GridGetCoord(grid, 1, farrayPtr=coords, _RC)
-         if (associated(this%lons)) deallocate(this%lons)
+         if (allocated(this%lons)) deallocate(this%lons)
          allocate(this%lons(size(coords,1), size(coords,2)), _STAT)
          this%lons = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(c_loc(this%lons(1,1)), pFIO_REAL64, shape(this%lons))
+         ref = ArrayReference(this%lons)
           request_id = o_client%collective_stage_data(collection_id,filename, 'lons', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, _RC)
-         if (associated(this%lats)) deallocate(this%lats)
+         if (allocated(this%lats)) deallocate(this%lats)
          allocate(this%lats(size(coords,1), size(coords,2)), _STAT)
          this%lats = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(c_loc(this%lats(1,1)), pFIO_REAL64, shape(this%lats))
+         ref = ArrayReference(this%lats)
           request_id = o_client%collective_stage_data(collection_id,filename, 'lats', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
@@ -98,18 +97,18 @@ contains
          local_start = server_bounds%get_corner_local_start()
 
          call ESMF_GridGetCoord(grid, 1, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
-         if (associated(this%corner_lons)) deallocate(this%corner_lons)
+         if (allocated(this%corner_lons)) deallocate(this%corner_lons)
          allocate(this%corner_lons(size(coords,1), size(coords,2)), _STAT)
          this%corner_lons = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(c_loc(this%corner_lons(1,1)), pFIO_REAL64, shape(this%corner_lons))
+         ref = ArrayReference(this%corner_lons)
            request_id = o_client%collective_stage_data(collection_id,filename, 'corner_lons', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
-         if (associated(this%corner_lats)) deallocate(this%corner_lats)
+         if (allocated(this%corner_lats)) deallocate(this%corner_lats)
          allocate(this%corner_lats(size(coords,1), size(coords,2)), _STAT)
          this%corner_lats = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(c_loc(this%corner_lats(1,1)), pFIO_REAL64, shape(this%corner_lats))
+         ref = ArrayReference(this%corner_lats)
            request_id = o_client%collective_stage_data(collection_id,filename, 'corner_lats', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 

--- a/infrastructure/geom_io/GridPFIO.F90
+++ b/infrastructure/geom_io/GridPFIO.F90
@@ -20,7 +20,8 @@ module mapl_GridPFIO_mod
    public :: GridPFIO
    type, extends (GeomPFIO) :: GridPFIO
       private
-      real(ESMF_KIND_R8), allocatable :: lons(:,:), lats(:,:), corner_lons(:,:), corner_lats(:,:)
+      real(ESMF_KIND_R8), pointer :: lons(:,:) => null(), lats(:,:) => null()
+      real(ESMF_KIND_R8), pointer :: corner_lons(:,:) => null(), corner_lats(:,:) => null()
    contains
       procedure :: stage_data_to_file
       procedure :: request_data_from_file
@@ -65,18 +66,18 @@ contains
          local_start = server_bounds%get_local_start()
 
          call ESMF_GridGetCoord(grid, 1, farrayPtr=coords, _RC)
-         if (allocated(this%lons)) deallocate(this%lons)
+         if (associated(this%lons)) deallocate(this%lons)
          allocate(this%lons(size(coords,1), size(coords,2)), _STAT)
          this%lons = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(this%lons)
+         ref = ArrayReference(c_loc(this%lons(1,1)), pFIO_REAL64, shape(this%lons))
           request_id = o_client%collective_stage_data(collection_id,filename, 'lons', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, _RC)
-         if (allocated(this%lats)) deallocate(this%lats)
+         if (associated(this%lats)) deallocate(this%lats)
          allocate(this%lats(size(coords,1), size(coords,2)), _STAT)
          this%lats = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(this%lats)
+         ref = ArrayReference(c_loc(this%lats(1,1)), pFIO_REAL64, shape(this%lats))
           request_id = o_client%collective_stage_data(collection_id,filename, 'lats', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
@@ -97,18 +98,18 @@ contains
          local_start = server_bounds%get_corner_local_start()
 
          call ESMF_GridGetCoord(grid, 1, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
-         if (allocated(this%corner_lats)) deallocate(this%corner_lats)
+         if (associated(this%corner_lons)) deallocate(this%corner_lons)
          allocate(this%corner_lons(size(coords,1), size(coords,2)), _STAT)
          this%corner_lons = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(this%corner_lons)
+         ref = ArrayReference(c_loc(this%corner_lons(1,1)), pFIO_REAL64, shape(this%corner_lons))
            request_id = o_client%collective_stage_data(collection_id,filename, 'corner_lons', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 
          call ESMF_GridGetCoord(grid, 2, farrayPtr=coords, staggerloc=ESMF_STAGGERLOC_CORNER, _RC)
-         if (allocated(this%corner_lats)) deallocate(this%corner_lats)
+         if (associated(this%corner_lats)) deallocate(this%corner_lats)
          allocate(this%corner_lats(size(coords,1), size(coords,2)), _STAT)
          this%corner_lats = coords*MAPL_RADIANS_TO_DEGREES
-         ref = ArrayReference(this%corner_lats)
+         ref = ArrayReference(c_loc(this%corner_lats(1,1)), pFIO_REAL64, shape(this%corner_lats))
            request_id = o_client%collective_stage_data(collection_id,filename, 'corner_lats', &
                 ref, start=local_start, global_start=global_start, global_count=global_count)
 


### PR DESCRIPTION
## Types of change(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)
- [ ] Refactor (no functional changes, no API changes)

## Checklist
- [ ] Tested this change with a run of GEOSgcm
- [x] Ran the Unit Tests (`make tests` or `ctest`)

## Description

The PFIO `ArrayReference` constructor takes a `TARGET` dummy and retains the address obtained with `c_loc`. `GridPFIO` passed allocatable coordinate components through `this`, but the `stage_coordinates_to_file` passed-object dummy did not have `TARGET`. With NAG, this produced corrupted first and last coordinate values in every cubed-sphere face-local tile.

This adds `TARGET` to the passed-object dummy in both the deferred `GeomPFIO` interface and the overriding `GridPFIO` procedure. The allocatable coordinate components and existing `ArrayReference` calls remain unchanged.

The updated `corner_lons` allocation check also contains the correction independently identified in #5319. That PR remains open, and credit for finding that allocation typo belongs there.

## Testing

```console
cmake --build build-nag-Debug -j 8
ctest --test-dir build-nag-Debug -R cs-cs --output-on-failure
```

Result: 1/1 test passed.

Fixes #5366